### PR TITLE
Added new input file command to specify interpolated user input waveforms

### DIFF
--- a/gprMax/input_cmds_file.py
+++ b/gprMax/input_cmds_file.py
@@ -178,7 +178,7 @@ def check_cmd_names(processedlines, checkessential=True):
     essentialcmds = ['#domain', '#dx_dy_dz', '#time_window']
 
     # Commands that there should only be one instance of in a model
-    singlecmds = dict.fromkeys(['#domain', '#dx_dy_dz', '#time_window', '#title', '#messages', '#num_threads', '#time_step_stability_factor', '#pml_cells', '#excitation_file', '#src_steps', '#rx_steps', '#taguchi', '#end_taguchi'], None)
+    singlecmds = dict.fromkeys(['#domain', '#dx_dy_dz', '#time_window', '#title', '#messages', '#num_threads', '#time_step_stability_factor', '#pml_cells', '#excitation_file', '#excitation_filefunc', '#src_steps', '#rx_steps', '#taguchi', '#end_taguchi'], None)
 
     # Commands that there can be multiple instances of in a model - these will be lists within the dictionary
     multiplecmds = {key: [] for key in ['#geometry_view', '#geometry_objects_write', '#material', '#soil_peplinski', '#add_dispersion_debye', '#add_dispersion_lorentz', '#add_dispersion_drude', '#waveform', '#voltage_source', '#hertzian_dipole', '#magnetic_dipole', '#transmission_line', '#rx', '#rx_array', '#snapshot', '#pml_cfs', '#include_file']}

--- a/gprMax/input_cmds_singleuse.py
+++ b/gprMax/input_cmds_singleuse.py
@@ -23,6 +23,7 @@ import sys
 from colorama import init, Fore, Style
 init()
 import numpy as np
+from scipy.interpolate import UnivariateSpline
 
 from gprMax.constants import c, floattype
 from gprMax.exceptions import CmdInputError, GeneralError
@@ -271,5 +272,50 @@ def process_singlecmds(singlecmds, G):
 
             if G.messages:
                 print('User waveform {} created.'.format(w.ID))
+
+            G.waveforms.append(w)
+            
+    # Excitation file for user-defined source waveforms using interpolated data
+    cmd = '#excitation_filefunc'
+    if singlecmds[cmd] is not None:
+        tmp = singlecmds[cmd].split()
+        if len(tmp) != 1:
+            raise CmdInputError(cmd + ' requires exactly one parameter')
+        excitationfile = tmp[0]
+
+        # See if file exists at specified path and if not try input file directory
+        if not os.path.isfile(excitationfile):
+            excitationfile = os.path.abspath(os.path.join(G.inputdirectory, excitationfile))
+
+        # Get waveform names
+        with open(excitationfile, 'r') as f:
+            waveformIDs = f.readline().split()
+
+        # Read all waveform values into an array
+        waveformvalues = np.loadtxt(excitationfile, skiprows=1, dtype=floattype)
+        
+        timedata = None
+
+        for waveform in range(len(waveformIDs)):
+            
+            if waveformIDs[waveform].lower() == 'time':
+                timedata = waveformvalues[:, waveform]
+                
+        if timedata is None:
+            raise CmdInputError('Excitation Function File must specify time domain')
+            
+        for waveform in range(len(waveformIDs)):   
+            if waveformIDs[waveform].lower() == 'time':
+                continue
+            
+            if any(x.ID == waveformIDs[waveform] for x in G.waveforms):
+                raise CmdInputError('Waveform with ID {} already exists'.format(waveformIDs[waveform]))
+            w = Waveform()
+            w.ID = waveformIDs[waveform]
+            w.type = 'userfunc'
+            w.userfunc = UnivariateSpline(timedata,waveformvalues[:, waveform],ext=1,k=2,s=0)
+
+            if G.messages:
+                print('User waveform-function {} created.'.format(w.ID))
 
             G.waveforms.append(w)

--- a/gprMax/waveforms.py
+++ b/gprMax/waveforms.py
@@ -24,7 +24,7 @@ from gprMax.utilities import round_value
 class Waveform(object):
     """Definitions of waveform shapes that can be used with sources."""
 
-    types = ['gaussian', 'gaussiandot', 'gaussiandotnorm', 'gaussiandotdot', 'gaussiandotdotnorm', 'ricker', 'sine', 'contsine', 'impulse', 'user']
+    types = ['gaussian', 'gaussiandot', 'gaussiandotnorm', 'gaussiandotdot', 'gaussiandotdotnorm', 'ricker', 'sine', 'contsine', 'impulse', 'user', 'userfunc']
 
     def __init__(self):
         self.ID = None
@@ -32,6 +32,7 @@ class Waveform(object):
         self.amp = 1
         self.freq = None
         self.uservalues = None
+        self.userfunc = None
 
     def calculate_value(self, time, dt):
         """Calculates value of the waveform at a specific time.
@@ -102,6 +103,12 @@ class Waveform(object):
                 ampvalue = 0
             else:
                 ampvalue = self.uservalues[index]
+        elif self.type == 'userfunc':
+                            
+            if self.userfunc is None:
+                ampvalue = 0
+            else:
+                ampvalue = float(self.userfunc(time))
 
         ampvalue *= self.amp
 


### PR DESCRIPTION
Use of the #excitation_file command is tricky because it does not specify the time domain in conjunction with waveform amplitude values. 

Even when using the exact same functions as standard gprMax waveforms, as well as a timestep value pulled from an output file with the same domain configuration, the resulting output file will be excessively unstable as seen below:

![usergauss](https://cloud.githubusercontent.com/assets/700223/24976340/0ea18cd8-1f97-11e7-8aec-4a70eae8cc6c.png)

Compared to the standard gaussian waveform of 2Ghz:
![usergauss3](https://cloud.githubusercontent.com/assets/700223/24976361/2486e142-1f97-11e7-82a2-56e78d93861a.png)

I wasn't sure the best approach to modifying this, so I put my changes in a new input command, #excitation_filefunc, which uses scipy UnivariateSplines to interpolate input data allowing the simulations to query the waveform at arbitrary time. Using the exact same input file as the first graph, but with the time domain specified and using this interpolation method results in vastly improved results:
![usergauss2](https://cloud.githubusercontent.com/assets/700223/24976438/6efb249a-1f97-11e7-945f-d50734abaf2e.png)

Hopefully you find this helpful. I've attached the input files and excitation files used below so you can replicate it yourself:
[usertest.zip](https://github.com/gprMax/gprMax/files/917697/usertest.zip)



