### PR TITLE
use process_time to measure only process execution time

### DIFF
--- a/gprMax/gprMax.py
+++ b/gprMax/gprMax.py
@@ -24,7 +24,6 @@ import os
 import sys
 
 from enum import Enum
-from time import perf_counter
 
 import h5py
 import numpy as np
@@ -42,7 +41,7 @@ from gprMax.utilities import get_terminal_width
 from gprMax.utilities import human_size
 from gprMax.utilities import logo
 from gprMax.utilities import open_path_file
-
+from gprMax.utilities import timer
 
 def main():
     """This is the main function for gprMax."""
@@ -216,7 +215,7 @@ def run_std_sim(args, inputfile, usernamespace, optparams=None):
         modelend = modelstart + args.n
     numbermodelruns = args.n
 
-    tsimstart = perf_counter()
+    tsimstart = timer()
     for currentmodelrun in range(modelstart, modelend):
         # If Taguchi optimistaion, add specific value for each parameter to
         # optimise for each experiment to user accessible namespace
@@ -228,7 +227,7 @@ def run_std_sim(args, inputfile, usernamespace, optparams=None):
         else:
             modelusernamespace = usernamespace
         run_model(args, currentmodelrun, modelend - 1, numbermodelruns, inputfile, modelusernamespace)
-    tsimend = perf_counter()
+    tsimend = timer()
     simcompletestr = '\n=== Simulation completed in [HH:MM:SS]: {}'.format(datetime.timedelta(seconds=tsimend - tsimstart))
     print('{} {}\n'.format(simcompletestr, '=' * (get_terminal_width() - 1 - len(simcompletestr))))
 
@@ -359,7 +358,7 @@ def run_mpi_sim(args, inputfile, usernamespace, optparams=None):
             comm = args.mpicomm
         else:
             comm = MPI.COMM_WORLD
-        tsimstart = perf_counter()
+        tsimstart = timer()
         mpistartstr = '\n=== MPI task farm (USING MPI Spawn)'
         print('{} {}'.format(mpistartstr, '=' * (get_terminal_width() - 1 - len(mpistartstr))))
         print('=== MPI master ({}, rank: {}) on {} spawning {} workers...'.format(comm.name, comm.Get_rank(), hostname, numworkers))
@@ -411,7 +410,7 @@ def run_mpi_sim(args, inputfile, usernamespace, optparams=None):
         # Shutdown communicators
         newcomm.Disconnect()
 
-        tsimend = perf_counter()
+        tsimend = timer()
         simcompletestr = '\n=== MPI master ({}, rank: {}) on {} completed simulation in [HH:MM:SS]: {}'.format(comm.name, comm.Get_rank(), hostname, datetime.timedelta(seconds=tsimend - tsimstart))
         print('{} {}\n'.format(simcompletestr, '=' * (get_terminal_width() - 1 - len(simcompletestr))))
 
@@ -497,7 +496,7 @@ def run_mpi_no_spawn_sim(args, inputfile, usernamespace, optparams=None):
     # Master process #
     ##################
     if rank == 0:
-        tsimstart = perf_counter()
+        tsimstart = timer()
         mpistartstr = '\n=== MPI task farm (WITHOUT using MPI Spawn)'
         print('{} {}'.format(mpistartstr, '=' * (get_terminal_width() - 1 - len(mpistartstr))))
         print('=== MPI master ({}, rank: {}) on {} using {} workers...'.format(comm.name, comm.Get_rank(), hostname, numworkers))
@@ -524,7 +523,7 @@ def run_mpi_no_spawn_sim(args, inputfile, usernamespace, optparams=None):
             elif tag == tags.EXIT.value:
                 closedworkers += 1
 
-        tsimend = perf_counter()
+        tsimend = timer()
         simcompletestr = '\n=== MPI master ({}, rank: {}) on {} completed simulation in [HH:MM:SS]: {}'.format(comm.name, comm.Get_rank(), hostname, datetime.timedelta(seconds=tsimend - tsimstart))
         print('{} {}\n'.format(simcompletestr, '=' * (get_terminal_width() - 1 - len(simcompletestr))))
 

--- a/gprMax/model_build_run.py
+++ b/gprMax/model_build_run.py
@@ -22,7 +22,6 @@ import itertools
 import os
 import psutil
 import sys
-from time import process_time
 
 from colorama import init
 from colorama import Fore
@@ -77,6 +76,7 @@ from gprMax.utilities import get_terminal_width
 from gprMax.utilities import human_size
 from gprMax.utilities import open_path_file
 from gprMax.utilities import round32
+from gprMax.utilities import timer
 from gprMax.yee_cell_build_ext import build_electric_components
 from gprMax.yee_cell_build_ext import build_magnetic_components
 
@@ -417,7 +417,7 @@ def solve_cpu(currentmodelrun, modelend, G):
         tsolve (float): Time taken to execute solving
     """
 
-    tsolvestart = process_time()
+    tsolvestart = timer()
 
     for iteration in tqdm(range(G.iterations), desc='Running simulation, model ' + str(currentmodelrun) + '/' + str(modelend), ncols=get_terminal_width() - 1, file=sys.stdout, disable=not G.progressbars):
         # Store field component values for every receiver and transmission line
@@ -467,7 +467,7 @@ def solve_cpu(currentmodelrun, modelend, G):
         elif Material.maxpoles > 1:
             update_electric_dispersive_multipole_B(G.nx, G.ny, G.nz, G.nthreads, Material.maxpoles, G.updatecoeffsdispersive, G.ID, G.Tx, G.Ty, G.Tz, G.Ex, G.Ey, G.Ez)
 
-    tsolve = process_time() - tsolvestart
+    tsolve = timer() - tsolvestart
 
     return tsolve
 

--- a/gprMax/model_build_run.py
+++ b/gprMax/model_build_run.py
@@ -22,7 +22,7 @@ import itertools
 import os
 import psutil
 import sys
-from time import perf_counter
+from time import process_time
 
 from colorama import init
 from colorama import Fore
@@ -417,7 +417,7 @@ def solve_cpu(currentmodelrun, modelend, G):
         tsolve (float): Time taken to execute solving
     """
 
-    tsolvestart = perf_counter()
+    tsolvestart = process_time()
 
     for iteration in tqdm(range(G.iterations), desc='Running simulation, model ' + str(currentmodelrun) + '/' + str(modelend), ncols=get_terminal_width() - 1, file=sys.stdout, disable=not G.progressbars):
         # Store field component values for every receiver and transmission line
@@ -467,7 +467,7 @@ def solve_cpu(currentmodelrun, modelend, G):
         elif Material.maxpoles > 1:
             update_electric_dispersive_multipole_B(G.nx, G.ny, G.nz, G.nthreads, Material.maxpoles, G.updatecoeffsdispersive, G.ID, G.Tx, G.Ty, G.Tz, G.Ex, G.Ey, G.Ez)
 
-    tsolve = perf_counter() - tsolvestart
+    tsolve = process_time() - tsolvestart
 
     return tsolve
 

--- a/gprMax/utilities.py
+++ b/gprMax/utilities.py
@@ -33,6 +33,7 @@ from colorama import Fore
 from colorama import Style
 init()
 import numpy as np
+from time import process_time
 
 from gprMax.constants import complextype
 from gprMax.constants import floattype
@@ -411,3 +412,7 @@ def detect_check_gpus(deviceIDs):
         allgpustext.append('{} - {}, {}'.format(gpu.deviceID, gpu.name, human_size(gpu.totalmem, a_kilobyte_is_1024_bytes=True)))
 
     return gpus, allgpustext
+
+def timer():
+    """Function to return the current process wide time in fractional seconds."""
+    return process_time()


### PR DESCRIPTION
were currently using perf_counter() to measure execution time. suggesting to we move to process_time(). from the docs process_time() measures only the process wide time where as perf_counter() measure the system wide time. system wide time presumably includes other processes. This is not so clear from the docs? in environments where multiple users are running scripts process_time should provide a more accurate execution time for gprMax scripts.