### PR TITLE
fix a typo in plot_source_wave.py

### DIFF
--- a/tools/plot_source_wave.py
+++ b/tools/plot_source_wave.py
@@ -119,7 +119,7 @@ def mpl_plot(w, timewindow, dt, iterations, fft=False):
         ax1.set_ylabel('Amplitude')
 
         # Plot frequency spectra
-        markerline, stemlines, baseline = ax2.stem(freqs[pltrange], power[pltrange], '-.' use_line_collection=True)
+        markerline, stemlines, baseline = ax2.stem(freqs[pltrange], power[pltrange], '-.', use_line_collection=True)
         plt.setp(baseline, 'linewidth', 0)
         plt.setp(stemlines, 'color', 'r')
         plt.setp(markerline, 'markerfacecolor', 'r', 'markeredgecolor', 'r')


### PR DESCRIPTION
Fix a typo preventing the plot_source_wave tool from plotting.

There was a comma missing in the `stem` function parameters, raising a `SyntaxError: invalid syntax`. Simply adding that comma fixed the issue.