### PR TITLE
fix a typo in plot_source_wave.py

### DIFF
--- a/tools/plot_source_wave.py
+++ b/tools/plot_source_wave.py
@@ -119,7 +119,7 @@ def mpl_plot(w, timewindow, dt, iterations, fft=False):
         ax1.set_ylabel('Amplitude')
 
         # Plot frequency spectra
-        markerline, stemlines, baseline = ax2.stem(freqs[pltrange], power[pltrange], '-.' use_line_collection=True)
+        markerline, stemlines, baseline = ax2.stem(freqs[pltrange], power[pltrange], '-.', use_line_collection=True)
         plt.setp(baseline, 'linewidth', 0)
         plt.setp(stemlines, 'color', 'r')
         plt.setp(markerline, 'markerfacecolor', 'r', 'markeredgecolor', 'r')


### PR DESCRIPTION
Added a comma between parameters for `stem`, which raised `SyntaxError: invalid syntax`.

I am recreating this pull request because of a typo in the commit name, which is very ironic considering what it is fixing.