### PR TITLE
Geometry file produced only once

### DIFF
--- a/gprMax/model_build_run.py
+++ b/gprMax/model_build_run.py
@@ -104,7 +104,8 @@ def run_model(args, currentmodelrun, modelend, numbermodelruns, inputfile, usern
     global G
 
     # Used for naming geometry and output files
-    appendmodelnumber = '' if numbermodelruns == 1 and not args.task and not args.restart else str(currentmodelrun)
+    appendmodelnumber = '' if numbermodelruns == 1 and not args.task and not args.restart else '_'+str(currentmodelrun)
+    appendmodelnumberGeometry = '' if numbermodelruns == 1 and not args.task and not args.restart or args.geometry_fixed else '_'+str(currentmodelrun)
 
     # Normal model reading/building process; bypassed if geometry information to be reused
     if 'G' not in globals():
@@ -326,10 +327,10 @@ def run_model(args, currentmodelrun, modelend, numbermodelruns, inputfile, usern
     # Write files for any geometry views and geometry object outputs
     if not (G.geometryviews or G.geometryobjectswrite) and args.geometry_only and G.messages:
         print(Fore.RED + '\nWARNING: No geometry views or geometry objects to output found.' + Style.RESET_ALL)
-    if G.geometryviews:
+    if G.geometryviews and (not args.geometry_fixed or currentmodelrun == 1):
         if G.messages: print()
         for i, geometryview in enumerate(G.geometryviews):
-            geometryview.set_filename(appendmodelnumber, G)
+            geometryview.set_filename(appendmodelnumberGeometry, G)
             pbar = tqdm(total=geometryview.datawritesize, unit='byte', unit_scale=True, desc='Writing geometry view file {}/{}, {}'.format(i + 1, len(G.geometryviews), os.path.split(geometryview.filename)[1]), ncols=get_terminal_width() - 1, file=sys.stdout, disable=not G.progressbars)
             geometryview.write_vtk(G, pbar)
             pbar.close()

--- a/tools/outputfiles_merge.py
+++ b/tools/outputfiles_merge.py
@@ -81,7 +81,7 @@ def merge_files(basefilename, removefiles=False):
 
     # Add positional data for rxs
     for model in range(modelruns):
-        fin = h5py.File(basefilename + str(model + 1) + '.out', 'r')
+        fin = h5py.File(basefilename + "_" + str(model + 1) + '.out', 'r')
         nrx = fin.attrs['nrx']
 
         # Write properties for merged file on first iteration
@@ -112,7 +112,7 @@ def merge_files(basefilename, removefiles=False):
 
     if removefiles:
         for model in range(modelruns):
-            file = basefilename + str(model + 1) + '.out'
+            file = basefilename + "_" + str(model + 1) + '.out'
             os.remove(file)
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Ensure geometry file produced only once if geometry_fixed option specified.
- Enforce underscore before model run number on geometry files (when more than one produced)