### PR TITLE
Fix theta in initial_save

### DIFF
--- a/user_libs/antenna_patterns/initial_save.py
+++ b/user_libs/antenna_patterns/initial_save.py
@@ -36,7 +36,7 @@ epsr = 5
 
 # Observation radii and angles
 radii = np.linspace(0.1, 0.3, 20)
-theta = np.linspace(3, 357, 60) * (180 / np.pi)
+theta = np.linspace(3, 357, 60) * (np.pi / 180)
 
 # Scaling of time-domain field pattern values by material impedance
 impscaling = False


### PR DESCRIPTION
`theta = np.linspace(3, 357, 60) * (180 / np.pi)` returns
```
array([  171.88733854,   515.66201562,   859.4366927 ,  1203.21136977,
        1546.98604685,  1890.76072393,  2234.53540101,  2578.31007809,
        2922.08475517,  3265.85943225,  3609.63410932,  3953.4087864 ,
        4297.18346348,  4640.95814056,  4984.73281764,  5328.50749472,
        5672.2821718 ,  6016.05684887,  6359.83152595,  6703.60620303,
        7047.38088011,  7391.15555719,  7734.93023427,  8078.70491134,
        8422.47958842,  8766.2542655 ,  9110.02894258,  9453.80361966,
        9797.57829674, 10141.35297382, 10485.12765089, 10828.90232797,
       11172.67700505, 11516.45168213, 11860.22635921, 12204.00103629,
       12547.77571337, 12891.55039044, 13235.32506752, 13579.0997446 ,
       13922.87442168, 14266.64909876, 14610.42377584, 14954.19845291,
       15297.97312999, 15641.74780707, 15985.52248415, 16329.29716123,
       16673.07183831, 17016.84651539, 17360.62119246, 17704.39586954,
       18048.17054662, 18391.9452237 , 18735.71990078, 19079.49457786,
       19423.26925493, 19767.04393201, 20110.81860909, 20454.59328617])
```

Whereas `theta = np.linspace(3, 357, 60) * (np.pi / 180)` returns
```
array([0.05235988, 0.15707963, 0.26179939, 0.36651914, 0.4712389 ,
       0.57595865, 0.68067841, 0.78539816, 0.89011792, 0.99483767,
       1.09955743, 1.20427718, 1.30899694, 1.41371669, 1.51843645,
       1.6231562 , 1.72787596, 1.83259571, 1.93731547, 2.04203522,
       2.14675498, 2.25147474, 2.35619449, 2.46091425, 2.565634  ,
       2.67035376, 2.77507351, 2.87979327, 2.98451302, 3.08923278,
       3.19395253, 3.29867229, 3.40339204, 3.5081118 , 3.61283155,
       3.71755131, 3.82227106, 3.92699082, 4.03171057, 4.13643033,
       4.24115008, 4.34586984, 4.45058959, 4.55530935, 4.6600291 ,
       4.76474886, 4.86946861, 4.97418837, 5.07890812, 5.18362788,
       5.28834763, 5.39306739, 5.49778714, 5.6025069 , 5.70722665,
       5.81194641, 5.91666616, 6.02138592, 6.12610567, 6.23082543])
```

I think we want the latter.