### PR TITLE
Bug when merging files

### DIFF
--- a/tools/outputfiles_merge.py
+++ b/tools/outputfiles_merge.py
@@ -72,7 +72,7 @@ def merge_files(basefilename, removefiles=False):
     """
 
     outputfile = basefilename + '_merged.out'
-    files = glob.glob(basefilename + '*.out')
+    files = glob.glob(basefilename + '[0-9]*.out')
     outputfiles = [filename for filename in files if '_merged' not in filename]
     modelruns = len(outputfiles)
 


### PR DESCRIPTION
When merging outputfiles basefilename + *.out was used
This includes files as basefilename + abcd234.out which causes issues

Also the bug when basefilename.out, after an A scan, caused issues is fixed