### PR TITLE
conda env for newer python version and cuda support

### DIFF
--- a/conda_env_cuda.yml
+++ b/conda_env_cuda.yml
@@ -1,0 +1,23 @@
+name: gprMaxCuda
+channels:
+  - conda-forge
+  - nvidia
+dependencies:
+  - python=3.10
+  - colorama
+  - cuda-libraries-dev
+  - cudatoolkit
+  - cython
+  - h5py
+  - jupyter
+  - libgcc
+  - libstdcxx-ng
+  - matplotlib
+  - mpi4py
+  - numpy
+  - pip
+  - psutil
+  - pycuda
+  - scipy
+  - terminaltables
+  - tqdm


### PR DESCRIPTION
- update to newer python version and added full support for cuda by default
- original env file is not replaced/changed