### PR TITLE
Fixed the bug in "tools/Jupyter_notebooks/plot_Bscan.ipynb".

### DIFF
--- a/tools/Jupyter_notebooks/plot_Bscan.ipynb
+++ b/tools/Jupyter_notebooks/plot_Bscan.ipynb
@@ -47,7 +47,7 @@
     "rxnumber = 1\n",
     "rxcomponent = 'Ez'\n",
     "outputdata, dt = get_output_data(filename, rxnumber, rxcomponent)\n",
-    "plt = mpl_plot(outputdata, dt, rxnumber, rxcomponent)\n",
+    "plt = mpl_plot(filename, outputdata, dt, rxnumber, rxcomponent)\n",
     "\n",
     "# Change from the default 'seismic' colormap\n",
     "#plt.set_cmap('gray')"


### PR DESCRIPTION
# Description

At present, the code has the error shown below. The reason is that the "filename" parameter is missing when calling the "mpl_plot()" function, this pull request fixed the tiny bug.
\---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
       ...
**----> 6 plt = mpl_plot(outputdata, dt, rxnumber, rxcomponent)**
       ...
TypeError: mpl_plot() missing 1 required positional argument: 'rxcomponent'
\---------------------------------------------------------------------------

# Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have made this from my own
- [x] My changes generate no new warnings
- [x] The title of my pull request is a short description of the requested changes.