### PR TITLE
Fixed grid global object persisting through multiple python api calls in master branch

### DIFF
--- a/gprMax/model_build_run.py
+++ b/gprMax/model_build_run.py
@@ -399,7 +399,7 @@ def run_model(args, currentmodelrun, modelend, numbermodelruns, inputfile, usern
 
     # If geometry information to be reused between model runs then FDTDGrid
     # class instance must be global so that it persists
-    if not args.geometry_fixed:
+    if not args.geometry_fixed or currentmodelrun == numbermodelruns:
         del G
 
     return tsolve


### PR DESCRIPTION
# PR Description

In the master branch, the `FDTDGrid` object G in `model_build_run.py` is not deleted at the end of multiple simulation runs (after multiple A-scans).

This causes the object to be still in the globals() of the module when the gprMax APIs are called again inside the same python program, causing all configuration and geometry to not be recalculated and be incorrectly derived only from the first input file, even in the second run.

## 🛠️ Related Issue (Number)

Closes # 402

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.
