### PR TITLE
fixed material index mismatch between Grid.solid and materials list

### DIFF
--- a/gprMax/input_cmds_geometry.py
+++ b/gprMax/input_cmds_geometry.py
@@ -867,7 +867,7 @@ def process_geometrycmds(geometry, G):
                 if nbins == 1:
                     raise CmdInputError("'" + ' '.join(tmp) + "'" + ' must be used with more than one material from the mixing model.')
                 # Create materials from mixing model as number of bins now known from fractal_box command
-                mixingmodel.calculate_debye_properties(nbins, G)
+                mixingmodel.calculate_debye_properties(nbins, G, tmp[13])
             elif not material:
                 raise CmdInputError("'" + ' '.join(tmp) + "'" + ' mixing model or material with ID {} does not exist'.format(tmp[12]))
 


### PR DESCRIPTION
# PR Description

This PR fixes the problem in #414 where an issue related to the generation of Peplinski materials caused a mismatch in material numID between the grid solid matrix and the materials list. This is fixed here by modifying the nomenclature of the mixing model materials from `|{water content}|`to `|{water content}_{fractal box name}|`. I first thought of using `|{water content}_{mixing model name}|`, but multiple fractal boxes can be built with the same mixing model and different number of bins, so this would not have solved the issue.

Since multiple fractal boxes will now have different materials, I also removed the check for an already existing material with the same name. This doesn't seem to affect the performance of the computations from what I can see.

## 🛠️ Related Issue (Number)
Closes #414 

## Type of change

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.
