### PR TITLE
Removing use_line_collection in plotting scripts

### DIFF
--- a/tools/plot_Ascan.py
+++ b/tools/plot_Ascan.py
@@ -105,7 +105,7 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False):
                 ax1.grid(which='both', axis='both', linestyle='-.')
 
                 # Plot frequency spectra
-                markerline, stemlines, baseline = ax2.stem(freqs[pltrange], power[pltrange], '-.', use_line_collection=True)
+                markerline, stemlines, baseline = ax2.stem(freqs[pltrange], power[pltrange], '-.')
                 plt.setp(baseline, 'linewidth', 0)
                 plt.setp(stemlines, 'color', 'r')
                 plt.setp(markerline, 'markerfacecolor', 'r', 'markeredgecolor', 'r')

--- a/tools/plot_antenna_params.py
+++ b/tools/plot_antenna_params.py
@@ -195,7 +195,7 @@ def mpl_plot(filename, time, freqs, Vinc, Vincp, Iinc, Iincp, Vref, Vrefp, Iref,
 
     # Plot frequency spectra of incident voltage
     ax = plt.subplot(gs1[0, 1])
-    markerline, stemlines, baseline = ax.stem(freqs[pltrange], Vincp[pltrange], '-.', use_line_collection=True)
+    markerline, stemlines, baseline = ax.stem(freqs[pltrange], Vincp[pltrange], '-.')
     plt.setp(baseline, 'linewidth', 0)
     plt.setp(stemlines, 'color', 'r')
     plt.setp(markerline, 'markerfacecolor', 'r', 'markeredgecolor', 'r')
@@ -216,7 +216,7 @@ def mpl_plot(filename, time, freqs, Vinc, Vincp, Iinc, Iincp, Vref, Vrefp, Iref,
 
     # Plot frequency spectra of incident current
     ax = plt.subplot(gs1[1, 1])
-    markerline, stemlines, baseline = ax.stem(freqs[pltrange], Iincp[pltrange], '-.', use_line_collection=True)
+    markerline, stemlines, baseline = ax.stem(freqs[pltrange], Iincp[pltrange], '-.')
     plt.setp(baseline, 'linewidth', 0)
     plt.setp(stemlines, 'color', 'b')
     plt.setp(markerline, 'markerfacecolor', 'b', 'markeredgecolor', 'b')
@@ -237,7 +237,7 @@ def mpl_plot(filename, time, freqs, Vinc, Vincp, Iinc, Iincp, Vref, Vrefp, Iref,
 
     # Plot frequency spectra of total voltage
     ax = plt.subplot(gs1[2, 1])
-    markerline, stemlines, baseline = ax.stem(freqs[pltrange], Vtotalp[pltrange], '-.', use_line_collection=True)
+    markerline, stemlines, baseline = ax.stem(freqs[pltrange], Vtotalp[pltrange], '-.')
     plt.setp(baseline, 'linewidth', 0)
     plt.setp(stemlines, 'color', 'r')
     plt.setp(markerline, 'markerfacecolor', 'r', 'markeredgecolor', 'r')
@@ -258,7 +258,7 @@ def mpl_plot(filename, time, freqs, Vinc, Vincp, Iinc, Iincp, Vref, Vrefp, Iref,
 
     # Plot frequency spectra of total current
     ax = plt.subplot(gs1[3, 1])
-    markerline, stemlines, baseline = ax.stem(freqs[pltrange], Itotalp[pltrange], '-.', use_line_collection=True)
+    markerline, stemlines, baseline = ax.stem(freqs[pltrange], Itotalp[pltrange], '-.')
     plt.setp(baseline, 'linewidth', 0)
     plt.setp(stemlines, 'color', 'b')
     plt.setp(markerline, 'markerfacecolor', 'b', 'markeredgecolor', 'b')
@@ -279,7 +279,7 @@ def mpl_plot(filename, time, freqs, Vinc, Vincp, Iinc, Iincp, Vref, Vrefp, Iref,
 
     # Plot frequency spectra of reflected voltage
     # ax = plt.subplot(gs1[4, 1])
-    # markerline, stemlines, baseline = ax.stem(freqs[pltrange], Vrefp[pltrange], '-.', use_line_collection=True)
+    # markerline, stemlines, baseline = ax.stem(freqs[pltrange], Vrefp[pltrange], '-.')
     # plt.setp(baseline, 'linewidth', 0)
     # plt.setp(stemlines, 'color', 'r')
     # plt.setp(markerline, 'markerfacecolor', 'r', 'markeredgecolor', 'r')
@@ -300,7 +300,7 @@ def mpl_plot(filename, time, freqs, Vinc, Vincp, Iinc, Iincp, Vref, Vrefp, Iref,
 
     # Plot frequency spectra of reflected current
     # ax = plt.subplot(gs1[5, 1])
-    # markerline, stemlines, baseline = ax.stem(freqs[pltrange], Irefp[pltrange], '-.', use_line_collection=True)
+    # markerline, stemlines, baseline = ax.stem(freqs[pltrange], Irefp[pltrange], '-.')
     # plt.setp(baseline, 'linewidth', 0)
     # plt.setp(stemlines, 'color', 'b')
     # plt.setp(markerline, 'markerfacecolor', 'b', 'markeredgecolor', 'b')
@@ -315,7 +315,7 @@ def mpl_plot(filename, time, freqs, Vinc, Vincp, Iinc, Iincp, Vref, Vrefp, Iref,
     fig2, ax = plt.subplots(num='Antenna parameters', figsize=(20, 12), facecolor='w', edgecolor='w')
     gs2 = gridspec.GridSpec(2, 2, hspace=0.3)
     ax = plt.subplot(gs2[0, 0])
-    markerline, stemlines, baseline = ax.stem(freqs[pltrange], s11[pltrange], '-.', use_line_collection=True)
+    markerline, stemlines, baseline = ax.stem(freqs[pltrange], s11[pltrange], '-.')
     plt.setp(baseline, 'linewidth', 0)
     plt.setp(stemlines, 'color', 'g')
     plt.setp(markerline, 'markerfacecolor', 'g', 'markeredgecolor', 'g')
@@ -330,7 +330,7 @@ def mpl_plot(filename, time, freqs, Vinc, Vincp, Iinc, Iincp, Vref, Vrefp, Iref,
     # Plot frequency spectra of s21
     if s21 is not None:
         ax = plt.subplot(gs2[0, 1])
-        markerline, stemlines, baseline = ax.stem(freqs[pltrange], s21[pltrange], '-.', use_line_collection=True)
+        markerline, stemlines, baseline = ax.stem(freqs[pltrange], s21[pltrange], '-.')
         plt.setp(baseline, 'linewidth', 0)
         plt.setp(stemlines, 'color', 'g')
         plt.setp(markerline, 'markerfacecolor', 'g', 'markeredgecolor', 'g')
@@ -344,7 +344,7 @@ def mpl_plot(filename, time, freqs, Vinc, Vincp, Iinc, Iincp, Vref, Vrefp, Iref,
 
     # Plot input resistance (real part of impedance)
     ax = plt.subplot(gs2[1, 0])
-    markerline, stemlines, baseline = ax.stem(freqs[pltrange], zin[pltrange].real, '-.', use_line_collection=True)
+    markerline, stemlines, baseline = ax.stem(freqs[pltrange], zin[pltrange].real, '-.')
     plt.setp(baseline, 'linewidth', 0)
     plt.setp(stemlines, 'color', 'g')
     plt.setp(markerline, 'markerfacecolor', 'g', 'markeredgecolor', 'g')
@@ -359,7 +359,7 @@ def mpl_plot(filename, time, freqs, Vinc, Vincp, Iinc, Iincp, Vref, Vrefp, Iref,
 
     # Plot input reactance (imaginery part of impedance)
     ax = plt.subplot(gs2[1, 1])
-    markerline, stemlines, baseline = ax.stem(freqs[pltrange], zin[pltrange].imag, '-.', use_line_collection=True)
+    markerline, stemlines, baseline = ax.stem(freqs[pltrange], zin[pltrange].imag, '-.')
     plt.setp(baseline, 'linewidth', 0)
     plt.setp(stemlines, 'color', 'g')
     plt.setp(markerline, 'markerfacecolor', 'g', 'markeredgecolor', 'g')
@@ -373,7 +373,7 @@ def mpl_plot(filename, time, freqs, Vinc, Vincp, Iinc, Iincp, Vref, Vrefp, Iref,
 
     # Plot input admittance (magnitude)
     # ax = plt.subplot(gs2[2, 0])
-    # markerline, stemlines, baseline = ax.stem(freqs[pltrange], np.abs(yin[pltrange]), '-.', use_line_collection=True)
+    # markerline, stemlines, baseline = ax.stem(freqs[pltrange], np.abs(yin[pltrange]), '-.')
     # plt.setp(baseline, 'linewidth', 0)
     # plt.setp(stemlines, 'color', 'g')
     # plt.setp(markerline, 'markerfacecolor', 'g', 'markeredgecolor', 'g')
@@ -387,7 +387,7 @@ def mpl_plot(filename, time, freqs, Vinc, Vincp, Iinc, Iincp, Vref, Vrefp, Iref,
 
     # Plot input admittance (phase)
     # ax = plt.subplot(gs2[2, 1])
-    # markerline, stemlines, baseline = ax.stem(freqs[pltrange], np.angle(yin[pltrange], deg=True), '-.', use_line_collection=True)
+    # markerline, stemlines, baseline = ax.stem(freqs[pltrange], np.angle(yin[pltrange], deg=True), '-.')
     # plt.setp(baseline, 'linewidth', 0)
     # plt.setp(stemlines, 'color', 'g')
     # plt.setp(markerline, 'markerfacecolor', 'g', 'markeredgecolor', 'g')

--- a/tools/plot_source_wave.py
+++ b/tools/plot_source_wave.py
@@ -119,7 +119,7 @@ def mpl_plot(w, timewindow, dt, iterations, fft=False):
         ax1.set_ylabel('Amplitude')
 
         # Plot frequency spectra
-        markerline, stemlines, baseline = ax2.stem(freqs[pltrange], power[pltrange], '-.', use_line_collection=True)
+        markerline, stemlines, baseline = ax2.stem(freqs[pltrange], power[pltrange], '-.')
         plt.setp(baseline, 'linewidth', 0)
         plt.setp(stemlines, 'color', 'r')
         plt.setp(markerline, 'markerfacecolor', 'r', 'markeredgecolor', 'r')


### PR DESCRIPTION
# PR Description

In this request, `use_line_collection = True` is removed from `plot_antenna_params.py`, `plot_Ascan.py` and `plot_source_wave.py`, because it is no longer supported and returns to error in the latest matplotlib 3.8 installed by `conda_env.yml` automatically. 

## 🛠️ Related Issue (Number)

Closes #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.
