### PR TITLE
Fix bound checking for '#triangle': comparing the values with the same unit

### DIFF
--- a/gprMax/input_cmds_geometry.py
+++ b/gprMax/input_cmds_geometry.py
@@ -349,11 +349,11 @@ def process_geometrycmds(geometry, G):
             z3 = round_value(float(tmp[9]) / G.dz) * G.dz
             thickness = float(tmp[10])
 
-            if x1 < 0 or x2 < 0 or x3 < 0 or x1 > G.nx or x2 > G.nx or x3 > G.nx:
+            if x1 < 0 or x2 < 0 or x3 < 0 or x1 > G.nx * G.dx or x2 > G.nx * G.dx or x3 > G.nx * G.dx:
                 raise CmdInputError("'" + ' '.join(tmp) + "'" + ' the one of the x-coordinates is not within the model domain')
-            if y1 < 0 or y2 < 0 or y3 < 0 or y1 > G.ny or y2 > G.ny or y3 > G.ny:
+            if y1 < 0 or y2 < 0 or y3 < 0 or y1 > G.ny * G.dy or y2 > G.ny * G.dy or y3 > G.ny * G.dy:
                 raise CmdInputError("'" + ' '.join(tmp) + "'" + ' the one of the y-coordinates is not within the model domain')
-            if z1 < 0 or z2 < 0 or z3 < 0 or z1 > G.nz or z2 > G.nz or z3 > G.nz:
+            if z1 < 0 or z2 < 0 or z3 < 0 or z1 > G.nz * G.dz or z2 > G.nz * G.dz or z3 > G.nz * G.dz:
                 raise CmdInputError("'" + ' '.join(tmp) + "'" + ' the one of the z-coordinates is not within the model domain')
             if thickness < 0:
                 raise CmdInputError("'" + ' '.join(tmp) + "'" + ' requires a positive value for thickness')


### PR DESCRIPTION
# PR Description

This PR includes a fix for bound checking for '#triangle' directive.

In current [master](https://github.com/gprMax/gprMax/blob/bc218849361f8dede67bc328454ae91fb445f916/gprMax/input_cmds_geometry.py#L341-L357), we have some bound checking when a triangle is added.

However, the left value, for example `x1`, has a unit in (meter).
The right value, `G.nx`, has a unit in (samples).

As a result, a legit triangle may not be able to be added, or an illegal one may be added, depending on the `dx,dy,dz` values.

To fix the issue, I changed the unit of all the right values to (meter).

An example of not being able to add a legit triangle:
``` triangle.in
#title: triangle
#domain: 1000 800 0.5
#dx_dy_dz: 2 2 0.5
#time_window: 8e-6

#waveform: ricker 100 3e6 my_ricker
#hertzian_dipole: z 200 750 0 my_ricker
#rx: 200 750 0

#triangle: 200 345 0 800 375 0 800 345 0 0.5 pec
#geometry_view: 0 0 0 1000 800 0.5 2 2 0.5 mymodel n
```

## 🛠️ Related Issue (Number)

This PR is not related to any existing opening issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [x] Did pre-commit passed all checks?
- [x] I have performed a self-review of my code.
- [x] I have added comments for my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.
