### PR TITLE
Fix autodoc errors when building the documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,24 +7,12 @@ version: 2
 
 build:
   os: ubuntu-22.04
-  apt_packages:
-    - mpich
-    - libfftw3-dev
   tools:
-    python: "mambaforge-22.9"
-  jobs:
-    post_create_environment:
-      - python -m pip install sphinx_rtd_theme
-      - python -m pip install reframe-hpc
-
-conda:
-  environment: conda_env.yml
+    python: "3.9"
 
 python:
   install:
     - requirements: docs/requirements.txt
-    - method: setuptools
-      path: .
 
 sphinx:
    configuration: docs/source/conf.py

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,6 +37,7 @@ autodoc_mock_imports = [
     "psutil",
     "terminaltables",
     "tqdm",
+    "gprMax.cython",
 ]
 
 # Figure numbering


### PR DESCRIPTION
# PR Description

Autodoc was producing warnings when building the documentation, e.g. in build [28976708](https://app.readthedocs.org/projects/gprmax/builds/28976708/). The main cause was: `ModuleNotFoundError: No module named 'gprMax.cython.pml_build`.

I believe this is because gprMax is not built when building the documentation, meaning the cython code is not compiled. This can be fixed by mocking the `gprMax.cython` module.

I have also simplified the `.readthedocs.yaml` file as installing `mpi`, `fftw3`, and the conda environment are no longer required for building the documentation. This also makes the build much quicker. The Python version could be changed to use a more recent version if preferred (or to keep using mambaforge).

The latest build is viewable in a test Read the Docs project: https://app.readthedocs.org/projects/gprmax-nmannall/builds/29001217/

## Type of change

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [x] Did pre-commit passed all checks?
- [x] I have performed a self-review of my code.
- [x] I have added comments for my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.
