### PR TITLE
Remove mpi4py_fft as a compulsory dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,9 +84,9 @@ The following steps provide guidance on how to install gprMax:
 
 1. Install a C compiler which supports OpenMP
 2. Install MPI
-3. Install FFTW
-4. Install Python, required Python packages, and get the gprMax source code from GitHub
-5. [Optional] Build h5py against Parallel HDF5
+3. Install Python, required Python packages, and get the gprMax source code from GitHub
+4. [Optional] Build h5py against Parallel HDF5
+5. [Optional] Install mpi4py_fft
 6. Build and install gprMax
 
 1. Install a C compiler which supports OpenMP
@@ -130,29 +130,7 @@ Microsoft Windows
 * It is recommended to use `Microsoft MPI <https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi>`_. Download and install both the .exe and .msi files.
 
 
-3. Install FFTW
----------------
-If you are running gprMax on a HPC system, FFTW may be available already - consult your site's documentation. Otherwise you will need to install it yourself.
-
-Linux
-^^^^^
-* It is possible binaries are available via your package manager. E.g. ``libfftw3-dev`` on Ubuntu.
-* Otherwise you can find the latest source code on the `fftw downloads page <https://fftw.org/download.html>`_. There are instructions to build from source in the `fftw docs <https://fftw.org/fftw3_doc/Installation-on-Unix.html>`_.
-
-macOS
-^^^^^
-* FFTW can be installed using the `Homebrew package manager <http://brew.sh>`_:
-
-.. code-block:: console
-
-    $ brew install fftw
-
-Microsoft Windows
-^^^^^^^^^^^^^^^^^
-* There is guidance to install FFTW on Windows available `here <https://fftw.org/install/windows.html>`_.
-
-
-4. Install Python, the required Python packages, and get the gprMax source
+3. Install Python, the required Python packages, and get the gprMax source
 --------------------------------------------------------------------------
 
 We recommend using Miniconda to install Python and the required Python packages for gprMax in a self-contained Python environment. Miniconda is a mini version of Anaconda which is a completely free Python distribution (including for commercial use and redistribution). It includes more than 300 of the most popular Python packages for science, math, engineering, and data analysis.
@@ -177,7 +155,7 @@ If you are using Arch Linux (https://www.archlinux.org/) you may need to also in
 
 .. _h5py_mpi:
 
-5. [Optional] Build h5py against Parallel HDF5
+4. [Optional] Build h5py against Parallel HDF5
 ----------------------------------------------
 
 If you plan to use the :ref:`MPI domain decomposition functionality <mpi_domain_decomposition>` available in gprMax, h5py must be built with MPI support.
@@ -203,6 +181,60 @@ Set your default compiler to the ``mpicc`` wrapper and build h5py with the ``HDF
     (gprMax)$ pip install --no-binary=h5py h5py  # Add --no-cache-dir if pip has cached a previous build of h5py
 
 Further guidance on building h5py against a parallel build of HDF5 is available in the `h5py documentation <https://docs.h5py.org/en/stable/build.html#building-against-parallel-hdf5>`_.
+
+
+5. [Optional] Install mpi4py_fft
+--------------------------------
+
+If you plan to use the :ref:`MPI domain decomposition functionality <mpi_domain_decomposition>` available in gprMax with :ref:`fractal user objects <fractals>`, you need to install mpi4py_fft.
+
+Install FFTW
+^^^^^^^^^^^^
+
+FFTW is a required dependency of mpi4py_fft, however, if you are running gprMax on a HPC system, FFTW may be available already - consult your site's documentation. Otherwise you will need to install it yourself.
+
+Linux
+#####
+
+* It is possible binaries are available via your package manager. E.g. ``libfftw3-dev`` on Ubuntu.
+* Otherwise you can find the latest source code on the `fftw downloads page <https://fftw.org/download.html>`_. There are instructions to build from source in the `fftw docs <https://fftw.org/fftw3_doc/Installation-on-Unix.html>`_.
+
+macOS
+#####
+
+* FFTW can be installed using the `Homebrew package manager <http://brew.sh>`_:
+
+.. code-block:: console
+
+    $ brew install fftw
+
+Microsoft Windows
+#################
+
+* While FFTW can be installed on Windows (guidance `here <https://fftw.org/install/windows.html>`_), it is not possible to build mpi4py_fft using the MSVC compiler.
+* Therefore, we recommend using `Windows Subsystem for Linux <https://docs.microsoft.com/en-gb/windows/wsl/about>`_ and then following the Linux install instructions for gprMax.
+
+Install mpi4py_fft with conda
+^^^^^^^^^^^^^^^^^^
+
+mpi4py_fft can be installed in a conda environment with:
+
+.. code:: console
+
+    (gprMax)$ conda install -c conda-forge mpi4py_fft
+
+Install mpi4py_fft with pip
+^^^^^^^^^^^^^^^^
+
+mpi4py_fft can be installed using pip with:
+
+.. code:: console
+
+    (gprMax)$ pip install mpi4py_fft
+
+.. tip::
+
+    It may be necessary to tell mpi4py_fft where FFTW is installed. This can be done by setting the `FFTW_INCLUDE_DIR` and `FFTW_LIBRARY_DIR` environment variables to the appropriate paths.
 
 
 6. Build and install gprMax

--- a/README.rst
+++ b/README.rst
@@ -214,7 +214,7 @@ Microsoft Windows
 * While FFTW can be installed on Windows (guidance `here <https://fftw.org/install/windows.html>`_), it is not possible to build mpi4py_fft using the MSVC compiler.
 * Therefore, we recommend using `Windows Subsystem for Linux <https://docs.microsoft.com/en-gb/windows/wsl/about>`_ and then following the Linux install instructions for gprMax.
 
-Install mpi4py_fft with conda
+Install with conda
 ^^^^^^^^^^^^^^^^^^
 
 mpi4py_fft can be installed in a conda environment with:
@@ -223,7 +223,7 @@ mpi4py_fft can be installed in a conda environment with:
 
     (gprMax)$ conda install -c conda-forge mpi4py_fft
 
-Install mpi4py_fft with pip
+Install with pip
 ^^^^^^^^^^^^^^^^
 
 mpi4py_fft can be installed using pip with:
@@ -234,7 +234,7 @@ mpi4py_fft can be installed using pip with:
 
 .. tip::
 
-    It may be necessary to tell mpi4py_fft where FFTW is installed. This can be done by setting the `FFTW_INCLUDE_DIR` and `FFTW_LIBRARY_DIR` environment variables to the appropriate paths.
+    It may be necessary to tell mpi4py_fft where FFTW is installed. This can be done by setting the ``FFTW_INCLUDE_DIR`` and ``FFTW_LIBRARY_DIR`` environment variables to the appropriate paths.
 
 
 6. Build and install gprMax

--- a/gprMax/fractals/fractal_surface.py
+++ b/gprMax/fractals/fractal_surface.py
@@ -23,8 +23,6 @@ from typing import List, Optional, Tuple
 import numpy as np
 import numpy.typing as npt
 from mpi4py import MPI
-from mpi4py_fft import PFFT, DistArray, newDistArray
-from mpi4py_fft.pencil import Subcomm
 from scipy import fftpack
 
 from gprMax import config
@@ -222,6 +220,11 @@ class MPIFractalSurface(FractalSurface):
 
     def generate_fractal_surface(self) -> bool:
         """Generate a 2D array with a fractal distribution."""
+
+        # Import from mpi4py_fft
+        # This is an optional dependency so only import if required
+        from mpi4py_fft import PFFT, DistArray, newDistArray
+        from mpi4py_fft.pencil import Subcomm
 
         if self.xs == self.xf:
             color = self.xs

--- a/gprMax/fractals/fractal_volume.py
+++ b/gprMax/fractals/fractal_volume.py
@@ -18,13 +18,11 @@
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Union
 
 import numpy as np
 import numpy.typing as npt
 from mpi4py import MPI
-from mpi4py_fft import PFFT, DistArray, newDistArray
-from mpi4py_fft.pencil import Subcomm
 from scipy import fftpack
 
 from gprMax import config
@@ -33,7 +31,6 @@ from gprMax.fractals.fractal_surface import FractalSurface
 from gprMax.fractals.mpi_utilities import calculate_starts_and_subshape, create_mpi_type
 from gprMax.materials import ListMaterial, PeplinskiSoil, RangeMaterial
 from gprMax.utilities.mpi import Dim, Dir, get_relative_neighbour
-from gprMax.utilities.utilities import round_value
 
 logger = logging.getLogger(__name__)
 np.seterr(divide="raise")
@@ -312,6 +309,11 @@ class MPIFractalVolume(FractalVolume):
 
     def generate_fractal_volume(self) -> bool:
         """Generate a 3D volume with a fractal distribution."""
+
+        # Import from mpi4py_fft
+        # This is an optional dependency so only import if required
+        from mpi4py_fft import PFFT, DistArray, newDistArray
+        from mpi4py_fft.pencil import Subcomm
 
         # Exit early if this rank does not contain the Fractal Volume
         # The size of a fractal volume can increase if a Fractal Surface

--- a/reframe_tests/tests/base_tests.py
+++ b/reframe_tests/tests/base_tests.py
@@ -52,6 +52,7 @@ class CreatePyenvTest(RunOnlyRegressionTest):
         f"source {PATH_TO_PYENV}",
         "CC=cc CXX=CC FC=ftn python -m pip install --upgrade pip",
         f"CC=cc CXX=CC FC=ftn python -m pip install -r {os.path.join(GPRMAX_ROOT_DIR, 'requirements.txt')}",
+        "CC=cc CXX=CC FC=ftn python -m pip install mpi4py_fft",
     ]
     executable = f"CC=cc CXX=CC FC=ftn python -m pip install -e {GPRMAX_ROOT_DIR}"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ jinja2
 jupyter
 matplotlib
 mpi4py
-mpi4py-fft
 numpy<2
 numpy-stl
 pandas
@@ -21,6 +20,12 @@ scipy
 terminaltables
 tqdm
 wheel
+
+# If running with mpi domain decomposition, the following dependencies
+# are also required:
+
+# mpi4py-fft
+
 
 # The following are required to run the ReFrame test suite (uncomment if
 # needed):


### PR DESCRIPTION
# PR Description

It is not possible to install `mpi4py_fft` on Windows (unless using WSL). Therefore as `mpi4py_fft` is only needed for the MPI domain decomposition functionality it should be removed as a compulsory dependency to allow gprMax to build and run on Windows.

## 🛠️ Related Issue (Number)

<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

Related to issue #498

## Type of change

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update.

## Checklist

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [x] Did pre-commit passed all checks?
- [x] I have performed a self-review of my code.
- [x] I have added comments for my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.
