### PR TITLE
Correction of material[i].sr into material[i].sm when needed

### DIFF
--- a/gprMax/input_cmds_geometry.py
+++ b/gprMax/input_cmds_geometry.py
@@ -402,7 +402,7 @@ def process_geometrycmds(geometry, G):
                         m.er = np.mean((materials[0].er, materials[1].er, materials[2].er), axis=0)
                         m.se = np.mean((materials[0].se, materials[1].se, materials[2].se), axis=0)
                         m.mr = np.mean((materials[0].mr, materials[1].mr, materials[2].mr), axis=0)
-                        m.sm = np.mean((materials[0].mr, materials[1].mr, materials[2].mr), axis=0)
+                        m.sm = np.mean((materials[0].sm, materials[1].sm, materials[2].sm), axis=0)
 
                         # Append the new material object to the materials list
                         G.materials.append(m)
@@ -510,7 +510,7 @@ def process_geometrycmds(geometry, G):
                     m.er = np.mean((materials[0].er, materials[1].er, materials[2].er), axis=0)
                     m.se = np.mean((materials[0].se, materials[1].se, materials[2].se), axis=0)
                     m.mr = np.mean((materials[0].mr, materials[1].mr, materials[2].mr), axis=0)
-                    m.sm = np.mean((materials[0].mr, materials[1].mr, materials[2].mr), axis=0)
+                    m.sm = np.mean((materials[0].sm, materials[1].sm, materials[2].sm), axis=0)
 
                     # Append the new material object to the materials list
                     G.materials.append(m)
@@ -591,7 +591,7 @@ def process_geometrycmds(geometry, G):
                     m.er = np.mean((materials[0].er, materials[1].er, materials[2].er), axis=0)
                     m.se = np.mean((materials[0].se, materials[1].se, materials[2].se), axis=0)
                     m.mr = np.mean((materials[0].mr, materials[1].mr, materials[2].mr), axis=0)
-                    m.sm = np.mean((materials[0].mr, materials[1].mr, materials[2].mr), axis=0)
+                    m.sm = np.mean((materials[0].sm, materials[1].sm, materials[2].sm), axis=0)
 
                     # Append the new material object to the materials list
                     G.materials.append(m)
@@ -681,7 +681,7 @@ def process_geometrycmds(geometry, G):
                         m.er = np.mean((materials[0].er, materials[1].er, materials[2].er), axis=0)
                         m.se = np.mean((materials[0].se, materials[1].se, materials[2].se), axis=0)
                         m.mr = np.mean((materials[0].mr, materials[1].mr, materials[2].mr), axis=0)
-                        m.sm = np.mean((materials[0].mr, materials[1].mr, materials[2].mr), axis=0)
+                        m.sm = np.mean((materials[0].sm, materials[1].sm, materials[2].sm), axis=0)
 
                         # Append the new material object to the materials list
                         G.materials.append(m)
@@ -791,7 +791,7 @@ def process_geometrycmds(geometry, G):
                     m.er = np.mean((materials[0].er, materials[1].er, materials[2].er), axis=0)
                     m.se = np.mean((materials[0].se, materials[1].se, materials[2].se), axis=0)
                     m.mr = np.mean((materials[0].mr, materials[1].mr, materials[2].mr), axis=0)
-                    m.sm = np.mean((materials[0].mr, materials[1].mr, materials[2].mr), axis=0)
+                    m.sm = np.mean((materials[0].sm, materials[1].sm, materials[2].sm), axis=0)
 
                     # Append the new material object to the materials list
                     G.materials.append(m)


### PR DESCRIPTION
# PR Description

This PR fixes a bug where magnetic susceptibility (sm) properties were incorrectly calculated using magnetic permeability (mr) values instead of the correct sm values when averaging material properties.
Corrects the calculation of sm to use materials[i].sm instead of incorrectly using materials[i].mr.

## 🛠️ Related Issue (Number)

Wrong attribution of some constants for materials (mr instead of sm).

Closes #

## Type of change

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [O] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update.

## Checklist

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [O] Did pre-commit passed all checks?
- [O] I have performed a self-review of my code.
- [O] I have added comments for my code, particularly in hard-to-understand areas.
- [O] I have made corresponding changes to the documentation.
- [O] My changes generate no new warnings.
- [O] The title of my pull request is a short description of my changes.
