### PR TITLE
Jetson Orin Nano lscpu fix

### DIFF
--- a/gprMax/utilities.py
+++ b/gprMax/utilities.py
@@ -298,7 +298,10 @@ def get_host_info():
             allcpuinfo = subprocess.check_output("lscpu", shell=True, env=my_env, stderr=subprocess.STDOUT).decode('utf-8').strip()
             for line in allcpuinfo.split('\n'):
                 if 'Socket(s)' in line:
-                    sockets = int(re.sub("\\D", "", line.strip()))
+                    try:
+                        sockets = int(re.sub("\\D", "", line.strip()))
+                    except:
+                        sockets = 1
                 if 'Thread(s) per core' in line:
                     threadspercore = int(re.sub("\\D", "", line.strip()))
                 if 'Core(s) per socket' in line:

--- a/gprMax/utilities.py
+++ b/gprMax/utilities.py
@@ -301,7 +301,9 @@ def get_host_info():
                     try:
                         sockets = int(re.sub("\\D", "", line.strip()))
                     except:
+                        # For NVIDIA Jetson, it returns "Socket(s): -" and never returns "Core(s) per socket", so we assume 1 socket and 1 core per socket
                         sockets = 1
+                        corespersocket = 1
                 if 'Thread(s) per core' in line:
                     threadspercore = int(re.sub("\\D", "", line.strip()))
                 if 'Core(s) per socket' in line:


### PR DESCRIPTION
# PR Description

This PR fixed issue running on NVIDIA Jetson Orin Nano, by setting `sockets=1` and `corespersocket=1`.

The issue is that on Jetson Orin `lscpu` it:
- Returns Socket(s): - (sic)
- Does not return Core(s) per socket at all.


Example `lscpu` from Jetson Orin Nano
```
Architecture:            aarch64
  CPU op-mode(s):        32-bit, 64-bit
  Byte Order:            Little Endian
CPU(s):                  6
  On-line CPU(s) list:   0-5
Vendor ID:               ARM
  Model name:            Cortex-A78AE
    Model:               1
    Thread(s) per core:  1
    Core(s) per cluster: 3
    Socket(s):           - <------ this is the issue
                                   <------ missing Core(s): 
    Cluster(s):          2
    Stepping:            r0p1
    CPU max MHz:         1728.0000
    CPU min MHz:         115.2000
    BogoMIPS:            62.50
    Flags:               fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdr
                         dm lrcpc dcpop asimddp uscat ilrcpc flagm paca pacg
Caches (sum of all):     
  L1d:                   384 KiB (6 instances)
  L1i:                   384 KiB (6 instances)
  L2:                    1.5 MiB (6 instances)
  L3:                    4 MiB (2 instances)
NUMA:                    
  NUMA node(s):          1
  NUMA node0 CPU(s):     0-5
Vulnerabilities:         
  Gather data sampling:  Not affected
  Itlb multihit:         Not affected
  L1tf:                  Not affected
  Mds:                   Not affected
  Meltdown:              Not affected
  Mmio stale data:       Not affected
  Retbleed:              Not affected
  Spec rstack overflow:  Not affected
  Spec store bypass:     Mitigation; Speculative Store Bypass disabled via prctl
  Spectre v1:            Mitigation; __user pointer sanitization
  Spectre v2:            Mitigation; CSV2, but not BHB
  Srbds:                 Not affected
  Tsx async abort:       Not affected
```

## 🛠️ Related Issue (Number)

N/A/

## Type of change

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update.

## Checklist

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [x] Did pre-commit passed all checks?
- [x] I have performed a self-review of my code.
- [x] I have added comments for my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.
