### PR TITLE
Modern install master base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 build/
 dist/
 *.egg-info/
+_build/
+docs/_build/
 
 # Backup files
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,7 @@
 build/
 dist/
 *.egg-info/
-_build/
-docs/_build/
+docs/html/
 
 # Backup files
 *~

--- a/README.rst
+++ b/README.rst
@@ -37,15 +37,15 @@ Package Overview
 
     gprMax/
         conda_env.yml
-    CREDITS
+        CREDITS
         docs/
         gprMax/
         LICENSE
-    MANIFEST.in
-    pyproject.toml
+        MANIFEST.in
+        pyproject.toml
         README.rst
         setup.py
-    requirements.txt
+        requirements.txt
         tests/
         tools/
         user_libs/
@@ -85,28 +85,27 @@ Linux
 
 macOS
 ^^^^^
-* Apple Clang (from Xcode) lacks OpenMP support by default. Install Homebrew ``gcc``:
+* Xcode (the IDE for macOS) comes with the LLVM (clang) compiler, but it does not currently support OpenMP, so you must install `gcc <https://gcc.gnu.org>`_. That said, it is still useful to have Xcode (with command line tools) installed. It can be downloaded from the App Store. Once Xcode is installed, download and install the `Homebrew package manager <http://brew.sh>`_ and then to install gcc, run:
 
-    .. code-block:: bash
+.. code-block:: bash
 
-            brew install gcc
-
-    Keep Xcode command line tools installed (SDK headers, linker, etc.).
+    $ brew install gcc
 
 Windows
 ^^^^^^^
-* Install Microsoft `Build Tools for Visual Studio 2022 <https://aka.ms/vs/17/release/vs_BuildTools.exe>`_ with the "Desktop development with C++" workload (MSVC v143 + latest Windows SDK). Ensure the appropriate "x64 Native Tools Command Prompt" (or environment variables) is used when building.
-* Alternative: Use WSL (Ubuntu or similar) and follow the Linux instructions.
 
-Two installation modes are available:
+* Download and install Microsoft `Build Tools for Visual Studio 2022 <https://aka.ms/vs/17/release/vs_BuildTools.exe>`_ (direct link). You can also find it on the `Microsoft Visual Studio downloads page <https://visualstudio.microsoft.com/downloads/>`_ by scrolling down to the 'All Downloads' section, clicking the disclosure triangle by 'Tools for Visual Studio 2022', then clicking the download button next to 'Build Tools for Visual Studio 2022'. When installing, choose the 'Desktop development with C++' Workload and select only 'MSVC v143' and 'Windows 10 SDK' or 'Windows 11 SDK options.
+* Set the Path and Environment Variables - this can be done by following the `instructions from Microsoft <https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-160#developer_command_file_locations>`_, or manually by adding a form of :code:`C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.23.28105\bin\Hostx64\x64` (this may vary according to your exact machine and installation) to your system Path environment variable.
 
-* Direct installation using pip + a virtual environment (recommended for most users)
-* Installation using conda (historical/legacy method, still supported)
+Alternatively, if you are using Windows 10/11 you can install the `Windows Subsystem for Linux <https://docs.microsoft.com/en-gb/windows/wsl/about>`_ and then follow the Linux install instructions for gprMax. Note however that currently WSL does not aim to support GUI desktops or applications, e.g. Gnome, KDE, etc....
 
 Environment setup
 -----------------
 
-Choose ONE of the following ways to prepare an isolated environment.
+Two installation modes are available:
+
+* Direct installation using pip + a virtual environment
+* Installation using conda (historical/legacy method)
 
 Pip / virtualenv
 ~~~~~~~~~~~~~~~~
@@ -120,8 +119,8 @@ Pip / virtualenv
     python -m venv .venv
     source .venv/bin/activate  # (Windows: .venv\\Scripts\\activate)
 
-Conda (legacy / alternative)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Conda
+~~~~~
 
 .. code-block:: bash
 
@@ -150,19 +149,19 @@ Examples:
 
 .. code-block:: bash
 
-    pip install -e .[docs]
-    pip install -e .[notebooks]
+    pip install -e ".[docs]"
+    pip install -e ".[notebooks]"
 
 Build documentation locally:
 
 .. code-block:: bash
 
-    pip install -e .[docs]
+    pip install -e ".[docs]"
     make -C docs html
-    open docs/_build/index.html  # macOS
+    open docs/html/index.html  # macOS
 
 1. Install Python, the required Python packages, and get gprMax source (conda variant detail)
--------------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------
 
 We recommend using Miniconda to install Python and the required Python packages for gprMax in a self-contained Python environment. Miniconda is a mini version of Anaconda which is a completely free Python distribution (including for commercial use and redistribution). It includes more than 300 of the most popular Python packages for science, math, engineering, and data analysis.
 

--- a/README.rst
+++ b/README.rst
@@ -37,29 +37,31 @@ Package Overview
 
     gprMax/
         conda_env.yml
-        CONTRIBUTORS
+    CREDITS
         docs/
         gprMax/
-        gsoc/
         LICENSE
+    MANIFEST.in
+    pyproject.toml
         README.rst
-        setup.cfg
         setup.py
+    requirements.txt
         tests/
         tools/
         user_libs/
         user_models/
 
 
-* ``conda_env.yml`` is a configuration file for Anaconda (Miniconda) that sets up a Python environment with all the required Python packages for gprMax.
-* ``CONTRIBUTORS`` contains a list of names of people who have contributed to the gprMax codebase.
+* ``conda_env.yml`` is a conda environment specification (legacy/alternative environment setup).
+* ``CREDITS`` lists people and organisations who have contributed.
 * ``docs`` contains source files for the User Guide. The User Guide is written using `reStructuredText <http://docutils.sourceforge.net/rst.html>`_ markup and is built using `Sphinx <http://sphinx-doc.org>`_ and `Read the Docs <https://readthedocs.org>`_.
 * ``gprMax`` is the main package. Within this package, the main module is ``gprMax.py``
-* ``gsoc`` contains information for `Google Summer of Code <https://summerofcode.withgoogle.com>`_ program - project ideas and proposal guidance.
 * ``LICENSE`` contains information on the `GNU General Public License v3 or higher <http://www.gnu.org/copyleft/gpl.html>`_.
+* ``MANIFEST.in`` includes additional non-Python files in source distributions.
+* ``pyproject.toml`` holds the core build configuration and project metadata (PEP 517/621).
 * ``README.rst`` contains getting started information on installation, usage, and new features/changes.
-* ``setup.cfg`` is used to set preferences for code formatting/styling using flake8.
-* ``setup.py`` is used to compile the Cython extension modules.
+* ``setup.py`` builds/compiles the Cython extension modules (kept for build logic; metadata lives in ``pyproject.toml``).
+* ``requirements.txt`` (optional/legacy) may pin dependencies for some workflows; primary dependency specification is now in ``pyproject.toml``.
 * ``tests`` is a sub-package that contains test modules and input files.
 * ``tools`` is a sub-package that contains scripts to assist with viewing and post-processing output from models.
 * ``user_libs`` is a sub-package where useful modules contributed by users are stored.
@@ -68,14 +70,99 @@ Package Overview
 Installation
 ============
 
-The following steps provide guidance on how to install gprMax:
+Prerequisites
+-------------
 
-1. Install Python, and the required Python packages, and get the gprMax source code from GitHub
-2. Install a C compiler that supports OpenMP
-3. Build and install gprMax
+* Python 3.7+
+* A C/C++ compiler with OpenMP support installed BEFORE running the installation.
 
-1. Install Python, the required Python packages, and get gprMax source
-------------------------------------------------------------------
+OpenMP compiler details
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Linux
+^^^^^
+* `gcc <https://gcc.gnu.org>`_ is usually already installed – verify with ``gcc --version``.
+
+macOS
+^^^^^
+* Apple Clang (from Xcode) lacks OpenMP support by default. Install Homebrew ``gcc``:
+
+    .. code-block:: bash
+
+            brew install gcc
+
+    Keep Xcode command line tools installed (SDK headers, linker, etc.).
+
+Windows
+^^^^^^^
+* Install Microsoft `Build Tools for Visual Studio 2022 <https://aka.ms/vs/17/release/vs_BuildTools.exe>`_ with the "Desktop development with C++" workload (MSVC v143 + latest Windows SDK). Ensure the appropriate "x64 Native Tools Command Prompt" (or environment variables) is used when building.
+* Alternative: Use WSL (Ubuntu or similar) and follow the Linux instructions.
+
+Two installation modes are available:
+
+* Direct installation using pip + a virtual environment (recommended for most users)
+* Installation using conda (historical/legacy method, still supported)
+
+Environment setup
+-----------------
+
+Choose ONE of the following ways to prepare an isolated environment.
+
+Pip / virtualenv
+~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    # Clone the repository
+    git clone https://github.com/gprMax/gprMax.git
+    cd gprMax
+    # Create an isolated environment (example with venv)
+    python -m venv .venv
+    source .venv/bin/activate  # (Windows: .venv\\Scripts\\activate)
+
+Conda (legacy / alternative)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    conda update conda
+    conda install git
+    git clone https://github.com/gprMax/gprMax.git
+    cd gprMax
+    conda env create -f conda_env.yml
+    conda activate gprMax
+
+Install gprMax (common step)
+----------------------------
+
+Run after activating either the venv or the conda environment:
+
+.. code-block:: bash
+
+    pip install -e .
+
+Extras:
+
+* ``.[docs]`` documentation (Sphinx)
+* ``.[notebooks]`` Jupyter stack
+
+Examples:
+
+.. code-block:: bash
+
+    pip install -e .[docs]
+    pip install -e .[notebooks]
+
+Build documentation locally:
+
+.. code-block:: bash
+
+    pip install -e .[docs]
+    make -C docs html
+    open docs/_build/index.html  # macOS
+
+1. Install Python, the required Python packages, and get gprMax source (conda variant detail)
+-------------------------------------------------------------------------------------------
 
 We recommend using Miniconda to install Python and the required Python packages for gprMax in a self-contained Python environment. Miniconda is a mini version of Anaconda which is a completely free Python distribution (including for commercial use and redistribution). It includes more than 300 of the most popular Python packages for science, math, engineering, and data analysis.
 
@@ -96,45 +183,7 @@ If you prefer to install Python and the required Python packages manually, i.e. 
 
 If you are using Arch Linux (https://www.archlinux.org/) you may need to also install ``wxPython`` by adding it to the conda environment file (``conda_env.yml``).
 
-2. Install a C compiler that supports OpenMP
----------------------------------------------
-
-Linux
-^^^^^
-
-* `gcc <https://gcc.gnu.org>`_ should be already installed, so no action is required.
-
-
-macOS
-^^^^^
-
-* Xcode (the IDE for macOS) comes with the LLVM (clang) compiler, but it does not currently support OpenMP, so you must install `gcc <https://gcc.gnu.org>`_. That said, it is still useful to have Xcode (with command line tools) installed. It can be downloaded from the App Store. Once Xcode is installed, download and install the `Homebrew package manager <http://brew.sh>`_ and then to install gcc, run:
-
-.. code-block:: bash
-
-    $ brew install gcc
-
-Microsoft Windows
-^^^^^^^^^^^^^^^^^
- 
-* Download and install Microsoft `Build Tools for Visual Studio 2022 <https://aka.ms/vs/17/release/vs_BuildTools.exe>`_ (direct link). You can also find it on the `Microsoft Visual Studio downloads page <https://visualstudio.microsoft.com/downloads/>`_ by scrolling down to the 'All Downloads' section, clicking the disclosure triangle by 'Tools for Visual Studio 2022', then clicking the download button next to 'Build Tools for Visual Studio 2022'. When installing, choose the 'Desktop development with C++' Workload and select only 'MSVC v143' and 'Windows 10 SDK' or 'Windows 11 SDK options.
-* Set the Path and Environment Variables - this can be done by following the `instructions from Microsoft <https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-160#developer_command_file_locations>`_, or manually by adding a form of :code:`C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.23.28105\bin\Hostx64\x64` (this may vary according to your exact machine and installation) to your system Path environment variable.
-
-Alternatively, if you are using Windows 10/11 you can install the `Windows Subsystem for Linux <https://docs.microsoft.com/en-gb/windows/wsl/about>`_ and then follow the Linux install instructions for gprMax. Note however that currently WSL does not aim to support GUI desktops or applications, e.g. Gnome, KDE, etc....
-
-3. Build and install gprMax
----------------------------
-
-Once you have installed the aforementioned tools follow these steps to build and install gprMax:
-
-* Open a Terminal (Linux/macOS) or Command Prompt (Windows), navigate into the top-level gprMax directory, and if it is not already active, activate the gprMax conda environment:code:`conda activate gprMax`. Run the following commands:
-
-.. code-block:: bash
-
-    (gprMax)$ python setup.py build
-    (gprMax)$ python setup.py install
-
-**You are now ready to proceed to running gprMax.**
+**gprMax is now ready to use once the common installation step above has completed.**
 
 Running gprMax
 ==============
@@ -185,19 +234,20 @@ Argument name          Type      Description
 ``-h`` or ``--help``   flag      is used to get help on command line options.
 ====================== ========= ===========
 
-Updating gprMax
-===============
-
-* Open a Terminal (Linux/macOS) or Command Prompt (Windows), navigate into the top-level gprMax directory, and if it is not already active, activate the gprMax conda environment :code:`conda activate gprMax`. Run the following commands:
+Updating gprMax (editable source)
+=================================
 
 .. code-block:: bash
 
-    (gprMax)$ git pull
-    (gprMax)$ python setup.py cleanall
-    (gprMax)$ python setup.py build
-    (gprMax)$ python setup.py install
+    git pull
+    pip install -e .  # rebuilds if needed
 
-This will pull the most recent gprMax source code from GitHub, remove/clean previously built modules, and then build and install the latest version of gprMax.
+To force a clean rebuild of the Cython extensions:
+
+.. code-block:: bash
+
+    find gprMax -name "*.cpython-*.so" -delete
+    pip install -e .
 
 
 Updating conda and Python packages
@@ -211,6 +261,6 @@ Periodically you should update conda and the required Python packages. With the 
     $ conda env update -f conda_env.yml
 
 Thanks To Our Contributors ✨🔗
-==========================
+================================
 .. image:: https://contrib.rocks/image?repo=gprMax/gprMax
    :target: https://github.com/gprMax/gprMax/graphs/contributors

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,7 +5,8 @@
 SPHINXOPTS    = -aE
 SPHINXBUILD   = sphinx-build
 PAPER         =
-BUILDDIR      = ./
+# Build output in dedicated directory to avoid 'make clean' deleting files from the repository.
+BUILDDIR      = _build
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
@@ -49,7 +50,8 @@ help:
 	@echo "  coverage   to run coverage check of the documentation (if enabled)"
 
 clean:
-	rm -rf $(BUILDDIR)/*
+	rm -rf $(BUILDDIR)
+	mkdir -p $(BUILDDIR)
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,7 +6,7 @@ SPHINXOPTS    = -aE
 SPHINXBUILD   = sphinx-build
 PAPER         =
 # Build output in dedicated directory to avoid 'make clean' deleting files from the repository.
-BUILDDIR      = _build
+BUILDDIR      = html
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,68 @@
+[build-system]
+# Build dependencies required before executing setup.py (which imports numpy)
+requires = [
+  "setuptools>=61",
+  "wheel",
+  "numpy>=1.26",
+  "Cython>=3.0"
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gprMax"
+# Version lue dynamiquement (voir section tool.setuptools.dynamic)
+dynamic = ["version"]
+description = "Electromagnetic Modelling Software based on the Finite-Difference Time-Domain (FDTD) method"
+readme = "README.rst"
+license = "GPL-3.0-or-later"
+authors = [
+  { name = "Craig Warren" },
+  { name = "Antonis Giannopoulos" }
+]
+classifiers = [
+  "Environment :: Console",
+  "Operating System :: MacOS",
+  "Operating System :: Microsoft :: Windows",
+  "Operating System :: POSIX :: Linux",
+  "Programming Language :: Cython",
+  "Programming Language :: Python :: 3",
+  "Topic :: Scientific/Engineering"
+]
+requires-python = ">=3.7"
+dependencies = [
+  "colorama",
+  "cython",
+  "h5py",
+  "matplotlib",
+  "numpy",
+  "psutil",
+  "scipy",
+  "terminaltables",
+  "tqdm"
+]
+license-files = ["LICENSE"]
+
+[project.optional-dependencies]
+docs = [
+  "sphinx",
+  "sphinx_rtd_theme"
+]
+notebooks = [
+  "jupyter",
+  "ipykernel",
+  "ipywidgets",
+  "jupyterlab"
+]
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.dynamic]
+# Utilise l'attribut Python pour extraire uniquement la chaîne de version PEP 440
+version = { attr = "gprMax._version.__version__" }
+
+# Contributor notes:
+# - Metadata now lives in pyproject.toml; setup.py handles extension build logic only.
+# - Editable install should work without pre‑installing numpy/cython thanks to build-system.requires.
+# - Jupyter stack moved to optional extra: pip install .[notebooks]
+# - Documentation extra: pip install .[docs]

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ executing==0.8.3
 fastjsonschema==2.16.2
 fonttools==4.25.0
 gprMax==3.1.7
-gprMax==3.1.7
 h5py==3.12.1
 idna==3.4
 ipykernel==6.28.0

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
-try:
-    from setuptools import setup, Extension
-except ImportError:
-    from distutils.core import setup
-    from distutils.extension import Extension
+from setuptools import setup, Extension  # type: ignore[import-not-found]
 
 try:
     import numpy as np

--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,9 @@ packages = [packagename, 'tests', 'tools', 'user_libs']
 with open('README.rst', 'r', encoding='utf-8') as fd:
     long_description = fd.read()
 
-# Python version
-if sys.version_info[:2] < (3, 4):
-    sys.exit('\nExited: Requires Python 3.4 or newer!\n')
+# Python version guard (align with pyproject.toml requires-python >=3.7)
+if sys.version_info < (3, 7):
+    sys.exit('\nExited: Requires Python 3.7 or newer.\n')
 
 # Process 'build' command line argument
 if 'build' in sys.argv:
@@ -141,7 +141,11 @@ elif sys.platform == 'darwin':
             raise('Cannot find gcc 4-10 in /usr/local/bin. gprMax requires gcc to be installed - easily done through the Homebrew package manager (http://brew.sh). Note: gcc with OpenMP support is required.')
     compile_args = ['-O3', '-w', '-fopenmp', '-march=native']  # Sometimes worth testing with '-fstrict-aliasing', '-fno-common'
     linker_args = ['-fopenmp', '-Wl,-rpath,' + rpath]
-    libraries = ['iomp5', 'pthread']
+    # Homebrew fournit GCC avec libgomp (runtime OpenMP GNU). L'ancienne configuration essayait de lier iomp5 (runtime Intel),
+    # absent sur la plupart des installations standard et cause une erreur: ld: library 'iomp5' not found.
+    # Avec -fopenmp, GCC ajoute déjà automatiquement libgomp, donc on n'a pas besoin de préciser libraries.
+    # Si on voulait être explicite on pourrait utiliser ['gomp'], mais on laisse vide pour portabilité.
+    libraries = []
     extra_objects = []
 # Linux
 elif sys.platform == 'linux':
@@ -149,6 +153,24 @@ elif sys.platform == 'linux':
     linker_args = ['-fopenmp']
     extra_objects = []
     libraries=[]
+
+# Optional: Intel OpenMP runtime (iomp5) support
+# ----------------------------------------------
+# Historically the project listed iomp5 which produced link failures on
+# standard GCC + libgomp installs. It is now optional so default builds rely
+# on the platform OpenMP runtime while still permitting Intel toolchains
+# (icx/icc/icl) to request iomp5.
+# Enable by exporting GPRMAX_USE_INTEL_OPENMP=1 before installation, or by
+# setting CC=icx/icc/icl for auto detection. Warning: if libiomp5.* is not
+# present on the system the link step will fail.
+use_intel_omp_env = os.environ.get('GPRMAX_USE_INTEL_OPENMP', '').lower() in ('1', 'true', 'yes')
+cc_lower = os.environ.get('CC', '').lower()
+detected_intel_cc = any(tok in cc_lower for tok in ('icx', 'icc', 'icl'))
+if use_intel_omp_env or detected_intel_cc:
+    # Évite les doublons si déjà ajouté
+    if 'iomp5' not in libraries and sys.platform != 'win32':  # Sous Windows Intel fournit généralement la DLL automatiquement
+        libraries.append('iomp5')
+        print("[gprMax] Activation du runtime Intel OpenMP: liaison avec iomp5 (détection compilateur Intel ou variable GPRMAX_USE_INTEL_OPENMP).")
 
 # Build a list of all the extensions
 extensions = []
@@ -181,40 +203,28 @@ if USE_CYTHON:
                            },
                            annotate=False)
 
-setup(name=packagename,
-      version=version,
-      author='Craig Warren and Antonis Giannopoulos',
-      url='http://www.gprmax.com',
-      description='Electromagnetic Modelling Software based on the Finite-Difference Time-Domain (FDTD) method',
-      long_description=long_description,
-      long_description_content_type="text/x-rst",
-      license='GPLv3+',
-      classifiers=[
-          'Environment :: Console',
-          'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
-          'Operating System :: MacOS',
-          'Operating System :: Microsoft :: Windows',
-          'Operating System :: POSIX :: Linux',
-          'Programming Language :: Cython',
-          'Programming Language :: Python :: 3',
-          'Topic :: Scientific/Engineering'
-      ],
-      #requirements
-      python_requires=">3.6",
-      install_requires=[
-          "colorama",
-          "cython",
-          "h5py",
-          "jupyter",
-          "matplotlib",
-          "numpy",
-          "psutil",
-          "scipy",
-          "terminaltables",
-          "tqdm",
-          ],
-      ext_modules=extensions,
-      packages=packages,
-      include_package_data=True,
-      include_dirs=[np.get_include()],
-      zip_safe=False)
+setup(
+    name=packagename,
+    version=version,
+    author='Craig Warren and Antonis Giannopoulos',
+    url='http://www.gprmax.com',
+    # Les métadonnées (description, license, classifiers, long_description) sont définies dans pyproject.toml.
+    python_requires=">=3.7",
+    install_requires=[
+        # Core runtime dependencies (Jupyter moved to optional extras in pyproject.toml)
+        "colorama",
+        "cython",
+        "h5py",
+        "matplotlib",
+        "numpy",
+        "psutil",
+        "scipy",
+        "terminaltables",
+        "tqdm",
+    ],
+    ext_modules=extensions,
+    packages=packages,
+    include_package_data=True,
+    include_dirs=[np.get_include()],
+    zip_safe=False,
+)


### PR DESCRIPTION
# PR Description

Modernises the build & installation workflow: introduces a PEP 517/621 `pyproject.toml`, simplifies macOS OpenMP linkage, cleans legacy references, and aligns README instructions with current Python packaging practices. Also removes duplicated requirement entries and adds minor quality-of-life improvements.

## 🎯 Motivation

The previous install path relied solely on `setup.py` plus a large conda environment file. Modern Python packaging expects declarative metadata in `pyproject.toml`, enabling consistent builds (wheels / source) and clearer dependency management. This PR makes the project friendlier to:
- Standard pip builds (including isolated build backends)
- CI systems and wheel distribution
- Users on macOS where incorrect OpenMP runtime linkage (iomp5 vs libgomp) caused failures

## ✨ Key Changes

| Area | Change | Impact |
|------|--------|--------|
| Build system | Added `pyproject.toml` (setuptools backend, pinned minimal build deps) | Enables PEP 517 isolated builds, centralises metadata |
| Metadata | Moved project metadata (description, authors, classifiers, requires-python) from `setup.py` to `pyproject.toml` | Cleaner `setup.py` (build logic only) |
| Python version | Guard updated to `>=3.7` consistent across files | Avoids silent installs on unsupported versions |
| macOS OpenMP | Removed hard-coded `iomp5` linkage; rely on GCC's `-fopenmp` (libgomp) | Fixes missing library error on typical Homebrew setups |
| README | Updated package overview (CREDITS, MANIFEST.in, pyproject) and clarified environment role | Reduces confusion for new contributors |
| .gitignore | Ignore built Sphinx HTML (`docs/html/`) | Prevent accidental doc artifact commits |
| requirements.txt | Removed duplicate `gprMax==3.1.7` line | Eliminates redundancy |
| setup.py | Simplified imports, version guard, clarified comments | More maintainable |
| MANIFEST inclusion | Added/confirmed `MANIFEST.in` mention in docs | Ensures non-Python files packaged |

## 🧩 Detailed Notes

- `pyproject.toml` now lists runtime dependencies; these mirror previous implicit requirements. Optional extras added for docs and notebooks.
- Retained `setup.py` to compile Cython extensions (ext modules logic unchanged) while moving pure metadata out.
- Added commentary explaining why `libraries=[]` on macOS (GCC automatically links OpenMP runtime; was previously failing on systems lacking Intel's iomp5).
- README restructure reflects removal of `gsoc/` entry and updates file list with new/renamed artifacts (`CREDITS`, `MANIFEST.in`).

## 🔄 Backward Compatibility

- Existing workflows (`python setup.py build/install`) still function.
- Users can now alternatively run `pip install .` with modern pip (isolated build env).
- No change to runtime APIs.

## 🧪 Validation

- Local build: `pip install -e .` succeeds (isolated build resolves numpy/Cython first).
- macOS test: OpenMP-enabled extensions compile without requiring `iomp5`.
- Verified wheel build via `python -m build` (PEP 517) produces expected artifacts (sdist + wheel).

## 🗂️ Files Changed (summary)

```
.gitignore       |   + docs/html/
README.rst       |   structural & explanatory updates
docs/Makefile    |   minor path/target adjustments
pyproject.toml   | + new (build system & project metadata)
requirements.txt | - duplicate entry
setup.py         | ~ simplified, macOS linkage fix, version guard
```

## 🛠️ Related Issue (Number)

Closes #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking improvement to build/packaging)
- [ ] Breaking change (existing functionality might fail)
- [x] This change requires a documentation update.

## Checklist

- [x] Pre-commit / linters pass locally
- [x] Self-review completed
- [x] Added/updated comments where clarity needed
- [x] Documentation updated (README & inline comments)
- [x] No new warnings during build
- [x] PR title concise and descriptive

## 🚀 Usage After Merge

Recommended install (user):
```
pip install .
```
Editable/dev mode:
```
pip install -e .[docs,notebooks]
```
Building wheels (maintainers):
```
python -m build
```
