### PR TITLE
Cuda overflow fix and Rx "get" GPU bug fix

### DIFF
--- a/gprMax/cuda_opencl/knl_common_base.tmpl
+++ b/gprMax/cuda_opencl/knl_common_base.tmpl
@@ -8,14 +8,40 @@
 #define IDX2D_SRCINFO(m, n) (m)*{{NY_SRCINFO}}+(n)
 #define IDX2D_SRCWAVES(m, n) (m)*({{NY_SRCWAVES}})+(n)
 
-#define IDX3D_FIELDS(i, j, k) (i)*({{NY_FIELDS}})*({{NZ_FIELDS}})+(j)*({{NZ_FIELDS}})+(k)
-#define IDX3D_RXS(i, j, k) (i)*({{NY_RXS}})*({{NZ_RXS}})+(j)*({{NZ_RXS}})+(k)
+#define IDX3D_FIELDS(i, j, k) ((size_t)(i)*(size_t)({{NY_FIELDS}})*(size_t)({{NZ_FIELDS}}) \
+                              + (size_t)(j)*(size_t)({{NZ_FIELDS}}) \
+                              + (size_t)(k))
 
-#define IDX4D_ID(p, i, j, k) (p)*({{NX_ID}})*({{NY_ID}})*({{NZ_ID}})+(i)*({{NY_ID}})*({{NZ_ID}})+(j)*({{NZ_ID}})+(k)
-#define IDX4D_SNAPS(p, i, j, k) (p)*({{NX_SNAPS}})*({{NY_SNAPS}})*({{NZ_SNAPS}})+(i)*({{NY_SNAPS}})*({{NZ_SNAPS}})+(j)*({{NZ_SNAPS}})+(k)
-#define IDX4D_T(p, i, j, k) (p)*({{NX_T}})*({{NY_T}})*({{NZ_T}})+(i)*({{NY_T}})*({{NZ_T}})+(j)*({{NZ_T}})+(k)
-#define IDX4D_PHI1(p, i, j, k) (p)*(NX_PHI1)*(NY_PHI1)*(NZ_PHI1)+(i)*(NY_PHI1)*(NZ_PHI1)+(j)*(NZ_PHI1)+(k)
-#define IDX4D_PHI2(p, i, j, k) (p)*(NX_PHI2)*(NY_PHI2)*(NZ_PHI2)+(i)*(NY_PHI2)*(NZ_PHI2)+(j)*(NZ_PHI2)+(k)
+#define IDX3D_RXS(i, j, k) ((size_t)(i)*(size_t)({{NY_RXS}})*(size_t)({{NZ_RXS}}) \
+                            + (size_t)(j)*(size_t)({{NZ_RXS}}) \
+                            + (size_t)(k))
+
+
+
+#define IDX4D_ID(p, i, j, k) ((size_t)(p)*(size_t)({{NX_ID}})*(size_t)({{NY_ID}})*(size_t)({{NZ_ID}}) \
+                             + (size_t)(i)*(size_t)({{NY_ID}})*(size_t)({{NZ_ID}}) \
+                             + (size_t)(j)*(size_t)({{NZ_ID}}) \
+                             + (size_t)(k))
+
+#define IDX4D_SNAPS(p, i, j, k) ((size_t)(p)*(size_t)({{NX_SNAPS}})*(size_t)({{NY_SNAPS}})*(size_t)({{NZ_SNAPS}}) \
+                                + (size_t)(i)*(size_t)({{NY_SNAPS}})*(size_t)({{NZ_SNAPS}}) \
+                                + (size_t)(j)*(size_t)({{NZ_SNAPS}}) \
+                                + (size_t)(k))
+
+#define IDX4D_T(p, i, j, k) ((size_t)(p)*(size_t)({{NX_T}})*(size_t)({{NY_T}})*(size_t)({{NZ_T}}) \
+                            + (size_t)(i)*(size_t)({{NY_T}})*(size_t)({{NZ_T}}) \
+                            + (size_t)(j)*(size_t)({{NZ_T}}) \
+                            + (size_t)(k))
+
+#define IDX4D_PHI1(p, i, j, k) ((size_t)(p)*(size_t)(NX_PHI1)*(size_t)(NY_PHI1)*(size_t)(NZ_PHI1) \
+                               + (size_t)(i)*(size_t)(NY_PHI1)*(size_t)(NZ_PHI1) \
+                               + (size_t)(j)*(size_t)(NZ_PHI1) \
+                               + (size_t)(k))
+
+#define IDX4D_PHI2(p, i, j, k) ((size_t)(p)*(size_t)(NX_PHI2)*(size_t)(NY_PHI2)*(size_t)(NZ_PHI2) \
+                               + (size_t)(i)*(size_t)(NY_PHI2)*(size_t)(NZ_PHI2) \
+                               + (size_t)(j)*(size_t)(NZ_PHI2) \
+                               + (size_t)(k))
 
 
 // Material coefficients (read-only) stored in constant memory of compute device

--- a/gprMax/cuda_opencl/knl_fields_updates.py
+++ b/gprMax/cuda_opencl/knl_fields_updates.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
 #                          and Nathan Mannall
 #
 # This file is part of gprMax.
@@ -79,9 +79,11 @@ update_electric = {
     int z = (i % ($NY_FIELDS * $NZ_FIELDS)) % $NZ_FIELDS;
 
     // Convert the linear index to subscripts for 4D material ID array
-    int x_ID = (i % ($NX_ID * $NY_ID * $NZ_ID)) / ($NY_ID * $NZ_ID);
-    int y_ID = ((i % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) / $NZ_ID;
-    int z_ID = ((i % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) % $NZ_ID;
+    long long nxyz_ID = ${NX_ID}LL * ${NY_ID}LL * ${NZ_ID}LL;
+    long long i_mod = i % nxyz_ID;
+    long long x_ID = i_mod / (${NY_ID}LL * ${NZ_ID}LL);
+    long long y_ID = (i_mod % (${NY_ID}LL * ${NZ_ID}LL)) / ${NZ_ID}LL;
+    long long z_ID = i_mod % ${NZ_ID}LL;
 
     // Ex component
     if ((NY != 1 || NZ != 1) && x >= 0 && x < NX && y > 0 && y < NY && z > 0 && z < NZ) {
@@ -170,9 +172,11 @@ update_magnetic = {
     int z = (i % ($NY_FIELDS * $NZ_FIELDS)) % $NZ_FIELDS;
 
     // Convert the linear index to subscripts for 4D material ID array
-    int x_ID = (i % ($NX_ID * $NY_ID * $NZ_ID)) / ($NY_ID * $NZ_ID);
-    int y_ID = ((i % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) / $NZ_ID;
-    int z_ID = ((i % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) % $NZ_ID;
+    long long nxyz_ID = ${NX_ID}LL * ${NY_ID}LL * ${NZ_ID}LL;
+    long long i_mod = i % nxyz_ID;
+    long long x_ID = i_mod / (${NY_ID}LL * ${NZ_ID}LL);
+    long long y_ID = (i_mod % (${NY_ID}LL * ${NZ_ID}LL)) / ${NZ_ID}LL;
+    long long z_ID = i_mod % ${NZ_ID}LL;
 
     // Hx component
     if (NX != 1 && x > 0 && x < NX && y >= 0 && y < NY && z >= 0 && z < NZ) {
@@ -281,14 +285,18 @@ update_electric_dispersive_A = {
     int z = (i % ($NY_FIELDS * $NZ_FIELDS)) % $NZ_FIELDS;
 
     // Convert the linear index to subscripts for 4D material ID array
-    int x_ID = (i % ($NX_ID * $NY_ID * $NZ_ID)) / ($NY_ID * $NZ_ID);
-    int y_ID = ((i % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) / $NZ_ID;
-    int z_ID = ((i % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) % $NZ_ID;
+    long long nxyz_ID = ${NX_ID}LL * ${NY_ID}LL * ${NZ_ID}LL;
+    long long i_mod = i % nxyz_ID;
+    long long x_ID = i_mod / (${NY_ID}LL * ${NZ_ID}LL);
+    long long y_ID = (i_mod % (${NY_ID}LL * ${NZ_ID}LL)) / ${NZ_ID}LL;
+    long long z_ID = i_mod % ${NZ_ID}LL;
 
     // Convert the linear index to subscripts for 4D dispersive array
-    int x_T = (i % ($NX_T * $NY_T * $NZ_T)) / ($NY_T * $NZ_T);
-    int y_T = ((i % ($NX_T * $NY_T * $NZ_T)) % ($NY_T * $NZ_T)) / $NZ_T;
-    int z_T = ((i % ($NX_T * $NY_T * $NZ_T)) % ($NY_T * $NZ_T)) % $NZ_T;
+    long long nxyz_T = ${NX_T}LL * ${NY_T}LL * ${NZ_T}LL;
+    long long i_mod_T = i % nxyz_T;
+    long long x_T = i_mod_T / (${NY_T}LL * ${NZ_T}LL);
+    long long y_T = (i_mod_T % (${NY_T}LL * ${NZ_T}LL)) / ${NZ_T}LL;
+    long long z_T = i_mod_T % ${NZ_T}LL;
 
     // Ex component
     if ((NY != 1 || NZ != 1) && x >= 0 && x < NX && y > 0 && y < NY && z > 0 && z < NZ) {
@@ -409,15 +417,18 @@ update_electric_dispersive_B = {
     int z = (i % ($NY_FIELDS * $NZ_FIELDS)) % $NZ_FIELDS;
 
     // Convert the linear index to subscripts for 4D material ID array
-    int x_ID = (i % ($NX_ID * $NY_ID * $NZ_ID)) / ($NY_ID * $NZ_ID);
-    int y_ID = ((i % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) / $NZ_ID;
-    int z_ID = ((i % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) % $NZ_ID;
+    long long nxyz_ID = ${NX_ID}LL * ${NY_ID}LL * ${NZ_ID}LL;
+    long long i_mod = i % nxyz_ID;
+    long long x_ID = i_mod / (${NY_ID}LL * ${NZ_ID}LL);
+    long long y_ID = (i_mod % (${NY_ID}LL * ${NZ_ID}LL)) / ${NZ_ID}LL;
+    long long z_ID = i_mod % ${NZ_ID}LL;
 
     // Convert the linear index to subscripts for 4D dispersive array
-    int x_T = (i % ($NX_T * $NY_T * $NZ_T)) / ($NY_T * $NZ_T);
-    int y_T = ((i % ($NX_T * $NY_T * $NZ_T)) % ($NY_T * $NZ_T)) / $NZ_T;
-    int z_T = ((i % ($NX_T * $NY_T * $NZ_T)) % ($NY_T * $NZ_T)) % $NZ_T;
-
+    long long nxyz_T = ${NX_T}LL * ${NY_T}LL * ${NZ_T}LL;
+    long long i_mod_T = i % nxyz_T;
+    long long x_T = i_mod_T / (${NY_T}LL * ${NZ_T}LL);
+    long long y_T = (i_mod_T % (${NY_T}LL * ${NZ_T}LL)) / ${NZ_T}LL;
+    long long z_T = i_mod_T % ${NZ_T}LL;
 
     // Ex component
     if ((NY != 1 || NZ != 1) && x >= 0 && x < NX && y > 0 && y < NY && z > 0 && z < NZ) {

--- a/gprMax/receivers.py
+++ b/gprMax/receivers.py
@@ -18,6 +18,7 @@
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+
 import numpy as np
 
 import gprMax.config as config
@@ -175,9 +176,7 @@ def dtoh_rx_array(rxs_dev, rxcoords_dev, G):
                 buffer_size = rxs_dev.length()
                 rxs_buffer = rxs_dev.contents().as_buffer(buffer_size)
                 rxs_np = (
-                    np.frombuffer(
-                        rxs_buffer, dtype=config.sim_config.dtypes["float_or_double"]
-                    )
+                    np.frombuffer(rxs_buffer, dtype=config.sim_config.dtypes["float_or_double"])
                     .reshape(rxs_shape)
                     .copy()
                 )
@@ -191,14 +190,18 @@ def dtoh_rx_array(rxs_dev, rxcoords_dev, G):
                 )
 
         except Exception as e:
-            logger.exception(f"Error copying Metal buffer data: {e}, using zero-filled arrays as fallback")
+            logger.exception(
+                f"Error copying Metal buffer data: {e}, using zero-filled arrays as fallback"
+            )
 
         # Use the numpy arrays
         rxcoords_dev = rxcoords_np
         rxs_dev = rxs_np
     else:
-        rxs_dev = rxs_dev.get()
-        rxcoords_dev = rxcoords_dev.get()
+        if hasattr(rxs_dev, "get"):
+            rxs_dev = rxs_dev.get()
+        if hasattr(rxcoords_dev, "get"):
+            rxcoords_dev = rxcoords_dev.get()
 
     for rx in G.rxs:
         for rxd in range(len(G.rxs)):
@@ -208,6 +211,4 @@ def dtoh_rx_array(rxs_dev, rxcoords_dev, G):
                 and rx.zcoord == rxcoords_dev[rxd, 2]
             ):
                 for output in rx.outputs.keys():
-                    rx.outputs[output] = rxs_dev[
-                        Rx.allowableoutputs_dev.index(output), :, rxd
-                    ]
+                    rx.outputs[output] = rxs_dev[Rx.allowableoutputs_dev.index(output), :, rxd]

--- a/gprMax/updates/cuda_updates.py
+++ b/gprMax/updates/cuda_updates.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
 #                          and Nathan Mannall
 #
 # This file is part of gprMax.
@@ -69,7 +69,7 @@ class CUDAUpdates(Updates[CUDAGrid]):
         # Substitutions in function bodies
         self.subs_func = {
             "REAL": config.sim_config.dtypes["C_float_or_double"],
-            "CUDA_IDX": "int i = blockIdx.x * blockDim.x + threadIdx.x;",
+            "CUDA_IDX": "size_t i = (size_t)blockIdx.x * (size_t)blockDim.x + (size_t)threadIdx.x;",
             "NX_FIELDS": self.grid.nx + 1,
             "NY_FIELDS": self.grid.ny + 1,
             "NZ_FIELDS": self.grid.nz + 1,
@@ -548,7 +548,6 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 block=(1, 1, 1),
                 grid=(round32(len(self.grid.hertziandipoles)), 1, 1),
             )
-
 
     def update_electric_b(self):
         """If there are any dispersive materials do 2nd part of dispersive


### PR DESCRIPTION
# PR Description

<!-- Please include a summary of the changes. Please also include relevant motivation and context for making this PR. -->

The change to receivers.py fixs the following bug when trying to run a simulation using a GPU:

```ruby
Traceback (most recent call last):
  File "c:\Users\w24036099\gprMax\examples\antenna_like_GSSI_1500_patterns.py", line 78, in <module>
    gprMax.run(scenes=[scene], geometry_only=False, outputfile=fn, gpu=[0])
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\w24036099\AppData\Local\Programs\Python\Python313\Lib\site-packages\gprMax\gprMax.py", line 226, in run
    run_main(args)
    ~~~~~~~~^^^^^^
  File "C:\Users\w24036099\AppData\Local\Programs\Python\Python313\Lib\site-packages\gprMax\gprMax.py", line 341, in run_main
    results = context.run()
  File "C:\Users\w24036099\AppData\Local\Programs\Python\Python313\Lib\site-packages\gprMax\contexts.py", line 94, in run
    self._run_model(i)
    ~~~~~~~~~~~~~~~^^^
  File "C:\Users\w24036099\AppData\Local\Programs\Python\Python313\Lib\site-packages\gprMax\contexts.py", line 120, in _run_model
    model.solve(solver)
    ~~~~~~~~~~~^^^^^^^^
  File "C:\Users\w24036099\AppData\Local\Programs\Python\Python313\Lib\site-packages\gprMax\model.py", line 543, in solve
    solver.solve(iterator)
    ~~~~~~~~~~~~^^^^^^^^^^
  File "C:\Users\w24036099\AppData\Local\Programs\Python\Python313\Lib\site-packages\gprMax\solvers.py", line 88, in solve
    self.updates.finalise()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File "C:\Users\w24036099\AppData\Local\Programs\Python\Python313\Lib\site-packages\gprMax\updates\cuda_updates.py", line 608, in finalise
    dtoh_rx_array(self.rxs_dev.get(), self.rxcoords_dev.get(), self.grid)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\w24036099\AppData\Local\Programs\Python\Python313\Lib\site-packages\gprMax\receivers.py", line 200, in dtoh_rx_array
    rxs_dev = rxs_dev.get()
              ^^^^^^^^^^^
AttributeError: 'numpy.ndarray' object has no attribute 'get'
-------------------------------------------------------------------
PyCUDA ERROR: The context stack was not empty upon module cleanup.
-------------------------------------------------------------------
A context was still active when the context stack was being
cleaned up. At this point in our execution, CUDA may already
have been deinitialized, so there is no way we can finish
cleanly. The program will be aborted now.
Use Context.pop() to avoid this problem.
-------------------------------------------------------------------
```

The changes to knl/cuda resolve overflows with memory when trying to use a GPU for a simulation that uses in excess of ~65Gb VRAM, by changing the previously used 32-bit int with 64-bit size_t and long long for relevant 3D and 4D calculations.

## Motivation

I'm currently using NVIDIA provided A100 80Gb GPUs to run simulations with gprMax, however, when trying to run models that require high memory usage (>~65Gb) with a GPU, overflow errors occur that crash the simulation, caused by the simulation being in excess of the 32-bit limit (having a domain larger than 2m^3). These fixes allow for the use of high-end GPUs and larger domain sizes for simulations using a GPU.

## 🛠️ Related Issue (Number)

<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

Closes N/A

## Type of change

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [x] Did pre-commit passed all checks?
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.
