### PR TITLE
Add --save and --output-dir options for plot_Bscan

### DIFF
--- a/tools/plot_Bscan.py
+++ b/tools/plot_Bscan.py
@@ -72,7 +72,7 @@ def mpl_plot(filename, outputdata, dt, rxnumber, rxcomponent):
     # fig.savefig(path + os.sep + savefile + '.png', dpi=150, format='png', 
     #             bbox_inches='tight', pad_inches=0.1)
 
-    return plt
+    return fig
 
 
 if __name__ == "__main__":
@@ -80,6 +80,7 @@ if __name__ == "__main__":
     # Parse command line arguments
     parser = argparse.ArgumentParser(description='Plots a B-scan image.', 
                                      usage='cd gprMax; python -m tools.plot_Bscan outputfile output')
+    parser.add_argument('--save', help='Path to save the plot image (e.g., output.png)', default=None)
     parser.add_argument('outputfile', help='name of output file including path')
     parser.add_argument('rx_component', help='name of output component to be plotted', 
                         choices=['Ex', 'Ey', 'Ez', 'Hx', 'Hy', 'Hz', 'Ix', 'Iy', 'Iz'])
@@ -96,6 +97,10 @@ if __name__ == "__main__":
 
     for rx in range(1, nrx + 1):
         outputdata, dt = get_output_data(args.outputfile, rx, args.rx_component)
-        plthandle = mpl_plot(args.outputfile, outputdata, dt, rx, args.rx_component)
+        fig = mpl_plot(args.outputfile, outputdata, dt, rx, args.rx_component)
 
-    plthandle.show()
+    if args.save:
+        fig.savefig(args.save, dpi=300)
+        print(f"Plot saved to {args.save}")
+    else:
+        fig.show()


### PR DESCRIPTION
# PR Description

This PR adds the ability to save B-scan plots directly from tools/plot_Bscan.py using a new --save argument.
Previously, the tool only supported plt.show(), which caused failures in Docker/HPC environments with no display.
This enhancement allows users to generate plots non-interactively.

Closes #

## Type of change

Added --save command-line option to specify output file path.

Added optional --output-dir argument (if you implemented it).

Enabled saving plots using fig.savefig().

Ensured backward compatibility — behaviour is unchanged if --save is not supplied.

The plotting tools currently cannot save figures unless modified manually.
Users running gprMax inside:

Docker containers

HPC clusters

Headless servers

…cannot use plt.show() because it fails without a display.

This PR solves that problem by allowing plots to be saved directly to file.
