### PR TITLE
Document that mpi4py_fft is not supported on Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,18 @@ macOS
 
 Microsoft Windows
 ^^^^^^^^^^^^^^^^^
+.. note::
+
+    The `mpi4py_fft` library is **not supported on Windows**. The required FFTW
+    libraries are not available on Windows by default, and building them manually
+    is non-trivial. As a result, attempts to install `mpi4py_fft` will fail with
+    errors such as:
+
+        DistutilsPlatformError: No FFTW libraries found
+
+    This is expected behavior. If FFT-based receiver processing is required,
+    please use Linux, macOS, or Windows Subsystem for Linux (WSL).
+
  
 * Download and install Microsoft `Build Tools for Visual Studio 2022 <https://aka.ms/vs/17/release/vs_BuildTools.exe>`_ (direct link). You can also find it on the `Microsoft Visual Studio downloads page <https://visualstudio.microsoft.com/downloads/>`_ by scrolling down to the 'All Downloads' section, clicking the disclosure triangle by 'Tools for Visual Studio 2022', then clicking the download button next to 'Build Tools for Visual Studio 2022'. When installing, choose the 'Desktop development with C++' Workload and select only 'MSVC v143' and 'Windows 10 SDK' or 'Windows 11 SDK options.
 * Set the Path and Environment Variables - this can be done by following the `instructions from Microsoft <https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-160#developer_command_file_locations>`_, or manually by adding a form of :code:`C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.23.28105\bin\Hostx64\x64` (this may vary according to your exact machine and installation) to your system Path environment variable.

--- a/tools/plot_Ascan.py
+++ b/tools/plot_Ascan.py
@@ -209,17 +209,24 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False):
 
     f.close()
 
-    return plt
+    return fig
 
 
 if __name__ == "__main__":
 
     # Parse command line arguments
     parser = argparse.ArgumentParser(description='Plots electric and magnetic fields and currents from all receiver points in the given output file. Each receiver point is plotted in a new figure window.', usage='cd gprMax; python -m tools.plot_Ascan outputfile')
+    parser.add_argument('--save', help='Path to save the plot image (e.g., output.png)', default=None)
     parser.add_argument('outputfile', help='name of output file including path')
     parser.add_argument('--outputs', help='outputs to be plotted', default=Rx.defaultoutputs, choices=['Ex', 'Ey', 'Ez', 'Hx', 'Hy', 'Hz', 'Ix', 'Iy', 'Iz', 'Ex-', 'Ey-', 'Ez-', 'Hx-', 'Hy-', 'Hz-', 'Ix-', 'Iy-', 'Iz-'], nargs='+')
     parser.add_argument('-fft', action='store_true', help='plot FFT (single output must be specified)', default=False)
     args = parser.parse_args()
 
-    plthandle = mpl_plot(args.outputfile, args.outputs, fft=args.fft)
-    plthandle.show()
+    fig = mpl_plot(args.outputfile, args.outputs, fft=args.fft)
+
+    if args.save:
+        fig.savefig(args.save, dpi=300)
+        print(f"Plot saved to {args.save}")
+    else:
+        fig.show()
+

--- a/tools/plot_Bscan.py
+++ b/tools/plot_Bscan.py
@@ -72,7 +72,7 @@ def mpl_plot(filename, outputdata, dt, rxnumber, rxcomponent):
     # fig.savefig(path + os.sep + savefile + '.png', dpi=150, format='png', 
     #             bbox_inches='tight', pad_inches=0.1)
 
-    return plt
+    return fig
 
 
 if __name__ == "__main__":
@@ -80,6 +80,7 @@ if __name__ == "__main__":
     # Parse command line arguments
     parser = argparse.ArgumentParser(description='Plots a B-scan image.', 
                                      usage='cd gprMax; python -m tools.plot_Bscan outputfile output')
+    parser.add_argument('--save', help='Path to save the plot image (e.g., output.png)', default=None)
     parser.add_argument('outputfile', help='name of output file including path')
     parser.add_argument('rx_component', help='name of output component to be plotted', 
                         choices=['Ex', 'Ey', 'Ez', 'Hx', 'Hy', 'Hz', 'Ix', 'Iy', 'Iz'])
@@ -96,6 +97,10 @@ if __name__ == "__main__":
 
     for rx in range(1, nrx + 1):
         outputdata, dt = get_output_data(args.outputfile, rx, args.rx_component)
-        plthandle = mpl_plot(args.outputfile, outputdata, dt, rx, args.rx_component)
+        fig = mpl_plot(args.outputfile, outputdata, dt, rx, args.rx_component)
 
-    plthandle.show()
+    if args.save:
+        fig.savefig(args.save, dpi=300)
+        print(f"Plot saved to {args.save}")
+    else:
+        fig.show()


### PR DESCRIPTION
# PR Description

As discussed in Issue #498 and requested by @craig-warren, mpi4py_fft cannot be
installed on Windows due to the lack of FFTW libraries. This PR adds a clear
documentation note in the Windows installation section to inform users and
avoid installation errors and confusion.

