### PR TITLE
Add a minimal CI workflow for basic checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+        
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        # Install gprMax (compiles extensions)
+        pip install .
+
+    - name: Run tests
+      run: |
+        # Run a fast, minimal test suite to verify installation and basic functionality
+        python -m unittest tests/test_input_cmd_funcs.py
+        # Verify the command line interface runs
+        python -m gprMax --version


### PR DESCRIPTION
This PR adds a minimal GitHub Actions workflow to run basic checks on pushes and pull requests.

The goal is to provide early feedback without changing any existing code, tests, or configuration, and to keep the setup as small and non-intrusive as possible.

Fixes #543 