### PR TITLE
Fix #plate to apply only electric material properties

### DIFF
--- a/gprMax/input_cmds_geometry.py
+++ b/gprMax/input_cmds_geometry.py
@@ -277,7 +277,11 @@ def process_geometrycmds(geometry, G):
 
                 for j in range(ys, yf):
                     for k in range(zs, zf):
-                        build_face_yz(xs, j, k, numIDy, numIDz, G.rigidE, G.rigidH, G.ID)
+                        # NOTE:
+                        # Plates only apply electric material properties.
+                        # Magnetic material assignment is intentionally disabled to match #edge behaviour.
+
+                        build_face_yz(xs, j, k, numIDy, numIDz, G.rigidE, None, G.ID)
 
             # xz-plane plate
             elif ys == yf:
@@ -292,7 +296,7 @@ def process_geometrycmds(geometry, G):
 
                 for i in range(xs, xf):
                     for k in range(zs, zf):
-                        build_face_xz(i, ys, k, numIDx, numIDz, G.rigidE, G.rigidH, G.ID)
+                        build_face_xz(i, ys, k, numIDx, numIDz, G.rigidE, None, G.ID)
 
             # xy-plane plate
             elif zs == zf:
@@ -307,7 +311,7 @@ def process_geometrycmds(geometry, G):
 
                 for i in range(xs, xf):
                     for j in range(ys, yf):
-                        build_face_xy(i, j, zs, numIDx, numIDy, G.rigidE, G.rigidH, G.ID)
+                        build_face_xy(i, j, zs, numIDx, numIDy, G.rigidE, None, G.ID)
 
             if G.messages:
                 tqdm.write('Plate from {:g}m, {:g}m, {:g}m, to {:g}m, {:g}m, {:g}m of material(s) {} created.'.format(xs * G.dx, ys * G.dy, zs * G.dz, xf * G.dx, yf * G.dy, zf * G.dz, ', '.join(materialsrequested)))


### PR DESCRIPTION
### Summary
This PR fixes the handling of material properties for `#plate` objects.

### Details
- `#plate` objects now apply **only electric material properties**
- Magnetic material assignment is explicitly disabled
- Behaviour is now consistent with the `#edge` command

This addresses issue #158, where magnetic material properties were previously applied to incorrect H-field components for plate objects.

### Notes
- Backward compatible
- No impact on volumetric (3D) objects

Fixes #158