### PR TITLE
fixing small typo bug

### DIFF
--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -43,7 +43,7 @@ availablecomponents = list(f[path].keys())
 # Check for polarity of output and if requested output is in file
 if args.output[0][0] == 'm':
     polarity = -1
-    args.outputs[0] = args.output[0][1:]
+    args.output[0] = args.output[0][1:]
 else:
     polarity = 1
 


### PR DESCRIPTION
# PR Description

This PR fixes a small but critical typo in [tests/test_experimental.py](cci:7://file:///d:/Coding/OpenSource/gprMax/tests/test_experimental.py:0:0-0:0). 

When a user attempts to plot a component with negative polarity (e.g., an output starting with `m`), the script correctly identifies the polarity but attempts to reassign the modified output string to `args.outputs[0]` instead of `args.output[0]`. Because `outputs` does not exist in the argparse namespace, this immediately crashes the script with an `AttributeError`. 

This PR applies a one-letter fix to resolve the bug, allowing the script to properly parse and plot negative polarity components.

## 🛠️ Related Issue (Number)

Closes #561

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update.

## Checklist

- [ ] Did pre-commit passed all checks?
- [x] I have performed a self-review of my code.
- [ ] I have added comments for my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.
