### PR TITLE
Fix outdated discrete plane wave test to use #plane_wave_angles

### DIFF
--- a/reframe_tests/tests/src/source_tests/discrete_plane_wave_fs.in
+++ b/reframe_tests/tests/src/source_tests/discrete_plane_wave_fs.in
@@ -4,5 +4,5 @@
 #time_window: 3e-9
 
 #waveform: gaussiandot 1 1e9 myWave
-#discrete_plane_wave: 0.010 0.010 0.010 0.040 0.040 0.040 90.0 63.4 36.7 myWave
+#plane_wave_angles: 0.010 0.010 0.010 0.040 0.040 0.040 36.7 63.4 90.0 myWave
 #rx: 0.070 0.070 0.070


### PR DESCRIPTION
## PR Description

The test `reframe_tests/tests/src/source_tests/discrete_plane_wave_fs.in`
currently uses the command `#discrete_plane_wave`, which is no longer
recognised by the parser in the `devel` branch.

This causes the example to fail with a `SyntaxError`.

This PR updates the test to use the current `#plane_wave_angles`
command with the correct parameter ordering so that the example
executes successfully with the CPU solver.

GPU execution still raises the expected limitation that plane wave
sources are not yet supported on CUDA/OpenCL backends.

Closes #553

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

---

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] The title of my pull request is a short description of my changes