### PR TITLE
Add GitHub Actions CI workflows for testing, linting, and documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,124 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install flake8
+        run: pip install flake8
+
+      - name: Check for syntax errors and undefined names (blocking)
+        run: |
+          flake8 gprMax/ tests/ tools/ \
+            --count --select=E9,F63,F7,F82 \
+            --show-source --statistics
+
+      - name: Check code style (informational, non-blocking)
+        run: |
+          flake8 gprMax/ tests/ tools/ \
+            --count --exit-zero \
+            --max-line-length=120 \
+            --statistics
+
+  build-and-unit-test:
+    name: Build & Unit Tests (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python-version: '3.10'
+          - os: ubuntu-latest
+            python-version: '3.11'
+          - os: ubuntu-latest
+            python-version: '3.12'
+          # macOS: continue-on-error because setup.py GCC detection
+          # uses glob patterns that may not match modern gcc-14+ versions correctly.
+          - os: macos-latest
+            python-version: '3.11'
+            continue-on-error: true
+          - os: windows-latest
+            python-version: '3.11'
+
+    # Per-matrix continue-on-error requires this workaround
+    continue-on-error: ${{ matrix.continue-on-error == true }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install GCC with OpenMP support (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y gcc
+
+      - name: Install GCC with OpenMP support (macOS)
+        if: runner.os == 'macOS'
+        run: brew install gcc
+
+      - name: Upgrade pip and install wheel
+        run: python -m pip install --upgrade pip wheel
+
+      - name: Build and install gprMax (compiles 11 Cython extensions)
+        run: pip install -e .
+
+      - name: Run unit tests
+        run: python -m unittest tests.test_input_cmd_funcs -v
+
+  model-tests:
+    name: Model Tests (Ubuntu, Python 3.11)
+    runs-on: ubuntu-latest
+    needs: build-and-unit-test
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install GCC
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y gcc
+
+      - name: Upgrade pip and install wheel
+        run: python -m pip install --upgrade pip wheel
+
+      - name: Build and install gprMax (compiles 11 Cython extensions)
+        run: pip install -e .
+
+      - name: Run basic model tests (9 FDTD simulations vs analytical/reference solutions)
+        run: python -m tests.test_models

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-docs:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install GCC (required for Cython extension compilation)
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y gcc
+
+      - name: Upgrade pip and install wheel
+        run: python -m pip install --upgrade pip wheel
+
+      - name: Build and install gprMax (gprMax must be importable for Sphinx autodoc)
+        run: pip install -e .
+
+      - name: Install Sphinx and documentation dependencies
+        run: pip install sphinx sphinx_rtd_theme
+
+      - name: Build HTML documentation
+        run: sphinx-build -b html docs/source docs/build/html
+
+      - name: Upload documentation as artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: documentation-html
+          path: docs/build/html/
+          retention-days: 7

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx_rtd_theme


### PR DESCRIPTION
## Summary

- Fixed #564 
- Add `.github/workflows/ci.yml` with lint, build, unit test, and model test jobs across Ubuntu, macOS, and Windows
- Add `.github/workflows/docs.yml` to verify Sphinx documentation builds on PRs to master
- Add `docs/requirements.txt` (was referenced in `.readthedocs.yaml` but missing, breaking ReadTheDocs builds)

## CI Workflow Details

**`ci.yml`** triggers on every push and PR:
| Job | Platform | Python |
|---|---|---|
| lint (flake8) | Ubuntu | 3.11 |
| build + unit tests | Ubuntu | 3.10, 3.11, 3.12 |
| build + unit tests | macOS (non-blocking) | 3.11 |
| build + unit tests | Windows | 3.11 |
| model tests (9 FDTD simulations) | Ubuntu | 3.11 |

**`docs.yml`** triggers on push/PR to `master` — builds Sphinx HTML and uploads as a downloadable artifact.

## Notes

- macOS is marked `continue-on-error: true` because `setup.py`'s GCC detection uses glob patterns (`gcc-[10-11]*`) that do not correctly match modern Homebrew `gcc-14+` binary names
- Model tests (`tests/test_models.py`) run all 9 basic models from `tests/models_basic/`; the job fails if any simulation crashes or produces NaN values
- `docs/requirements.txt` fix also resolves the broken ReadTheDocs build

