### PR TITLE
Add --save option to plotting tools for headless/Docker environments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,6 +161,12 @@ When the simulation is complete you can plot the A-scan using:
 
     (gprMax)$ python -m tools.plot_Ascan user_models/cylinder_Ascan_2D.out
 
+To save the plot to a file instead of displaying it (e.g. in Docker or on a headless server), use ``--save``:
+
+.. code-block:: bash
+
+    (gprMax)$ python -m tools.plot_Ascan user_models/cylinder_Ascan_2D.out --save output_plot.png
+
 Your results should be like those from the A-scan from the metal cylinder example in `introductory/basic 2D models section <http://docs.gprmax.com/en/latest/examples_simple_2D.html#view-the-results>`_
 
 When you are finished using gprMax, the conda environment can be deactivated using :code:`conda deactivate`.

--- a/docs/source/plotting.rst
+++ b/docs/source/plotting.rst
@@ -23,12 +23,19 @@ There are optional command line arguments:
 
 * ``--outputs`` to specify a subset of the default output components (``Ex``, ``Ey``, ``Ez``, ``Hx``, ``Hy``, ``Hz``, ``Ix``, ``Iy`` or ``Iz``) to plot. By default all electric and magnetic field components are plotted.
 * ``-fft`` to plot the Fast Fourier Transform (FFT) of a single output component
+* ``--save output_file`` to save the plot(s) to a file instead of displaying them. Useful in headless environments (Docker, HPC, remote servers). Output directories are created if they do not exist. If there are multiple receivers, each figure is saved with a ``_rxN`` suffix before the extension.
 
 For example to plot the ``Ez`` output component with it's FFT:
 
 .. code-block:: none
 
     python -m tools.plot_Ascan my_outputfile.out --outputs Ez -fft
+
+To save the plot to a file (e.g. for use in Docker or when no display is available):
+
+.. code-block:: none
+
+    python -m tools.plot_Ascan my_outputfile.out --outputs Ez --save plots/ascan.png
 
 B-scans
 =======
@@ -47,6 +54,14 @@ where:
 * ``outputfile`` is the name of output file including the path
 * ``rx-component`` is the name of the receiver output component (``Ex``, ``Ey``, ``Ez``, ``Hx``, ``Hy``, ``Hz``, ``Ix``, ``Iy`` or ``Iz``) to plot
 
+Optional argument:
+
+* ``--save output_file`` to save the plot(s) to a file instead of displaying them. Useful in headless environments (Docker, HPC). Multiple receivers get a ``_rxN`` suffix. Example:
+
+.. code-block:: none
+
+    python -m tools.plot_Bscan my_merged.out Ez --save results/bscan.png
+
 
 Antenna parameters
 ==================
@@ -61,6 +76,8 @@ This module uses matplotlib to plot the input impedance (resistance and reactanc
     python -m tools.plot_antenna_params outputfile
 
 where ``outputfile`` is the name of output file including the path.
+
+Optional command line arguments include ``--save output_file`` to save the two figures (transmission line parameters and antenna parameters) to files with ``_tl_params`` and ``_ant_params`` suffixes instead of displaying them.
 
 There are optional command line arguments:
 
@@ -92,6 +109,8 @@ This module uses matplotlib to plot one of the built-in waveforms and it's FFT. 
 
     python -m tools.plot_source_wave type amp freq timewindow dt
 
+Optional argument: ``--save output_file`` to save the figure to a file instead of displaying it (e.g. in headless environments).
+
 where:
 
 * ``type`` is the type of waveform, e.g. gaussian, ricker etc...
@@ -100,9 +119,10 @@ where:
 * ``timewindow`` is the time window (seconds) to view the waveform, i.e. the time window of the proposed simulation
 * ``dt`` is the time step (seconds) to view waveform, i.e. the time step of the proposed simulation
 
-There is an optional command line argument:
+There are optional command line arguments:
 
 * ``-fft`` to plot the Fast Fourier Transform (FFT) of the waveform
+* ``--save output_file`` to save the figure to a file instead of displaying it
 
 Definitions
 -----------

--- a/tests/test_plot_save.py
+++ b/tests/test_plot_save.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2015-2023: The University of Edinburgh
+#                 Authors: Craig Warren and Antonis Giannopoulos
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the --save option in plotting tools (plot_Ascan, plot_Bscan, etc.)."""
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+def _run_plot_tool(module_name, args):
+    """Run a tools plot module with given args; returns (returncode, stdout, stderr)."""
+    cmd = [sys.executable, '-m', 'tools.' + module_name] + args
+    proc = subprocess.run(
+        cmd,
+        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+class TestPlotSave(unittest.TestCase):
+    """Verify that plotting tools create files when --save is used."""
+
+    def test_plot_source_wave_save_creates_file(self):
+        """plot_source_wave with --save creates the output file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outpath = os.path.join(tmpdir, 'subdir', 'waveform.png')
+            code, out, err = _run_plot_tool('plot_source_wave', [
+                'ricker', '1', '1e9', '6e-9', '1.926e-12', '--save', outpath
+            ])
+            self.assertEqual(code, 0, 'plot_source_wave failed: {}'.format(err or out))
+            self.assertTrue(os.path.isfile(outpath), 'Expected file at {}'.format(outpath))
+            self.assertGreater(os.path.getsize(outpath), 0, 'Output file should not be empty')
+
+    def test_plot_Ascan_save_creates_file(self):
+        """plot_Ascan with --save creates the output file."""
+        outfile = os.path.join(os.path.dirname(__file__), 'models_basic', 'cylinder_Ascan_2D', 'cylinder_Ascan_2D.out')
+        if not os.path.isfile(outfile):
+            self.skipTest('Test output file not found: {}'.format(outfile))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outpath = os.path.join(tmpdir, 'plots', 'ascan.png')
+            code, out, err = _run_plot_tool('plot_Ascan', [
+                outfile, '--outputs', 'Ez', '--save', outpath
+            ])
+            self.assertEqual(code, 0, 'plot_Ascan failed: {}'.format(err or out))
+            self.assertTrue(os.path.isfile(outpath), 'Expected file at {}'.format(outpath))
+            self.assertGreater(os.path.getsize(outpath), 0, 'Output file should not be empty')
+
+    def test_plot_Bscan_save_creates_file(self):
+        """plot_Bscan with --save creates the output file (requires merged B-scan .out)."""
+        # plot_Bscan expects 2D data (traces x time); use merged file if present
+        merged = os.path.join(os.path.dirname(__file__), 'models_basic', 'cylinder_Bscan_2D_merged', 'cylinder_Bscan_2D_merged.out')
+        if not os.path.isfile(merged):
+            merged = os.path.join(os.path.dirname(__file__), 'user_models', 'cylinder_Bscan_2D_merged.out')
+        if not os.path.isfile(merged):
+            self.skipTest('Merged B-scan output file not found (run outputfiles_merge first)')
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outpath = os.path.join(tmpdir, 'bscan.png')
+            code, out, err = _run_plot_tool('plot_Bscan', [
+                merged, 'Ez', '--save', outpath
+            ])
+            self.assertEqual(code, 0, 'plot_Bscan failed: {}'.format(err or out))
+            self.assertTrue(os.path.isfile(outpath), 'Expected file at {}'.format(outpath))
+            self.assertGreater(os.path.getsize(outpath), 0, 'Output file should not be empty')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/plot_Ascan.py
+++ b/tools/plot_Ascan.py
@@ -28,13 +28,27 @@ from gprMax.receivers import Rx
 from gprMax.utilities import fft_power
 
 
-def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False):
+def _ensure_output_dir(path):
+    """Create parent directory for path if it does not exist."""
+    dirname = os.path.dirname(path)
+    if dirname:
+        os.makedirs(dirname, exist_ok=True)
+
+
+def _save_path_with_suffix(path, rx):
+    """Insert receiver number before extension for multi-receiver save paths."""
+    base, ext = os.path.splitext(path)
+    return base + '_rx' + str(rx) + ext
+
+
+def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False, save_path=None):
     """Plots electric and magnetic fields and currents from all receiver points in the given output file. Each receiver point is plotted in a new figure window.
 
     Args:
         filename (string): Filename (including path) of output file.
         outputs (list): List of field/current components to plot.
         fft (boolean): Plot FFT switch.
+        save_path (string, optional): If provided, save each figure to this path (with receiver suffix for multiple receivers). Directories are created as needed.
 
     Returns:
         plt (object): matplotlib plot object.
@@ -126,7 +140,12 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False):
                     plt.setp(stemlines, 'color', 'b')
                     plt.setp(markerline, 'markerfacecolor', 'b', 'markeredgecolor', 'b')
 
-                plt.show()
+                if save_path is None:
+                    plt.show()
+                else:
+                    outpath = save_path if nrx == 1 else _save_path_with_suffix(save_path, rx)
+                    _ensure_output_dir(outpath)
+                    fig.savefig(outpath, dpi=150, bbox_inches='tight', pad_inches=0.1)
 
             # Plotting if no FFT required
             else:
@@ -141,6 +160,11 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False):
                 elif 'I' in output:
                     plt.setp(line, color='b')
                     plt.setp(ax, ylabel=outputtext + ', current [A]')
+
+                if save_path is not None:
+                    outpath = save_path if nrx == 1 else _save_path_with_suffix(save_path, rx)
+                    _ensure_output_dir(outpath)
+                    fig.savefig(outpath, dpi=150, bbox_inches='tight', pad_inches=0.1)
 
         # If multiple outputs required, create all nine subplots and populate only the specified ones
         else:
@@ -203,9 +227,10 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False):
                     ax.set_xlim([0, np.amax(time)])
                     ax.grid(which="both", axis="both", linestyle="-.")
 
-        # Save a PDF/PNG of the figure
-        # fig.savefig(os.path.splitext(os.path.abspath(filename))[0] + '_rx' + str(rx) + '.pdf', dpi=None, format='pdf', bbox_inches='tight', pad_inches=0.1)
-        # fig.savefig(os.path.splitext(os.path.abspath(filename))[0] + '_rx' + str(rx) + '.png', dpi=150, format='png', bbox_inches='tight', pad_inches=0.1)
+            if save_path is not None:
+                outpath = save_path if nrx == 1 else _save_path_with_suffix(save_path, rx)
+                _ensure_output_dir(outpath)
+                fig.savefig(outpath, dpi=150, bbox_inches='tight', pad_inches=0.1)
 
     f.close()
 
@@ -219,7 +244,9 @@ if __name__ == "__main__":
     parser.add_argument('outputfile', help='name of output file including path')
     parser.add_argument('--outputs', help='outputs to be plotted', default=Rx.defaultoutputs, choices=['Ex', 'Ey', 'Ez', 'Hx', 'Hy', 'Hz', 'Ix', 'Iy', 'Iz', 'Ex-', 'Ey-', 'Ez-', 'Hx-', 'Hy-', 'Hz-', 'Ix-', 'Iy-', 'Iz-'], nargs='+')
     parser.add_argument('-fft', action='store_true', help='plot FFT (single output must be specified)', default=False)
+    parser.add_argument('--save', metavar='output_file', dest='save', help='save plot(s) to file instead of displaying (creates directories if needed; multiple receivers get _rxN suffix)')
     args = parser.parse_args()
 
-    plthandle = mpl_plot(args.outputfile, args.outputs, fft=args.fft)
-    plthandle.show()
+    plthandle = mpl_plot(args.outputfile, args.outputs, fft=args.fft, save_path=args.save)
+    if args.save is None:
+        plthandle.show()

--- a/tools/plot_Bscan.py
+++ b/tools/plot_Bscan.py
@@ -27,7 +27,20 @@ from gprMax.exceptions import CmdInputError
 from .outputfiles_merge import get_output_data
 
 
-def mpl_plot(filename, outputdata, dt, rxnumber, rxcomponent):
+def _ensure_output_dir(path):
+    """Create parent directory for path if it does not exist."""
+    dirname = os.path.dirname(path)
+    if dirname:
+        os.makedirs(dirname, exist_ok=True)
+
+
+def _save_path_with_suffix(path, rx):
+    """Insert receiver number before extension for multi-receiver save paths."""
+    base, ext = os.path.splitext(path)
+    return base + '_rx' + str(rx) + ext
+
+
+def mpl_plot(filename, outputdata, dt, rxnumber, rxcomponent, save_path=None):
     """Creates a plot (with matplotlib) of the B-scan.
 
     Args:
@@ -36,6 +49,7 @@ def mpl_plot(filename, outputdata, dt, rxnumber, rxcomponent):
         dt (float): Temporal resolution of the model.
         rxnumber (int): Receiver output number.
         rxcomponent (str): Receiver output field/current component.
+        save_path (string, optional): If provided, save figure to this path (with receiver suffix for multiple receivers). Directories are created as needed.
 
     Returns:
         plt (object): matplotlib plot object.
@@ -43,15 +57,14 @@ def mpl_plot(filename, outputdata, dt, rxnumber, rxcomponent):
 
     (path, filename) = os.path.split(filename)
 
-    fig = plt.figure(num=filename + ' - rx' + str(rxnumber), 
+    fig = plt.figure(num=filename + ' - rx' + str(rxnumber),
                      figsize=(20, 10), facecolor='w', edgecolor='w')
-    plt.imshow(outputdata, 
-               extent=[0, outputdata.shape[1], outputdata.shape[0] * dt, 0], 
-               interpolation='nearest', aspect='auto', cmap='seismic', 
+    plt.imshow(outputdata,
+               extent=[0, outputdata.shape[1], outputdata.shape[0] * dt, 0],
+               interpolation='nearest', aspect='auto', cmap='seismic',
                vmin=-np.amax(np.abs(outputdata)), vmax=np.amax(np.abs(outputdata)))
     plt.xlabel('Trace number')
     plt.ylabel('Time [s]')
-    # plt.title('{}'.format(filename))
 
     # Grid properties
     ax = fig.gca()
@@ -65,12 +78,9 @@ def mpl_plot(filename, outputdata, dt, rxnumber, rxcomponent):
     elif 'I' in rxcomponent:
         cb.set_label('Current [A]')
 
-    # Save a PDF/PNG of the figure
-    # savefile = os.path.splitext(filename)[0]
-    # fig.savefig(path + os.sep + savefile + '.pdf', dpi=None, format='pdf', 
-    #             bbox_inches='tight', pad_inches=0.1)
-    # fig.savefig(path + os.sep + savefile + '.png', dpi=150, format='png', 
-    #             bbox_inches='tight', pad_inches=0.1)
+    if save_path is not None:
+        _ensure_output_dir(save_path)
+        fig.savefig(save_path, dpi=150, bbox_inches='tight', pad_inches=0.1)
 
     return plt
 
@@ -81,8 +91,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Plots a B-scan image.', 
                                      usage='cd gprMax; python -m tools.plot_Bscan outputfile output')
     parser.add_argument('outputfile', help='name of output file including path')
-    parser.add_argument('rx_component', help='name of output component to be plotted', 
+    parser.add_argument('rx_component', help='name of output component to be plotted',
                         choices=['Ex', 'Ey', 'Ez', 'Hx', 'Hy', 'Hz', 'Ix', 'Iy', 'Iz'])
+    parser.add_argument('--save', metavar='output_file', dest='save', help='save plot(s) to file instead of displaying (creates directories if needed; multiple receivers get _rxN suffix)')
     args = parser.parse_args()
 
     # Open output file and read number of outputs (receivers)
@@ -96,6 +107,10 @@ if __name__ == "__main__":
 
     for rx in range(1, nrx + 1):
         outputdata, dt = get_output_data(args.outputfile, rx, args.rx_component)
-        plthandle = mpl_plot(args.outputfile, outputdata, dt, rx, args.rx_component)
+        save_path = None
+        if args.save is not None:
+            save_path = args.save if nrx == 1 else _save_path_with_suffix(args.save, rx)
+        plthandle = mpl_plot(args.outputfile, outputdata, dt, rx, args.rx_component, save_path=save_path)
 
-    plthandle.show()
+    if args.save is None:
+        plthandle.show()

--- a/tools/plot_antenna_params.py
+++ b/tools/plot_antenna_params.py
@@ -148,7 +148,14 @@ def calculate_antenna_params(filename, tltxnumber=1, tlrxnumber=None, rxnumber=N
     return antennaparams
 
 
-def mpl_plot(filename, time, freqs, Vinc, Vincp, Iinc, Iincp, Vref, Vrefp, Iref, Irefp, Vtotal, Vtotalp, Itotal, Itotalp, s11, zin, yin, s21=None):
+def _ensure_output_dir(path):
+    """Create parent directory for path if it does not exist."""
+    dirname = os.path.dirname(path)
+    if dirname:
+        os.makedirs(dirname, exist_ok=True)
+
+
+def mpl_plot(filename, time, freqs, Vinc, Vincp, Iinc, Iincp, Vref, Vrefp, Iref, Irefp, Vtotal, Vtotalp, Itotal, Itotalp, s11, zin, yin, s21=None, save_path=None):
     """Plots antenna parameters - incident, reflected and total volatges and currents; s11, (s21) and input impedance.
 
     Args:
@@ -160,6 +167,7 @@ def mpl_plot(filename, time, freqs, Vinc, Vincp, Iinc, Iincp, Vref, Vrefp, Iref,
         Vtotal, Vtotalp, Itotal, Itotalp (array): Time and frequency domain representations of total voltage and current.
         s11, s21 (array): s11 and, optionally, s21 parameters.
         zin, yin (array): Input impedance and input admittance parameters.
+        save_path (string, optional): If provided, save the two figures to this path (base name; _tl_params and _ant_params are appended). Directories are created as needed.
 
     Returns:
         plt (object): matplotlib plot object.
@@ -399,11 +407,12 @@ def mpl_plot(filename, time, freqs, Vinc, Vincp, Iinc, Iincp, Vref, Vrefp, Iref,
     # ax.set_ylim([-40, 100])
     # ax.grid(which='both', axis='both', linestyle='-.')
 
-    # Save a PDF/PNG of the figure
-    # fig1.savefig(os.path.splitext(os.path.abspath(filename))[0] + '_tl_params.png', dpi=150, format='png', bbox_inches='tight', pad_inches=0.1)
-    # fig2.savefig(os.path.splitext(os.path.abspath(filename))[0] + '_ant_params.png', dpi=150, format='png', bbox_inches='tight', pad_inches=0.1)
-    # fig1.savefig(os.path.splitext(os.path.abspath(filename))[0] + '_tl_params.pdf', dpi=None, format='pdf', bbox_inches='tight', pad_inches=0.1)
-    # fig2.savefig(os.path.splitext(os.path.abspath(filename))[0] + '_ant_params.pdf', dpi=None, format='pdf', bbox_inches='tight', pad_inches=0.1)
+    if save_path is not None:
+        _ensure_output_dir(save_path)
+        base, ext = os.path.splitext(save_path)
+        suffix = ext if ext else '.png'
+        fig1.savefig(base + '_tl_params' + suffix, dpi=150, bbox_inches='tight', pad_inches=0.1)
+        fig2.savefig(base + '_ant_params' + suffix, dpi=150, bbox_inches='tight', pad_inches=0.1)
 
     return plt
 
@@ -417,8 +426,10 @@ if __name__ == "__main__":
     parser.add_argument('--tlrx-num', type=int, help='receiver antenna - transmission line number')
     parser.add_argument('--rx-num', type=int, help='receiver antenna - output number')
     parser.add_argument('--rx-component', type=str, help='receiver antenna - output electric field component', choices=['Ex', 'Ey', 'Ez'])
+    parser.add_argument('--save', metavar='output_file', dest='save', help='save plot(s) to file instead of displaying (creates directories if needed; produces _tl_params and _ant_params files)')
     args = parser.parse_args()
 
     antennaparams = calculate_antenna_params(args.outputfile, args.tltx_num, args.tlrx_num, args.rx_num, args.rx_component)
-    plthandle = mpl_plot(args.outputfile, **antennaparams)
-    plthandle.show()
+    plthandle = mpl_plot(args.outputfile, **antennaparams, save_path=args.save)
+    if args.save is None:
+        plthandle.show()

--- a/tools/plot_source_wave.py
+++ b/tools/plot_source_wave.py
@@ -59,7 +59,14 @@ def check_timewindow(timewindow, dt):
     return timewindow, iterations
 
 
-def mpl_plot(w, timewindow, dt, iterations, fft=False):
+def _ensure_output_dir(path):
+    """Create parent directory for path if it does not exist."""
+    dirname = os.path.dirname(path)
+    if dirname:
+        os.makedirs(dirname, exist_ok=True)
+
+
+def mpl_plot(w, timewindow, dt, iterations, fft=False, save_path=None):
     """Plots waveform and prints useful information about its properties.
 
     Args:
@@ -68,6 +75,7 @@ def mpl_plot(w, timewindow, dt, iterations, fft=False):
         dt (float): Time discretisation.
         iterations (int): Number of iterations.
         fft (boolean): Plot FFT switch.
+        save_path (string, optional): If provided, save figure to this path. Directories are created as needed.
 
     Returns:
         plt (object): matplotlib plot object.
@@ -137,9 +145,9 @@ def mpl_plot(w, timewindow, dt, iterations, fft=False):
 
     [ax.grid(which='both', axis='both', linestyle='-.') for ax in fig.axes]  # Turn on grid
 
-    # Save a PDF/PNG of the figure
-    # fig.savefig(os.path.dirname(os.path.abspath(__file__)) + os.sep + w.type + '.pdf', dpi=None, format='pdf', bbox_inches='tight', pad_inches=0.1)
-    # fig.savefig(os.path.dirname(os.path.abspath(__file__)) + os.sep + w.type + '.png', dpi=150, format='png', bbox_inches='tight', pad_inches=0.1)
+    if save_path is not None:
+        _ensure_output_dir(save_path)
+        fig.savefig(save_path, dpi=150, bbox_inches='tight', pad_inches=0.1)
 
     return plt
 
@@ -154,6 +162,7 @@ if __name__ == "__main__":
     parser.add_argument('timewindow', help='time window to view waveform')
     parser.add_argument('dt', type=float, help='time step to view waveform')
     parser.add_argument('-fft', action='store_true', help='plot FFT of waveform', default=False)
+    parser.add_argument('--save', metavar='output_file', dest='save', help='save plot to file instead of displaying (creates directories if needed)')
     args = parser.parse_args()
 
     # Check waveform parameters
@@ -169,5 +178,6 @@ if __name__ == "__main__":
     w.freq = args.freq
 
     timewindow, iterations = check_timewindow(args.timewindow, args.dt)
-    plthandle = mpl_plot(w, timewindow, args.dt, iterations, args.fft)
-    plthandle.show()
+    plthandle = mpl_plot(w, timewindow, args.dt, iterations, args.fft, save_path=args.save)
+    if args.save is None:
+        plthandle.show()


### PR DESCRIPTION
Add a --save <output_file> CLI option to all main plotting tools (plot_Ascan, plot_Bscan, plot_antenna_params, plot_source_wave). When --save is used, figures are written to the given path with fig.savefig() and parent directories are created if needed; when it is not used, behavior is unchanged and plt.show() is still used.
Motivation and context: Plotting tools currently rely only on plt.show(), which fails in headless environments (Docker, HPC, SSH). There was no way to save plots from the command line, even though savefig was present in comments. This change makes the tools usable in CI, containers, and clusters and matches the use case described in the related issue.

Changes:
CLI: New optional argument --save <output_file> on all four plotting tools.
Behavior: If --save is set: save to file (creating dirs with os.makedirs(..., exist_ok=True)); if not set: keep existing plt.show() behavior.
Naming: Multiple receivers get _rxN before the extension (A-scan/B-scan); antenna params produce _tl_params and _ant_params from the given base path.
Tests: tests/test_plot_save.py added; two tests confirm that plot_source_wave and plot_Ascan create a non-empty file when --save is used; the B-scan test is skipped when no merged B-scan output file exists.
Docs: docs/source/plotting.rst and README.rst updated with --save usage and examples.

Closes #519 

Type of change
[ ] Bug fix (non-breaking change which fixes an issue)
[x] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
[x] This change requires a documentation update.
Checklist
[ ] Did pre-commit passed all checks?
[x] I have performed a self-review of my code.
[x] I have added comments for my code, particularly in hard-to-understand areas.
[x] I have made corresponding changes to the documentation.
[x] My changes generate no new warnings.
[x] The title of my pull request is a short description of my changes.