### PR TITLE
Fix: remove self-dependency on gprMax from requirements.txt

### DIFF
--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -11,7 +11,7 @@ inputfile_old2new.py
 
 This modules assists with the process of migrating input files from the syntax of the old (pre v.3) version of gprMax to the new syntax. It will produce a new input file with the old syntax (attempted to be!) translated to the new syntax. Usage (from the top-level gprMax directory) is:
 
-.. code-block:: none
+.. code-block:: bash
 
     python -m tools.inputfile_old2new inputfile
 
@@ -23,7 +23,7 @@ outputfiles_merge.py
 
 gprMax produces a separate output file for each trace (A-scan) in a B-scan. This module combines the separate output files into a single file, and can remove the separate output files afterwards. Usage (from the top-level gprMax directory) is:
 
-.. code-block:: none
+.. code-block:: bash
 
     python -m tools.outputfiles_merge basefilename --remove-files
 
@@ -38,7 +38,7 @@ convert_png2h5.py
 
 This module enables a Portable Network Graphics (PNG) image file to be converted into a HDF5 file that can then be used to import geometry into gprMax (see the ``#geometry_objects_read`` command for information on how to use the HDF5 file with a materials file to import the geometry). The resulting geometry will be 2D but maybe extended in the z-(invariate) direction if a 3D model was desired. Usage (from the top-level gprMax directory) is:
 
-.. code-block:: none
+.. code-block:: bash
 
     python -m tools.convert_png2h5 imagefile dxdydz
 
@@ -53,7 +53,7 @@ There is an optional command line argument:
 
 For example create a HDF5 geometry objects file from the PNG image ``my_layers.png`` with a spatial discretisation of :math:`\Delta x = \Delta y = \Delta z = 0.002` metres, and extending 150 cells in the z-(invariate) direction of the model:
 
-.. code-block:: none
+.. code-block:: bash
 
     python -m tools.convert_png2h5 my_layers.png 0.002 0.002 0.002 -zcells 150
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,8 +25,6 @@ defusedxml==0.7.1
 executing==0.8.3
 fastjsonschema==2.16.2
 fonttools==4.25.0
-gprMax==3.1.7
-gprMax==3.1.7
 h5py==3.12.1
 idna==3.7
 ipykernel==6.28.0


### PR DESCRIPTION
The requirements.txt file listed gprMax as a dependency.
Since gprMax is installed from source (pip install -e .) and is not
available on PyPI, this caused installation to fail for new users.
This PR removes the self-dependency to allow clean installation.