### PR TITLE
Fix receiver start index detection in antenna pattern initial_save

### DIFF
--- a/user_libs/antenna_patterns/initial_save.py
+++ b/user_libs/antenna_patterns/initial_save.py
@@ -77,8 +77,17 @@ iterations = f.attrs['Iterations']
 dt = f.attrs['dt']
 nrx = f.attrs['nrx']
 if antenna:
-    nrx = nrx - 1  # Ignore first receiver point with full antenna model
-    start = 2
+    nrx = nrx - 1  # Ignore the antenna's internal receiver point
+    # Determine start index by checking whether the first receiver has all
+    # default field outputs. If it does, the antenna's internal receiver (which
+    # only saves a single component, e.g. 'Ey') must be at the end of the list,
+    # so observation receivers begin at rx1. Otherwise the antenna receiver is
+    # first and observation receivers begin at rx2.
+    first_rx_outputs = list(f['/rxs/rx1/'].keys())
+    if all(c in first_rx_outputs for c in ['Ex', 'Ey', 'Ez', 'Hx', 'Hy', 'Hz']):
+        start = 1  # Antenna receiver is last; observation receivers start at rx1
+    else:
+        start = 2  # Antenna receiver is first; observation receivers start at rx2
 else:
     start = 1
 time = np.arange(0, dt * iterations, dt)


### PR DESCRIPTION
# PR Description

<!-- Please include a summary of the changes. Please also include relevant motivation and context for making this PR. -->

The `initial_save.py` script hardcoded `start = 2` when `antenna = True`, assuming the antenna's internal receiver (`rxbowtie`) is always the first receiver (rx1) in the output file. This assumption holds when the antenna function is called before the observation receivers in the input file, which is the case in the example `.in` files. However, if a user places the observation `#rx:` points before the antenna call, `rxbowtie` ends up as the last receiver. The loop then attempts to read `Ex`, `Ey`, `Ez`, `Hx`, `Hy`, `Hz` from `rxbowtie`, which only saves a single field component (`Ey` or `Ex`), causing a `KeyError`.

The fix dynamically determines the correct `start` index by inspecting the first receiver's stored field components. If the first receiver has all six default outputs (`Ex`, `Ey`, `Ez`, `Hx`, `Hy`, `Hz`), it is an observation receiver and `start` is set to `1`. If it only has a subset (as is the case for `rxbowtie`), it is the antenna's internal receiver and `start` is set to `2`. This makes the code robust to both receiver orderings.

## 🛠️ Related Issue (Number)

<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

Closes #577

## Type of change

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update.

## Checklist

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [ ] Did pre-commit passed all checks?
- [x] I have performed a self-review of my code.
- [x] I have added comments for my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.
