### PR TITLE
Incorrect Drude multi-pole permittivity calculation in calculate_er

### DIFF
--- a/gprMax/materials.py
+++ b/gprMax/materials.py
@@ -169,7 +169,7 @@ class Material(object):
                 ersum = 0
                 for pole in range(self.poles):
                     ersum += self.tau[pole]**2 / (w**2 - 1j * w * self.alpha[pole])
-                    er -= ersum
+                er -= ersum
 
         return er
 


### PR DESCRIPTION
# PR Description

<!-- Please include a summary of the changes. Please also include relevant motivation and context for making this PR. -->

**Before (incorrect):** `N·P₀ + (N-1)·P₁ + … + 1·Pₙ₋₁`  
**After (correct):** `P₀ + P₁ + … + Pₙ₋₁`

This over-counting of earlier poles produced wrong permittivity values, which could affect:
- Numerical dispersion analysis results
- Dispersion warnings/errors shown to the user
- Any post-processing that calls [calculate_er()]
## 🛠️ Related Issue (Number)

<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

Closes #

## Type of change

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update.

## Checklist

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [X] Did pre-commit passed all checks?
- [X] I have performed a self-review of my code.
- [] I have added comments for my code, particularly in hard-to-understand areas.
- [] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] The title of my pull request is a short description of my changes.
