### PR TITLE
Fix unsupported waveform membership checks in inputfile_old2new

### DIFF
--- a/tools/inputfile_old2new.py
+++ b/tools/inputfile_old2new.py
@@ -331,8 +331,8 @@ while(lindex < len(inputlines)):
 # Convert separate #line_source and associated #tx to #waveform and #hertzian_dipole
 for source in linesources:
     params = source.split()
-    if params[3] is badwaveforms:
-        raise CmdInputError("Waveform types {} are not compatible between new and old versions of gprMax.".format(''.join(badwaveforms)))
+    if params[3] in badwaveforms:
+        raise CmdInputError("Waveform types {} are not compatible between new and old versions of gprMax.".format(', '.join(badwaveforms)))
     elif params[3] == 'ricker':
         params[3] = 'gaussiandotnorm'
     waveform = '#waveform: {} {} {} {}'.format(params[3], params[1], params[2], params[4])


### PR DESCRIPTION
# PR Description

This PR fixes a logical issue in `tools/inputfile_old2new.py` where unsupported waveform types were incorrectly checked using the identity operator (`is`) instead of the membership operator (`in`).

In several locations in the file, the code checks whether a parsed waveform parameter belongs to a list of unsupported waveform types:

```python
badwaveforms = ['gaussiandot', 'gaussiandotdot']
```

However, the code used the following condition:

```python
if params[3] is badwaveforms:
```

Since `params[3]` is a string and `badwaveforms` is a list, the identity comparison always evaluates to `False`. As a result, unsupported waveform types such as `gaussiandot` and `gaussiandotdot` would not trigger the expected exception.

This PR replaces the identity comparison with a membership check:

```python
if params[3] in badwaveforms:
```

This ensures that unsupported waveform parameters are correctly detected and handled.

Additionally, the error message formatting was improved by replacing:

```python
''.join(badwaveforms)
```

with

```python
', '.join(badwaveforms)
```

so that unsupported waveform names are displayed clearly in the exception message.

## 🛠️ Related Issue (Number)

Closes #589

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Did pre-commit passed all checks?
- [x] I have performed a self-review of my code.
- [ ] I have added comments for my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.