### PR TITLE
Fix three bugs in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ from setuptools import Extension, find_packages, setup
 MIN_PYTHON_VERSION = (3, 7)
 if sys.version_info[:2] < MIN_PYTHON_VERSION:
     sys.exit(
-        "\nExited: Requires Python {MIN_PYTHON_VERSION[0]}.{MIN_PYTHON_VERSION[1]} or newer!\n"
+        f"\nExited: Requires Python {MIN_PYTHON_VERSION[0]}.{MIN_PYTHON_VERSION[1]} or newer!\n"
     )
 
 # Importing gprMax _version__.py before building can cause issues.
@@ -204,7 +204,7 @@ else:
             if "Apple" in cpuID:
                 rpath = "/opt/homebrew/opt/gcc/lib/gcc/" + gccpath[-1].split(os.sep)[-1][-1] + "/"
         else:
-            raise (
+            raise SystemExit(
                 f"Cannot find gcc in {gccbasepath}. gprMax requires gcc "
                 + "to be installed - easily done through the Homebrew package "
                 + "manager (http://brew.sh). Note: gcc with OpenMP support "
@@ -214,9 +214,8 @@ else:
         # Set minimum supported macOS deployment target to installed macOS version
         MIN_MACOS_VERSION = platform.mac_ver()[0]
         try:
-            os.environ["MACOSX_DEPLOYMENT_TARGET"]
             del os.environ["MACOSX_DEPLOYMENT_TARGET"]
-        except:
+        except KeyError:
             pass
         os.environ["MIN_SUPPORTED_MACOSX_DEPLOYMENT_TARGET"] = MIN_MACOS_VERSION
         # Sometimes worth testing with '-fstrict-aliasing', '-fno-common'


### PR DESCRIPTION
Fix three Python 3 correctness bugs in setup.py that affect error handling and user-facing messages.

## Related Issue (Number)
No existing issue — bugs identified during code review.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Summary of changes

**1. Missing f-string prefix in version check exit message**
The error message printed literally `{MIN_PYTHON_VERSION[0]}.{MIN_PYTHON_VERSION[1]}`
instead of `3.7` when Python version was too old.

**2. `raise` with a plain string on macOS gcc-not-found path**
Python 3 cannot raise a plain string — doing so raises `TypeError: exceptions must
derive from BaseException` instead of showing the intended message.
Fixed by using `raise SystemExit(...)`.

**3. Bare `except:` in macOS environment variable cleanup**
Only `KeyError` is expected here. Bare `except:` silently swallows
`KeyboardInterrupt` and `SystemExit`. Replaced with `except KeyError:`.
Also simplified the try block by removing the redundant key lookup before deletion.

## Checklist
- [x] Did pre-commit passed all checks?
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.