### PR TITLE
perf: pass nsources as runtime arg to avoid multiple JIT compilations

### DIFF
--- a/gprMax/model_build_run.py
+++ b/gprMax/model_build_run.py
@@ -651,7 +651,7 @@ def solve_gpu(currentmodelrun, modelend, G):
                                        block=(1, 1, 1), grid=(round32(len(G.magneticdipoles)), 1, 1))
 
         # Update electric field components
-        # If all materials are non-dispersive do standard update
+        # If all materials are non-dispersive do standard updates
         if Material.maxpoles == 0:
             update_e_gpu(np.int32(G.nx), np.int32(G.ny), np.int32(G.nz), G.ID_gpu.gpudata,
                          G.Ex_gpu.gpudata, G.Ey_gpu.gpudata, G.Ez_gpu.gpudata,

--- a/gprMax/model_build_run.py
+++ b/gprMax/model_build_run.py
@@ -558,21 +558,27 @@ def solve_gpu(currentmodelrun, modelend, G):
 
     # Sources - initialise arrays on GPU, prepare kernel and get kernel functions
     if G.voltagesources + G.hertziandipoles + G.magneticdipoles:
-        kernels_sources = SourceModule(kernels_template_sources.substitute(REAL=cudafloattype, N_updatecoeffsE=G.updatecoeffsE.size, N_updatecoeffsH=G.updatecoeffsH.size, NY_MATCOEFFS=G.updatecoeffsE.shape[1], NY_SRCINFO=4, NY_SRCWAVES=G.iterations, NX_FIELDS=G.nx + 1, NY_FIELDS=G.ny + 1, NZ_FIELDS=G.nz + 1, NX_ID=G.ID.shape[1], NY_ID=G.ID.shape[2], NZ_ID=G.ID.shape[3]), options=compiler_opts)
-        # Copy material coefficient arrays to constant memory of GPU (must be <64KB) for source kernels
-        updatecoeffsE = kernels_sources.get_global('updatecoeffsE')[0]
-        updatecoeffsH = kernels_sources.get_global('updatecoeffsH')[0]
-        drv.memcpy_htod(updatecoeffsE, G.updatecoeffsE)
-        drv.memcpy_htod(updatecoeffsH, G.updatecoeffsH)
         if G.hertziandipoles:
             srcinfo1_hertzian_gpu, srcinfo2_hertzian_gpu, srcwaves_hertzian_gpu = gpu_initialise_src_arrays(G.hertziandipoles, G)
-            update_hertzian_dipole_gpu = kernels_sources.get_function("update_hertzian_dipole")
+            kernels_hertzian = SourceModule(kernels_template_sources.substitute(REAL=cudafloattype, N_updatecoeffsE=G.updatecoeffsE.size, N_updatecoeffsH=G.updatecoeffsH.size, NY_MATCOEFFS=G.updatecoeffsE.shape[1], NSOURCES=len(G.hertziandipoles), NX_FIELDS=G.nx + 1, NY_FIELDS=G.ny + 1, NZ_FIELDS=G.nz + 1, NX_ID=G.ID.shape[1], NY_ID=G.ID.shape[2], NZ_ID=G.ID.shape[3]), options=compiler_opts)
+            update_hertzian_dipole_gpu = kernels_hertzian.get_function("update_hertzian_dipole")
+            kernels_sources_last = kernels_hertzian
         if G.magneticdipoles:
             srcinfo1_magnetic_gpu, srcinfo2_magnetic_gpu, srcwaves_magnetic_gpu = gpu_initialise_src_arrays(G.magneticdipoles, G)
-            update_magnetic_dipole_gpu = kernels_sources.get_function("update_magnetic_dipole")
+            kernels_magnetic = SourceModule(kernels_template_sources.substitute(REAL=cudafloattype, N_updatecoeffsE=G.updatecoeffsE.size, N_updatecoeffsH=G.updatecoeffsH.size, NY_MATCOEFFS=G.updatecoeffsE.shape[1], NSOURCES=len(G.magneticdipoles), NX_FIELDS=G.nx + 1, NY_FIELDS=G.ny + 1, NZ_FIELDS=G.nz + 1, NX_ID=G.ID.shape[1], NY_ID=G.ID.shape[2], NZ_ID=G.ID.shape[3]), options=compiler_opts)
+            update_magnetic_dipole_gpu = kernels_magnetic.get_function("update_magnetic_dipole")
+            kernels_sources_last = kernels_magnetic
         if G.voltagesources:
             srcinfo1_voltage_gpu, srcinfo2_voltage_gpu, srcwaves_voltage_gpu = gpu_initialise_src_arrays(G.voltagesources, G)
-            update_voltage_source_gpu = kernels_sources.get_function("update_voltage_source")
+            kernels_voltage = SourceModule(kernels_template_sources.substitute(REAL=cudafloattype, N_updatecoeffsE=G.updatecoeffsE.size, N_updatecoeffsH=G.updatecoeffsH.size, NY_MATCOEFFS=G.updatecoeffsE.shape[1], NSOURCES=len(G.voltagesources), NX_FIELDS=G.nx + 1, NY_FIELDS=G.ny + 1, NZ_FIELDS=G.nz + 1, NX_ID=G.ID.shape[1], NY_ID=G.ID.shape[2], NZ_ID=G.ID.shape[3]), options=compiler_opts)
+            update_voltage_source_gpu = kernels_voltage.get_function("update_voltage_source")
+            kernels_sources_last = kernels_voltage
+        # Copy material coefficient arrays to constant memory of GPU once
+        # (same arrays shared across all source kernels, no need to copy per source type)
+        updatecoeffsE = kernels_sources_last.get_global('updatecoeffsE')[0]
+        updatecoeffsH = kernels_sources_last.get_global('updatecoeffsH')[0]
+        drv.memcpy_htod(updatecoeffsE, G.updatecoeffsE)
+        drv.memcpy_htod(updatecoeffsH, G.updatecoeffsH)
 
     # Snapshots - initialise arrays on GPU, prepare kernel and get kernel functions
     if G.snapshots:

--- a/gprMax/model_build_run.py
+++ b/gprMax/model_build_run.py
@@ -558,27 +558,22 @@ def solve_gpu(currentmodelrun, modelend, G):
 
     # Sources - initialise arrays on GPU, prepare kernel and get kernel functions
     if G.voltagesources + G.hertziandipoles + G.magneticdipoles:
-        if G.hertziandipoles:
-            srcinfo1_hertzian_gpu, srcinfo2_hertzian_gpu, srcwaves_hertzian_gpu = gpu_initialise_src_arrays(G.hertziandipoles, G)
-            kernels_hertzian = SourceModule(kernels_template_sources.substitute(REAL=cudafloattype, N_updatecoeffsE=G.updatecoeffsE.size, N_updatecoeffsH=G.updatecoeffsH.size, NY_MATCOEFFS=G.updatecoeffsE.shape[1], NSOURCES=len(G.hertziandipoles), NX_FIELDS=G.nx + 1, NY_FIELDS=G.ny + 1, NZ_FIELDS=G.nz + 1, NX_ID=G.ID.shape[1], NY_ID=G.ID.shape[2], NZ_ID=G.ID.shape[3]), options=compiler_opts)
-            update_hertzian_dipole_gpu = kernels_hertzian.get_function("update_hertzian_dipole")
-            kernels_sources_last = kernels_hertzian
-        if G.magneticdipoles:
-            srcinfo1_magnetic_gpu, srcinfo2_magnetic_gpu, srcwaves_magnetic_gpu = gpu_initialise_src_arrays(G.magneticdipoles, G)
-            kernels_magnetic = SourceModule(kernels_template_sources.substitute(REAL=cudafloattype, N_updatecoeffsE=G.updatecoeffsE.size, N_updatecoeffsH=G.updatecoeffsH.size, NY_MATCOEFFS=G.updatecoeffsE.shape[1], NSOURCES=len(G.magneticdipoles), NX_FIELDS=G.nx + 1, NY_FIELDS=G.ny + 1, NZ_FIELDS=G.nz + 1, NX_ID=G.ID.shape[1], NY_ID=G.ID.shape[2], NZ_ID=G.ID.shape[3]), options=compiler_opts)
-            update_magnetic_dipole_gpu = kernels_magnetic.get_function("update_magnetic_dipole")
-            kernels_sources_last = kernels_magnetic
-        if G.voltagesources:
-            srcinfo1_voltage_gpu, srcinfo2_voltage_gpu, srcwaves_voltage_gpu = gpu_initialise_src_arrays(G.voltagesources, G)
-            kernels_voltage = SourceModule(kernels_template_sources.substitute(REAL=cudafloattype, N_updatecoeffsE=G.updatecoeffsE.size, N_updatecoeffsH=G.updatecoeffsH.size, NY_MATCOEFFS=G.updatecoeffsE.shape[1], NSOURCES=len(G.voltagesources), NX_FIELDS=G.nx + 1, NY_FIELDS=G.ny + 1, NZ_FIELDS=G.nz + 1, NX_ID=G.ID.shape[1], NY_ID=G.ID.shape[2], NZ_ID=G.ID.shape[3]), options=compiler_opts)
-            update_voltage_source_gpu = kernels_voltage.get_function("update_voltage_source")
-            kernels_sources_last = kernels_voltage
+        # Single JIT compilation shared across all source types - nsources passed as runtime arg
+        kernels_sources = SourceModule(kernels_template_sources.substitute(REAL=cudafloattype, N_updatecoeffsE=G.updatecoeffsE.size, N_updatecoeffsH=G.updatecoeffsH.size, NY_MATCOEFFS=G.updatecoeffsE.shape[1], NX_FIELDS=G.nx + 1, NY_FIELDS=G.ny + 1, NZ_FIELDS=G.nz + 1, NX_ID=G.ID.shape[1], NY_ID=G.ID.shape[2], NZ_ID=G.ID.shape[3]), options=compiler_opts)
         # Copy material coefficient arrays to constant memory of GPU once
-        # (same arrays shared across all source kernels, no need to copy per source type)
-        updatecoeffsE = kernels_sources_last.get_global('updatecoeffsE')[0]
-        updatecoeffsH = kernels_sources_last.get_global('updatecoeffsH')[0]
+        updatecoeffsE = kernels_sources.get_global('updatecoeffsE')[0]
+        updatecoeffsH = kernels_sources.get_global('updatecoeffsH')[0]
         drv.memcpy_htod(updatecoeffsE, G.updatecoeffsE)
         drv.memcpy_htod(updatecoeffsH, G.updatecoeffsH)
+        if G.hertziandipoles:
+            srcinfo1_hertzian_gpu, srcinfo2_hertzian_gpu, srcwaves_hertzian_gpu = gpu_initialise_src_arrays(G.hertziandipoles, G)
+            update_hertzian_dipole_gpu = kernels_sources.get_function("update_hertzian_dipole")
+        if G.magneticdipoles:
+            srcinfo1_magnetic_gpu, srcinfo2_magnetic_gpu, srcwaves_magnetic_gpu = gpu_initialise_src_arrays(G.magneticdipoles, G)
+            update_magnetic_dipole_gpu = kernels_sources.get_function("update_magnetic_dipole")
+        if G.voltagesources:
+            srcinfo1_voltage_gpu, srcinfo2_voltage_gpu, srcwaves_voltage_gpu = gpu_initialise_src_arrays(G.voltagesources, G)
+            update_voltage_source_gpu = kernels_sources.get_function("update_voltage_source")
 
     # Snapshots - initialise arrays on GPU, prepare kernel and get kernel functions
     if G.snapshots:
@@ -648,6 +643,7 @@ def solve_gpu(currentmodelrun, modelend, G):
         # Update magnetic field components for magetic dipole sources
         if G.magneticdipoles:
             update_magnetic_dipole_gpu(np.int32(len(G.magneticdipoles)), np.int32(iteration),
+                                       np.int32(len(G.magneticdipoles)),
                                        floattype(G.dx), floattype(G.dy), floattype(G.dz),
                                        srcinfo1_magnetic_gpu.gpudata, srcinfo2_magnetic_gpu.gpudata,
                                        srcwaves_magnetic_gpu.gpudata, G.ID_gpu.gpudata,
@@ -678,6 +674,7 @@ def solve_gpu(currentmodelrun, modelend, G):
         # Update electric field components for voltage sources
         if G.voltagesources:
             update_voltage_source_gpu(np.int32(len(G.voltagesources)), np.int32(iteration),
+                                      np.int32(len(G.voltagesources)),
                                       floattype(G.dx), floattype(G.dy), floattype(G.dz),
                                       srcinfo1_voltage_gpu.gpudata, srcinfo2_voltage_gpu.gpudata,
                                       srcwaves_voltage_gpu.gpudata, G.ID_gpu.gpudata,
@@ -687,6 +684,7 @@ def solve_gpu(currentmodelrun, modelend, G):
         # Update electric field components for Hertzian dipole sources (update any Hertzian dipole sources last)
         if G.hertziandipoles:
             update_hertzian_dipole_gpu(np.int32(len(G.hertziandipoles)), np.int32(iteration),
+                                       np.int32(len(G.hertziandipoles)),
                                        floattype(G.dx), floattype(G.dy), floattype(G.dz),
                                        srcinfo1_hertzian_gpu.gpudata, srcinfo2_hertzian_gpu.gpudata,
                                        srcwaves_hertzian_gpu.gpudata, G.ID_gpu.gpudata,

--- a/gprMax/model_build_run.py
+++ b/gprMax/model_build_run.py
@@ -654,9 +654,9 @@ def solve_gpu(currentmodelrun, modelend, G):
         # If all materials are non-dispersive do standard update
         if Material.maxpoles == 0:
             update_e_gpu(np.int32(G.nx), np.int32(G.ny), np.int32(G.nz), G.ID_gpu.gpudata,
-                         G.Ex_gpu.gpudata, G.Ey_gpu.gpudata, G.Ez_gpu.gpudata,
-                         G.Hx_gpu.gpudata, G.Hy_gpu.gpudata, G.Hz_gpu.gpudata,
-                         block=G.tpb, grid=G.bpg)
+                                        G.Ex_gpu.gpudata, G.Ey_gpu.gpudata, G.Ez_gpu.gpudata,
+                                        G.Hx_gpu.gpudata, G.Hy_gpu.gpudata, G.Hz_gpu.gpudata,
+                                        block=G.tpb, grid=G.bpg)
         # If there are any dispersive materials do 1st part of dispersive update
         # (it is split into two parts as it requires present and updated electric field values).
         else:

--- a/gprMax/model_build_run.py
+++ b/gprMax/model_build_run.py
@@ -651,7 +651,7 @@ def solve_gpu(currentmodelrun, modelend, G):
                                        block=(1, 1, 1), grid=(round32(len(G.magneticdipoles)), 1, 1))
 
         # Update electric field components
-        # If all materials are non-dispersive do standard updates
+        # If all materials are non-dispersive do standard update
         if Material.maxpoles == 0:
             update_e_gpu(np.int32(G.nx), np.int32(G.ny), np.int32(G.nz), G.ID_gpu.gpudata,
                          G.Ex_gpu.gpudata, G.Ey_gpu.gpudata, G.Ez_gpu.gpudata,

--- a/gprMax/source_updates_gpu.py
+++ b/gprMax/source_updates_gpu.py
@@ -22,8 +22,8 @@ kernels_template_sources = Template("""
 
 // Macros for converting subscripts to linear index:
 #define INDEX2D_MAT(m, n) (m)*($NY_MATCOEFFS)+(n)
-#define INDEX2D_SRCINFO(m, n) (m)*$NY_SRCINFO+(n)
-#define INDEX2D_SRCWAVES(m, n) (m)*($NY_SRCWAVES)+(n)
+#define INDEX2D_SRCINFO(field, src, nsources) (field)*(nsources)+(src)
+#define INDEX2D_SRCWAVES(iteration, src, nsources) (iteration)*(nsources)+(src)
 #define INDEX3D_FIELDS(i, j, k) (i)*($NY_FIELDS)*($NZ_FIELDS)+(j)*($NZ_FIELDS)+(k)
 #define INDEX4D_ID(p, i, j, k) (p)*($NX_ID)*($NY_ID)*($NZ_ID)+(i)*($NY_ID)*($NZ_ID)+(j)*($NZ_ID)+(k)
 
@@ -35,7 +35,7 @@ __device__ __constant__ $REAL updatecoeffsH[$N_updatecoeffsH];
 // Hertzian dipole electric field update //
 ///////////////////////////////////////////
 
-__global__ void update_hertzian_dipole(int NHERTZDIPOLE, int iteration, $REAL dx, $REAL dy, $REAL dz, const int* __restrict__ srcinfo1, const $REAL* __restrict__ srcinfo2, const $REAL* __restrict__ srcwaveforms, const unsigned int* __restrict__ ID, $REAL *Ex, $REAL *Ey, $REAL *Ez) {
+__global__ void update_hertzian_dipole(int NHERTZDIPOLE, int iteration, int nsources, $REAL dx, $REAL dy, $REAL dz, const int* __restrict__ srcinfo1, const $REAL* __restrict__ srcinfo2, const $REAL* __restrict__ srcwaveforms, const unsigned int* __restrict__ ID, $REAL *Ex, $REAL *Ey, $REAL *Ez) {
 
     //  This function updates electric field values for Hertzian dipole sources.
     //
@@ -56,28 +56,28 @@ __global__ void update_hertzian_dipole(int NHERTZDIPOLE, int iteration, $REAL dx
         $REAL dl;
         int i, j, k, polarisation;
 
-        i = srcinfo1[INDEX2D_SRCINFO(src,0)];
-        j = srcinfo1[INDEX2D_SRCINFO(src,1)];
-        k = srcinfo1[INDEX2D_SRCINFO(src,2)];
-        polarisation = srcinfo1[INDEX2D_SRCINFO(src,3)];
+        i = srcinfo1[INDEX2D_SRCINFO(0,src,nsources)];
+        j = srcinfo1[INDEX2D_SRCINFO(1,src,nsources)];
+        k = srcinfo1[INDEX2D_SRCINFO(2,src,nsources)];
+        polarisation = srcinfo1[INDEX2D_SRCINFO(3,src,nsources)];
         dl = srcinfo2[src];
 
         // 'x' polarised source
         if (polarisation == 0) {
             int materialEx = ID[INDEX4D_ID(0,i,j,k)];
-            Ex[INDEX3D_FIELDS(i,j,k)] = Ex[INDEX3D_FIELDS(i,j,k)] - updatecoeffsE[INDEX2D_MAT(materialEx,4)] * srcwaveforms[INDEX2D_SRCWAVES(src,iteration)] * dl * (1 / (dx * dy * dz));
+            Ex[INDEX3D_FIELDS(i,j,k)] = Ex[INDEX3D_FIELDS(i,j,k)] - updatecoeffsE[INDEX2D_MAT(materialEx,4)] * srcwaveforms[INDEX2D_SRCWAVES(iteration,src,nsources)] * dl * (1 / (dx * dy * dz));
         }
 
         // 'y' polarised source
         else if (polarisation == 1) {
             int materialEy = ID[INDEX4D_ID(1,i,j,k)];
-            Ey[INDEX3D_FIELDS(i,j,k)] = Ey[INDEX3D_FIELDS(i,j,k)] - updatecoeffsE[INDEX2D_MAT(materialEy,4)] * srcwaveforms[INDEX2D_SRCWAVES(src,iteration)] * dl * (1 / (dx * dy * dz));
+            Ey[INDEX3D_FIELDS(i,j,k)] = Ey[INDEX3D_FIELDS(i,j,k)] - updatecoeffsE[INDEX2D_MAT(materialEy,4)] * srcwaveforms[INDEX2D_SRCWAVES(iteration,src,nsources)] * dl * (1 / (dx * dy * dz));
         }
 
         // 'z' polarised source
         else if (polarisation == 2) {
             int materialEz = ID[INDEX4D_ID(2,i,j,k)];
-            Ez[INDEX3D_FIELDS(i,j,k)] = Ez[INDEX3D_FIELDS(i,j,k)] - updatecoeffsE[INDEX2D_MAT(materialEz,4)] * srcwaveforms[INDEX2D_SRCWAVES(src,iteration)] * dl * (1 / (dx * dy * dz));
+            Ez[INDEX3D_FIELDS(i,j,k)] = Ez[INDEX3D_FIELDS(i,j,k)] - updatecoeffsE[INDEX2D_MAT(materialEz,4)] * srcwaveforms[INDEX2D_SRCWAVES(iteration,src,nsources)] * dl * (1 / (dx * dy * dz));
         }
     }
 }
@@ -87,7 +87,7 @@ __global__ void update_hertzian_dipole(int NHERTZDIPOLE, int iteration, $REAL dx
 // Magnetic dipole magnetic field update //
 ///////////////////////////////////////////
 
-__global__ void update_magnetic_dipole(int NMAGDIPOLE, int iteration, $REAL dx, $REAL dy, $REAL dz, const int* __restrict__ srcinfo1, const $REAL* __restrict__ srcinfo2, const $REAL* __restrict__ srcwaveforms, const unsigned int* __restrict__ ID, $REAL *Hx, $REAL *Hy, $REAL *Hz) {
+__global__ void update_magnetic_dipole(int NMAGDIPOLE, int iteration, int nsources, $REAL dx, $REAL dy, $REAL dz, const int* __restrict__ srcinfo1, const $REAL* __restrict__ srcinfo2, const $REAL* __restrict__ srcwaveforms, const unsigned int* __restrict__ ID, $REAL *Hx, $REAL *Hy, $REAL *Hz) {
 
     //  This function updates magnetic field values for magnetic dipole sources.
     //
@@ -107,27 +107,27 @@ __global__ void update_magnetic_dipole(int NMAGDIPOLE, int iteration, $REAL dx, 
 
         int i, j, k, polarisation;
 
-        i = srcinfo1[INDEX2D_SRCINFO(src,0)];
-        j = srcinfo1[INDEX2D_SRCINFO(src,1)];
-        k = srcinfo1[INDEX2D_SRCINFO(src,2)];
-        polarisation = srcinfo1[INDEX2D_SRCINFO(src,3)];
+        i = srcinfo1[INDEX2D_SRCINFO(0,src,nsources)];
+        j = srcinfo1[INDEX2D_SRCINFO(1,src,nsources)];
+        k = srcinfo1[INDEX2D_SRCINFO(2,src,nsources)];
+        polarisation = srcinfo1[INDEX2D_SRCINFO(3,src,nsources)];
 
         // 'x' polarised source
         if (polarisation == 0) {
             int materialHx = ID[INDEX4D_ID(3,i,j,k)];
-            Hx[INDEX3D_FIELDS(i,j,k)] = Hx[INDEX3D_FIELDS(i,j,k)] - updatecoeffsH[INDEX2D_MAT(materialHx,4)] * srcwaveforms[INDEX2D_SRCWAVES(src,iteration)] * (1 / (dx * dy * dz));
+            Hx[INDEX3D_FIELDS(i,j,k)] = Hx[INDEX3D_FIELDS(i,j,k)] - updatecoeffsH[INDEX2D_MAT(materialHx,4)] * srcwaveforms[INDEX2D_SRCWAVES(iteration,src,nsources)] * (1 / (dx * dy * dz));
         }
 
         // 'y' polarised source
         else if (polarisation == 1) {
             int materialHy = ID[INDEX4D_ID(4,i,j,k)];
-            Hy[INDEX3D_FIELDS(i,j,k)] = Hy[INDEX3D_FIELDS(i,j,k)] - updatecoeffsH[INDEX2D_MAT(materialHy,4)] * srcwaveforms[INDEX2D_SRCWAVES(src,iteration)] * (1 / (dx * dy * dz));
+            Hy[INDEX3D_FIELDS(i,j,k)] = Hy[INDEX3D_FIELDS(i,j,k)] - updatecoeffsH[INDEX2D_MAT(materialHy,4)] * srcwaveforms[INDEX2D_SRCWAVES(iteration,src,nsources)] * (1 / (dx * dy * dz));
         }
 
         // 'z' polarised source
         else if (polarisation == 2) {
             int materialHz = ID[INDEX4D_ID(5,i,j,k)];
-            Hz[INDEX3D_FIELDS(i,j,k)] = Hz[INDEX3D_FIELDS(i,j,k)] - updatecoeffsH[INDEX2D_MAT(materialHz,4)] * srcwaveforms[INDEX2D_SRCWAVES(src,iteration)] * (1 / (dx * dy * dz));
+            Hz[INDEX3D_FIELDS(i,j,k)] = Hz[INDEX3D_FIELDS(i,j,k)] - updatecoeffsH[INDEX2D_MAT(materialHz,4)] * srcwaveforms[INDEX2D_SRCWAVES(iteration,src,nsources)] * (1 / (dx * dy * dz));
         }
     }
 }
@@ -137,7 +137,7 @@ __global__ void update_magnetic_dipole(int NMAGDIPOLE, int iteration, $REAL dx, 
 // Voltage source electric field update //
 //////////////////////////////////////////
 
-__global__ void update_voltage_source(int NVOLTSRC, int iteration, $REAL dx, $REAL dy, $REAL dz, const int* __restrict__ srcinfo1, const $REAL* __restrict__ srcinfo2, const $REAL* __restrict__ srcwaveforms, const unsigned int* __restrict__ ID, $REAL *Ex, $REAL *Ey, $REAL *Ez) {
+__global__ void update_voltage_source(int NVOLTSRC, int iteration, int nsources, $REAL dx, $REAL dy, $REAL dz, const int* __restrict__ srcinfo1, const $REAL* __restrict__ srcinfo2, const $REAL* __restrict__ srcwaveforms, const unsigned int* __restrict__ ID, $REAL *Ex, $REAL *Ey, $REAL *Ez) {
 
     //  This function updates electric field values for voltage sources.
     //
@@ -158,20 +158,20 @@ __global__ void update_voltage_source(int NVOLTSRC, int iteration, $REAL dx, $RE
         $REAL resistance;
         int i, j, k, polarisation;
 
-        i = srcinfo1[INDEX2D_SRCINFO(src,0)];
-        j = srcinfo1[INDEX2D_SRCINFO(src,1)];
-        k = srcinfo1[INDEX2D_SRCINFO(src,2)];
-        polarisation = srcinfo1[INDEX2D_SRCINFO(src,3)];
+        i = srcinfo1[INDEX2D_SRCINFO(0,src,nsources)];
+        j = srcinfo1[INDEX2D_SRCINFO(1,src,nsources)];
+        k = srcinfo1[INDEX2D_SRCINFO(2,src,nsources)];
+        polarisation = srcinfo1[INDEX2D_SRCINFO(3,src,nsources)];
         resistance = srcinfo2[src];
 
         // 'x' polarised source
         if (polarisation == 0) {
             if (resistance != 0) {
                 int materialEx = ID[INDEX4D_ID(0,i,j,k)];
-                Ex[INDEX3D_FIELDS(i,j,k)] = Ex[INDEX3D_FIELDS(i,j,k)] - updatecoeffsE[INDEX2D_MAT(materialEx,4)] * srcwaveforms[INDEX2D_SRCWAVES(src,iteration)] * (1 / (resistance * dy * dz));
+                Ex[INDEX3D_FIELDS(i,j,k)] = Ex[INDEX3D_FIELDS(i,j,k)] - updatecoeffsE[INDEX2D_MAT(materialEx,4)] * srcwaveforms[INDEX2D_SRCWAVES(iteration,src,nsources)] * (1 / (resistance * dy * dz));
             }
             else {
-                Ex[INDEX3D_FIELDS(i,j,k)] = -1 * srcwaveforms[INDEX2D_SRCWAVES(src,iteration)] / dx;
+                Ex[INDEX3D_FIELDS(i,j,k)] = -1 * srcwaveforms[INDEX2D_SRCWAVES(iteration,src,nsources)] / dx;
             }
         }
 
@@ -179,10 +179,10 @@ __global__ void update_voltage_source(int NVOLTSRC, int iteration, $REAL dx, $RE
         else if (polarisation == 1) {
             if (resistance != 0) {
                 int materialEy = ID[INDEX4D_ID(1,i,j,k)];
-                Ey[INDEX3D_FIELDS(i,j,k)] = Ey[INDEX3D_FIELDS(i,j,k)] - updatecoeffsE[INDEX2D_MAT(materialEy,4)] * srcwaveforms[INDEX2D_SRCWAVES(src,iteration)] * (1 / (resistance * dx * dz));
+                Ey[INDEX3D_FIELDS(i,j,k)] = Ey[INDEX3D_FIELDS(i,j,k)] - updatecoeffsE[INDEX2D_MAT(materialEy,4)] * srcwaveforms[INDEX2D_SRCWAVES(iteration,src,nsources)] * (1 / (resistance * dx * dz));
             }
             else {
-                Ey[INDEX3D_FIELDS(i,j,k)] = -1 * srcwaveforms[INDEX2D_SRCWAVES(src,iteration)] / dy;
+                Ey[INDEX3D_FIELDS(i,j,k)] = -1 * srcwaveforms[INDEX2D_SRCWAVES(iteration,src,nsources)] / dy;
             }
         }
 
@@ -190,10 +190,10 @@ __global__ void update_voltage_source(int NVOLTSRC, int iteration, $REAL dx, $RE
         else if (polarisation == 2) {
             if (resistance != 0) {
                 int materialEz = ID[INDEX4D_ID(2,i,j,k)];
-                Ez[INDEX3D_FIELDS(i,j,k)] = Ez[INDEX3D_FIELDS(i,j,k)] - updatecoeffsE[INDEX2D_MAT(materialEz,4)] * srcwaveforms[INDEX2D_SRCWAVES(src,iteration)] * (1 / (resistance * dx * dy));
+                Ez[INDEX3D_FIELDS(i,j,k)] = Ez[INDEX3D_FIELDS(i,j,k)] - updatecoeffsE[INDEX2D_MAT(materialEz,4)] * srcwaveforms[INDEX2D_SRCWAVES(iteration,src,nsources)] * (1 / (resistance * dx * dy));
             }
             else {
-                Ez[INDEX3D_FIELDS(i,j,k)] = -1 * srcwaveforms[INDEX2D_SRCWAVES(src,iteration)] / dz;
+                Ez[INDEX3D_FIELDS(i,j,k)] = -1 * srcwaveforms[INDEX2D_SRCWAVES(iteration,src,nsources)] / dz;
             }
         }
     }


### PR DESCRIPTION
## Related Issue (Number)

Closes #582

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Summary

Previously each source type (hertzian dipole, magnetic dipole, voltage source) 
required a separate SourceModule compiled with its own NSOURCES baked into the 
macro at compile time, causing up to 3 JIT compilations at startup for models 
with multiple source types.

Additionally, updatecoeffsE and updatecoeffsH were being copied to GPU once per 
source type (up to 3 times), even though they are the same arrays every time.

### Changes made:
- `source_updates_gpu.py`: Updated `INDEX2D_SRCINFO` and `INDEX2D_SRCWAVES` macros 
  to accept `nsources` as a runtime parameter instead of a compile-time substitution
- `source_updates_gpu.py`: Added `nsources` parameter to all 3 kernel signatures
- `model_build_run.py`: Replaced 3 separate `SourceModule` compilations with a 
  single shared one
- `model_build_run.py`: `updatecoeffsE` and `updatecoeffsH` now copied to GPU once 
  instead of per source type
- `model_build_run.py`: `nsources` passed as runtime argument at each kernel call site

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added comments for my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.