### PR TITLE
perf: split update_e and update_h into per-component kernels to reduce warp divergence

### DIFF
--- a/gprMax/fields_updates_gpu.py
+++ b/gprMax/fields_updates_gpu.py
@@ -37,13 +37,13 @@ __device__ __constant__ $REAL updatecoeffsH[$N_updatecoeffsH];
 // Electric field updates - standard materials //
 /////////////////////////////////////////////////
 
-__global__ void update_e(int NX, int NY, int NZ, const unsigned int* __restrict__ ID, $REAL *Ex, $REAL *Ey, $REAL *Ez, const $REAL* __restrict__ Hx, const $REAL* __restrict__ Hy, const $REAL* __restrict__ Hz) {
+__global__ void update_ex(int NX, int NY, int NZ, const unsigned int* __restrict__ ID, $REAL *Ex, const $REAL* __restrict__ Hy, const $REAL* __restrict__ Hz) {
 
-    //  This function updates electric field values.
+    //  This function updates Ex field values.
     //
     //  Args:
     //      NX, NY, NZ: Number of cells of the model domain
-    //      ID, E, H: Access to ID and field component arrays
+    //      ID, Ex, Hy, Hz: Access to ID and field component arrays
 
     // Obtain the linear index corresponding to the current thread
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -58,19 +58,60 @@ __global__ void update_e(int NX, int NY, int NZ, const unsigned int* __restrict_
     int j_ID = ((idx % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) / $NZ_ID;
     int k_ID = ((idx % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) % $NZ_ID;
 
-    // Ex component
     if ((NY != 1 || NZ != 1) && i >= 0 && i < NX && j > 0 && j < NY && k > 0 && k < NZ) {
         int materialEx = ID[INDEX4D_ID(0,i_ID,j_ID,k_ID)];
         Ex[INDEX3D_FIELDS(i,j,k)] = updatecoeffsE[INDEX2D_MAT(materialEx,0)] * Ex[INDEX3D_FIELDS(i,j,k)] + updatecoeffsE[INDEX2D_MAT(materialEx,2)] * (Hz[INDEX3D_FIELDS(i,j,k)] - Hz[INDEX3D_FIELDS(i,j-1,k)]) - updatecoeffsE[INDEX2D_MAT(materialEx,3)] * (Hy[INDEX3D_FIELDS(i,j,k)] - Hy[INDEX3D_FIELDS(i,j,k-1)]);
     }
+}
 
-    // Ey component
+__global__ void update_ey(int NX, int NY, int NZ, const unsigned int* __restrict__ ID, $REAL *Ey, const $REAL* __restrict__ Hx, const $REAL* __restrict__ Hz) {
+
+    //  This function updates Ey field values.
+    //
+    //  Args:
+    //      NX, NY, NZ: Number of cells of the model domain
+    //      ID, Ey, Hx, Hz: Access to ID and field component arrays
+
+    // Obtain the linear index corresponding to the current thread
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    // Convert the linear index to subscripts for 3D field arrays
+    int i = idx / ($NY_FIELDS * $NZ_FIELDS);
+    int j = (idx % ($NY_FIELDS * $NZ_FIELDS)) / $NZ_FIELDS;
+    int k = (idx % ($NY_FIELDS * $NZ_FIELDS)) % $NZ_FIELDS;
+
+    // Convert the linear index to subscripts for 4D material ID array
+    int i_ID = (idx % ($NX_ID * $NY_ID * $NZ_ID)) / ($NY_ID * $NZ_ID);
+    int j_ID = ((idx % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) / $NZ_ID;
+    int k_ID = ((idx % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) % $NZ_ID;
+
     if ((NX != 1 || NZ != 1) && i > 0 && i < NX && j >= 0 && j < NY && k > 0 && k < NZ) {
         int materialEy = ID[INDEX4D_ID(1,i_ID,j_ID,k_ID)];
         Ey[INDEX3D_FIELDS(i,j,k)] = updatecoeffsE[INDEX2D_MAT(materialEy,0)] * Ey[INDEX3D_FIELDS(i,j,k)] + updatecoeffsE[INDEX2D_MAT(materialEy,3)] * (Hx[INDEX3D_FIELDS(i,j,k)] - Hx[INDEX3D_FIELDS(i,j,k-1)]) - updatecoeffsE[INDEX2D_MAT(materialEy,1)] * (Hz[INDEX3D_FIELDS(i,j,k)] - Hz[INDEX3D_FIELDS(i-1,j,k)]);
     }
+}
 
-    // Ez component
+__global__ void update_ez(int NX, int NY, int NZ, const unsigned int* __restrict__ ID, $REAL *Ez, const $REAL* __restrict__ Hx, const $REAL* __restrict__ Hy) {
+
+    //  This function updates Ez field values.
+    //
+    //  Args:
+    //      NX, NY, NZ: Number of cells of the model domain
+    //      ID, Ez, Hx, Hy: Access to ID and field component arrays
+
+    // Obtain the linear index corresponding to the current thread
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    // Convert the linear index to subscripts for 3D field arrays
+    int i = idx / ($NY_FIELDS * $NZ_FIELDS);
+    int j = (idx % ($NY_FIELDS * $NZ_FIELDS)) / $NZ_FIELDS;
+    int k = (idx % ($NY_FIELDS * $NZ_FIELDS)) % $NZ_FIELDS;
+
+    // Convert the linear index to subscripts for 4D material ID array
+    int i_ID = (idx % ($NX_ID * $NY_ID * $NZ_ID)) / ($NY_ID * $NZ_ID);
+    int j_ID = ((idx % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) / $NZ_ID;
+    int k_ID = ((idx % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) % $NZ_ID;
+
     if ((NX != 1 || NY != 1) && i > 0 && i < NX && j > 0 && j < NY && k >= 0 && k < NZ) {
         int materialEz = ID[INDEX4D_ID(2,i_ID,j_ID,k_ID)];
         Ez[INDEX3D_FIELDS(i,j,k)] = updatecoeffsE[INDEX2D_MAT(materialEz,0)] * Ez[INDEX3D_FIELDS(i,j,k)] + updatecoeffsE[INDEX2D_MAT(materialEz,1)] * (Hy[INDEX3D_FIELDS(i,j,k)] - Hy[INDEX3D_FIELDS(i-1,j,k)]) - updatecoeffsE[INDEX2D_MAT(materialEz,2)] * (Hx[INDEX3D_FIELDS(i,j,k)] - Hx[INDEX3D_FIELDS(i,j-1,k)]);
@@ -199,13 +240,13 @@ __global__ void update_e_dispersive_B(int NX, int NY, int NZ, int MAXPOLES, cons
 // Magnetic field updates //
 ////////////////////////////
 
-__global__ void update_h(int NX, int NY, int NZ, const unsigned int* __restrict__ ID, $REAL *Hx, $REAL *Hy, $REAL *Hz, const $REAL* __restrict__ Ex, const $REAL* __restrict__ Ey, const $REAL* __restrict__ Ez) {
+__global__ void update_hx(int NX, int NY, int NZ, const unsigned int* __restrict__ ID, $REAL *Hx, const $REAL* __restrict__ Ey, const $REAL* __restrict__ Ez) {
 
-    //  This function updates magnetic field values.
+    //  This function updates Hx field values.
     //
     //  Args:
     //      NX, NY, NZ: Number of cells of the model domain
-    //      ID, E, H: Access to ID and field component arrays
+    //      ID, Hx, Ey, Ez: Access to ID and field component arrays
 
     // Obtain the linear index corresponding to the current thread
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -220,23 +261,65 @@ __global__ void update_h(int NX, int NY, int NZ, const unsigned int* __restrict_
     int j_ID = ((idx % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) / $NZ_ID;
     int k_ID = ((idx % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) % $NZ_ID;
 
-    // Hx component
     if (NX != 1 && i > 0 && i < NX && j >= 0 && j < NY && k >= 0 && k < NZ) {
         int materialHx = ID[INDEX4D_ID(3,i_ID,j_ID,k_ID)];
         Hx[INDEX3D_FIELDS(i,j,k)] = updatecoeffsH[INDEX2D_MAT(materialHx,0)] * Hx[INDEX3D_FIELDS(i,j,k)] - updatecoeffsH[INDEX2D_MAT(materialHx,2)] * (Ez[INDEX3D_FIELDS(i,j+1,k)] - Ez[INDEX3D_FIELDS(i,j,k)]) + updatecoeffsH[INDEX2D_MAT(materialHx,3)] * (Ey[INDEX3D_FIELDS(i,j,k+1)] - Ey[INDEX3D_FIELDS(i,j,k)]);
     }
+}
 
-    // Hy component
+__global__ void update_hy(int NX, int NY, int NZ, const unsigned int* __restrict__ ID, $REAL *Hy, const $REAL* __restrict__ Ex, const $REAL* __restrict__ Ez) {
+
+    //  This function updates Hy field values.
+    //
+    //  Args:
+    //      NX, NY, NZ: Number of cells of the model domain
+    //      ID, Hy, Ex, Ez: Access to ID and field component arrays
+
+    // Obtain the linear index corresponding to the current thread
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    // Convert the linear index to subscripts for 3D field arrays
+    int i = idx / ($NY_FIELDS * $NZ_FIELDS);
+    int j = (idx % ($NY_FIELDS * $NZ_FIELDS)) / $NZ_FIELDS;
+    int k = (idx % ($NY_FIELDS * $NZ_FIELDS)) % $NZ_FIELDS;
+
+    // Convert the linear index to subscripts for 4D material ID array
+    int i_ID = (idx % ($NX_ID * $NY_ID * $NZ_ID)) / ($NY_ID * $NZ_ID);
+    int j_ID = ((idx % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) / $NZ_ID;
+    int k_ID = ((idx % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) % $NZ_ID;
+
     if (NY != 1 && i >= 0 && i < NX && j > 0 && j < NY && k >= 0 && k < NZ) {
         int materialHy = ID[INDEX4D_ID(4,i_ID,j_ID,k_ID)];
         Hy[INDEX3D_FIELDS(i,j,k)] = updatecoeffsH[INDEX2D_MAT(materialHy,0)] * Hy[INDEX3D_FIELDS(i,j,k)] - updatecoeffsH[INDEX2D_MAT(materialHy,3)] * (Ex[INDEX3D_FIELDS(i,j,k+1)] - Ex[INDEX3D_FIELDS(i,j,k)]) + updatecoeffsH[INDEX2D_MAT(materialHy,1)] * (Ez[INDEX3D_FIELDS(i+1,j,k)] - Ez[INDEX3D_FIELDS(i,j,k)]);
     }
+}
 
-    // Hz component
+__global__ void update_hz(int NX, int NY, int NZ, const unsigned int* __restrict__ ID, $REAL *Hz, const $REAL* __restrict__ Ex, const $REAL* __restrict__ Ey) {
+
+    //  This function updates Hz field values.
+    //
+    //  Args:
+    //      NX, NY, NZ: Number of cells of the model domain
+    //      ID, Hz, Ex, Ey: Access to ID and field component arrays
+
+    // Obtain the linear index corresponding to the current thread
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    // Convert the linear index to subscripts for 3D field arrays
+    int i = idx / ($NY_FIELDS * $NZ_FIELDS);
+    int j = (idx % ($NY_FIELDS * $NZ_FIELDS)) / $NZ_FIELDS;
+    int k = (idx % ($NY_FIELDS * $NZ_FIELDS)) % $NZ_FIELDS;
+
+    // Convert the linear index to subscripts for 4D material ID array
+    int i_ID = (idx % ($NX_ID * $NY_ID * $NZ_ID)) / ($NY_ID * $NZ_ID);
+    int j_ID = ((idx % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) / $NZ_ID;
+    int k_ID = ((idx % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) % $NZ_ID;
+
     if (NZ != 1 && i >= 0 && i < NX && j >= 0 && j < NY && k > 0 && k < NZ) {
         int materialHz = ID[INDEX4D_ID(5,i_ID,j_ID,k_ID)];
         Hz[INDEX3D_FIELDS(i,j,k)] = updatecoeffsH[INDEX2D_MAT(materialHz,0)] * Hz[INDEX3D_FIELDS(i,j,k)] - updatecoeffsH[INDEX2D_MAT(materialHz,1)] * (Ey[INDEX3D_FIELDS(i+1,j,k)] - Ey[INDEX3D_FIELDS(i,j,k)]) + updatecoeffsH[INDEX2D_MAT(materialHz,2)] * (Ex[INDEX3D_FIELDS(i,j+1,k)] - Ex[INDEX3D_FIELDS(i,j,k)]);
     }
+
 }
 
 """)

--- a/gprMax/model_build_run.py
+++ b/gprMax/model_build_run.py
@@ -506,8 +506,12 @@ def solve_gpu(currentmodelrun, modelend, G):
         kernels_fields = SourceModule(kernels_template_fields.substitute(REAL=cudafloattype, COMPLEX=cudacomplextype, N_updatecoeffsE=G.updatecoeffsE.size, N_updatecoeffsH=G.updatecoeffsH.size, NY_MATCOEFFS=G.updatecoeffsE.shape[1], NY_MATDISPCOEFFS=G.updatecoeffsdispersive.shape[1], NX_FIELDS=G.nx + 1, NY_FIELDS=G.ny + 1, NZ_FIELDS=G.nz + 1, NX_ID=G.ID.shape[1], NY_ID=G.ID.shape[2], NZ_ID=G.ID.shape[3], NX_T=G.Tx.shape[1], NY_T=G.Tx.shape[2], NZ_T=G.Tx.shape[3]), options=compiler_opts)
     else:   # Set to one any substitutions for dispersive materials
         kernels_fields = SourceModule(kernels_template_fields.substitute(REAL=cudafloattype, COMPLEX=cudacomplextype, N_updatecoeffsE=G.updatecoeffsE.size, N_updatecoeffsH=G.updatecoeffsH.size, NY_MATCOEFFS=G.updatecoeffsE.shape[1], NY_MATDISPCOEFFS=1, NX_FIELDS=G.nx + 1, NY_FIELDS=G.ny + 1, NZ_FIELDS=G.nz + 1, NX_ID=G.ID.shape[1], NY_ID=G.ID.shape[2], NZ_ID=G.ID.shape[3], NX_T=1, NY_T=1, NZ_T=1), options=compiler_opts)
-    update_e_gpu = kernels_fields.get_function("update_e")
-    update_h_gpu = kernels_fields.get_function("update_h")
+    update_ex_gpu = kernels_fields.get_function("update_ex")
+    update_hx_gpu = kernels_fields.get_function("update_hx")
+    update_hy_gpu = kernels_fields.get_function("update_hy")
+    update_ez_gpu = kernels_fields.get_function("update_ez")
+    update_hz_gpu = kernels_fields.get_function("update_hz")
+    update_ey_gpu = kernels_fields.get_function("update_ey")
 
     # Copy material coefficient arrays to constant memory of GPU (must be <64KB) for fields kernels
     updatecoeffsE = kernels_fields.get_global('updatecoeffsE')[0]
@@ -630,10 +634,18 @@ def solve_gpu(currentmodelrun, modelend, G):
                                            snapHx_gpu.get(), snapHy_gpu.get(), snapHz_gpu.get(), 0, snap)
 
         # Update magnetic field components
-        update_h_gpu(np.int32(G.nx), np.int32(G.ny), np.int32(G.nz),
-                     G.ID_gpu.gpudata, G.Hx_gpu.gpudata, G.Hy_gpu.gpudata,
-                     G.Hz_gpu.gpudata, G.Ex_gpu.gpudata, G.Ey_gpu.gpudata,
-                     G.Ez_gpu.gpudata, block=G.tpb, grid=G.bpg)
+        update_hx_gpu(np.int32(G.nx), np.int32(G.ny), np.int32(G.nz),
+                     G.ID_gpu.gpudata, G.Hx_gpu.gpudata,
+                     G.Ey_gpu.gpudata, G.Ez_gpu.gpudata,
+                     block=G.tpb, grid=G.bpg)
+        update_hy_gpu(np.int32(G.nx), np.int32(G.ny), np.int32(G.nz),
+                     G.ID_gpu.gpudata, G.Hy_gpu.gpudata,
+                     G.Ex_gpu.gpudata, G.Ez_gpu.gpudata,
+                     block=G.tpb, grid=G.bpg)
+        update_hz_gpu(np.int32(G.nx), np.int32(G.ny), np.int32(G.nz),
+                     G.ID_gpu.gpudata, G.Hz_gpu.gpudata,
+                     G.Ex_gpu.gpudata, G.Ey_gpu.gpudata,
+                     block=G.tpb, grid=G.bpg)
 
         # Update magnetic field components with the PML correction
         for pml in G.pmls:
@@ -651,9 +663,17 @@ def solve_gpu(currentmodelrun, modelend, G):
         # Update electric field components
         # If all materials are non-dispersive do standard update
         if Material.maxpoles == 0:
-            update_e_gpu(np.int32(G.nx), np.int32(G.ny), np.int32(G.nz), G.ID_gpu.gpudata,
-                         G.Ex_gpu.gpudata, G.Ey_gpu.gpudata, G.Ez_gpu.gpudata,
-                         G.Hx_gpu.gpudata, G.Hy_gpu.gpudata, G.Hz_gpu.gpudata,
+            update_ex_gpu(np.int32(G.nx), np.int32(G.ny), np.int32(G.nz), G.ID_gpu.gpudata,
+                         G.Ex_gpu.gpudata,
+                         G.Hy_gpu.gpudata, G.Hz_gpu.gpudata,
+                         block=G.tpb, grid=G.bpg)
+            update_ey_gpu(np.int32(G.nx), np.int32(G.ny), np.int32(G.nz), G.ID_gpu.gpudata,
+                         G.Ey_gpu.gpudata,
+                         G.Hx_gpu.gpudata, G.Hz_gpu.gpudata,
+                         block=G.tpb, grid=G.bpg)
+            update_ez_gpu(np.int32(G.nx), np.int32(G.ny), np.int32(G.nz), G.ID_gpu.gpudata,
+                         G.Ez_gpu.gpudata,
+                         G.Hx_gpu.gpudata, G.Hy_gpu.gpudata,
                          block=G.tpb, grid=G.bpg)
         # If there are any dispersive materials do 1st part of dispersive update
         # (it is split into two parts as it requires present and updated electric field values).


### PR DESCRIPTION
Each combined kernel handled all 3 field components with different
boundary conditions, causing warp divergence for threads near domain
boundaries. Splitting into per-component kernels isolates boundary
threads so all threads in a warp take the same branch.

- update_e split into update_ex, update_ey, update_ez
- update_h split into update_hx, update_hy, update_hz
- Each kernel only receives the field arrays it needs
- model_build_run.py updated to get and call the new kernel functions

Closes #608

# PR Description

<!-- Please include a summary of the changes. Please also include relevant motivation and context for making this PR. -->

##  Related Issue  #608

<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

Closes #

## Type of change

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update.

## Checklist

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [ ] Did pre-commit passed all checks?
- [ ] I have performed a self-review of my code.
- [ ] I have added comments for my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] The title of my pull request is a short description of my changes.
