### PR TITLE
perf: remove redundant multiplication in MRIPML order1 PHI updates

### DIFF
--- a/gprMax/pml_updates/pml_updates_electric_MRIPML_gpu.py
+++ b/gprMax/pml_updates/pml_updates_electric_MRIPML_gpu.py
@@ -83,7 +83,7 @@ __global__ void order1_xminus(int xs, int xf, int ys, int yf, int zs, int zf, in
         materialEy = ID[INDEX4D_ID(1,ii,jj,kk)];
         dHz = (Hz[INDEX3D_FIELDS(ii,jj,kk)] - Hz[INDEX3D_FIELDS(ii-1,jj,kk)]) / dx;
         Ey[INDEX3D_FIELDS(ii,jj,kk)] = Ey[INDEX3D_FIELDS(ii,jj,kk)] - updatecoeffsE[INDEX2D_MAT(materialEy,4)] * (IRA1 * dHz - IRA * PHI1[INDEX4D_PHI1(0,i1,j1,k1)]);
-        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = RE0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dHz - RC0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)];
+        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = (RE0 - RC0) * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dHz;
     }
 
     if (p2 == 0 && i2 < nx && j2 < ny && k2 < nz) {
@@ -104,7 +104,7 @@ __global__ void order1_xminus(int xs, int xf, int ys, int yf, int zs, int zf, in
         materialEz = ID[INDEX4D_ID(2,ii,jj,kk)];
         dHy = (Hy[INDEX3D_FIELDS(ii,jj,kk)] - Hy[INDEX3D_FIELDS(ii-1,jj,kk)]) / dx;
         Ez[INDEX3D_FIELDS(ii,jj,kk)] = Ez[INDEX3D_FIELDS(ii,jj,kk)] + updatecoeffsE[INDEX2D_MAT(materialEz,4)] * (IRA1 * dHy - IRA * PHI2[INDEX4D_PHI2(0,i2,j2,k2)]);
-        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = RE0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dHy - RC0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)];
+        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = (RE0 - RC0) * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dHy;
     }
 }
 
@@ -249,7 +249,7 @@ __global__ void order1_xplus(int xs, int xf, int ys, int yf, int zs, int zf, int
         materialEy = ID[INDEX4D_ID(1,ii,jj,kk)];
         dHz = (Hz[INDEX3D_FIELDS(ii,jj,kk)] - Hz[INDEX3D_FIELDS(ii-1,jj,kk)]) / dx;
         Ey[INDEX3D_FIELDS(ii,jj,kk)] = Ey[INDEX3D_FIELDS(ii,jj,kk)] - updatecoeffsE[INDEX2D_MAT(materialEy,4)] * (IRA1 * dHz - IRA * PHI1[INDEX4D_PHI1(0,i1,j1,k1)]);
-        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = RE0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dHz - RC0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)];
+        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] =(RE0 - RC0) * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dHz ;
     }
 
     if (p2 == 0 && i2 < nx && j2 < ny && k2 < nz) {
@@ -270,7 +270,7 @@ __global__ void order1_xplus(int xs, int xf, int ys, int yf, int zs, int zf, int
         materialEz = ID[INDEX4D_ID(2,ii,jj,kk)];
         dHy = (Hy[INDEX3D_FIELDS(ii,jj,kk)] - Hy[INDEX3D_FIELDS(ii-1,jj,kk)]) / dx;
         Ez[INDEX3D_FIELDS(ii,jj,kk)] = Ez[INDEX3D_FIELDS(ii,jj,kk)] + updatecoeffsE[INDEX2D_MAT(materialEz,4)] * (IRA1 * dHy - IRA * PHI2[INDEX4D_PHI2(0,i2,j2,k2)]);
-        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = RE0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dHy - RC0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)];
+        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = (RE0 - RC0) * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dHy;
     }
 }
 
@@ -415,7 +415,7 @@ __global__ void order1_yminus(int xs, int xf, int ys, int yf, int zs, int zf, in
         materialEx = ID[INDEX4D_ID(0,ii,jj,kk)];
         dHz = (Hz[INDEX3D_FIELDS(ii,jj,kk)] - Hz[INDEX3D_FIELDS(ii,jj-1,kk)]) / dy;
         Ex[INDEX3D_FIELDS(ii,jj,kk)] = Ex[INDEX3D_FIELDS(ii,jj,kk)] + updatecoeffsE[INDEX2D_MAT(materialEx,4)] * (IRA1 * dHz - IRA * PHI1[INDEX4D_PHI1(0,i1,j1,k1)]);
-        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = RE0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dHz - RC0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)];
+        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = (RE0 - RC0) * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dHz;
     }
 
     if (p2 == 0 && i2 < nx && j2 < ny && k2 < nz) {
@@ -436,7 +436,7 @@ __global__ void order1_yminus(int xs, int xf, int ys, int yf, int zs, int zf, in
         materialEz = ID[INDEX4D_ID(2,ii,jj,kk)];
         dHx = (Hx[INDEX3D_FIELDS(ii,jj,kk)] - Hx[INDEX3D_FIELDS(ii,jj-1,kk)]) / dy;
         Ez[INDEX3D_FIELDS(ii,jj,kk)] = Ez[INDEX3D_FIELDS(ii,jj,kk)] - updatecoeffsE[INDEX2D_MAT(materialEz,4)] * (IRA1 * dHx - IRA * PHI2[INDEX4D_PHI2(0,i2,j2,k2)]);
-        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = RE0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dHx - RC0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)];
+        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = (RE0 - RC0) * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dHx;
     }
 }
 
@@ -581,7 +581,7 @@ __global__ void order1_yplus(int xs, int xf, int ys, int yf, int zs, int zf, int
         materialEx = ID[INDEX4D_ID(0,ii,jj,kk)];
         dHz = (Hz[INDEX3D_FIELDS(ii,jj,kk)] - Hz[INDEX3D_FIELDS(ii,jj-1,kk)]) / dy;
         Ex[INDEX3D_FIELDS(ii,jj,kk)] = Ex[INDEX3D_FIELDS(ii,jj,kk)] + updatecoeffsE[INDEX2D_MAT(materialEx,4)] * (IRA1 * dHz - IRA * PHI1[INDEX4D_PHI1(0,i1,j1,k1)]);
-        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = RE0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dHz - RC0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)];
+        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = (RE0 - RC0) * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dHz;
     }
 
     if (p2 == 0 && i2 < nx && j2 < ny && k2 < nz) {
@@ -602,7 +602,7 @@ __global__ void order1_yplus(int xs, int xf, int ys, int yf, int zs, int zf, int
         materialEz = ID[INDEX4D_ID(2,ii,jj,kk)];
         dHx = (Hx[INDEX3D_FIELDS(ii,jj,kk)] - Hx[INDEX3D_FIELDS(ii,jj-1,kk)]) / dy;
         Ez[INDEX3D_FIELDS(ii,jj,kk)] = Ez[INDEX3D_FIELDS(ii,jj,kk)] - updatecoeffsE[INDEX2D_MAT(materialEz,4)] * (IRA1 * dHx - IRA * PHI2[INDEX4D_PHI2(0,i2,j2,k2)]);
-        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = RE0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dHx - RC0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)];
+        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = (RE0 - RC0) * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dHx;
     }
 }
 
@@ -747,7 +747,7 @@ __global__ void order1_zminus(int xs, int xf, int ys, int yf, int zs, int zf, in
         materialEx = ID[INDEX4D_ID(0,ii,jj,kk)];
         dHy = (Hy[INDEX3D_FIELDS(ii,jj,kk)] - Hy[INDEX3D_FIELDS(ii,jj,kk-1)]) / dz;
         Ex[INDEX3D_FIELDS(ii,jj,kk)] = Ex[INDEX3D_FIELDS(ii,jj,kk)] - updatecoeffsE[INDEX2D_MAT(materialEx,4)] * (IRA1 * dHy - IRA * PHI1[INDEX4D_PHI1(0,i1,j1,k1)]);
-        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = RE0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dHy - RC0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)];
+        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = (RE0 - RC0) * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dHy;
     }
 
     if (p2 == 0 && i2 < nx && j2 < ny && k2 < nz) {
@@ -768,7 +768,7 @@ __global__ void order1_zminus(int xs, int xf, int ys, int yf, int zs, int zf, in
         materialEy = ID[INDEX4D_ID(1,ii,jj,kk)];
         dHx = (Hx[INDEX3D_FIELDS(ii,jj,kk)] - Hx[INDEX3D_FIELDS(ii,jj,kk-1)]) / dz;
         Ey[INDEX3D_FIELDS(ii,jj,kk)] = Ey[INDEX3D_FIELDS(ii,jj,kk)] + updatecoeffsE[INDEX2D_MAT(materialEy,4)] * (IRA1 * dHx - IRA * PHI2[INDEX4D_PHI2(0,i2,j2,k2)]);
-        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = RE0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dHx - RC0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)];
+        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = (RE0 - RC0) * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dHx;
     }
 }
 
@@ -913,7 +913,7 @@ __global__ void order1_zplus(int xs, int xf, int ys, int yf, int zs, int zf, int
         materialEx = ID[INDEX4D_ID(0,ii,jj,kk)];
         dHy = (Hy[INDEX3D_FIELDS(ii,jj,kk)] - Hy[INDEX3D_FIELDS(ii,jj,kk-1)]) / dz;
         Ex[INDEX3D_FIELDS(ii,jj,kk)] = Ex[INDEX3D_FIELDS(ii,jj,kk)] - updatecoeffsE[INDEX2D_MAT(materialEx,4)] * (IRA1 * dHy - IRA * PHI1[INDEX4D_PHI1(0,i1,j1,k1)]);
-        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = RE0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dHy - RC0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)];
+        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = (RE0 - RC0) * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dHy;
     }
 
     if (p2 == 0 && i2 < nx && j2 < ny && k2 < nz) {
@@ -934,7 +934,7 @@ __global__ void order1_zplus(int xs, int xf, int ys, int yf, int zs, int zf, int
         materialEy = ID[INDEX4D_ID(1,ii,jj,kk)];
         dHx = (Hx[INDEX3D_FIELDS(ii,jj,kk)] - Hx[INDEX3D_FIELDS(ii,jj,kk-1)]) / dz;
         Ey[INDEX3D_FIELDS(ii,jj,kk)] = Ey[INDEX3D_FIELDS(ii,jj,kk)] + updatecoeffsE[INDEX2D_MAT(materialEy,4)] * (IRA1 * dHx - IRA * PHI2[INDEX4D_PHI2(0,i2,j2,k2)]);
-        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = RE0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dHx - RC0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)];
+        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = (RE0 - RC0) * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dHx;
     }
 }
 

--- a/gprMax/pml_updates/pml_updates_magnetic_MRIPML_gpu.py
+++ b/gprMax/pml_updates/pml_updates_magnetic_MRIPML_gpu.py
@@ -270,7 +270,7 @@ __global__ void order1_xplus(int xs, int xf, int ys, int yf, int zs, int zf, int
         materialHz = ID[INDEX4D_ID(5,ii,jj,kk)];
         dEy = (Ey[INDEX3D_FIELDS(ii+1,jj,kk)] - Ey[INDEX3D_FIELDS(ii,jj,kk)]) / dx;
         Hz[INDEX3D_FIELDS(ii,jj,kk)] = Hz[INDEX3D_FIELDS(ii,jj,kk)] - updatecoeffsH[INDEX2D_MAT(materialHz,4)] * (IRA1 * dEy - IRA * PHI2[INDEX4D_PHI2(0,i2,j2,k2)]);
-        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = (RE0 - RC0) * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dEx;
+        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = (RE0 - RC0) * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dEy;
     }
 }
 

--- a/gprMax/pml_updates/pml_updates_magnetic_MRIPML_gpu.py
+++ b/gprMax/pml_updates/pml_updates_magnetic_MRIPML_gpu.py
@@ -83,7 +83,7 @@ __global__ void order1_xminus(int xs, int xf, int ys, int yf, int zs, int zf, in
         materialHy = ID[INDEX4D_ID(4,ii,jj,kk)];
         dEz = (Ez[INDEX3D_FIELDS(ii+1,jj,kk)] - Ez[INDEX3D_FIELDS(ii,jj,kk)]) / dx;
         Hy[INDEX3D_FIELDS(ii,jj,kk)] = Hy[INDEX3D_FIELDS(ii,jj,kk)] + updatecoeffsH[INDEX2D_MAT(materialHy,4)] * (IRA1 * dEz - IRA * PHI1[INDEX4D_PHI1(0,i1,j1,k1)]);
-        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = RE0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dEz - RC0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)];
+        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] =(RE0 - RC0) * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dEz;
     }
 
     if (p2 == 0 && i2 < nx && j2 < ny && k2 < nz) {
@@ -104,7 +104,7 @@ __global__ void order1_xminus(int xs, int xf, int ys, int yf, int zs, int zf, in
         materialHz = ID[INDEX4D_ID(5,ii,jj,kk)];
         dEy = (Ey[INDEX3D_FIELDS(ii+1,jj,kk)] - Ey[INDEX3D_FIELDS(ii,jj,kk)]) / dx;
         Hz[INDEX3D_FIELDS(ii,jj,kk)] = Hz[INDEX3D_FIELDS(ii,jj,kk)] - updatecoeffsH[INDEX2D_MAT(materialHz,4)] * (IRA1 * dEy - IRA * PHI2[INDEX4D_PHI2(0,i2,j2,k2)]);
-        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = RE0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dEy - RC0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)];
+        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = (RE0 - RC0) * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dEy;
     }
 }
 
@@ -249,7 +249,7 @@ __global__ void order1_xplus(int xs, int xf, int ys, int yf, int zs, int zf, int
         materialHy = ID[INDEX4D_ID(4,ii,jj,kk)];
         dEz = (Ez[INDEX3D_FIELDS(ii+1,jj,kk)] - Ez[INDEX3D_FIELDS(ii,jj,kk)]) / dx;
         Hy[INDEX3D_FIELDS(ii,jj,kk)] = Hy[INDEX3D_FIELDS(ii,jj,kk)] + updatecoeffsH[INDEX2D_MAT(materialHy,4)] * (IRA1 * dEz - IRA * PHI1[INDEX4D_PHI1(0,i1,j1,k1)]);
-        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = RE0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dEz - RC0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)];
+        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = (RE0 - RC0) * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dEz;
     }
 
     if (p2 == 0 && i2 < nx && j2 < ny && k2 < nz) {
@@ -270,7 +270,7 @@ __global__ void order1_xplus(int xs, int xf, int ys, int yf, int zs, int zf, int
         materialHz = ID[INDEX4D_ID(5,ii,jj,kk)];
         dEy = (Ey[INDEX3D_FIELDS(ii+1,jj,kk)] - Ey[INDEX3D_FIELDS(ii,jj,kk)]) / dx;
         Hz[INDEX3D_FIELDS(ii,jj,kk)] = Hz[INDEX3D_FIELDS(ii,jj,kk)] - updatecoeffsH[INDEX2D_MAT(materialHz,4)] * (IRA1 * dEy - IRA * PHI2[INDEX4D_PHI2(0,i2,j2,k2)]);
-        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = RE0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dEy - RC0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)];
+        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = (RE0 - RC0) * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dEx;
     }
 }
 
@@ -415,7 +415,7 @@ __global__ void order1_yminus(int xs, int xf, int ys, int yf, int zs, int zf, in
         materialHx = ID[INDEX4D_ID(3,ii,jj,kk)];
         dEz = (Ez[INDEX3D_FIELDS(ii,jj+1,kk)] - Ez[INDEX3D_FIELDS(ii,jj,kk)]) / dy;
         Hx[INDEX3D_FIELDS(ii,jj,kk)] = Hx[INDEX3D_FIELDS(ii,jj,kk)] - updatecoeffsH[INDEX2D_MAT(materialHx,4)] * (IRA1 * dEz - IRA * PHI1[INDEX4D_PHI1(0,i1,j1,k1)]);
-        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = RE0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dEz - RC0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)];
+        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = (RE0 - RC0) * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dEz;
     }
 
     if (p2 == 0 && i2 < nx && j2 < ny && k2 < nz) {
@@ -436,7 +436,7 @@ __global__ void order1_yminus(int xs, int xf, int ys, int yf, int zs, int zf, in
         materialHz = ID[INDEX4D_ID(5,ii,jj,kk)];
         dEx = (Ex[INDEX3D_FIELDS(ii,jj+1,kk)] - Ex[INDEX3D_FIELDS(ii,jj,kk)]) / dy;
         Hz[INDEX3D_FIELDS(ii,jj,kk)] = Hz[INDEX3D_FIELDS(ii,jj,kk)] + updatecoeffsH[INDEX2D_MAT(materialHz,4)] * (IRA1 * dEx - IRA * PHI2[INDEX4D_PHI2(0,i2,j2,k2)]);
-        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = RE0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dEx - RC0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)];
+        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = (RE0 - RC0) * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dEx;
     }
 }
 
@@ -581,7 +581,7 @@ __global__ void order1_yplus(int xs, int xf, int ys, int yf, int zs, int zf, int
         materialHx = ID[INDEX4D_ID(3,ii,jj,kk)];
         dEz = (Ez[INDEX3D_FIELDS(ii,jj+1,kk)] - Ez[INDEX3D_FIELDS(ii,jj,kk)]) / dy;
         Hx[INDEX3D_FIELDS(ii,jj,kk)] = Hx[INDEX3D_FIELDS(ii,jj,kk)] - updatecoeffsH[INDEX2D_MAT(materialHx,4)] * (IRA1 * dEz - IRA * PHI1[INDEX4D_PHI1(0,i1,j1,k1)]);
-        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = RE0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dEz - RC0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)];
+        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = (RE0 - RC0) * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dEz;
     }
 
     if (p2 == 0 && i2 < nx && j2 < ny && k2 < nz) {
@@ -602,7 +602,7 @@ __global__ void order1_yplus(int xs, int xf, int ys, int yf, int zs, int zf, int
         materialHz = ID[INDEX4D_ID(5,ii,jj,kk)];
         dEx = (Ex[INDEX3D_FIELDS(ii,jj+1,kk)] - Ex[INDEX3D_FIELDS(ii,jj,kk)]) / dy;
         Hz[INDEX3D_FIELDS(ii,jj,kk)] = Hz[INDEX3D_FIELDS(ii,jj,kk)] + updatecoeffsH[INDEX2D_MAT(materialHz,4)] * (IRA1 * dEx - IRA * PHI2[INDEX4D_PHI2(0,i2,j2,k2)]);
-        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = RE0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dEx - RC0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)];
+        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = (RE0 - RC0) * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dEx;
     }
 }
 
@@ -747,7 +747,7 @@ __global__ void order1_zminus(int xs, int xf, int ys, int yf, int zs, int zf, in
         materialHx = ID[INDEX4D_ID(3,ii,jj,kk)];
         dEy = (Ey[INDEX3D_FIELDS(ii,jj,kk+1)] - Ey[INDEX3D_FIELDS(ii,jj,kk)]) / dz;
         Hx[INDEX3D_FIELDS(ii,jj,kk)] = Hx[INDEX3D_FIELDS(ii,jj,kk)] + updatecoeffsH[INDEX2D_MAT(materialHx,4)] * (IRA1 * dEy - IRA * PHI1[INDEX4D_PHI1(0,i1,j1,k1)]);
-        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = RE0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dEy - RC0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)];
+        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = (RE0 - RC0) * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dEy;
     }
 
     if (p2 == 0 && i2 < nx && j2 < ny && k2 < nz) {
@@ -768,7 +768,7 @@ __global__ void order1_zminus(int xs, int xf, int ys, int yf, int zs, int zf, in
         materialHy = ID[INDEX4D_ID(4,ii,jj,kk)];
         dEx = (Ex[INDEX3D_FIELDS(ii,jj,kk+1)] - Ex[INDEX3D_FIELDS(ii,jj,kk)]) / dz;
         Hy[INDEX3D_FIELDS(ii,jj,kk)] = Hy[INDEX3D_FIELDS(ii,jj,kk)] - updatecoeffsH[INDEX2D_MAT(materialHy,4)] * (IRA1 * dEx - IRA * PHI2[INDEX4D_PHI2(0,i2,j2,k2)]);
-        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = RE0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dEx - RC0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)];
+        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = (RE0 - RC0) * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dEx;
     }
 }
 
@@ -913,7 +913,7 @@ __global__ void order1_zplus(int xs, int xf, int ys, int yf, int zs, int zf, int
         materialHx = ID[INDEX4D_ID(3,ii,jj,kk)];
         dEy = (Ey[INDEX3D_FIELDS(ii,jj,kk+1)] - Ey[INDEX3D_FIELDS(ii,jj,kk)]) / dz;
         Hx[INDEX3D_FIELDS(ii,jj,kk)] = Hx[INDEX3D_FIELDS(ii,jj,kk)] + updatecoeffsH[INDEX2D_MAT(materialHx,4)] * (IRA1 * dEy - IRA * PHI1[INDEX4D_PHI1(0,i1,j1,k1)]);
-        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = RE0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dEy - RC0 * PHI1[INDEX4D_PHI1(0,i1,j1,k1)];
+        PHI1[INDEX4D_PHI1(0,i1,j1,k1)] = (RE0 - RC0) * PHI1[INDEX4D_PHI1(0,i1,j1,k1)] + RC0 * dEy;
     }
 
     if (p2 == 0 && i2 < nx && j2 < ny && k2 < nz) {
@@ -934,7 +934,7 @@ __global__ void order1_zplus(int xs, int xf, int ys, int yf, int zs, int zf, int
         materialHy = ID[INDEX4D_ID(4,ii,jj,kk)];
         dEx = (Ex[INDEX3D_FIELDS(ii,jj,kk+1)] - Ex[INDEX3D_FIELDS(ii,jj,kk)]) / dz;
         Hy[INDEX3D_FIELDS(ii,jj,kk)] = Hy[INDEX3D_FIELDS(ii,jj,kk)] - updatecoeffsH[INDEX2D_MAT(materialHy,4)] * (IRA1 * dEx - IRA * PHI2[INDEX4D_PHI2(0,i2,j2,k2)]);
-        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = RE0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dEx - RC0 * PHI2[INDEX4D_PHI2(0,i2,j2,k2)];
+        PHI2[INDEX4D_PHI2(0,i2,j2,k2)] = (RE0 - RC0) * PHI2[INDEX4D_PHI2(0,i2,j2,k2)] + RC0 * dEx;
     }
 }
 


### PR DESCRIPTION
## Related Issue (Number)

Closes #618

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Summary

In all 6 order1 kernels across both electric and magnetic MRIPML GPU 
files, the PHI array update had a redundant multiplication:
```c
// BEFORE - RC0 * PHI computed twice
PHI = RE0 * PHI + RC0 * dH - RC0 * PHI

// AFTER - factored out, one less multiplication per thread
PHI = (RE0 - RC0) * PHI + RC0 * dH
```

The result is mathematically identical but eliminates one floating 
point multiplication per thread across all 12 PHI update lines 
(2 per kernel × 6 kernels) in both files.

### Files changed:
- `gprMax/pml_updates/pml_updates_electric_MRIPML_gpu.py` — 12 lines fixed
- `gprMax/pml_updates/pml_updates_magnetic_MRIPML_gpu.py` — 12 lines fixed

### What was not changed:
The order2 kernels are unaffected — they use a different Psi-based 
formulation that does not have this pattern.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added comments for my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.