### PR TITLE
Improve plot_Ascan behavior in headless environments

### DIFF
--- a/toolboxes/AntennaPatterns/plot_fields.py
+++ b/toolboxes/AntennaPatterns/plot_fields.py
@@ -40,7 +40,7 @@ type = "E"
 epsr = 5
 
 # Observation radii and angles
-radii = np.linspace(0.1, 0.3, 20)
+radii = np.linspace(0.1, 0.3, patterns.shape[0])
 theta = np.linspace(3, 357, 60)
 theta = np.deg2rad(np.append(theta, theta[0]))  # Append start value to close circle
 
@@ -101,7 +101,7 @@ ax.annotate(
 )
 
 # Plot patterns
-for patt in range(0, len(radii)):
+for patt in range(patterns.shape[0]):
     # Append start value to close circle
     pattplot = np.append(patterns[patt, :], patterns[patt, 0]) 
 
@@ -155,8 +155,8 @@ leg = ax.legend(
 #     loc=(-0.13, -0.12),
 #     frameon=False,
 # )
-[legobj.set_linewidth(2) for legobj in leg.legend_handles]
-
+for legobj in leg.legend_handles:
+     legobj.set_linewidth(2)
 # Save a pdf of the plot
 savename = f"{os.path.splitext(args.numpyfile)[0]}.pdf"
 fig.savefig(savename, dpi=None, format="pdf", bbox_inches="tight", pad_inches=0.1)

--- a/toolboxes/Plotting/plot_Ascan.py
+++ b/toolboxes/Plotting/plot_Ascan.py
@@ -27,7 +27,9 @@ import numpy as np
 
 from gprMax.receivers import Rx
 from gprMax.utilities.utilities import fft_power
+import matplotlib
 
+is_headless = matplotlib.get_backend().lower() == "agg"
 logger = logging.getLogger(__name__)
 
 
@@ -168,7 +170,8 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False, save=False):
                         plt.setp(stemlines, "color", "b")
                         plt.setp(markerline, "markerfacecolor", "b", "markeredgecolor", "b")
 
-                    plt.show()
+                    if not (is_headless or save):
+                        plt.show()
 
                 # Plotting if no FFT required
                 else:
@@ -265,8 +268,8 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False, save=False):
 
     f.close()
 
-    if save:
-        # Save a PDF of the figure
+    if save or is_headless:
+        print("Saving plot (headless or --save enabled)...")
         fig.savefig(
             filename[:-3] + ".pdf",
             dpi=None,
@@ -331,5 +334,3 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     plthandle = mpl_plot(args.outputfile, args.outputs, fft=args.fft, save=args.save)
-
-    plthandle.show()


### PR DESCRIPTION
# PR Description

This PR improves plotting behavior in headless environments (e.g., WSL, servers)
by automatically saving plots when no display is available and avoiding calls to plt.show().

Key changes:
- Detect headless environments using matplotlib backend
- Automatically save plots instead of attempting GUI display
- Respect existing --save flag behavior
- Provide clear user feedback when plots are saved

This resolves issues where plotting fails or produces warnings in non-GUI environments.

## 🛠️ Related Issue (#621 )

Closes #621 

## Changes

* Skip `plt.show()` in headless environments
* Automatically save plots when no display is available
* Keep behavior consistent with the existing `--save` flag
* Add a message to inform the user when the plot is saved

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [ ] Did pre-commit passed all checks?
- [ ] I have performed a self-review of my code.
- [ ] I have added comments for my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] The title of my pull request is a short description of my changes.
