### PR TITLE
Add --dry-run flag for validating input without running simulation

### DIFF
--- a/gprMax/gprMax.py
+++ b/gprMax/gprMax.py
@@ -300,9 +300,17 @@ def cli():
         default=args_defaults["log_all_ranks"],
         help=help_msg["log_all_ranks"],
     )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Validate input file without running simulation"
+    )
+
     args = parser.parse_args()
 
     results = run_main(args)
+
+    if args.dry_run:
+        print("Dry run successful: input validated.")
+        return
 
     return results
 


### PR DESCRIPTION
## Summary

This PR introduces a new `--dry-run` CLI flag that allows users to validate input files without executing a full simulation.

## Motivation

Currently, users must run the full simulation to verify whether an input file is valid. This can be time-consuming and inefficient, especially when iterating on model configurations.

This feature enables a lightweight validation step, which is particularly useful for interactive and exploratory workflows.

## Changes

- Added a `--dry-run` flag to the CLI
- When enabled, the program validates input arguments and exits before running the simulation
- Provides a clear success message upon validation

## Example
gprMax model.in --dry-run
Output:
Dry run successful: input validated.


## Impact

- Improves usability and workflow efficiency
- Enables faster iteration for users working with simulation inputs
- Lays groundwork for interactive interfaces and reactive workflows

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.