### PR TITLE
Make legacy test scripts safe to import

### DIFF
--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -28,63 +28,68 @@ from gprMax.exceptions import CmdInputError
 
 """Plots a comparison of fields between given simulation output and experimental data files."""
 
-# Parse command line arguments
-parser = argparse.ArgumentParser(description='Plots a comparison of fields between given simulation output and experimental data files.', usage='cd gprMax; python -m tests.test_compare_experimental modelfile realfile output')
-parser.add_argument('modelfile', help='name of model output file including path')
-parser.add_argument('realfile', help='name of file containing experimental data including path')
-parser.add_argument('output', help='output to be plotted, i.e. Ex Ey Ez', nargs='+')
-args = parser.parse_args()
+def main():
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description='Plots a comparison of fields between given simulation output and experimental data files.', usage='cd gprMax; python -m tests.test_compare_experimental modelfile realfile output')
+    parser.add_argument('modelfile', help='name of model output file including path')
+    parser.add_argument('realfile', help='name of file containing experimental data including path')
+    parser.add_argument('output', help='output to be plotted, i.e. Ex Ey Ez', nargs='+')
+    args = parser.parse_args()
 
-# Model results
-f = h5py.File(args.modelfile, 'r')
-path = '/rxs/rx1/'
-availablecomponents = list(f[path].keys())
+    # Model results
+    f = h5py.File(args.modelfile, 'r')
+    path = '/rxs/rx1/'
+    availablecomponents = list(f[path].keys())
 
-# Check for polarity of output and if requested output is in file
-if args.output[0][0] == 'm':
-    polarity = -1
-    args.outputs[0] = args.output[0][1:]
-else:
-    polarity = 1
+    # Check for polarity of output and if requested output is in file
+    if args.output[0][0] == 'm':
+        polarity = -1
+        args.output[0] = args.output[0][1:]
+    else:
+        polarity = 1
 
-if args.output[0] not in availablecomponents:
-    raise CmdInputError('{} output requested to plot, but the available output for receiver 1 is {}'.format(args.output[0], ', '.join(availablecomponents)))
+    if args.output[0] not in availablecomponents:
+        raise CmdInputError('{} output requested to plot, but the available output for receiver 1 is {}'.format(args.output[0], ', '.join(availablecomponents)))
 
-floattype = f[path + args.output[0]].dtype
-iterations = f.attrs['Iterations']
-dt = f.attrs['dt']
-model = np.zeros(iterations, dtype=floattype)
-model = f[path + args.output[0]][:] * polarity
-model /= np.amax(np.abs(model))
-timemodel = np.linspace(0, 1, iterations)
-timemodel *= (iterations * dt)
-f.close()
+    floattype = f[path + args.output[0]].dtype
+    iterations = f.attrs['Iterations']
+    dt = f.attrs['dt']
+    model = np.zeros(iterations, dtype=floattype)
+    model = f[path + args.output[0]][:] * polarity
+    model /= np.amax(np.abs(model))
+    timemodel = np.linspace(0, 1, iterations)
+    timemodel *= (iterations * dt)
+    f.close()
 
-# Find location of maximum value from model
-modelmax = np.where(np.abs(model) == 1)[0][0]
+    # Find location of maximum value from model
+    modelmax = np.where(np.abs(model) == 1)[0][0]
 
-# Real results
-with open(args.realfile, 'r') as f:
-    real = np.loadtxt(f)
-real[:, 1] = real[:, 1] / np.amax(np.abs(real[:, 1]))
-realmax = np.where(np.abs(real[:, 1]) == 1)[0][0]
+    # Real results
+    with open(args.realfile, 'r') as f:
+        real = np.loadtxt(f)
+    real[:, 1] = real[:, 1] / np.amax(np.abs(real[:, 1]))
+    realmax = np.where(np.abs(real[:, 1]) == 1)[0][0]
 
-difftime = - (timemodel[modelmax] - real[realmax, 0])
+    difftime = - (timemodel[modelmax] - real[realmax, 0])
 
-# Plot modelled and real data
-fig, ax = plt.subplots(num=args.modelfile + ' versus ' + args.realfile, figsize=(20, 10), facecolor='w', edgecolor='w')
-ax.plot(timemodel + difftime, model, 'r', lw=2, label='Model')
-ax.plot(real[:, 0], real[:, 1], 'r', ls='--', lw=2, label='Experiment')
-ax.set_xlabel('Time [s]')
-ax.set_ylabel('Amplitude')
-ax.set_xlim([0, timemodel[-1]])
-ax.set_ylim([-1, 1])
-ax.legend()
-ax.grid()
+    # Plot modelled and real data
+    fig, ax = plt.subplots(num=args.modelfile + ' versus ' + args.realfile, figsize=(20, 10), facecolor='w', edgecolor='w')
+    ax.plot(timemodel + difftime, model, 'r', lw=2, label='Model')
+    ax.plot(real[:, 0], real[:, 1], 'r', ls='--', lw=2, label='Experiment')
+    ax.set_xlabel('Time [s]')
+    ax.set_ylabel('Amplitude')
+    ax.set_xlim([0, timemodel[-1]])
+    ax.set_ylim([-1, 1])
+    ax.legend()
+    ax.grid()
 
-# Save a PDF/PNG of the figure
-savename = os.path.abspath(os.path.dirname(args.modelfile)) + os.sep + os.path.splitext(os.path.split(args.modelfile)[1])[0] + '_vs_' + os.path.splitext(os.path.split(args.realfile)[1])[0]
-# fig.savefig(savename + '.pdf', dpi=None, format='pdf', bbox_inches='tight', pad_inches=0.1)
-# fig.savefig((savename + '.png', dpi=150, format='png', bbox_inches='tight', pad_inches=0.1)
+    # Save a PDF/PNG of the figure
+    savename = os.path.abspath(os.path.dirname(args.modelfile)) + os.sep + os.path.splitext(os.path.split(args.modelfile)[1])[0] + '_vs_' + os.path.splitext(os.path.split(args.realfile)[1])[0]
+    # fig.savefig(savename + '.pdf', dpi=None, format='pdf', bbox_inches='tight', pad_inches=0.1)
+    # fig.savefig((savename + '.png', dpi=150, format='png', bbox_inches='tight', pad_inches=0.1)
 
-plt.show()
+    plt.show()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -56,150 +56,156 @@ testmodels = ['hertzian_dipole_fs_analytical', '2D_ExHyHz', '2D_EyHxHz', '2D_EzH
 # Select a specific model if desired
 # testmodels = testmodels[:-1]
 # testmodels = [testmodels[6]]
-testresults = dict.fromkeys(testmodels)
 path = '/rxs/rx1/'
 
 # Minimum value of difference to plot (dB)
 plotmin = -160
 
-for i, model in enumerate(testmodels):
+def main():
+    testresults = dict.fromkeys(testmodels)
 
-    testresults[model] = {}
+    for i, model in enumerate(testmodels):
 
-    # Run model
-    inputfile = os.path.join(basepath, model + os.path.sep + model + '.in')
-    api(inputfile, gpu=None)
+        testresults[model] = {}
 
-    # Special case for analytical comparison
-    if model == 'hertzian_dipole_fs_analytical':
-        # Get output for model file
-        filetest = h5py.File(os.path.join(basepath, model + os.path.sep + model + '.out'), 'r')
-        testresults[model]['Test version'] = filetest.attrs['gprMax']
+        # Run model
+        inputfile = os.path.join(basepath, model + os.path.sep + model + '.in')
+        api(inputfile, gpu=None)
 
-        # Get available field output component names
-        outputstest = list(filetest[path].keys())
+        # Special case for analytical comparison
+        if model == 'hertzian_dipole_fs_analytical':
+            # Get output for model file
+            filetest = h5py.File(os.path.join(basepath, model + os.path.sep + model + '.out'), 'r')
+            testresults[model]['Test version'] = filetest.attrs['gprMax']
 
-        # Arrays for storing time
-        floattype = filetest[path + outputstest[0]].dtype
-        timetest = np.linspace(0, (filetest.attrs['Iterations'] - 1) * filetest.attrs['dt'], num=filetest.attrs['Iterations']) / 1e-9
-        timeref = timetest
+            # Get available field output component names
+            outputstest = list(filetest[path].keys())
 
-        # Arrays for storing field data
-        datatest = np.zeros((filetest.attrs['Iterations'], len(outputstest)), dtype=floattype)
-        for ID, name in enumerate(outputstest):
-            datatest[:, ID] = filetest[path + str(name)][:]
-            if np.any(np.isnan(datatest[:, ID])):
-                raise GeneralError('Test data contains NaNs')
+            # Arrays for storing time
+            floattype = filetest[path + outputstest[0]].dtype
+            timetest = np.linspace(0, (filetest.attrs['Iterations'] - 1) * filetest.attrs['dt'], num=filetest.attrs['Iterations']) / 1e-9
+            timeref = timetest
 
-        # Tx/Rx position to feed to analytical solution
-        rxpos = filetest[path].attrs['Position']
-        txpos = filetest['/srcs/src1/'].attrs['Position']
-        rxposrelative = ((rxpos[0] - txpos[0]), (rxpos[1] - txpos[1]), (rxpos[2] - txpos[2]))
+            # Arrays for storing field data
+            datatest = np.zeros((filetest.attrs['Iterations'], len(outputstest)), dtype=floattype)
+            for ID, name in enumerate(outputstest):
+                datatest[:, ID] = filetest[path + str(name)][:]
+                if np.any(np.isnan(datatest[:, ID])):
+                    raise GeneralError('Test data contains NaNs')
 
-        # Analytical solution of a dipole in free space
-        dataref = hertzian_dipole_fs(filetest.attrs['Iterations'], filetest.attrs['dt'], filetest.attrs['dx_dy_dz'], rxposrelative)
+            # Tx/Rx position to feed to analytical solution
+            rxpos = filetest[path].attrs['Position']
+            txpos = filetest['/srcs/src1/'].attrs['Position']
+            rxposrelative = ((rxpos[0] - txpos[0]), (rxpos[1] - txpos[1]), (rxpos[2] - txpos[2]))
 
-        filetest.close()
+            # Analytical solution of a dipole in free space
+            dataref = hertzian_dipole_fs(filetest.attrs['Iterations'], filetest.attrs['dt'], filetest.attrs['dx_dy_dz'], rxposrelative)
 
-    else:
-        # Get output for model and reference files
-        fileref = h5py.File(os.path.join(basepath, model + os.path.sep + model + '_ref.out'), 'r')
-        filetest = h5py.File(os.path.join(basepath, model + os.path.sep + model + '.out'), 'r')
-        testresults[model]['Ref version'] = fileref.attrs['gprMax']
-        testresults[model]['Test version'] = filetest.attrs['gprMax']
+            filetest.close()
 
-        # Get available field output component names
-        outputsref = list(fileref[path].keys())
-        outputstest = list(filetest[path].keys())
-        if outputsref != outputstest:
-            raise GeneralError('Field output components do not match reference solution')
+        else:
+            # Get output for model and reference files
+            fileref = h5py.File(os.path.join(basepath, model + os.path.sep + model + '_ref.out'), 'r')
+            filetest = h5py.File(os.path.join(basepath, model + os.path.sep + model + '.out'), 'r')
+            testresults[model]['Ref version'] = fileref.attrs['gprMax']
+            testresults[model]['Test version'] = filetest.attrs['gprMax']
 
-        # Check that type of float used to store fields matches
-        if filetest[path + outputstest[0]].dtype != fileref[path + outputsref[0]].dtype:
-            print(Fore.RED + 'WARNING: Type of floating point number in test model ({}) does not match type in reference solution ({})\n'.format(filetest[path + outputstest[0]].dtype, fileref[path + outputsref[0]].dtype) + Style.RESET_ALL)
-        floattyperef = fileref[path + outputsref[0]].dtype
-        floattypetest = filetest[path + outputstest[0]].dtype
+            # Get available field output component names
+            outputsref = list(fileref[path].keys())
+            outputstest = list(filetest[path].keys())
+            if outputsref != outputstest:
+                raise GeneralError('Field output components do not match reference solution')
 
-        # Arrays for storing time
-        timeref = np.zeros((fileref.attrs['Iterations']), dtype=floattyperef)
-        timeref = np.linspace(0, (fileref.attrs['Iterations'] - 1) * fileref.attrs['dt'], num=fileref.attrs['Iterations']) / 1e-9
-        timetest = np.zeros((filetest.attrs['Iterations']), dtype=floattypetest)
-        timetest = np.linspace(0, (filetest.attrs['Iterations'] - 1) * filetest.attrs['dt'], num=filetest.attrs['Iterations']) / 1e-9
+            # Check that type of float used to store fields matches
+            if filetest[path + outputstest[0]].dtype != fileref[path + outputsref[0]].dtype:
+                print(Fore.RED + 'WARNING: Type of floating point number in test model ({}) does not match type in reference solution ({})\n'.format(filetest[path + outputstest[0]].dtype, fileref[path + outputsref[0]].dtype) + Style.RESET_ALL)
+            floattyperef = fileref[path + outputsref[0]].dtype
+            floattypetest = filetest[path + outputstest[0]].dtype
 
-        # Arrays for storing field data
-        dataref = np.zeros((fileref.attrs['Iterations'], len(outputsref)), dtype=floattyperef)
-        datatest = np.zeros((filetest.attrs['Iterations'], len(outputstest)), dtype=floattypetest)
-        for ID, name in enumerate(outputsref):
-            dataref[:, ID] = fileref[path + str(name)][:]
-            datatest[:, ID] = filetest[path + str(name)][:]
-            if np.any(np.isnan(datatest[:, ID])):
-                raise GeneralError('Test data contains NaNs')
+            # Arrays for storing time
+            timeref = np.zeros((fileref.attrs['Iterations']), dtype=floattyperef)
+            timeref = np.linspace(0, (fileref.attrs['Iterations'] - 1) * fileref.attrs['dt'], num=fileref.attrs['Iterations']) / 1e-9
+            timetest = np.zeros((filetest.attrs['Iterations']), dtype=floattypetest)
+            timetest = np.linspace(0, (filetest.attrs['Iterations'] - 1) * filetest.attrs['dt'], num=filetest.attrs['Iterations']) / 1e-9
 
-        fileref.close()
-        filetest.close()
+            # Arrays for storing field data
+            dataref = np.zeros((fileref.attrs['Iterations'], len(outputsref)), dtype=floattyperef)
+            datatest = np.zeros((filetest.attrs['Iterations'], len(outputstest)), dtype=floattypetest)
+            for ID, name in enumerate(outputsref):
+                dataref[:, ID] = fileref[path + str(name)][:]
+                datatest[:, ID] = filetest[path + str(name)][:]
+                if np.any(np.isnan(datatest[:, ID])):
+                    raise GeneralError('Test data contains NaNs')
 
-    # Diffs
-    datadiffs = np.zeros(datatest.shape, dtype=np.float64)
-    for i in range(len(outputstest)):
-        max = np.amax(np.abs(dataref[:, i]))
-        datadiffs[:, i] = np.divide(np.abs(dataref[:, i] - datatest[:, i]), max, out=np.zeros_like(dataref[:, i]), where=max != 0)  # Replace any division by zero with zero
+            fileref.close()
+            filetest.close()
 
-        # Calculate power (ignore warning from taking a log of any zero values)
-        with np.errstate(divide='ignore'):
-            datadiffs[:, i] = 20 * np.log10(datadiffs[:, i])
-        # Replace any NaNs or Infs from zero division
-        datadiffs[:, i][np.invert(np.isfinite(datadiffs[:, i]))] = 0
+        # Diffs
+        datadiffs = np.zeros(datatest.shape, dtype=np.float64)
+        for i in range(len(outputstest)):
+            max = np.amax(np.abs(dataref[:, i]))
+            datadiffs[:, i] = np.divide(np.abs(dataref[:, i] - datatest[:, i]), max, out=np.zeros_like(dataref[:, i]), where=max != 0)  # Replace any division by zero with zero
 
-    # Store max difference
-    maxdiff = np.amax(np.amax(datadiffs))
-    testresults[model]['Max diff'] = maxdiff
+            # Calculate power (ignore warning from taking a log of any zero values)
+            with np.errstate(divide='ignore'):
+                datadiffs[:, i] = 20 * np.log10(datadiffs[:, i])
+            # Replace any NaNs or Infs from zero division
+            datadiffs[:, i][np.invert(np.isfinite(datadiffs[:, i]))] = 0
 
-    # Plot datasets
-    fig1, ((ex1, hx1), (ey1, hy1), (ez1, hz1)) = plt.subplots(nrows=3, ncols=2, sharex=False, sharey='col', subplot_kw=dict(xlabel='Time [ns]'), num=model + '.in', figsize=(20, 10), facecolor='w', edgecolor='w')
-    ex1.plot(timetest, datatest[:, 0], 'r', lw=2, label=model)
-    ex1.plot(timeref, dataref[:, 0], 'g', lw=2, ls='--', label=model + '(Ref)')
-    ey1.plot(timetest, datatest[:, 1], 'r', lw=2, label=model)
-    ey1.plot(timeref, dataref[:, 1], 'g', lw=2, ls='--', label=model + '(Ref)')
-    ez1.plot(timetest, datatest[:, 2], 'r', lw=2, label=model)
-    ez1.plot(timeref, dataref[:, 2], 'g', lw=2, ls='--', label=model + '(Ref)')
-    hx1.plot(timetest, datatest[:, 3], 'r', lw=2, label=model)
-    hx1.plot(timeref, dataref[:, 3], 'g', lw=2, ls='--', label=model + '(Ref)')
-    hy1.plot(timetest, datatest[:, 4], 'r', lw=2, label=model)
-    hy1.plot(timeref, dataref[:, 4], 'g', lw=2, ls='--', label=model + '(Ref)')
-    hz1.plot(timetest, datatest[:, 5], 'r', lw=2, label=model)
-    hz1.plot(timeref, dataref[:, 5], 'g', lw=2, ls='--', label=model + '(Ref)')
-    ylabels = ['$E_x$, field strength [V/m]', '$H_x$, field strength [A/m]', '$E_y$, field strength [V/m]', '$H_y$, field strength [A/m]', '$E_z$, field strength [V/m]', '$H_z$, field strength [A/m]']
-    for i, ax in enumerate(fig1.axes):
-        ax.set_ylabel(ylabels[i])
-        ax.set_xlim(0, np.amax(timetest))
-        ax.grid()
-        ax.legend()
+        # Store max difference
+        maxdiff = np.amax(np.amax(datadiffs))
+        testresults[model]['Max diff'] = maxdiff
 
-    # Plot diffs
-    fig2, ((ex2, hx2), (ey2, hy2), (ez2, hz2)) = plt.subplots(nrows=3, ncols=2, sharex=False, sharey='col', subplot_kw=dict(xlabel='Time [ns]'), num='Diffs: ' + model + '.in', figsize=(20, 10), facecolor='w', edgecolor='w')
-    ex2.plot(timeref, datadiffs[:, 0], 'r', lw=2, label='Ex')
-    ey2.plot(timeref, datadiffs[:, 1], 'r', lw=2, label='Ey')
-    ez2.plot(timeref, datadiffs[:, 2], 'r', lw=2, label='Ez')
-    hx2.plot(timeref, datadiffs[:, 3], 'r', lw=2, label='Hx')
-    hy2.plot(timeref, datadiffs[:, 4], 'r', lw=2, label='Hy')
-    hz2.plot(timeref, datadiffs[:, 5], 'r', lw=2, label='Hz')
-    ylabels = ['$E_x$, difference [dB]', '$H_x$, difference [dB]', '$E_y$, difference [dB]', '$H_y$, difference [dB]', '$E_z$, difference [dB]', '$H_z$, difference [dB]']
-    for i, ax in enumerate(fig2.axes):
-        ax.set_ylabel(ylabels[i])
-        ax.set_xlim(0, np.amax(timetest))
-        ax.set_ylim([plotmin, np.amax(np.amax(datadiffs))])
-        ax.grid()
+        # Plot datasets
+        fig1, ((ex1, hx1), (ey1, hy1), (ez1, hz1)) = plt.subplots(nrows=3, ncols=2, sharex=False, sharey='col', subplot_kw=dict(xlabel='Time [ns]'), num=model + '.in', figsize=(20, 10), facecolor='w', edgecolor='w')
+        ex1.plot(timetest, datatest[:, 0], 'r', lw=2, label=model)
+        ex1.plot(timeref, dataref[:, 0], 'g', lw=2, ls='--', label=model + '(Ref)')
+        ey1.plot(timetest, datatest[:, 1], 'r', lw=2, label=model)
+        ey1.plot(timeref, dataref[:, 1], 'g', lw=2, ls='--', label=model + '(Ref)')
+        ez1.plot(timetest, datatest[:, 2], 'r', lw=2, label=model)
+        ez1.plot(timeref, dataref[:, 2], 'g', lw=2, ls='--', label=model + '(Ref)')
+        hx1.plot(timetest, datatest[:, 3], 'r', lw=2, label=model)
+        hx1.plot(timeref, dataref[:, 3], 'g', lw=2, ls='--', label=model + '(Ref)')
+        hy1.plot(timetest, datatest[:, 4], 'r', lw=2, label=model)
+        hy1.plot(timeref, dataref[:, 4], 'g', lw=2, ls='--', label=model + '(Ref)')
+        hz1.plot(timetest, datatest[:, 5], 'r', lw=2, label=model)
+        hz1.plot(timeref, dataref[:, 5], 'g', lw=2, ls='--', label=model + '(Ref)')
+        ylabels = ['$E_x$, field strength [V/m]', '$H_x$, field strength [A/m]', '$E_y$, field strength [V/m]', '$H_y$, field strength [A/m]', '$E_z$, field strength [V/m]', '$H_z$, field strength [A/m]']
+        for i, ax in enumerate(fig1.axes):
+            ax.set_ylabel(ylabels[i])
+            ax.set_xlim(0, np.amax(timetest))
+            ax.grid()
+            ax.legend()
 
-    # Save a PDF/PNG of the figure
-    savename = os.path.join(basepath, model + os.path.sep + model)
-    # fig1.savefig(savename + '.pdf', dpi=None, format='pdf', bbox_inches='tight', pad_inches=0.1)
-    # fig2.savefig(savename + '_diffs.pdf', dpi=None, format='pdf', bbox_inches='tight', pad_inches=0.1)
-    fig1.savefig(savename + '.png', dpi=150, format='png', bbox_inches='tight', pad_inches=0.1)
-    fig2.savefig(savename + '_diffs.png', dpi=150, format='png', bbox_inches='tight', pad_inches=0.1)
+        # Plot diffs
+        fig2, ((ex2, hx2), (ey2, hy2), (ez2, hz2)) = plt.subplots(nrows=3, ncols=2, sharex=False, sharey='col', subplot_kw=dict(xlabel='Time [ns]'), num='Diffs: ' + model + '.in', figsize=(20, 10), facecolor='w', edgecolor='w')
+        ex2.plot(timeref, datadiffs[:, 0], 'r', lw=2, label='Ex')
+        ey2.plot(timeref, datadiffs[:, 1], 'r', lw=2, label='Ey')
+        ez2.plot(timeref, datadiffs[:, 2], 'r', lw=2, label='Ez')
+        hx2.plot(timeref, datadiffs[:, 3], 'r', lw=2, label='Hx')
+        hy2.plot(timeref, datadiffs[:, 4], 'r', lw=2, label='Hy')
+        hz2.plot(timeref, datadiffs[:, 5], 'r', lw=2, label='Hz')
+        ylabels = ['$E_x$, difference [dB]', '$H_x$, difference [dB]', '$E_y$, difference [dB]', '$H_y$, difference [dB]', '$E_z$, difference [dB]', '$H_z$, difference [dB]']
+        for i, ax in enumerate(fig2.axes):
+            ax.set_ylabel(ylabels[i])
+            ax.set_xlim(0, np.amax(timetest))
+            ax.set_ylim([plotmin, np.amax(np.amax(datadiffs))])
+            ax.grid()
 
-# Summary of results
-for name, data in sorted(testresults.items()):
-    if 'analytical' in name:
-        print(Fore.CYAN + "Test '{}.in' using v.{} compared to analytical solution. Max difference {:.2f}dB.".format(name, data['Test version'], data['Max diff']) + Style.RESET_ALL)
-    else:
-        print(Fore.CYAN + "Test '{}.in' using v.{} compared to reference solution using v.{}. Max difference {:.2f}dB.".format(name, data['Test version'], data['Ref version'], data['Max diff']) + Style.RESET_ALL)
+        # Save a PDF/PNG of the figure
+        savename = os.path.join(basepath, model + os.path.sep + model)
+        # fig1.savefig(savename + '.pdf', dpi=None, format='pdf', bbox_inches='tight', pad_inches=0.1)
+        # fig2.savefig(savename + '_diffs.pdf', dpi=None, format='pdf', bbox_inches='tight', pad_inches=0.1)
+        fig1.savefig(savename + '.png', dpi=150, format='png', bbox_inches='tight', pad_inches=0.1)
+        fig2.savefig(savename + '_diffs.png', dpi=150, format='png', bbox_inches='tight', pad_inches=0.1)
+
+    # Summary of results
+    for name, data in sorted(testresults.items()):
+        if 'analytical' in name:
+            print(Fore.CYAN + "Test '{}.in' using v.{} compared to analytical solution. Max difference {:.2f}dB.".format(name, data['Test version'], data['Max diff']) + Style.RESET_ALL)
+        else:
+            print(Fore.CYAN + "Test '{}.in' using v.{} compared to reference solution using v.{}. Max difference {:.2f}dB.".format(name, data['Test version'], data['Ref version'], data['Max diff']) + Style.RESET_ALL)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
# PR Description

This PR makes the legacy test scripts in `tests/` safer to import and easier to automate in the future.

Specifically, it:
- fixes the negative-polarity parsing bug in `tests/test_experimental.py` by changing `args.outputs[0]` to `args.output[0]`
- moves the executable script logic in `tests/test_experimental.py` into `main()` and guards it with `if __name__ == "__main__":`
- moves the executable script logic in `tests/test_models.py` into `main()` and guards it with `if __name__ == "__main__":`
- preserves the existing script/CLI behavior while avoiding import-time side effects

This is a small preparatory refactor aimed at making these legacy scripts friendlier to future `pytest` collection and CI automation. It does not add a full CI pipeline or convert the full suite to pytest.

## 🛠️ Related Issue (Number)

Closes #561

Related to #627

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [ ] Did pre-commit passed all checks?
- [x] I have performed a self-review of my code.
- [ ] I have added comments for my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.

## Validation

I ran:

```bash
python3 -m py_compile tests/test_experimental.py tests/test_models.py
