### PR TITLE
fix: configure matplotlib Agg backend for headless CI environments (#621)

### DIFF
--- a/tools/plot_Ascan.py
+++ b/tools/plot_Ascan.py
@@ -21,6 +21,13 @@ import os
 
 import h5py
 import numpy as np
+import matplotlib
+# --- FIX FOR HEADLESS ENVIRONMENTS (#621) ---
+# Force non-interactive Agg backend for headless CI/CD environments or 
+# Linux nodes without a display to prevent _tkinter.TclError crashes.
+if os.environ.get('CI') or os.environ.get('GITHUB_ACTIONS') or (os.name == 'posix' and not os.environ.get('DISPLAY')):
+    matplotlib.use('Agg')
+# --------------------------------------------
 import matplotlib.pyplot as plt
 
 from gprMax.exceptions import CmdInputError

--- a/tools/plot_Bscan.py
+++ b/tools/plot_Bscan.py
@@ -21,6 +21,12 @@ import os
 
 import h5py
 import numpy as np
+import matplotlib
+# --- FIX FOR HEADLESS ENVIRONMENTS (#621) ---
+# Force non-interactive Agg backend for headless CI/CD environments or 
+# Linux nodes without a display to prevent _tkinter.TclError crashes.
+if os.environ.get('CI') or os.environ.get('GITHUB_ACTIONS') or (os.name == 'posix' and not os.environ.get('DISPLAY')):
+    matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
 from gprMax.exceptions import CmdInputError

--- a/tools/plot_antenna_params.py
+++ b/tools/plot_antenna_params.py
@@ -22,6 +22,12 @@ import sys
 
 import h5py
 import numpy as np
+import matplotlib
+# --- FIX FOR HEADLESS ENVIRONMENTS (#621) ---
+# Force non-interactive Agg backend for headless CI/CD environments or 
+# Linux nodes without a display to prevent _tkinter.TclError crashes.
+if os.environ.get('CI') or os.environ.get('GITHUB_ACTIONS') or (os.name == 'posix' and not os.environ.get('DISPLAY')):
+    matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 

--- a/tools/plot_source_wave.py
+++ b/tools/plot_source_wave.py
@@ -21,6 +21,12 @@ import os
 import sys
 
 import numpy as np
+import matplotlib
+# --- FIX FOR HEADLESS ENVIRONMENTS (#621) ---
+# Force non-interactive Agg backend for headless CI/CD environments or 
+# Linux nodes without a display to prevent _tkinter.TclError crashes.
+if os.environ.get('CI') or os.environ.get('GITHUB_ACTIONS') or (os.name == 'posix' and not os.environ.get('DISPLAY')):
+    matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
 from gprMax.exceptions import CmdInputError


### PR DESCRIPTION
# PR Description

When executing plotting scripts (`plot_Ascan.py`, `plot_Bscan.py`, `plot_source_wave.py`, and `plot_antenna_params.py`) in headless environments—such as Ubuntu GitHub Actions runners or remote nodes—`matplotlib` attempts to initialize default interactive backends (like `TkAgg`). This results in a fatal `_tkinter.TclError: no display name and no $DISPLAY environment variable`, crashing the scripts.

This PR implements a dynamic check during the module import phase across the `tools` directory. If it detects a CI environment (`CI` or `GITHUB_ACTIONS`) or a POSIX system lacking a `$DISPLAY` variable, it forces `matplotlib` to fall back to the non-interactive `Agg` backend *before* `pyplot` is initialized. 

This preserves standard interactive plotting for local users while unblocking the pathway for automating the full physics validation test suite via GitHub Actions.

## 🛠 Related Issue (Number)

Closes #621 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update.

## Checklist

- [x] Did pre-commit passed all checks?