### PR TITLE
Enhance A-scan/B-scan visualization with grid, labels, and save option

### DIFF
--- a/tools/plot_Ascan.py
+++ b/tools/plot_Ascan.py
@@ -28,17 +28,40 @@ from gprMax.receivers import Rx
 from gprMax.utilities import fft_power
 
 
-def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False):
-    """Plots electric and magnetic fields and currents from all receiver points in the given output file. Each receiver point is plotted in a new figure window.
+def _normalize_data(data):
+    """Normalize data to [0, 1] range with safe division.
+
+    Args:
+        data (ndarray): Input signal data.
+
+    Returns:
+        ndarray: Normalized data, or zeros if max amplitude is zero.
+    """
+    max_val = np.amax(np.abs(data))
+    if max_val == 0:
+        return np.zeros_like(data)
+    return data / max_val
+
+
+def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False,
+             show_grid=True, normalize=False):
+    """Plots electric and magnetic fields and currents from all receiver points
+    in the given output file. Each receiver point is plotted in a new figure
+    window.
 
     Args:
         filename (string): Filename (including path) of output file.
         outputs (list): List of field/current components to plot.
         fft (boolean): Plot FFT switch.
+        show_grid (boolean): Whether to display grid lines on plots.
+        normalize (boolean): Normalize output signals to [0, 1] range.
 
     Returns:
         plt (object): matplotlib plot object.
     """
+
+    # Derive display name from filename for titles
+    basename = os.path.basename(filename)
 
     # Open output file and read some attributes
     f = h5py.File(filename, 'r')
@@ -46,6 +69,9 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False):
     dt = f.attrs['dt']
     iterations = f.attrs['Iterations']
     time = np.linspace(0, (iterations - 1) * dt, num=iterations)
+
+    # Convert time to nanoseconds for display
+    time_ns = time * 1e9
 
     # Check there are any receivers
     if nrx == 0:
@@ -79,6 +105,10 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False):
 
             outputdata = f[path + output][:] * polarity
 
+            # Optionally normalize the output data
+            if normalize:
+                outputdata = _normalize_data(outputdata)
+
             # Plotting if FFT required
             if fft:
                 # FFT
@@ -86,7 +116,7 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False):
                 freqmaxpower = np.where(np.isclose(power, 0))[0][0]
 
                 # Set plotting range to -60dB from maximum power or 4 times
-                # frequency at maximum power
+                # frequency at maximum power
                 try:
                     pltrange = np.where(power[freqmaxpower:] < -60)[0][0] + freqmaxpower + 1
                 except:
@@ -96,11 +126,16 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False):
 
                 # Plot time history of output component
                 fig, (ax1, ax2) = plt.subplots(nrows=1, ncols=2, num='rx' + str(rx), figsize=(20, 10), facecolor='w', edgecolor='w')
-                line1 = ax1.plot(time, outputdata, 'r', lw=2, label=outputtext)
-                ax1.set_xlabel('Time [s]')
-                ax1.set_ylabel(outputtext + ' field strength [V/m]')
-                ax1.set_xlim([0, np.amax(time)])
-                ax1.grid(which='both', axis='both', linestyle='-.')
+
+                fig.suptitle('A-scan Output — {} (rx{})'.format(basename, rx))
+
+                ylabel = 'Normalized amplitude' if normalize else outputtext + ' field strength [V/m]'
+                line1 = ax1.plot(time_ns, outputdata, 'r', lw=2, label=outputtext)
+                ax1.set_xlabel('Time (ns)')
+                ax1.set_ylabel(ylabel)
+                ax1.set_xlim([0, np.amax(time_ns)])
+                if show_grid:
+                    ax1.grid(which='both', axis='both', linestyle='-.')
 
                 # Plot frequency spectra
                 markerline, stemlines, baseline = ax2.stem(freqs[pltrange], power[pltrange], '-.')
@@ -110,51 +145,64 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False):
                 line2 = ax2.plot(freqs[pltrange], power[pltrange], 'r', lw=2)
                 ax2.set_xlabel('Frequency [Hz]')
                 ax2.set_ylabel('Power [dB]')
-                ax2.grid(which='both', axis='both', linestyle='-.')
+                if show_grid:
+                    ax2.grid(which='both', axis='both', linestyle='-.')
 
                 # Change colours and labels for magnetic field components or currents
                 if 'H' in outputs[0]:
                     plt.setp(line1, color='g')
                     plt.setp(line2, color='g')
-                    plt.setp(ax1, ylabel=outputtext + ' field strength [A/m]')
+                    if not normalize:
+                        plt.setp(ax1, ylabel=outputtext + ' field strength [A/m]')
                     plt.setp(stemlines, 'color', 'g')
                     plt.setp(markerline, 'markerfacecolor', 'g', 'markeredgecolor', 'g')
                 elif 'I' in outputs[0]:
                     plt.setp(line1, color='b')
                     plt.setp(line2, color='b')
-                    plt.setp(ax1, ylabel=outputtext + ' current [A]')
+                    if not normalize:
+                        plt.setp(ax1, ylabel=outputtext + ' current [A]')
                     plt.setp(stemlines, 'color', 'b')
                     plt.setp(markerline, 'markerfacecolor', 'b', 'markeredgecolor', 'b')
 
+                plt.tight_layout()
                 plt.show()
 
             # Plotting if no FFT required
             else:
-                fig, ax = plt.subplots(subplot_kw=dict(xlabel='Time [s]', ylabel=outputtext + ' field strength [V/m]'), num='rx' + str(rx), figsize=(20, 10), facecolor='w', edgecolor='w')
-                line = ax.plot(time, outputdata, 'r', lw=2, label=outputtext)
-                ax.set_xlim([0, np.amax(time)])
-                ax.grid(which='both', axis='both', linestyle='-.')
+                ylabel = 'Normalized amplitude' if normalize else outputtext + ' field strength [V/m]'
+                fig, ax = plt.subplots(subplot_kw=dict(xlabel='Time (ns)', ylabel=ylabel), num='rx' + str(rx), figsize=(20, 10), facecolor='w', edgecolor='w')
+
+                fig.suptitle('A-scan Output — {} (rx{})'.format(basename, rx))
+
+                line = ax.plot(time_ns, outputdata, 'r', lw=2, label=outputtext)
+                ax.set_xlim([0, np.amax(time_ns)])
+                if show_grid:
+                    ax.grid(which='both', axis='both', linestyle='-.')
 
                 if 'H' in output:
                     plt.setp(line, color='g')
-                    plt.setp(ax, ylabel=outputtext + ', field strength [A/m]')
+                    if not normalize:
+                        plt.setp(ax, ylabel=outputtext + ', field strength [A/m]')
                 elif 'I' in output:
                     plt.setp(line, color='b')
-                    plt.setp(ax, ylabel=outputtext + ', current [A]')
+                    if not normalize:
+                        plt.setp(ax, ylabel=outputtext + ', current [A]')
 
-        # If multiple outputs required, create all nine subplots and populate only the specified ones
+        # If multiple outputs required, create all subplots and populate
         else:
             plt_cols = 3 if len(outputs) == 9 else 2
-                
+
             fig, axs = plt.subplots(
-                subplot_kw=dict(xlabel="Time [s]"),
+                subplot_kw=dict(xlabel="Time (ns)"),
                 num='rx' + str(rx),
                 figsize=(20, 10),
-                nrows = 3,
-                ncols = plt_cols,
+                nrows=3,
+                ncols=plt_cols,
                 facecolor="w",
                 edgecolor="w",
             )
+
+            fig.suptitle('A-scan Output — {} (rx{})'.format(basename, rx))
 
             for output in outputs:
                 # Check for polarity of output and if requested output is in file
@@ -172,36 +220,57 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False):
 
                 outputdata = f[path + output][:] * polarity
 
+                # Optionally normalize the output data
+                if normalize:
+                    outputdata = _normalize_data(outputdata)
+
+                # Determine y-axis label based on component type and normalization
+                if normalize:
+                    ylabel = 'Normalized amplitude'
+                elif output.startswith(('E',)):
+                    ylabel = outputtext + ", field strength [V/m]"
+                elif output.startswith(('H',)):
+                    ylabel = outputtext + ", field strength [A/m]"
+                elif output.startswith(('I',)):
+                    ylabel = outputtext + ", current [A]"
+                else:
+                    ylabel = "Amplitude"
+
                 if output == "Ex":
-                        axs[0, 0].plot(time, outputdata, "r", lw=2, label=outputtext)
-                        axs[0, 0].set_ylabel(outputtext + ", field strength [V/m]")
+                    axs[0, 0].plot(time_ns, outputdata, "r", lw=2, label=outputtext)
+                    axs[0, 0].set_ylabel(ylabel)
                 elif output == "Ey":
-                    axs[1, 0].plot(time, outputdata, "r", lw=2, label=outputtext)
-                    axs[1, 0].set_ylabel(outputtext + ", field strength [V/m]")
+                    axs[1, 0].plot(time_ns, outputdata, "r", lw=2, label=outputtext)
+                    axs[1, 0].set_ylabel(ylabel)
                 elif output == "Ez":
-                    axs[2, 0].plot(time, outputdata, "r", lw=2, label=outputtext)
-                    axs[2, 0].set_ylabel(outputtext + ", field strength [V/m]")
+                    axs[2, 0].plot(time_ns, outputdata, "r", lw=2, label=outputtext)
+                    axs[2, 0].set_ylabel(ylabel)
                 elif output == "Hx":
-                    axs[0, 1].plot(time, outputdata, "g", lw=2, label=outputtext)
-                    axs[0, 1].set_ylabel(outputtext + ", field strength [A/m]")
+                    axs[0, 1].plot(time_ns, outputdata, "g", lw=2, label=outputtext)
+                    axs[0, 1].set_ylabel(ylabel)
                 elif output == "Hy":
-                    axs[1, 1].plot(time, outputdata, "g", lw=2, label=outputtext)
-                    axs[1, 1].set_ylabel(outputtext + ", field strength [A/m]")
+                    axs[1, 1].plot(time_ns, outputdata, "g", lw=2, label=outputtext)
+                    axs[1, 1].set_ylabel(ylabel)
                 elif output == "Hz":
-                    axs[2, 1].plot(time, outputdata, "g", lw=2, label=outputtext)
-                    axs[2, 1].set_ylabel(outputtext + ", field strength [A/m]")
+                    axs[2, 1].plot(time_ns, outputdata, "g", lw=2, label=outputtext)
+                    axs[2, 1].set_ylabel(ylabel)
                 elif output == "Ix":
-                    axs[0, 2].plot(time, outputdata, "b", lw=2, label=outputtext)
-                    axs[0, 2].set_ylabel(outputtext + ", current [A]")
+                    axs[0, 2].plot(time_ns, outputdata, "b", lw=2, label=outputtext)
+                    axs[0, 2].set_ylabel(ylabel)
                 elif output == "Iy":
-                    axs[1, 2].plot(time, outputdata, "b", lw=2, label=outputtext)
-                    axs[1, 2].set_ylabel(outputtext + ", current [A]")
+                    axs[1, 2].plot(time_ns, outputdata, "b", lw=2, label=outputtext)
+                    axs[1, 2].set_ylabel(ylabel)
                 elif output == "Iz":
-                    axs[2, 2].plot(time, outputdata, "b", lw=2, label=outputtext)
-                    axs[2, 2].set_ylabel(outputtext + ", current [A]")
+                    axs[2, 2].plot(time_ns, outputdata, "b", lw=2, label=outputtext)
+                    axs[2, 2].set_ylabel(ylabel)
+
                 for ax in fig.axes:
-                    ax.set_xlim([0, np.amax(time)])
-                    ax.grid(which="both", axis="both", linestyle="-.")
+                    ax.set_xlim([0, np.amax(time_ns)])
+                    if show_grid:
+                        ax.grid(which="both", axis="both", linestyle="-.")
+
+        # Apply tight layout to prevent label clipping
+        fig.tight_layout()
 
         # Save a PDF/PNG of the figure
         # fig.savefig(os.path.splitext(os.path.abspath(filename))[0] + '_rx' + str(rx) + '.pdf', dpi=None, format='pdf', bbox_inches='tight', pad_inches=0.1)
@@ -215,11 +284,38 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False):
 if __name__ == "__main__":
 
     # Parse command line arguments
-    parser = argparse.ArgumentParser(description='Plots electric and magnetic fields and currents from all receiver points in the given output file. Each receiver point is plotted in a new figure window.', usage='cd gprMax; python -m tools.plot_Ascan outputfile')
+    parser = argparse.ArgumentParser(
+        description='Plots electric and magnetic fields and currents from all '
+                    'receiver points in the given output file. Each receiver '
+                    'point is plotted in a new figure window.',
+        usage='cd gprMax; python -m tools.plot_Ascan outputfile'
+    )
     parser.add_argument('outputfile', help='name of output file including path')
-    parser.add_argument('--outputs', help='outputs to be plotted', default=Rx.defaultoutputs, choices=['Ex', 'Ey', 'Ez', 'Hx', 'Hy', 'Hz', 'Ix', 'Iy', 'Iz', 'Ex-', 'Ey-', 'Ez-', 'Hx-', 'Hy-', 'Hz-', 'Ix-', 'Iy-', 'Iz-'], nargs='+')
-    parser.add_argument('-fft', action='store_true', help='plot FFT (single output must be specified)', default=False)
+    parser.add_argument('--outputs', help='outputs to be plotted',
+                        default=Rx.defaultoutputs,
+                        choices=['Ex', 'Ey', 'Ez', 'Hx', 'Hy', 'Hz',
+                                 'Ix', 'Iy', 'Iz', 'Ex-', 'Ey-', 'Ez-',
+                                 'Hx-', 'Hy-', 'Hz-', 'Ix-', 'Iy-', 'Iz-'],
+                        nargs='+')
+    parser.add_argument('-fft', action='store_true',
+                        help='plot FFT (single output must be specified)',
+                        default=False)
+    parser.add_argument('--save', metavar='FILENAME',
+                        help='save plot to file (e.g. output.png, output.pdf)')
+    parser.add_argument('--no-grid', action='store_true', default=False,
+                        help='disable grid lines on plots')
+    parser.add_argument('--normalize', action='store_true', default=False,
+                        help='normalize signal amplitudes to [0, 1] range')
     args = parser.parse_args()
 
-    plthandle = mpl_plot(args.outputfile, args.outputs, fft=args.fft)
-    plthandle.show()
+    plthandle = mpl_plot(args.outputfile, args.outputs, fft=args.fft,
+                         show_grid=not args.no_grid,
+                         normalize=args.normalize)
+
+    # Save plot to file if --save is provided, otherwise show interactively
+    if args.save:
+        plthandle.savefig(args.save, dpi=150, bbox_inches='tight',
+                          pad_inches=0.1)
+        print('Plot saved to: {}'.format(os.path.abspath(args.save)))
+    else:
+        plthandle.show()

--- a/tools/plot_Bscan.py
+++ b/tools/plot_Bscan.py
@@ -41,17 +41,23 @@ def mpl_plot(filename, outputdata, dt, rxnumber, rxcomponent):
         plt (object): matplotlib plot object.
     """
 
-    (path, filename) = os.path.split(filename)
+    (path, basename) = os.path.split(filename)
 
-    fig = plt.figure(num=filename + ' - rx' + str(rxnumber), 
+    # Convert time axis to nanoseconds for readability
+    time_max_ns = outputdata.shape[0] * dt * 1e9
+
+    fig = plt.figure(num=basename + ' - rx' + str(rxnumber),
                      figsize=(20, 10), facecolor='w', edgecolor='w')
-    plt.imshow(outputdata, 
-               extent=[0, outputdata.shape[1], outputdata.shape[0] * dt, 0], 
-               interpolation='nearest', aspect='auto', cmap='seismic', 
-               vmin=-np.amax(np.abs(outputdata)), vmax=np.amax(np.abs(outputdata)))
+
+    plt.imshow(outputdata,
+               extent=[0, outputdata.shape[1], time_max_ns, 0],
+               interpolation='nearest', aspect='auto', cmap='seismic',
+               vmin=-np.amax(np.abs(outputdata)),
+               vmax=np.amax(np.abs(outputdata)))
+
     plt.xlabel('Trace number')
-    plt.ylabel('Time [s]')
-    # plt.title('{}'.format(filename))
+    plt.ylabel('Time (ns)')
+    plt.title('B-scan — {} (rx{}, {})'.format(basename, rxnumber, rxcomponent))
 
     # Grid properties
     ax = fig.gca()
@@ -65,11 +71,13 @@ def mpl_plot(filename, outputdata, dt, rxnumber, rxcomponent):
     elif 'I' in rxcomponent:
         cb.set_label('Current [A]')
 
+    plt.tight_layout()
+
     # Save a PDF/PNG of the figure
     # savefile = os.path.splitext(filename)[0]
-    # fig.savefig(path + os.sep + savefile + '.pdf', dpi=None, format='pdf', 
+    # fig.savefig(path + os.sep + savefile + '.pdf', dpi=None, format='pdf',
     #             bbox_inches='tight', pad_inches=0.1)
-    # fig.savefig(path + os.sep + savefile + '.png', dpi=150, format='png', 
+    # fig.savefig(path + os.sep + savefile + '.png', dpi=150, format='png',
     #             bbox_inches='tight', pad_inches=0.1)
 
     return plt
@@ -78,11 +86,13 @@ def mpl_plot(filename, outputdata, dt, rxnumber, rxcomponent):
 if __name__ == "__main__":
 
     # Parse command line arguments
-    parser = argparse.ArgumentParser(description='Plots a B-scan image.', 
+    parser = argparse.ArgumentParser(description='Plots a B-scan image.',
                                      usage='cd gprMax; python -m tools.plot_Bscan outputfile output')
     parser.add_argument('outputfile', help='name of output file including path')
-    parser.add_argument('rx_component', help='name of output component to be plotted', 
+    parser.add_argument('rx_component', help='name of output component to be plotted',
                         choices=['Ex', 'Ey', 'Ez', 'Hx', 'Hy', 'Hz', 'Ix', 'Iy', 'Iz'])
+    parser.add_argument('--save', metavar='FILENAME',
+                        help='save plot to file (e.g. output.png, output.pdf)')
     args = parser.parse_args()
 
     # Open output file and read number of outputs (receivers)
@@ -98,4 +108,10 @@ if __name__ == "__main__":
         outputdata, dt = get_output_data(args.outputfile, rx, args.rx_component)
         plthandle = mpl_plot(args.outputfile, outputdata, dt, rx, args.rx_component)
 
-    plthandle.show()
+    # Save plot to file if --save is provided, otherwise show interactively
+    if args.save:
+        plthandle.savefig(args.save, dpi=150, bbox_inches='tight',
+                          pad_inches=0.1)
+        print('Plot saved to: {}'.format(os.path.abspath(args.save)))
+    else:
+        plthandle.show()


### PR DESCRIPTION
## 🔧 Related Issue
N/A

---

## ✨ Summary

This PR improves the usability and clarity of A-scan and B-scan visualization in gprMax by introducing several small but impactful enhancements.

---

## 🚀 Changes Introduced

- Added axis labels for better interpretability:
  - Time (ns)
  - Amplitude
- Enabled grid by default for clearer signal analysis
- Added optional CLI argument `--save` to export plots as image files
- Improved plot layout using `tight_layout()` to avoid clipping
- (Optional) Added normalization support via `--normalize`
- Minor improvements to plot readability and structure

---

## 🎯 Motivation

The existing visualization tools provide basic plotting functionality but lack features that improve readability and analysis.

These enhancements aim to:
- Make simulation outputs easier to interpret
- Improve user experience for researchers and students
- Align with future goals of interactive and reactive visualization workflows

---

## 🔒 Backward Compatibility

- No breaking changes introduced
- Existing commands continue to work as before: