### PR TITLE
Feature/marimo poc1

### DIFF
--- a/marimo_pocs/01_interactive_material.py
+++ b/marimo_pocs/01_interactive_material.py
@@ -1,0 +1,75 @@
+import marimo
+
+__generated_with = "0.1.0"
+app = marimo.App()
+
+@app.cell
+def __():
+    import marimo as mo
+    return mo,
+
+@app.cell
+def __(mo):
+    mo.md(
+        """
+        # gprMax Material Parameter Generator POC
+        Adjust the physical parameters below to dynamically generate a valid gprMax `#material` command. 
+        This demonstrates how `marimo` can act as a reactive, interactive dashboard for gprMax models.
+        """
+    )
+    return
+
+@app.cell
+def __(mo):
+    # Sliders for key physical properties in gprMax
+    permittivity_slider = mo.ui.slider(start=1.0, stop=80.0, step=0.1, value=1.0, label="Relative Permittivity ($\epsilon_r$)")
+    conductivity_slider = mo.ui.slider(start=0.0, stop=10.0, step=0.01, value=0.0, label="Conductivity ($\sigma$) [S/m]")
+    permeability_slider = mo.ui.slider(start=1.0, stop=5.0, step=0.1, value=1.0, label="Relative Permeability ($\mu_r$)")
+    mag_loss_slider = mo.ui.slider(start=0.0, stop=10.0, step=0.1, value=0.0, label="Magnetic Loss ($\sigma_m$) [Ohms/m]")
+    
+    # Text input for the material name
+    name_input = mo.ui.text(value="my_new_material", label="Material Identifier")
+    
+    # Display the interactive UI elements
+    mo.vstack([
+        permittivity_slider,
+        conductivity_slider,
+        permeability_slider,
+        mag_loss_slider,
+        name_input
+    ])
+    return (
+        conductivity_slider,
+        mag_loss_slider,
+        name_input,
+        permeability_slider,
+        permittivity_slider,
+    )
+
+@app.cell
+def __(
+    conductivity_slider,
+    mag_loss_slider,
+    name_input,
+    permeability_slider,
+    permittivity_slider,
+    mo,
+):
+    # The reactive hook: This cell automatically updates whenever any of the sliders change
+    generated_command = f"#material: {permittivity_slider.value:.2f} {conductivity_slider.value:.2f} {permeability_slider.value:.2f} {mag_loss_slider.value:.2f} {name_input.value}"
+    
+    # Visualizing as markdown
+    mo.md(
+        f"""
+        ### Live Generated Command:
+        
+        Copy and paste this directly into your gprMax `.in` file:
+        ```text
+        {generated_command}
+        ```
+        """
+    )
+    return generated_command,
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
### Description
This Pull Request introduces a Proof of Concept (POC) demonstrating the integration of `marimo` to create a reactive, UI-driven workflow for `gprMax`. This PR is submitted in support of my GSoC 2026 proposal: **"Reactive Simulation & Analytics: Integrating marimo with gprMax."**

Currently, users build input `.in` files statically, which can lead to formatting issues or out-of-order parameters. To address this, `marimo` can be leveraged to create a "computational notebook" that doubles as an interactive GUI. 

This POC (`marimo_pocs/01_interactive_material.py`) provides a simple, reactive dashboard where users can adjust physical parameters (Permittivity, Conductivity, etc.) via UI sliders. The notebook dynamically and instantly generates the corresponding `#material` command string without requiring manual text editing.

### Objectives Demonstrated:
- [x] Usage of `marimo` UI components (`mo.ui.slider`, `mo.ui.text`).
- [x] Reactive data flow that instantly updates dependent elements based on user input.
- [x] Elimination of manual `#material` syntax errors.

### How to test this POC locally:
1. Ensure you have `marimo` installed: `pip install marimo`
2. Run the interactive dashboard:
   ```bash
   marimo run marimo_pocs/01_interactive_material.py
