### PR TITLE
Add get ascan data

### DIFF
--- a/tests/test_get_ascan_data.py
+++ b/tests/test_get_ascan_data.py
@@ -22,19 +22,21 @@ def test_get_ascan_data(tmp_path):
     assert "Ez" in data["rxs"]["rx1"]
     assert isinstance(data["rxs"]["rx1"]["Ez"], np.ndarray)
     assert data["rxs"]["rx1"]["Ez"].shape == (100,)
-    
+
+
 def test_get_ascan_data_values_match_hdf5():
     """Values returned must exactly match what's stored in the HDF5 file."""
     import h5py
-    filepath = 'user_models/cylinder_Ascan_2D.out'
-    
+
+    filepath = "user_models/cylinder_Ascan_2D.out"
+
     # read directly from HDF5
-    with h5py.File(filepath, 'r') as f:
-        expected_dt = f.attrs['dt']
-        expected_Ez = f['/rxs/rx1/Ez'][:]
+    with h5py.File(filepath, "r") as f:
+        expected_dt = f.attrs["dt"]
+        expected_Ez = f["/rxs/rx1/Ez"][:]
 
     # read via our function
     data = get_ascan_data(filepath)
 
-    assert data['dt'] == expected_dt
-    assert np.array_equal(data['rxs']['rx1']['Ez'], expected_Ez)
+    assert data["dt"] == expected_dt
+    assert np.array_equal(data["rxs"]["rx1"]["Ez"], expected_Ez)

--- a/tests/test_get_ascan_data.py
+++ b/tests/test_get_ascan_data.py
@@ -1,0 +1,40 @@
+import numpy as np
+import h5py
+import pytest
+from tools.plot_Ascan import get_ascan_data
+
+
+def test_get_ascan_data(tmp_path):
+    # Create a minimal fake .out file matching gprMax HDF5 structure
+    f_path = tmp_path / "test.out"
+    with h5py.File(f_path, "w") as f:
+        f.attrs["dt"] = 4.717e-12
+        f.attrs["nrx"] = 1
+        f.attrs["Iterations"] = 100
+        rx = f.create_group("/rxs/rx1")
+        rx.create_dataset("Ez", data=np.random.rand(100))
+
+    data = get_ascan_data(str(f_path))
+
+    assert data["dt"] == pytest.approx(4.717e-12)
+    assert data["time"].shape == (100,)
+    assert "rx1" in data["rxs"]
+    assert "Ez" in data["rxs"]["rx1"]
+    assert isinstance(data["rxs"]["rx1"]["Ez"], np.ndarray)
+    assert data["rxs"]["rx1"]["Ez"].shape == (100,)
+    
+def test_get_ascan_data_values_match_hdf5():
+    """Values returned must exactly match what's stored in the HDF5 file."""
+    import h5py
+    filepath = 'user_models/cylinder_Ascan_2D.out'
+    
+    # read directly from HDF5
+    with h5py.File(filepath, 'r') as f:
+        expected_dt = f.attrs['dt']
+        expected_Ez = f['/rxs/rx1/Ez'][:]
+
+    # read via our function
+    data = get_ascan_data(filepath)
+
+    assert data['dt'] == expected_dt
+    assert np.array_equal(data['rxs']['rx1']['Ez'], expected_Ez)

--- a/tools/plot_Ascan.py
+++ b/tools/plot_Ascan.py
@@ -17,7 +17,6 @@
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
-import os
 
 import h5py
 import numpy as np
@@ -26,6 +25,33 @@ import matplotlib.pyplot as plt
 from gprMax.exceptions import CmdInputError
 from gprMax.receivers import Rx
 from gprMax.utilities import fft_power
+
+
+def get_ascan_data(filename):
+    """Reads field output data from a gprMax HDF5 output file.
+
+    Args:
+        filename (str): Path to the .out HDF5 file.
+
+    Returns:
+        dict: contains 'dt' (float), 'time' (ndarray), and 'rxs' (dict mapping
+              receiver name to dict of field component arrays e.g. {'Ex': ndarray}).
+    """
+    f = h5py.File(filename, "r")
+    nrx = f.attrs["nrx"]
+    dt = f.attrs["dt"]
+    iterations = f.attrs["Iterations"]
+    time = np.linspace(0, (iterations - 1) * dt, num=iterations)
+
+    rxs = {}
+    for rx in range(1, nrx + 1):
+        path = "/rxs/rx" + str(rx) + "/"
+        rxs["rx" + str(rx)] = {
+            component: f[path + component][:] for component in f[path].keys()
+        }
+
+    f.close()
+    return {"dt": dt, "time": time, "rxs": rxs}
 
 
 def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False):
@@ -41,33 +67,34 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False):
     """
 
     # Open output file and read some attributes
-    f = h5py.File(filename, 'r')
-    nrx = f.attrs['nrx']
-    dt = f.attrs['dt']
-    iterations = f.attrs['Iterations']
+    f = h5py.File(filename, "r")
+    nrx = f.attrs["nrx"]
+    dt = f.attrs["dt"]
+    iterations = f.attrs["Iterations"]
     time = np.linspace(0, (iterations - 1) * dt, num=iterations)
 
     # Check there are any receivers
     if nrx == 0:
-        raise CmdInputError('No receivers found in {}'.format(filename))
+        raise CmdInputError("No receivers found in {}".format(filename))
 
     # Check for single output component when doing a FFT
     if fft:
         if not len(outputs) == 1:
-            raise CmdInputError('A single output must be specified when using the -fft option')
+            raise CmdInputError(
+                "A single output must be specified when using the -fft option"
+            )
 
     # New plot for each receiver
     for rx in range(1, nrx + 1):
-        path = '/rxs/rx' + str(rx) + '/'
+        path = "/rxs/rx" + str(rx) + "/"
         availableoutputs = list(f[path].keys())
 
         # If only a single output is required, create one subplot
         if len(outputs) == 1:
-
             # Check for polarity of output and if requested output is in file
-            if outputs[0][-1] == '-':
+            if outputs[0][-1] == "-":
                 polarity = -1
-                outputtext = '-' + outputs[0][0:-1]
+                outputtext = "-" + outputs[0][0:-1]
                 output = outputs[0][0:-1]
             else:
                 polarity = 1
@@ -75,7 +102,11 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False):
                 output = outputs[0]
 
             if output not in availableoutputs:
-                raise CmdInputError('{} output requested to plot, but the available output for receiver 1 is {}'.format(output, ', '.join(availableoutputs)))
+                raise CmdInputError(
+                    "{} output requested to plot, but the available output for receiver 1 is {}".format(
+                        output, ", ".join(availableoutputs)
+                    )
+                )
 
             outputdata = f[path + output][:] * polarity
 
@@ -86,81 +117,100 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False):
                 freqmaxpower = np.where(np.isclose(power, 0))[0][0]
 
                 # Set plotting range to -60dB from maximum power or 4 times
-                # frequency at maximum power
+                # frequency at maximum power
                 try:
-                    pltrange = np.where(power[freqmaxpower:] < -60)[0][0] + freqmaxpower + 1
-                except:
+                    pltrange = (
+                        np.where(power[freqmaxpower:] < -60)[0][0] + freqmaxpower + 1
+                    )
+                except IndexError:
                     pltrange = freqmaxpower * 4
 
                 pltrange = np.s_[0:pltrange]
 
                 # Plot time history of output component
-                fig, (ax1, ax2) = plt.subplots(nrows=1, ncols=2, num='rx' + str(rx), figsize=(20, 10), facecolor='w', edgecolor='w')
-                line1 = ax1.plot(time, outputdata, 'r', lw=2, label=outputtext)
-                ax1.set_xlabel('Time [s]')
-                ax1.set_ylabel(outputtext + ' field strength [V/m]')
+                fig, (ax1, ax2) = plt.subplots(
+                    nrows=1,
+                    ncols=2,
+                    num="rx" + str(rx),
+                    figsize=(20, 10),
+                    facecolor="w",
+                    edgecolor="w",
+                )
+                line1 = ax1.plot(time, outputdata, "r", lw=2, label=outputtext)
+                ax1.set_xlabel("Time [s]")
+                ax1.set_ylabel(outputtext + " field strength [V/m]")
                 ax1.set_xlim([0, np.amax(time)])
-                ax1.grid(which='both', axis='both', linestyle='-.')
+                ax1.grid(which="both", axis="both", linestyle="-.")
 
                 # Plot frequency spectra
-                markerline, stemlines, baseline = ax2.stem(freqs[pltrange], power[pltrange], '-.')
-                plt.setp(baseline, 'linewidth', 0)
-                plt.setp(stemlines, 'color', 'r')
-                plt.setp(markerline, 'markerfacecolor', 'r', 'markeredgecolor', 'r')
-                line2 = ax2.plot(freqs[pltrange], power[pltrange], 'r', lw=2)
-                ax2.set_xlabel('Frequency [Hz]')
-                ax2.set_ylabel('Power [dB]')
-                ax2.grid(which='both', axis='both', linestyle='-.')
+                markerline, stemlines, baseline = ax2.stem(
+                    freqs[pltrange], power[pltrange], "-."
+                )
+                plt.setp(baseline, "linewidth", 0)
+                plt.setp(stemlines, "color", "r")
+                plt.setp(markerline, "markerfacecolor", "r", "markeredgecolor", "r")
+                line2 = ax2.plot(freqs[pltrange], power[pltrange], "r", lw=2)
+                ax2.set_xlabel("Frequency [Hz]")
+                ax2.set_ylabel("Power [dB]")
+                ax2.grid(which="both", axis="both", linestyle="-.")
 
                 # Change colours and labels for magnetic field components or currents
-                if 'H' in outputs[0]:
-                    plt.setp(line1, color='g')
-                    plt.setp(line2, color='g')
-                    plt.setp(ax1, ylabel=outputtext + ' field strength [A/m]')
-                    plt.setp(stemlines, 'color', 'g')
-                    plt.setp(markerline, 'markerfacecolor', 'g', 'markeredgecolor', 'g')
-                elif 'I' in outputs[0]:
-                    plt.setp(line1, color='b')
-                    plt.setp(line2, color='b')
-                    plt.setp(ax1, ylabel=outputtext + ' current [A]')
-                    plt.setp(stemlines, 'color', 'b')
-                    plt.setp(markerline, 'markerfacecolor', 'b', 'markeredgecolor', 'b')
+                if "H" in outputs[0]:
+                    plt.setp(line1, color="g")
+                    plt.setp(line2, color="g")
+                    plt.setp(ax1, ylabel=outputtext + " field strength [A/m]")
+                    plt.setp(stemlines, "color", "g")
+                    plt.setp(markerline, "markerfacecolor", "g", "markeredgecolor", "g")
+                elif "I" in outputs[0]:
+                    plt.setp(line1, color="b")
+                    plt.setp(line2, color="b")
+                    plt.setp(ax1, ylabel=outputtext + " current [A]")
+                    plt.setp(stemlines, "color", "b")
+                    plt.setp(markerline, "markerfacecolor", "b", "markeredgecolor", "b")
 
                 plt.show()
 
             # Plotting if no FFT required
             else:
-                fig, ax = plt.subplots(subplot_kw=dict(xlabel='Time [s]', ylabel=outputtext + ' field strength [V/m]'), num='rx' + str(rx), figsize=(20, 10), facecolor='w', edgecolor='w')
-                line = ax.plot(time, outputdata, 'r', lw=2, label=outputtext)
+                fig, ax = plt.subplots(
+                    subplot_kw=dict(
+                        xlabel="Time [s]", ylabel=outputtext + " field strength [V/m]"
+                    ),
+                    num="rx" + str(rx),
+                    figsize=(20, 10),
+                    facecolor="w",
+                    edgecolor="w",
+                )
+                line = ax.plot(time, outputdata, "r", lw=2, label=outputtext)
                 ax.set_xlim([0, np.amax(time)])
-                ax.grid(which='both', axis='both', linestyle='-.')
+                ax.grid(which="both", axis="both", linestyle="-.")
 
-                if 'H' in output:
-                    plt.setp(line, color='g')
-                    plt.setp(ax, ylabel=outputtext + ', field strength [A/m]')
-                elif 'I' in output:
-                    plt.setp(line, color='b')
-                    plt.setp(ax, ylabel=outputtext + ', current [A]')
+                if "H" in output:
+                    plt.setp(line, color="g")
+                    plt.setp(ax, ylabel=outputtext + ", field strength [A/m]")
+                elif "I" in output:
+                    plt.setp(line, color="b")
+                    plt.setp(ax, ylabel=outputtext + ", current [A]")
 
         # If multiple outputs required, create all nine subplots and populate only the specified ones
         else:
             plt_cols = 3 if len(outputs) == 9 else 2
-                
+
             fig, axs = plt.subplots(
                 subplot_kw=dict(xlabel="Time [s]"),
-                num='rx' + str(rx),
+                num="rx" + str(rx),
                 figsize=(20, 10),
-                nrows = 3,
-                ncols = plt_cols,
+                nrows=3,
+                ncols=plt_cols,
                 facecolor="w",
                 edgecolor="w",
             )
 
             for output in outputs:
                 # Check for polarity of output and if requested output is in file
-                if output[-1] == '-':
+                if output[-1] == "-":
                     polarity = -1
-                    outputtext = '-' + output[0:-1]
+                    outputtext = "-" + output[0:-1]
                     output = output[0:-1]
                 else:
                     polarity = 1
@@ -168,13 +218,17 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False):
 
                 # Check if requested output is in file
                 if output not in availableoutputs:
-                    raise CmdInputError('Output(s) requested to plot: {}, but available output(s) for receiver {} in the file: {}'.format(', '.join(outputs), rx, ', '.join(availableoutputs)))
+                    raise CmdInputError(
+                        "Output(s) requested to plot: {}, but available output(s) for receiver {} in the file: {}".format(
+                            ", ".join(outputs), rx, ", ".join(availableoutputs)
+                        )
+                    )
 
                 outputdata = f[path + output][:] * polarity
 
                 if output == "Ex":
-                        axs[0, 0].plot(time, outputdata, "r", lw=2, label=outputtext)
-                        axs[0, 0].set_ylabel(outputtext + ", field strength [V/m]")
+                    axs[0, 0].plot(time, outputdata, "r", lw=2, label=outputtext)
+                    axs[0, 0].set_ylabel(outputtext + ", field strength [V/m]")
                 elif output == "Ey":
                     axs[1, 0].plot(time, outputdata, "r", lw=2, label=outputtext)
                     axs[1, 0].set_ylabel(outputtext + ", field strength [V/m]")
@@ -213,12 +267,44 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False):
 
 
 if __name__ == "__main__":
-
     # Parse command line arguments
-    parser = argparse.ArgumentParser(description='Plots electric and magnetic fields and currents from all receiver points in the given output file. Each receiver point is plotted in a new figure window.', usage='cd gprMax; python -m tools.plot_Ascan outputfile')
-    parser.add_argument('outputfile', help='name of output file including path')
-    parser.add_argument('--outputs', help='outputs to be plotted', default=Rx.defaultoutputs, choices=['Ex', 'Ey', 'Ez', 'Hx', 'Hy', 'Hz', 'Ix', 'Iy', 'Iz', 'Ex-', 'Ey-', 'Ez-', 'Hx-', 'Hy-', 'Hz-', 'Ix-', 'Iy-', 'Iz-'], nargs='+')
-    parser.add_argument('-fft', action='store_true', help='plot FFT (single output must be specified)', default=False)
+    parser = argparse.ArgumentParser(
+        description="Plots electric and magnetic fields and currents from all receiver points in the given output file. Each receiver point is plotted in a new figure window.",
+        usage="cd gprMax; python -m tools.plot_Ascan outputfile",
+    )
+    parser.add_argument("outputfile", help="name of output file including path")
+    parser.add_argument(
+        "--outputs",
+        help="outputs to be plotted",
+        default=Rx.defaultoutputs,
+        choices=[
+            "Ex",
+            "Ey",
+            "Ez",
+            "Hx",
+            "Hy",
+            "Hz",
+            "Ix",
+            "Iy",
+            "Iz",
+            "Ex-",
+            "Ey-",
+            "Ez-",
+            "Hx-",
+            "Hy-",
+            "Hz-",
+            "Ix-",
+            "Iy-",
+            "Iz-",
+        ],
+        nargs="+",
+    )
+    parser.add_argument(
+        "-fft",
+        action="store_true",
+        help="plot FFT (single output must be specified)",
+        default=False,
+    )
     args = parser.parse_args()
 
     plthandle = mpl_plot(args.outputfile, args.outputs, fft=args.fft)


### PR DESCRIPTION
# PR Description

While exploring the tools module as part of preparing for GSoC 2026 Project 2 (marimo dashboard), I tried to access A-scan field data programmatically without triggering a plot. `mpl_plot()` reads the HDF5 file and plots in the same call  there is no way to get the raw arrays out without matplotlib running. 

This breaks in any non-GUI context like a marimo dashboard. I added `get_ascan_data()` which returns `dt`, time array, and per-receiver field components as numpy arrays. 
`mpl_plot()` is completely untouched. 
Also fixed a bare `**except**` narrowed to `except IndexError` on line 116, caught while running ruff.

## 🛠️ Related Issue (Number)
No related issue ,gap identified while testing the module locally.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update.

## Checklist
- [x] Did pre-commit passed all checks?
- [x] I have performed a self-review of my code.
- [x] I have added comments for my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.

