### PR TITLE
build: add missing setup.cfg with flake8 and pytest configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,16 @@
+[flake8]
+max-line-length = 200
+ignore = E402, W503
+exclude =
+    .git,
+    __pycache__,
+    build,
+    dist
+
+[tool:pytest]
+testpaths = tests
+addopts = -v --tb=short
+markers =
+    slow: marks tests as slow (full simulation runs - deselect with '-m "not slow"')
+    gpu: marks tests that require a CUDA-capable GPU
+    mpi: marks tests that require an MPI installation


### PR DESCRIPTION
## Problem

The project README explicitly references `setup.cfg` as the location for flake8 configuration, but this file does not exist in the repository. This causes two concrete issues for contributors:

- Running `flake8` without a config file causes it to fall back to defaults, which do not match gprMax's codebase conventions (200-character line length used in GPU kernel files).
- - Running `pytest` emits `PytestUnknownMarkWarning` for every test marked with `@pytest.mark.slow`, `@pytest.mark.gpu`, or `@pytest.mark.mpi`, because these markers are not registered anywhere.
## Solution

Add the missing `setup.cfg` with two sections:

- `[flake8]` - max-line-length 200, E402 ignored for conditional pycuda/mpi4py imports, W503 ignored as style preference.
- - `[tool:pytest]` - Registers the slow, gpu, and mpi markers, eliminating PytestUnknownMarkWarning.
## Notes

This PR targets the `devel` branch as per project contribution guidelines. No functional source changes - purely additive configuration.

Supports #600 and #598.