### PR TITLE
tests: add conftest.py with headless matplotlib backend fix

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+"""
+Pytest configuration and shared fixtures for the gprMax test suite.
+
+This file is automatically loaded by pytest before any tests are collected.
+It performs two tasks:
+
+1. Forces matplotlib to use the non-interactive 'Agg' backend *before* any
+   test module imports pyplot. Without this, tests crash in headless CI
+   environments (Linux runners, Docker containers) with:
+       "cannot connect to X server" or "_tkinter.TclError"
+   Fixes #621.
+
+2. Provides shared path fixtures so individual test modules do not need to
+   hard-code paths to the test model directories.
+"""
+import os
+
+import matplotlib
+matplotlib.use('Agg')  # noqa: E402 — must be called before pyplot is imported
+
+import pytest  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Path fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def models_basic_path():
+    """Absolute path to the directory containing basic test models."""
+    return os.path.join(os.path.dirname(__file__), 'models_basic')
+
+
+@pytest.fixture
+def models_advanced_path():
+    """Absolute path to the directory containing advanced test models."""
+    return os.path.join(os.path.dirname(__file__), 'models_advanced')


### PR DESCRIPTION
## Problem

Running `pytest` on the current gprMax test suite fails in any headless environment because `test_models.py` imports `matplotlib.pyplot` at module level, which immediately attempts to connect to a display server:

```
_tkinter.TclError: no display name and no DISPLAY variable
```

This crash prevents the entire test suite from being collected by pytest - meaning zero tests run in CI.

## Solution

Add `tests/conftest.py` which pytest loads automatically before collecting any tests:

1. Forces the `Agg` matplotlib backend before any import of pyplot - works in all headless environments.
2. 2. Provides shared path fixtures for test model directories (models_basic_path, models_advanced_path).
## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
## Checklist

* [x] I have performed a self-review of my code.
* [ ] * [x] My changes generate no new warnings.
* [ ] * [x] The title of my pull request is a short description of my changes.
Closes #621