### PR TITLE
Build: Add pyproject.toml (Resolves #652)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = [
+    "setuptools>=61.0.0",
+    "wheel",
+    "cython",
+    "numpy",
+    "jinja2"
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Resolves #652

Modern Python packaging requires `pyproject.toml` to declare build-system requirements (PEP 517/518). Currently, running `pip install -e .` fails on modern environments because the compiler tools aren't initialized before `setup.py` runs.

This PR introduces the standard `[build-system]` table specifying `setuptools`, `Cython`, `numpy`, and `jinja2` as explicit build prerequisites to completely resolve this pipeline friction.