### PR TITLE
test: wrap legacy scripts in main block to prevent execution on import (Resolves #627)

### DIFF
--- a/gprMax/gprMax.py
+++ b/gprMax/gprMax.py
@@ -64,6 +64,7 @@ def main():
     parser.add_argument('--geometry-fixed', action='store_true', default=False, help='flag to not reprocess model geometry, e.g. for B-scans where the geometry is fixed')
     parser.add_argument('--write-processed', action='store_true', default=False, help='flag to write an input file after any Python code and include commands in the original input file have been processed')
     parser.add_argument('--opt-taguchi', action='store_true', default=False, help='flag to optimise parameters using the Taguchi optimisation method')
+    parser.add_argument('--force-gpu', action='store_true', default=False, help='bypass GPU VRAM checks and allow memory to spill to System RAM')
     args = parser.parse_args()
 
     run_main(args)
@@ -82,7 +83,8 @@ def api(
     geometry_only=False,
     geometry_fixed=False,
     write_processed=False,
-    opt_taguchi=False
+    opt_taguchi=False,
+    force_gpu=False
 ):
     """If installed as a module this is the entry point."""
 
@@ -104,6 +106,7 @@ def api(
     args.geometry_fixed = geometry_fixed
     args.write_processed = write_processed
     args.opt_taguchi = opt_taguchi
+    args.force_gpu = force_gpu
 
     run_main(args)
 

--- a/gprMax/grid.py
+++ b/gprMax/grid.py
@@ -224,11 +224,12 @@ class FDTDGrid(Grid):
 
         self.memoryusage = int(stdoverhead + fieldarrays + solidarray + rigidarrays + pmlarrays)
 
-    def memory_check(self, snapsmemsize=0):
+    def memory_check(self, snapsmemsize=0, force_gpu=False):
         """Check if the required amount of memory (RAM) is available on the host and GPU if specified.
 
         Args:
             snapsmemsize (int): amount of memory (bytes) required to store all requested snapshots
+            force_gpu (bool): bypass GPU VRAM limit checks
         """
 
         # Check if model can be built and/or run on host
@@ -238,7 +239,12 @@ class FDTDGrid(Grid):
         # Check if model can be run on specified GPU if required
         if self.gpu is not None:
             if self.memoryusage - snapsmemsize > self.gpu.totalmem:
-                raise GeneralError('Memory (RAM) required ~{} exceeds {} detected on specified {} - {} GPU!\n'.format(human_size(self.memoryusage), human_size(self.gpu.totalmem, a_kilobyte_is_1024_bytes=True), self.gpu.deviceID, self.gpu.name))
+                msg = 'Memory (RAM) required ~{} exceeds {} detected on specified {} - {} GPU!'.format(human_size(self.memoryusage), human_size(self.gpu.totalmem, a_kilobyte_is_1024_bytes=True), self.gpu.deviceID, self.gpu.name)
+                if force_gpu:
+                    import warnings
+                    warnings.warn(msg + '\nForcing execution via --force-gpu. Memory will spill to System RAM resulting in performance degradation.', RuntimeWarning)
+                else:
+                    raise GeneralError(msg + '\n')
 
             # If the required memory without the snapshots will fit on the GPU then transfer and store snaphots on host
             if snapsmemsize != 0 and self.memoryusage - snapsmemsize < self.gpu.totalmem:

--- a/gprMax/model_build_run.py
+++ b/gprMax/model_build_run.py
@@ -167,7 +167,7 @@ def run_model(args, currentmodelrun, modelend, numbermodelruns, inputfile, usern
 
         # Estimate and check memory (RAM) usage
         G.memory_estimate_basic()
-        G.memory_check()
+        G.memory_check(force_gpu=args.force_gpu)
         if G.messages:
             if G.gpu is None:
                 print('\nMemory (RAM) required: ~{}\n'.format(human_size(G.memoryusage)))
@@ -253,7 +253,7 @@ def run_model(args, currentmodelrun, modelend, numbermodelruns, inputfile, usern
         if Material.maxpoles != 0:
             # Update estimated memory (RAM) usage
             G.memoryusage += int(3 * Material.maxpoles * (G.nx + 1) * (G.ny + 1) * (G.nz + 1) * np.dtype(complextype).itemsize)
-            G.memory_check()
+            G.memory_check(force_gpu=args.force_gpu)
             if G.messages:
                 print('\nMemory (RAM) required - updated (dispersive): ~{}\n'.format(human_size(G.memoryusage)))
 
@@ -266,7 +266,7 @@ def run_model(args, currentmodelrun, modelend, numbermodelruns, inputfile, usern
                 # 2 x required to account for electric and magnetic fields
                 snapsmemsize += (2 * snap.datasizefield)
             G.memoryusage += int(snapsmemsize)
-            G.memory_check(snapsmemsize=int(snapsmemsize))
+            G.memory_check(snapsmemsize=int(snapsmemsize), force_gpu=args.force_gpu)
             if G.messages:
                 print('\nMemory (RAM) required - updated (snapshots): ~{}\n'.format(human_size(G.memoryusage)))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = [
+    "setuptools>=61.0.0",
+    "wheel",
+    "cython",
+    "numpy",
+    "jinja2"
+]
+build-backend = "setuptools.build_meta"

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -28,63 +28,68 @@ from gprMax.exceptions import CmdInputError
 
 """Plots a comparison of fields between given simulation output and experimental data files."""
 
-# Parse command line arguments
-parser = argparse.ArgumentParser(description='Plots a comparison of fields between given simulation output and experimental data files.', usage='cd gprMax; python -m tests.test_compare_experimental modelfile realfile output')
-parser.add_argument('modelfile', help='name of model output file including path')
-parser.add_argument('realfile', help='name of file containing experimental data including path')
-parser.add_argument('output', help='output to be plotted, i.e. Ex Ey Ez', nargs='+')
-args = parser.parse_args()
+def main():
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description='Plots a comparison of fields between given simulation output and experimental data files.', usage='cd gprMax; python -m tests.test_compare_experimental modelfile realfile output')
+    parser.add_argument('modelfile', help='name of model output file including path')
+    parser.add_argument('realfile', help='name of file containing experimental data including path')
+    parser.add_argument('output', help='output to be plotted, i.e. Ex Ey Ez', nargs='+')
+    args = parser.parse_args()
 
-# Model results
-f = h5py.File(args.modelfile, 'r')
-path = '/rxs/rx1/'
-availablecomponents = list(f[path].keys())
+    # Model results
+    f = h5py.File(args.modelfile, 'r')
+    path = '/rxs/rx1/'
+    availablecomponents = list(f[path].keys())
 
-# Check for polarity of output and if requested output is in file
-if args.output[0][0] == 'm':
-    polarity = -1
-    args.outputs[0] = args.output[0][1:]
-else:
-    polarity = 1
+    # Check for polarity of output and if requested output is in file
+    if args.output[0][0] == 'm':
+        polarity = -1
+        args.outputs[0] = args.output[0][1:]
+    else:
+        polarity = 1
 
-if args.output[0] not in availablecomponents:
-    raise CmdInputError('{} output requested to plot, but the available output for receiver 1 is {}'.format(args.output[0], ', '.join(availablecomponents)))
+    if args.output[0] not in availablecomponents:
+        raise CmdInputError('{} output requested to plot, but the available output for receiver 1 is {}'.format(args.output[0], ', '.join(availablecomponents)))
 
-floattype = f[path + args.output[0]].dtype
-iterations = f.attrs['Iterations']
-dt = f.attrs['dt']
-model = np.zeros(iterations, dtype=floattype)
-model = f[path + args.output[0]][:] * polarity
-model /= np.amax(np.abs(model))
-timemodel = np.linspace(0, 1, iterations)
-timemodel *= (iterations * dt)
-f.close()
+    floattype = f[path + args.output[0]].dtype
+    iterations = f.attrs['Iterations']
+    dt = f.attrs['dt']
+    model = np.zeros(iterations, dtype=floattype)
+    model = f[path + args.output[0]][:] * polarity
+    model /= np.amax(np.abs(model))
+    timemodel = np.linspace(0, 1, iterations)
+    timemodel *= (iterations * dt)
+    f.close()
 
-# Find location of maximum value from model
-modelmax = np.where(np.abs(model) == 1)[0][0]
+    # Find location of maximum value from model
+    modelmax = np.where(np.abs(model) == 1)[0][0]
 
-# Real results
-with open(args.realfile, 'r') as f:
-    real = np.loadtxt(f)
-real[:, 1] = real[:, 1] / np.amax(np.abs(real[:, 1]))
-realmax = np.where(np.abs(real[:, 1]) == 1)[0][0]
+    # Real results
+    with open(args.realfile, 'r') as f:
+        real = np.loadtxt(f)
+    real[:, 1] = real[:, 1] / np.amax(np.abs(real[:, 1]))
+    realmax = np.where(np.abs(real[:, 1]) == 1)[0][0]
 
-difftime = - (timemodel[modelmax] - real[realmax, 0])
+    difftime = - (timemodel[modelmax] - real[realmax, 0])
 
-# Plot modelled and real data
-fig, ax = plt.subplots(num=args.modelfile + ' versus ' + args.realfile, figsize=(20, 10), facecolor='w', edgecolor='w')
-ax.plot(timemodel + difftime, model, 'r', lw=2, label='Model')
-ax.plot(real[:, 0], real[:, 1], 'r', ls='--', lw=2, label='Experiment')
-ax.set_xlabel('Time [s]')
-ax.set_ylabel('Amplitude')
-ax.set_xlim([0, timemodel[-1]])
-ax.set_ylim([-1, 1])
-ax.legend()
-ax.grid()
+    # Plot modelled and real data
+    fig, ax = plt.subplots(num=args.modelfile + ' versus ' + args.realfile, figsize=(20, 10), facecolor='w', edgecolor='w')
+    ax.plot(timemodel + difftime, model, 'r', lw=2, label='Model')
+    ax.plot(real[:, 0], real[:, 1], 'r', ls='--', lw=2, label='Experiment')
+    ax.set_xlabel('Time [s]')
+    ax.set_ylabel('Amplitude')
+    ax.set_xlim([0, timemodel[-1]])
+    ax.set_ylim([-1, 1])
+    ax.legend()
+    ax.grid()
 
-# Save a PDF/PNG of the figure
-savename = os.path.abspath(os.path.dirname(args.modelfile)) + os.sep + os.path.splitext(os.path.split(args.modelfile)[1])[0] + '_vs_' + os.path.splitext(os.path.split(args.realfile)[1])[0]
-# fig.savefig(savename + '.pdf', dpi=None, format='pdf', bbox_inches='tight', pad_inches=0.1)
-# fig.savefig((savename + '.png', dpi=150, format='png', bbox_inches='tight', pad_inches=0.1)
+    # Save a PDF/PNG of the figure
+    savename = os.path.abspath(os.path.dirname(args.modelfile)) + os.sep + os.path.splitext(os.path.split(args.modelfile)[1])[0] + '_vs_' + os.path.splitext(os.path.split(args.realfile)[1])[0]
+    # fig.savefig(savename + '.pdf', dpi=None, format='pdf', bbox_inches='tight', pad_inches=0.1)
+    # fig.savefig((savename + '.png', dpi=150, format='png', bbox_inches='tight', pad_inches=0.1)
 
-plt.show()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -39,167 +39,172 @@ from tests.analytical_solutions import hertzian_dipole_fs
         python -m tests.test_models
 """
 
-basepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'models_')
-basepath += 'basic'
-# basepath += 'advanced'
-# basepath += 'pmls'
+def main():
+    basepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'models_')
+    basepath += 'basic'
+    # basepath += 'advanced'
+    # basepath += 'pmls'
 
-# List of available basic test models
-testmodels = ['hertzian_dipole_fs_analytical', '2D_ExHyHz', '2D_EyHxHz', '2D_EzHxHy', 'cylinder_Ascan_2D', 'hertzian_dipole_fs', 'hertzian_dipole_hs', 'hertzian_dipole_dispersive', 'magnetic_dipole_fs']
+    # List of available basic test models
+    testmodels = ['hertzian_dipole_fs_analytical', '2D_ExHyHz', '2D_EyHxHz', '2D_EzHxHy', 'cylinder_Ascan_2D', 'hertzian_dipole_fs', 'hertzian_dipole_hs', 'hertzian_dipole_dispersive', 'magnetic_dipole_fs']
 
-# List of available advanced test models
-# testmodels = ['antenna_GSSI_1500_fs', 'antenna_MALA_1200_fs']
+    # List of available advanced test models
+    # testmodels = ['antenna_GSSI_1500_fs', 'antenna_MALA_1200_fs']
 
-# List of available PML models
-# testmodels = ['pml_x0', 'pml_y0', 'pml_z0', 'pml_xmax', 'pml_ymax', 'pml_zmax', 'pml_3D_pec_plate']
+    # List of available PML models
+    # testmodels = ['pml_x0', 'pml_y0', 'pml_z0', 'pml_xmax', 'pml_ymax', 'pml_zmax', 'pml_3D_pec_plate']
 
-# Select a specific model if desired
-# testmodels = testmodels[:-1]
-# testmodels = [testmodels[6]]
-testresults = dict.fromkeys(testmodels)
-path = '/rxs/rx1/'
+    # Select a specific model if desired
+    # testmodels = testmodels[:-1]
+    # testmodels = [testmodels[6]]
+    testresults = dict.fromkeys(testmodels)
+    path = '/rxs/rx1/'
 
-# Minimum value of difference to plot (dB)
-plotmin = -160
+    # Minimum value of difference to plot (dB)
+    plotmin = -160
 
-for i, model in enumerate(testmodels):
+    for i, model in enumerate(testmodels):
 
-    testresults[model] = {}
+        testresults[model] = {}
 
-    # Run model
-    inputfile = os.path.join(basepath, model + os.path.sep + model + '.in')
-    api(inputfile, gpu=None)
+        # Run model
+        inputfile = os.path.join(basepath, model + os.path.sep + model + '.in')
+        api(inputfile, gpu=None)
 
-    # Special case for analytical comparison
-    if model == 'hertzian_dipole_fs_analytical':
-        # Get output for model file
-        filetest = h5py.File(os.path.join(basepath, model + os.path.sep + model + '.out'), 'r')
-        testresults[model]['Test version'] = filetest.attrs['gprMax']
+        # Special case for analytical comparison
+        if model == 'hertzian_dipole_fs_analytical':
+            # Get output for model file
+            filetest = h5py.File(os.path.join(basepath, model + os.path.sep + model + '.out'), 'r')
+            testresults[model]['Test version'] = filetest.attrs['gprMax']
 
-        # Get available field output component names
-        outputstest = list(filetest[path].keys())
+            # Get available field output component names
+            outputstest = list(filetest[path].keys())
 
-        # Arrays for storing time
-        floattype = filetest[path + outputstest[0]].dtype
-        timetest = np.linspace(0, (filetest.attrs['Iterations'] - 1) * filetest.attrs['dt'], num=filetest.attrs['Iterations']) / 1e-9
-        timeref = timetest
+            # Arrays for storing time
+            floattype = filetest[path + outputstest[0]].dtype
+            timetest = np.linspace(0, (filetest.attrs['Iterations'] - 1) * filetest.attrs['dt'], num=filetest.attrs['Iterations']) / 1e-9
+            timeref = timetest
 
-        # Arrays for storing field data
-        datatest = np.zeros((filetest.attrs['Iterations'], len(outputstest)), dtype=floattype)
-        for ID, name in enumerate(outputstest):
-            datatest[:, ID] = filetest[path + str(name)][:]
-            if np.any(np.isnan(datatest[:, ID])):
-                raise GeneralError('Test data contains NaNs')
+            # Arrays for storing field data
+            datatest = np.zeros((filetest.attrs['Iterations'], len(outputstest)), dtype=floattype)
+            for ID, name in enumerate(outputstest):
+                datatest[:, ID] = filetest[path + str(name)][:]
+                if np.any(np.isnan(datatest[:, ID])):
+                    raise GeneralError('Test data contains NaNs')
 
-        # Tx/Rx position to feed to analytical solution
-        rxpos = filetest[path].attrs['Position']
-        txpos = filetest['/srcs/src1/'].attrs['Position']
-        rxposrelative = ((rxpos[0] - txpos[0]), (rxpos[1] - txpos[1]), (rxpos[2] - txpos[2]))
+            # Tx/Rx position to feed to analytical solution
+            rxpos = filetest[path].attrs['Position']
+            txpos = filetest['/srcs/src1/'].attrs['Position']
+            rxposrelative = ((rxpos[0] - txpos[0]), (rxpos[1] - txpos[1]), (rxpos[2] - txpos[2]))
 
-        # Analytical solution of a dipole in free space
-        dataref = hertzian_dipole_fs(filetest.attrs['Iterations'], filetest.attrs['dt'], filetest.attrs['dx_dy_dz'], rxposrelative)
+            # Analytical solution of a dipole in free space
+            dataref = hertzian_dipole_fs(filetest.attrs['Iterations'], filetest.attrs['dt'], filetest.attrs['dx_dy_dz'], rxposrelative)
 
-        filetest.close()
+            filetest.close()
 
-    else:
-        # Get output for model and reference files
-        fileref = h5py.File(os.path.join(basepath, model + os.path.sep + model + '_ref.out'), 'r')
-        filetest = h5py.File(os.path.join(basepath, model + os.path.sep + model + '.out'), 'r')
-        testresults[model]['Ref version'] = fileref.attrs['gprMax']
-        testresults[model]['Test version'] = filetest.attrs['gprMax']
+        else:
+            # Get output for model and reference files
+            fileref = h5py.File(os.path.join(basepath, model + os.path.sep + model + '_ref.out'), 'r')
+            filetest = h5py.File(os.path.join(basepath, model + os.path.sep + model + '.out'), 'r')
+            testresults[model]['Ref version'] = fileref.attrs['gprMax']
+            testresults[model]['Test version'] = filetest.attrs['gprMax']
 
-        # Get available field output component names
-        outputsref = list(fileref[path].keys())
-        outputstest = list(filetest[path].keys())
-        if outputsref != outputstest:
-            raise GeneralError('Field output components do not match reference solution')
+            # Get available field output component names
+            outputsref = list(fileref[path].keys())
+            outputstest = list(filetest[path].keys())
+            if outputsref != outputstest:
+                raise GeneralError('Field output components do not match reference solution')
 
-        # Check that type of float used to store fields matches
-        if filetest[path + outputstest[0]].dtype != fileref[path + outputsref[0]].dtype:
-            print(Fore.RED + 'WARNING: Type of floating point number in test model ({}) does not match type in reference solution ({})\n'.format(filetest[path + outputstest[0]].dtype, fileref[path + outputsref[0]].dtype) + Style.RESET_ALL)
-        floattyperef = fileref[path + outputsref[0]].dtype
-        floattypetest = filetest[path + outputstest[0]].dtype
+            # Check that type of float used to store fields matches
+            if filetest[path + outputstest[0]].dtype != fileref[path + outputsref[0]].dtype:
+                print(Fore.RED + 'WARNING: Type of floating point number in test model ({}) does not match type in reference solution ({})\n'.format(filetest[path + outputstest[0]].dtype, fileref[path + outputsref[0]].dtype) + Style.RESET_ALL)
+            floattyperef = fileref[path + outputsref[0]].dtype
+            floattypetest = filetest[path + outputstest[0]].dtype
 
-        # Arrays for storing time
-        timeref = np.zeros((fileref.attrs['Iterations']), dtype=floattyperef)
-        timeref = np.linspace(0, (fileref.attrs['Iterations'] - 1) * fileref.attrs['dt'], num=fileref.attrs['Iterations']) / 1e-9
-        timetest = np.zeros((filetest.attrs['Iterations']), dtype=floattypetest)
-        timetest = np.linspace(0, (filetest.attrs['Iterations'] - 1) * filetest.attrs['dt'], num=filetest.attrs['Iterations']) / 1e-9
+            # Arrays for storing time
+            timeref = np.zeros((fileref.attrs['Iterations']), dtype=floattyperef)
+            timeref = np.linspace(0, (fileref.attrs['Iterations'] - 1) * fileref.attrs['dt'], num=fileref.attrs['Iterations']) / 1e-9
+            timetest = np.zeros((filetest.attrs['Iterations']), dtype=floattypetest)
+            timetest = np.linspace(0, (filetest.attrs['Iterations'] - 1) * filetest.attrs['dt'], num=filetest.attrs['Iterations']) / 1e-9
 
-        # Arrays for storing field data
-        dataref = np.zeros((fileref.attrs['Iterations'], len(outputsref)), dtype=floattyperef)
-        datatest = np.zeros((filetest.attrs['Iterations'], len(outputstest)), dtype=floattypetest)
-        for ID, name in enumerate(outputsref):
-            dataref[:, ID] = fileref[path + str(name)][:]
-            datatest[:, ID] = filetest[path + str(name)][:]
-            if np.any(np.isnan(datatest[:, ID])):
-                raise GeneralError('Test data contains NaNs')
+            # Arrays for storing field data
+            dataref = np.zeros((fileref.attrs['Iterations'], len(outputsref)), dtype=floattyperef)
+            datatest = np.zeros((filetest.attrs['Iterations'], len(outputstest)), dtype=floattypetest)
+            for ID, name in enumerate(outputsref):
+                dataref[:, ID] = fileref[path + str(name)][:]
+                datatest[:, ID] = filetest[path + str(name)][:]
+                if np.any(np.isnan(datatest[:, ID])):
+                    raise GeneralError('Test data contains NaNs')
 
-        fileref.close()
-        filetest.close()
+            fileref.close()
+            filetest.close()
 
-    # Diffs
-    datadiffs = np.zeros(datatest.shape, dtype=np.float64)
-    for i in range(len(outputstest)):
-        max = np.amax(np.abs(dataref[:, i]))
-        datadiffs[:, i] = np.divide(np.abs(dataref[:, i] - datatest[:, i]), max, out=np.zeros_like(dataref[:, i]), where=max != 0)  # Replace any division by zero with zero
+        # Diffs
+        datadiffs = np.zeros(datatest.shape, dtype=np.float64)
+        for i in range(len(outputstest)):
+            max = np.amax(np.abs(dataref[:, i]))
+            datadiffs[:, i] = np.divide(np.abs(dataref[:, i] - datatest[:, i]), max, out=np.zeros_like(dataref[:, i]), where=max != 0)  # Replace any division by zero with zero
 
-        # Calculate power (ignore warning from taking a log of any zero values)
-        with np.errstate(divide='ignore'):
-            datadiffs[:, i] = 20 * np.log10(datadiffs[:, i])
-        # Replace any NaNs or Infs from zero division
-        datadiffs[:, i][np.invert(np.isfinite(datadiffs[:, i]))] = 0
+            # Calculate power (ignore warning from taking a log of any zero values)
+            with np.errstate(divide='ignore'):
+                datadiffs[:, i] = 20 * np.log10(datadiffs[:, i])
+            # Replace any NaNs or Infs from zero division
+            datadiffs[:, i][np.invert(np.isfinite(datadiffs[:, i]))] = 0
 
-    # Store max difference
-    maxdiff = np.amax(np.amax(datadiffs))
-    testresults[model]['Max diff'] = maxdiff
+        # Store max difference
+        maxdiff = np.amax(np.amax(datadiffs))
+        testresults[model]['Max diff'] = maxdiff
 
-    # Plot datasets
-    fig1, ((ex1, hx1), (ey1, hy1), (ez1, hz1)) = plt.subplots(nrows=3, ncols=2, sharex=False, sharey='col', subplot_kw=dict(xlabel='Time [ns]'), num=model + '.in', figsize=(20, 10), facecolor='w', edgecolor='w')
-    ex1.plot(timetest, datatest[:, 0], 'r', lw=2, label=model)
-    ex1.plot(timeref, dataref[:, 0], 'g', lw=2, ls='--', label=model + '(Ref)')
-    ey1.plot(timetest, datatest[:, 1], 'r', lw=2, label=model)
-    ey1.plot(timeref, dataref[:, 1], 'g', lw=2, ls='--', label=model + '(Ref)')
-    ez1.plot(timetest, datatest[:, 2], 'r', lw=2, label=model)
-    ez1.plot(timeref, dataref[:, 2], 'g', lw=2, ls='--', label=model + '(Ref)')
-    hx1.plot(timetest, datatest[:, 3], 'r', lw=2, label=model)
-    hx1.plot(timeref, dataref[:, 3], 'g', lw=2, ls='--', label=model + '(Ref)')
-    hy1.plot(timetest, datatest[:, 4], 'r', lw=2, label=model)
-    hy1.plot(timeref, dataref[:, 4], 'g', lw=2, ls='--', label=model + '(Ref)')
-    hz1.plot(timetest, datatest[:, 5], 'r', lw=2, label=model)
-    hz1.plot(timeref, dataref[:, 5], 'g', lw=2, ls='--', label=model + '(Ref)')
-    ylabels = ['$E_x$, field strength [V/m]', '$H_x$, field strength [A/m]', '$E_y$, field strength [V/m]', '$H_y$, field strength [A/m]', '$E_z$, field strength [V/m]', '$H_z$, field strength [A/m]']
-    for i, ax in enumerate(fig1.axes):
-        ax.set_ylabel(ylabels[i])
-        ax.set_xlim(0, np.amax(timetest))
-        ax.grid()
-        ax.legend()
+        # Plot datasets
+        fig1, ((ex1, hx1), (ey1, hy1), (ez1, hz1)) = plt.subplots(nrows=3, ncols=2, sharex=False, sharey='col', subplot_kw=dict(xlabel='Time [ns]'), num=model + '.in', figsize=(20, 10), facecolor='w', edgecolor='w')
+        ex1.plot(timetest, datatest[:, 0], 'r', lw=2, label=model)
+        ex1.plot(timeref, dataref[:, 0], 'g', lw=2, ls='--', label=model + '(Ref)')
+        ey1.plot(timetest, datatest[:, 1], 'r', lw=2, label=model)
+        ey1.plot(timeref, dataref[:, 1], 'g', lw=2, ls='--', label=model + '(Ref)')
+        ez1.plot(timetest, datatest[:, 2], 'r', lw=2, label=model)
+        ez1.plot(timeref, dataref[:, 2], 'g', lw=2, ls='--', label=model + '(Ref)')
+        hx1.plot(timetest, datatest[:, 3], 'r', lw=2, label=model)
+        hx1.plot(timeref, dataref[:, 3], 'g', lw=2, ls='--', label=model + '(Ref)')
+        hy1.plot(timetest, datatest[:, 4], 'r', lw=2, label=model)
+        hy1.plot(timeref, dataref[:, 4], 'g', lw=2, ls='--', label=model + '(Ref)')
+        hz1.plot(timetest, datatest[:, 5], 'r', lw=2, label=model)
+        hz1.plot(timeref, dataref[:, 5], 'g', lw=2, ls='--', label=model + '(Ref)')
+        ylabels = ['$E_x$, field strength [V/m]', '$H_x$, field strength [A/m]', '$E_y$, field strength [V/m]', '$H_y$, field strength [A/m]', '$E_z$, field strength [V/m]', '$H_z$, field strength [A/m]']
+        for i, ax in enumerate(fig1.axes):
+            ax.set_ylabel(ylabels[i])
+            ax.set_xlim(0, np.amax(timetest))
+            ax.grid()
+            ax.legend()
 
-    # Plot diffs
-    fig2, ((ex2, hx2), (ey2, hy2), (ez2, hz2)) = plt.subplots(nrows=3, ncols=2, sharex=False, sharey='col', subplot_kw=dict(xlabel='Time [ns]'), num='Diffs: ' + model + '.in', figsize=(20, 10), facecolor='w', edgecolor='w')
-    ex2.plot(timeref, datadiffs[:, 0], 'r', lw=2, label='Ex')
-    ey2.plot(timeref, datadiffs[:, 1], 'r', lw=2, label='Ey')
-    ez2.plot(timeref, datadiffs[:, 2], 'r', lw=2, label='Ez')
-    hx2.plot(timeref, datadiffs[:, 3], 'r', lw=2, label='Hx')
-    hy2.plot(timeref, datadiffs[:, 4], 'r', lw=2, label='Hy')
-    hz2.plot(timeref, datadiffs[:, 5], 'r', lw=2, label='Hz')
-    ylabels = ['$E_x$, difference [dB]', '$H_x$, difference [dB]', '$E_y$, difference [dB]', '$H_y$, difference [dB]', '$E_z$, difference [dB]', '$H_z$, difference [dB]']
-    for i, ax in enumerate(fig2.axes):
-        ax.set_ylabel(ylabels[i])
-        ax.set_xlim(0, np.amax(timetest))
-        ax.set_ylim([plotmin, np.amax(np.amax(datadiffs))])
-        ax.grid()
+        # Plot diffs
+        fig2, ((ex2, hx2), (ey2, hy2), (ez2, hz2)) = plt.subplots(nrows=3, ncols=2, sharex=False, sharey='col', subplot_kw=dict(xlabel='Time [ns]'), num='Diffs: ' + model + '.in', figsize=(20, 10), facecolor='w', edgecolor='w')
+        ex2.plot(timeref, datadiffs[:, 0], 'r', lw=2, label='Ex')
+        ey2.plot(timeref, datadiffs[:, 1], 'r', lw=2, label='Ey')
+        ez2.plot(timeref, datadiffs[:, 2], 'r', lw=2, label='Ez')
+        hx2.plot(timeref, datadiffs[:, 3], 'r', lw=2, label='Hx')
+        hy2.plot(timeref, datadiffs[:, 4], 'r', lw=2, label='Hy')
+        hz2.plot(timeref, datadiffs[:, 5], 'r', lw=2, label='Hz')
+        ylabels = ['$E_x$, difference [dB]', '$H_x$, difference [dB]', '$E_y$, difference [dB]', '$H_y$, difference [dB]', '$E_z$, difference [dB]', '$H_z$, difference [dB]']
+        for i, ax in enumerate(fig2.axes):
+            ax.set_ylabel(ylabels[i])
+            ax.set_xlim(0, np.amax(timetest))
+            ax.set_ylim([plotmin, np.amax(np.amax(datadiffs))])
+            ax.grid()
 
-    # Save a PDF/PNG of the figure
-    savename = os.path.join(basepath, model + os.path.sep + model)
-    # fig1.savefig(savename + '.pdf', dpi=None, format='pdf', bbox_inches='tight', pad_inches=0.1)
-    # fig2.savefig(savename + '_diffs.pdf', dpi=None, format='pdf', bbox_inches='tight', pad_inches=0.1)
-    fig1.savefig(savename + '.png', dpi=150, format='png', bbox_inches='tight', pad_inches=0.1)
-    fig2.savefig(savename + '_diffs.png', dpi=150, format='png', bbox_inches='tight', pad_inches=0.1)
+        # Save a PDF/PNG of the figure
+        savename = os.path.join(basepath, model + os.path.sep + model)
+        # fig1.savefig(savename + '.pdf', dpi=None, format='pdf', bbox_inches='tight', pad_inches=0.1)
+        # fig2.savefig(savename + '_diffs.pdf', dpi=None, format='pdf', bbox_inches='tight', pad_inches=0.1)
+        fig1.savefig(savename + '.png', dpi=150, format='png', bbox_inches='tight', pad_inches=0.1)
+        fig2.savefig(savename + '_diffs.png', dpi=150, format='png', bbox_inches='tight', pad_inches=0.1)
 
-# Summary of results
-for name, data in sorted(testresults.items()):
-    if 'analytical' in name:
-        print(Fore.CYAN + "Test '{}.in' using v.{} compared to analytical solution. Max difference {:.2f}dB.".format(name, data['Test version'], data['Max diff']) + Style.RESET_ALL)
-    else:
-        print(Fore.CYAN + "Test '{}.in' using v.{} compared to reference solution using v.{}. Max difference {:.2f}dB.".format(name, data['Test version'], data['Ref version'], data['Max diff']) + Style.RESET_ALL)
+    # Summary of results
+    for name, data in sorted(testresults.items()):
+        if 'analytical' in name:
+            print(Fore.CYAN + "Test '{}.in' using v.{} compared to analytical solution. Max difference {:.2f}dB.".format(name, data['Test version'], data['Max diff']) + Style.RESET_ALL)
+        else:
+            print(Fore.CYAN + "Test '{}.in' using v.{} compared to reference solution using v.{}. Max difference {:.2f}dB.".format(name, data['Test version'], data['Ref version'], data['Max diff']) + Style.RESET_ALL)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #627

### Description
This PR resolves the issue where Pytest collection blocks aggressively because legacy test configurations ran massive simulations synchronously at import-time.

By sweeping the global script execution logic inside `tests/test_models.py` and `tests/test_experimental.py` under standard `def main():` scopes guarded by `if __name__ == "__main__":`, we completely sidestep the bug. Both scripts are now 100% safe to import by CI pipelines without exploding, while retaining full backwards compatibility for users who trigger the scripts manually via the command line.