### PR TITLE
adds device (GPU) memory usage for OpenCL

### DIFF
--- a/gprMax/model.py
+++ b/gprMax/model.py
@@ -541,17 +541,15 @@ class Model:
 
         # Run solver
         solver.solve(iterator)
-
         # Write output data, i.e. field data for receivers and snapshots to file(s)
         self.write_output_data()
-
         # Print information about memory usage and solving time for a model
         # Add a string on device (GPU) memory usage if applicable
         mem_str = ""
         if config.sim_config.general["solver"] == "cuda":
             mem_str = f" host + ~{humanize.naturalsize(solver.memused)} device"
         elif config.sim_config.general["solver"] == "opencl":
-            mem_str = f" host + unknown for device"
+            mem_str = f" host + ~{humanize.naturalsize(solver.memused)} device (estimated, excludes driver overhead)"
 
         logger.info(
             f"Memory used (estimated): "

--- a/gprMax/solvers.py
+++ b/gprMax/solvers.py
@@ -94,7 +94,7 @@ class Solver:
 
             if isinstance(self.updates, MPIUpdates):
                 self.updates.halo_swap_electric()
-            if isinstance(self.updates, CUDAUpdates):
+            if isinstance(self.updates, (CUDAUpdates, OpenCLUpdates)):
                 self.memused = self.updates.calculate_memory_used(iteration)
 
         self.updates.finalise()

--- a/gprMax/updates/opencl_updates.py
+++ b/gprMax/updates/opencl_updates.py
@@ -573,16 +573,63 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
         self.event_marker1.wait()
 
     def calculate_memory_used(self, iteration):
-        """Calculates memory used on last iteration.
+        """Calculates memory used on last iteration by summing sizes of all
+        device buffers allocated by this solver.
+
+        Note: Unlike the CUDA backend (which can query free vs total device
+        memory directly via mem_get_info), OpenCL provides no runtime API to
+        query currently-used device memory. This method instead sums the sizes
+        of all buffers explicitly allocated by gprMax on the device, which
+        accurately reflects model memory usage but excludes driver/context
+        overhead (~15-65 MB depending on device).
 
         Args:
             iteration: int for iteration number.
 
         Returns:
-            Memory (RAM) used on compute device.
+            Memory used on compute device in bytes, or None if not last iteration.
         """
-        # No clear way to determine memory used from PyOpenCL unlike PyCUDA.
-        pass
+        if iteration == self.grid.iterations - 1:
+            mem_info = self.cl.mem_info
+
+            def buf_size(cl_array_or_none):
+                """Return byte size of a pyopencl.array.Array, or 0 if None."""
+                if cl_array_or_none is None:
+                    return 0
+                return cl_array_or_none.nbytes
+
+            # Core field arrays
+            total = sum(buf_size(b) for b in [
+                self.grid.ID_dev,
+                self.grid.Ex_dev, self.grid.Ey_dev, self.grid.Ez_dev,
+                self.grid.Hx_dev, self.grid.Hy_dev, self.grid.Hz_dev,
+            ])
+
+            # Dispersive material arrays (optional)
+            for attr in ("updatecoeffsdispersive_dev", "Tx_dev", "Ty_dev", "Tz_dev"):
+                total += buf_size(getattr(self.grid, attr, None))
+
+            # Receiver arrays
+            for attr in ("rxcoords_dev", "rxs_dev"):
+                total += buf_size(getattr(self, attr, None))
+
+            # Source arrays
+            for attr in (
+                "srcinfo1_hertzian_dev", "srcinfo2_hertzian_dev", "srcwaves_hertzian_dev",
+                "srcinfo1_magnetic_dev", "srcinfo2_magnetic_dev", "srcwaves_magnetic_dev",
+                "srcinfo1_voltage_dev",  "srcinfo2_voltage_dev",  "srcwaves_voltage_dev",
+            ):
+                total += buf_size(getattr(self, attr, None))
+
+            # Snapshot arrays
+            for attr in ("snapEx_dev", "snapEy_dev", "snapEz_dev",
+                        "snapHx_dev", "snapHy_dev", "snapHz_dev"):
+                total += buf_size(getattr(self, attr, None))
+            print(f'Total Memory : {total}')
+
+            return total
+        
+        return None
 
     def calculate_solve_time(self):
         """Calculates solving time for model."""


### PR DESCRIPTION
builds on #673 

## Problem

Currently, memory usage reporting is only available for the CUDA backend via `mem_get_info`.  OpenCL does not provide a direct API to query device memory usage at runtime. 

## Implementation

Memory usage is estimated by summing the sizes of all allocated device buffers using `.nbytes`. The following categories are included:

1)  Core field arrays (E and H fields, ID grid)
2)  Dispersive material arrays (if present)
3) Source arrays (Hertzian, magnetic, voltage)
4)  Receiver arrays
5)  Snapshot arrays

The solver loop was updated to invoke `calculate_memory_used` in a backend-agnostic way.

## Validation

1)  Memory usage was verified to scale proportionally with domain size (number of grid cells).
2)  Increasing the domain dimensions resulted in expected increases in memory usage (~O(N) with respect to number of cells).

## Images 

Case 1 : 
Domain 2, 2 , 0.1 

<img width="867" height="54" alt="Screenshot 2026-04-15 at 22 22 29" src="https://github.com/user-attachments/assets/88205ae1-80a7-4dfd-bdbb-7a12e2fd691b" />

<img width="298" height="46" alt="Screenshot 2026-04-15 at 22 22 42" src="https://github.com/user-attachments/assets/35b2870a-cb21-4fdd-860a-0e6e29a420b1" />


Case 2 : 
Domain 20, 20, 0.1 

<img width="274" height="46" alt="Screenshot 2026-04-15 at 22 23 40" src="https://github.com/user-attachments/assets/4f779635-2ac3-4dab-9cbd-159f927cc11e" />

<img width="866" height="59" alt="Screenshot 2026-04-15 at 22 23 36" src="https://github.com/user-attachments/assets/ec1ff1a6-37a3-4ee5-ab66-1156dbd17ebe" />

Increase by 100x ( 2x10, 2x10, 0.1x1 = 20, 20, 0.1 ) 
increase in memory : ~100x