### PR TITLE
feat: export material property arrays (er, se) in geometry_view VTI o…

### DIFF
--- a/docs/source/input.rst
+++ b/docs/source/input.rst
@@ -394,13 +394,14 @@ Allows you output to file(s) information about the geometry of model. The file(s
 
 .. code-block:: none
 
-    #geometry_view: f1 f2 f3 f4 f5 f6 f7 f8 f9 file1 c1
+    #geometry_view: f1 f2 f3 f4 f5 f6 f7 f8 f9 file1 c1 [p]
 
 * ``f1 f2 f3`` are the lower left (x,y,z) coordinates of the volume of the geometry view in metres.
 * ``f4 f5 f6`` are the upper right (x,y,z) coordinates of the volume of the geometry view in metres.
 * ``f7 f8 f9`` are the spatial discretisation of the geometry view in metres. Typically these will be the same as the spatial discretisation of the model but they can be courser if desired.
 * ``file1`` is the filename of the file where the geometry view will be stored in the same directory as the input file.
 * ``c1`` can be either n (normal) or f (fine) which specifies whether to output the geometry information on a per-cell basis (n) or a per-cell-edge basis (f). The fine mode should be reserved for viewing detailed parts of the geometry that occupy small volumes, as using this mode can generate geometry files with large file sizes.
+* ``p`` is optional and can only be used with normal (``n``) geometry views. It also writes ``relative_permittivity`` and ``conductivity`` ``.vti`` property files that can be processed with the ``gprMax_info.py`` macro.
 
 .. tip::
 

--- a/docs/source/output.rst
+++ b/docs/source/output.rst
@@ -137,7 +137,7 @@ Geometry output
 
 Geometry files use the open source `Visualization ToolKit (VTK) <http://www.vtk.org>`_ format which can be viewed in many free readers, such as `Paraview <http://www.paraview.org>`_. Paraview is an open-source, multi-platform data analysis and visualization application. It is available for Linux, Mac OS X, and Windows.
 
-The ``#geometry_view:`` command produces either ImageData (.vti) for a per-cell geometry view, or PolygonalData (.vtp) for a per-cell-edge geometry view. The per-cell geometry views also show the location of the PML regions and any sources and receivers in the model. The following are steps to get started with viewing geometry files in Paraview:
+The ``#geometry_view:`` command produces either ImageData (.vti) for a per-cell geometry view, or PolygonalData (.vtp) for a per-cell-edge geometry view. The per-cell geometry views also show the location of the PML regions and any sources and receivers in the model. If the optional ``p`` flag is used with a normal geometry view, additional ``.vti`` property files are written for ``relative_permittivity`` and ``conductivity``. These property files can be processed with the ``gprMax_info.py`` macro to create separate ``free_space`` and model pipeline items. The following are steps to get started with viewing geometry files in Paraview:
 
 .. _pv_toolbar:
 

--- a/gprMax/geometry_outputs.py
+++ b/gprMax/geometry_outputs.py
@@ -37,7 +37,7 @@ class GeometryView(object):
     else:
         byteorder = 'BigEndian'
 
-    def __init__(self, xs=None, ys=None, zs=None, xf=None, yf=None, zf=None, dx=None, dy=None, dz=None, filename=None, fileext=None):
+    def __init__(self, xs=None, ys=None, zs=None, xf=None, yf=None, zf=None, dx=None, dy=None, dz=None, filename=None, fileext=None, export_properties=False):
         """
         Args:
             xs, xf, ys, yf, zs, zf (int): Extent of the volume in cells.
@@ -45,6 +45,8 @@ class GeometryView(object):
             filename (str): Filename to save to.
             fileext (str): File extension of VTK file - either '.vti' for a per cell
                     geometry view, or '.vtp' for a per cell edge geometry view.
+            export_properties (bool): If True, also write permittivity and
+                    conductivity .vti files alongside the main geometry view.
         """
 
         self.xs = xs
@@ -61,6 +63,7 @@ class GeometryView(object):
         self.dz = dz
         self.basefilename = filename
         self.fileext = fileext
+        self.export_properties = export_properties
 
         if self.fileext == '.vti':
             # Calculate number of cells according to requested sampling for geometry view
@@ -77,6 +80,11 @@ class GeometryView(object):
             self.datawritesize = (np.dtype(np.uint32).itemsize * self.vtk_ncells
                                   + 2 * np.dtype(np.int8).itemsize * self.vtk_ncells
                                   + 3 * np.dtype(np.uint32).itemsize)
+            if self.export_properties:
+                self.propertydatawritesize = (np.dtype(np.uint32).itemsize * self.vtk_ncells
+                                              + np.dtype(np.float32).itemsize * self.vtk_ncells
+                                              + 2 * np.dtype(np.int8).itemsize * self.vtk_ncells
+                                              + 4 * np.dtype(np.uint32).itemsize)
 
         elif self.fileext == '.vtp':
             self.vtk_numpoints = (self.nx + 1) * (self.ny + 1) * (self.nz + 1)
@@ -115,6 +123,76 @@ class GeometryView(object):
 
         self.filename = os.path.abspath(os.path.join(G.inputdirectory, self.basefilename + appendmodelnumber))
         self.filename += self.fileext
+
+    def _get_material_property_values(self, G, solid_geometry, property_name):
+        """Maps material numeric IDs in the geometry view to a material property."""
+
+        property_attrs = {
+            'relative_permittivity': 'er',
+            'conductivity': 'se',
+        }
+        lut = np.zeros(max(m.numID for m in G.materials) + 1, dtype=np.float32)
+        attr = property_attrs[property_name]
+        for material in G.materials:
+            lut[material.numID] = np.float32(getattr(material, attr))
+
+        return np.ascontiguousarray(lut[solid_geometry], dtype=np.float32)
+
+    def write_property_vti(self, G, pbar, solid_geometry, srcs_pml_geometry, rxs_geometry, dataarray_name, filepath):
+        """
+        Writes a material property field as a VTK ImageData file.
+
+        Args:
+            G (class): Grid class instance - holds essential parameters describing the model.
+            pbar (class): Progress bar class instance.
+            solid_geometry (array): 1-D uint32 array of material numeric IDs per cell.
+            srcs_pml_geometry (array): 1-D int8 array of source and PML numeric IDs per cell.
+            rxs_geometry (array): 1-D int8 array of receiver numeric IDs per cell.
+            dataarray_name (str): Name for the VTK DataArray, e.g. 'relative_permittivity'.
+            filepath (str): Full path of the .vti file to write.
+        """
+
+        property_geometry = self._get_material_property_values(G, solid_geometry, dataarray_name)
+        vtk_property_offset = round_value(np.dtype(np.uint32).itemsize + solid_geometry.nbytes)
+        vtk_srcs_pml_offset = round_value(vtk_property_offset + np.dtype(np.uint32).itemsize + property_geometry.nbytes)
+        vtk_rxs_offset = round_value(vtk_srcs_pml_offset + np.dtype(np.uint32).itemsize + srcs_pml_geometry.nbytes)
+
+        with open(filepath, 'wb') as f:
+            f.write('<?xml version="1.0"?>\n'.encode('utf-8'))
+            f.write('<VTKFile type="ImageData" version="1.0" byte_order="{}">\n'.format(GeometryView.byteorder).encode('utf-8'))
+            f.write('<ImageData WholeExtent="{} {} {} {} {} {}" Origin="0 0 0" Spacing="{:.3} {:.3} {:.3}">\n'.format(self.vtk_xscells, self.vtk_xfcells, self.vtk_yscells, self.vtk_yfcells, self.vtk_zscells, self.vtk_zfcells, self.dx * G.dx, self.dy * G.dy, self.dz * G.dz).encode('utf-8'))
+            f.write('<Piece Extent="{} {} {} {} {} {}">\n'.format(self.vtk_xscells, self.vtk_xfcells, self.vtk_yscells, self.vtk_yfcells, self.vtk_zscells, self.vtk_zfcells).encode('utf-8'))
+            f.write('<CellData Scalars="{}">\n'.format(dataarray_name).encode('utf-8'))
+            f.write('<DataArray type="UInt32" Name="Material" format="appended" offset="0" />\n'.encode('utf-8'))
+            f.write('<DataArray type="Float32" Name="{}" format="appended" offset="{}" />\n'.format(dataarray_name, vtk_property_offset).encode('utf-8'))
+            f.write('<DataArray type="Int8" Name="Sources_PML" format="appended" offset="{}" />\n'.format(vtk_srcs_pml_offset).encode('utf-8'))
+            f.write('<DataArray type="Int8" Name="Receivers" format="appended" offset="{}" />\n'.format(vtk_rxs_offset).encode('utf-8'))
+            f.write('</CellData>\n'.encode('utf-8'))
+            f.write('</Piece>\n</ImageData>\n<AppendedData encoding="raw">\n_'.encode('utf-8'))
+
+            f.write(pack('I', solid_geometry.nbytes))
+            pbar.update(n=4)
+            f.write(solid_geometry)
+            pbar.update(n=solid_geometry.nbytes)
+
+            f.write(pack('I', property_geometry.nbytes))
+            pbar.update(n=4)
+            f.write(property_geometry)
+            pbar.update(n=property_geometry.nbytes)
+
+            f.write(pack('I', srcs_pml_geometry.nbytes))
+            pbar.update(n=4)
+            f.write(srcs_pml_geometry)
+            pbar.update(n=srcs_pml_geometry.nbytes)
+
+            f.write(pack('I', rxs_geometry.nbytes))
+            pbar.update(n=4)
+            f.write(rxs_geometry)
+            pbar.update(n=rxs_geometry.nbytes)
+
+            f.write('\n</AppendedData>\n</VTKFile>'.encode('utf-8'))
+
+            self.write_gprmax_info(f, G)
 
     def write_vtk(self, G, pbar):
         """
@@ -200,6 +278,13 @@ class GeometryView(object):
                 f.write('\n</AppendedData>\n</VTKFile>'.encode('utf-8'))
 
                 self.write_gprmax_info(f, G)
+
+            # Retain the material ID array so that property files can be
+            # written with a separate progress bar from model_build_run.
+            if self.export_properties:
+                self.solid_geometry = solid_geometry
+                self.srcs_pml_geometry = srcs_pml_geometry
+                self.rxs_geometry = rxs_geometry
 
         elif self.fileext == '.vtp':
             with open(self.filename, 'wb') as f:

--- a/gprMax/input_cmd_funcs.py
+++ b/gprMax/input_cmd_funcs.py
@@ -216,7 +216,7 @@ def material(permittivity, conductivity, permeability, magconductivity, name):
     command('material', permittivity, conductivity, permeability, magconductivity, name)
 
 
-def geometry_view(xs, ys, zs, xf, yf, zf, dx, dy, dz, filename, type='n'):
+def geometry_view(xs, ys, zs, xf, yf, zf, dx, dy, dz, filename, type='n', export_properties=False):
     """Prints the gprMax #geometry_view command.
 
     Args:
@@ -226,6 +226,8 @@ def geometry_view(xs, ys, zs, xf, yf, zf, dx, dy, dz, filename, type='n'):
         type (str): Can be either n (normal) or f (fine) which specifies whether
                 to output the geometry information on a per-cell basis (n) or a
                 per-cell-edge basis (f).
+        export_properties (bool): If True, add a final p to also write
+                permittivity and conductivity .vti files (only with type n).
 
     Returns:
         s, f, d (tuple): 3 namedtuple Coordinate for the start,
@@ -235,7 +237,10 @@ def geometry_view(xs, ys, zs, xf, yf, zf, dx, dy, dz, filename, type='n'):
     s = Coordinate(xs, ys, zs)
     f = Coordinate(xf, yf, zf)
     d = Coordinate(dx, dy, dz)
-    command('geometry_view', s, f, d, filename, type)
+    if export_properties:
+        command('geometry_view', s, f, d, filename, type, 'p')
+    else:
+        command('geometry_view', s, f, d, filename, type)
 
     return s, f, d
 

--- a/gprMax/input_cmds_multiuse.py
+++ b/gprMax/input_cmds_multiuse.py
@@ -726,8 +726,8 @@ def process_multicmds(multicmds, G):
     if multicmds[cmdname] is not None:
         for cmdinstance in multicmds[cmdname]:
             tmp = cmdinstance.split()
-            if len(tmp) != 11:
-                raise CmdInputError("'" + cmdname + ': ' + ' '.join(tmp) + "'" + ' requires exactly eleven parameters')
+            if len(tmp) not in (11, 12):
+                raise CmdInputError("'" + cmdname + ': ' + ' '.join(tmp) + "'" + ' requires eleven parameters, or twelve with a final p to also write permittivity/conductivity .vti files')
 
             xs = G.calculate_coord('x', tmp[0])
             ys = G.calculate_coord('y', tmp[1])
@@ -757,16 +757,27 @@ def process_multicmds(multicmds, G):
             if tmp[10].lower() == 'f' and (dx * G.dx != G.dx or dy * G.dy != G.dy or dz * G.dz != G.dz):
                 raise CmdInputError("'" + cmdname + ': ' + ' '.join(tmp) + "'" + ' requires the spatial discretisation for the geometry view to be the same as the model for geometry view of type f (fine)')
 
+            export_properties = False
+            if len(tmp) == 12:
+                if tmp[11].lower() != 'p':
+                    raise CmdInputError("'" + cmdname + ': ' + ' '.join(tmp) + "'" + ' when using twelve parameters the last must be p (write permittivity and conductivity from material properties)')
+                if tmp[10].lower() != 'n':
+                    raise CmdInputError("'" + cmdname + ': ' + ' '.join(tmp) + "'" + ' permittivity/conductivity export (p) is only available with type n (normal, .vti)')
+                export_properties = True
+
             # Set type of geometry file
             if tmp[10].lower() == 'n':
                 fileext = '.vti'
             else:
                 fileext = '.vtp'
 
-            g = GeometryView(xs, ys, zs, xf, yf, zf, dx, dy, dz, tmp[9], fileext)
+            g = GeometryView(xs, ys, zs, xf, yf, zf, dx, dy, dz, tmp[9], fileext, export_properties=export_properties)
 
             if G.messages:
-                print('Geometry view from {:g}m, {:g}m, {:g}m, to {:g}m, {:g}m, {:g}m, discretisation {:g}m, {:g}m, {:g}m, with filename base {} created.'.format(xs * G.dx, ys * G.dy, zs * G.dz, xf * G.dx, yf * G.dy, zf * G.dz, dx * G.dx, dy * G.dy, dz * G.dz, g.basefilename))
+                msg = 'Geometry view from {:g}m, {:g}m, {:g}m, to {:g}m, {:g}m, {:g}m, discretisation {:g}m, {:g}m, {:g}m, with filename base {} created.'.format(xs * G.dx, ys * G.dy, zs * G.dz, xf * G.dx, yf * G.dy, zf * G.dz, dx * G.dx, dy * G.dy, dz * G.dz, g.basefilename)
+                if export_properties:
+                    msg += ' Permittivity and conductivity .vti files will also be written.'
+                print(msg)
 
             # Append the new GeometryView object to the geometry views list
             G.geometryviews.append(g)

--- a/gprMax/model_build_run.py
+++ b/gprMax/model_build_run.py
@@ -333,6 +333,20 @@ def run_model(args, currentmodelrun, modelend, numbermodelruns, inputfile, usern
             pbar = tqdm(total=geometryview.datawritesize, unit='byte', unit_scale=True, desc='Writing geometry view file {}/{}, {}'.format(i + 1, len(G.geometryviews), os.path.split(geometryview.filename)[1]), ncols=get_terminal_width() - 1, file=sys.stdout, disable=not G.progressbars)
             geometryview.write_vtk(G, pbar)
             pbar.close()
+
+            if geometryview.export_properties:
+                basefilepath = os.path.splitext(geometryview.filename)[0]
+                property_views = [('_relative_permittivity', 'relative_permittivity'),
+                                  ('_conductivity', 'conductivity')]
+                for j, (suffix, arrayname) in enumerate(property_views):
+                    filepath = basefilepath + suffix + '.vti'
+                    pbar = tqdm(total=geometryview.propertydatawritesize, unit='byte', unit_scale=True, desc='Writing geometry property view file {}/{}, {}'.format(j + 1, len(property_views), os.path.basename(filepath)), ncols=get_terminal_width() - 1, file=sys.stdout, disable=not G.progressbars)
+                    geometryview.write_property_vti(G, pbar, geometryview.solid_geometry, geometryview.srcs_pml_geometry, geometryview.rxs_geometry, arrayname, filepath)
+                    pbar.close()
+                del geometryview.solid_geometry
+                del geometryview.srcs_pml_geometry
+                del geometryview.rxs_geometry
+
     if G.geometryobjectswrite:
         for i, geometryobject in enumerate(G.geometryobjectswrite):
             pbar = tqdm(total=geometryobject.datawritesize, unit='byte', unit_scale=True, desc='Writing geometry object file {}/{}, {}'.format(i + 1, len(G.geometryobjectswrite), os.path.split(geometryobject.filename)[1]), ncols=get_terminal_width() - 1, file=sys.stdout, disable=not G.progressbars)

--- a/tests/test_input_cmd_funcs.py
+++ b/tests/test_input_cmd_funcs.py
@@ -1,9 +1,14 @@
+import os
 import sys
+import tempfile
 import unittest
 
 # http://stackoverflow.com/a/17981937/1942837
 from contextlib import contextmanager
 from io import StringIO
+from unittest.mock import patch
+
+import numpy as np
 
 
 @contextmanager
@@ -19,6 +24,47 @@ def captured_output():
 # end stack copy
 
 from gprMax.input_cmd_funcs import *
+from gprMax.exceptions import CmdInputError
+from gprMax.geometry_outputs import GeometryView
+from gprMax.input_cmds_file import check_cmd_names
+from gprMax.input_cmds_multiuse import process_multicmds
+from gprMax.materials import Material
+
+
+class DummyProgressBar(object):
+    def __init__(self):
+        self.total = 0
+
+    def update(self, n=1):
+        self.total += n
+
+
+class DummyGrid(object):
+    def __init__(self):
+        self.messages = False
+        self.nx = 10
+        self.ny = 10
+        self.nz = 10
+        self.dx = 0.1
+        self.dy = 0.1
+        self.dz = 0.1
+        self.geometryviews = []
+
+    def calculate_coord(self, coord, val):
+        return int(round(float(val) / getattr(self, 'd' + coord)))
+
+    def within_bounds(self, **kwargs):
+        for coord, val in kwargs.items():
+            if val < 0 or val > getattr(self, 'n' + coord):
+                raise ValueError(coord)
+
+
+def process_geometry_view_cmd(command):
+    G = DummyGrid()
+    processedlines = [command + '\n']
+    _, multicmds, _ = check_cmd_names(processedlines, checkessential=False)
+    process_multicmds(multicmds, G)
+    return G
 
 
 class My_input_cmd_funcs_test(unittest.TestCase):
@@ -80,6 +126,73 @@ class My_input_cmd_funcs_test(unittest.TestCase):
         with captured_output() as (out, err):
             rx_steps(42, 43, 44.2)
         self.assert_output(out, '#rx_steps: 42 43 44.2')
+
+    def test_geometry_view_export_properties(self):
+        with captured_output() as (out, err):
+            geometry_view(0, 0, 0, 1, 1, 1, 0.1, 0.1, 0.1, 'geo', export_properties=True)
+        self.assert_output(out, '#geometry_view: 0 0 0 1 1 1 0.1 0.1 0.1 geo n p')
+
+    def test_geometry_view_p_flag_parses_for_normal_view(self):
+        G = process_geometry_view_cmd('#geometry_view: 0 0 0 1 1 1 0.1 0.1 0.1 geo n p')
+
+        self.assertEqual(len(G.geometryviews), 1)
+        self.assertTrue(G.geometryviews[0].export_properties)
+        self.assertEqual(G.geometryviews[0].fileext, '.vti')
+
+    def test_geometry_view_p_flag_rejects_fine_view(self):
+        with self.assertRaises(CmdInputError):
+            process_geometry_view_cmd('#geometry_view: 0 0 0 1 1 1 0.1 0.1 0.1 geo f p')
+
+    def test_geometry_view_rejects_unknown_twelfth_parameter(self):
+        with self.assertRaises(CmdInputError):
+            process_geometry_view_cmd('#geometry_view: 0 0 0 1 1 1 0.1 0.1 0.1 geo n x')
+
+    def test_geometry_view_property_files_are_written(self):
+        G = DummyGrid()
+        G.nx = 2
+        G.ny = 2
+        G.nz = 2
+        G.inputdirectory = ''
+        G.pmls = []
+        G.hertziandipoles = []
+        G.magneticdipoles = []
+        G.voltagesources = []
+        G.transmissionlines = []
+        G.rxs = []
+
+        pec = Material(0, 'pec')
+        pec.se = float('inf')
+        free_space = Material(1, 'free_space')
+        soil = Material(2, 'soil')
+        soil.er = 9.0
+        soil.se = 0.01
+        G.materials = [pec, free_space, soil]
+
+        G.solid = np.ones((2, 2, 2), dtype=np.uint32)
+
+        def define_geometry(*args):
+            solid_geometry = args[-3]
+            srcs_pml_geometry = args[-2]
+            rxs_geometry = args[-1]
+            solid_geometry[:] = np.array([1, 2, 2, 1, 0, 2, 1, 2], dtype=np.uint32)
+            srcs_pml_geometry[:] = 0
+            rxs_geometry[:] = 0
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            geometryview = GeometryView(0, 0, 0, 2, 2, 2, 1, 1, 1, 'geo', '.vti', export_properties=True)
+            geometryview.filename = os.path.join(tmpdir, 'geo.vti')
+
+            with patch('gprMax.geometry_outputs.define_normal_geometry', side_effect=define_geometry):
+                geometryview.write_vtk(G, DummyProgressBar())
+
+            for suffix, arrayname in (('_relative_permittivity', 'relative_permittivity'), ('_conductivity', 'conductivity')):
+                filepath = os.path.join(tmpdir, 'geo' + suffix + '.vti')
+                geometryview.write_property_vti(G, DummyProgressBar(), geometryview.solid_geometry, geometryview.srcs_pml_geometry, geometryview.rxs_geometry, arrayname, filepath)
+                self.assertTrue(os.path.exists(filepath))
+                with open(filepath, 'rb') as f:
+                    data = f.read()
+                self.assertIn(('Name="{}"'.format(arrayname)).encode(), data)
+                self.assertIn(b'<DataArray type="Float32"', data)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tools/Paraview macros/gprMax_info.py
+++ b/tools/Paraview macros/gprMax_info.py
@@ -199,6 +199,9 @@ pmls = {}
 # To hold the maximum numerical ID for materials across multiple files
 material_ID_max = 0
 
+# Property arrays written by gprMax geometry views with the optional p flag
+property_arrays = set()
+
 #################################################################
 # Read and display data from file(s), i.e. materials, sources,  #
 #                                           receivers, and PMLs #
@@ -213,6 +216,9 @@ for file in files:
         # Determine gprMax version
         # Read XML data
         mm = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
+        for array_name in ('relative_permittivity', 'conductivity'):
+            if mm.find(('Name="{}"'.format(array_name)).encode()) != -1:
+                property_arrays.add(array_name)
         
         # Look for <gprMax> tag which indicates version <4
         try:
@@ -323,18 +329,52 @@ for file in files:
                 thresholddisplay.ColorArrayName = 'Receivers'
                 threshold.UpdatePipeline()
 
-# Display materials
+# Display materials or property views
 material_range = range(0, material_ID_max + 1)
-for k, v in sorted(materials.items(), key=lambda x: x[1]):
-    if v in material_range:
-        threshold = threshold_filt(model, v, v, ['CELLS', 'Material'])
-        RenameSource(k, threshold)
-
-        # Show data in view, except for free_space
-        if v != 1:
-            thresholddisplay = Show(threshold, renderview)
-            thresholddisplay.ColorArrayName = ['CELLS', 'Material']
+if property_arrays:
+    free_space_property = sorted(property_arrays)[0]
+    if 0 in material_range:
+        threshold = threshold_filt(model, 0, 0, ['CELLS', 'Material'])
+        RenameSource('pec', threshold)
+        thresholddisplay = Show(threshold, renderview)
+        thresholddisplay.ColorArrayName = [None, '']
+        thresholddisplay.DiffuseColor = [0.05, 0.05, 0.05]
         threshold.UpdatePipeline()
+
+    if 1 in material_range:
+        threshold = threshold_filt(model, 1, 1, ['CELLS', 'Material'])
+        RenameSource('free_space', threshold)
+        thresholddisplay = Show(threshold, renderview)
+        thresholddisplay.ColorArrayName = ['CELLS', free_space_property]
+        thresholddisplay.Opacity = 0.35
+        threshold.UpdatePipeline()
+        try:
+            thresholddisplay.RescaleTransferFunctionToDataRange(True, False)
+        except Exception:
+            pass
+
+    for property_name in sorted(property_arrays):
+        if material_ID_max >= 2:
+            threshold = threshold_filt(model, 2, material_ID_max, ['CELLS', 'Material'])
+            RenameSource('model - ' + property_name, threshold)
+            thresholddisplay = Show(threshold, renderview)
+            thresholddisplay.ColorArrayName = ['CELLS', property_name]
+            threshold.UpdatePipeline()
+            try:
+                thresholddisplay.RescaleTransferFunctionToDataRange(True, False)
+            except Exception:
+                pass
+else:
+    for k, v in sorted(materials.items(), key=lambda x: x[1]):
+        if v in material_range:
+            threshold = threshold_filt(model, v, v, ['CELLS', 'Material'])
+            RenameSource(k, threshold)
+
+            # Show data in view, except for free_space
+            if v != 1:
+                thresholddisplay = Show(threshold, renderview)
+                thresholddisplay.ColorArrayName = ['CELLS', 'Material']
+            threshold.UpdatePipeline()
 
 
 RenderAllViews()


### PR DESCRIPTION
…utput

Add optional p flag to #geometry_view command. When used with normal (n) geometry views, additional .vti files are written containing relative_permittivity and conductivity cell data, mapped from the corresponding material properties.

- geometry_outputs.py: new write_property_vti() method and export_properties parameter on GeometryView
- input_cmds_multiuse.py: accept 12th p parameter, enforce .vti-only
- input_cmd_funcs.py: Python API export_properties kwarg
- model_build_run.py: trigger property file writes after geometry view
- gprMax_info.py: detect property arrays, auto-create separate pec/free_space/model display pipelines in ParaView
- docs: document optional p flag
- tests: 5 new test cases for parsing, validation, and file output

# PR Description

Currently geometry_view only exports material IDs, making it difficult to visualize which materials have what electromagnetic properties without manually cross-referencing the material table. This PR adds an optional p flag that exports relative_permittivity and conductivity as separate VTI arrays for direct color mapping in ParaView.

## 🛠️ Related Issue (Number)

<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

Closes #

## Type of change

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update.

## Checklist

<!----Please delete options that are not relevant and to tick the check box just add x inside them for example [x] like this----->
- [ ] Did pre-commit passed all checks?
- [x ] I have performed a self-review of my code.
- [x ] I have added comments for my code, particularly in hard-to-understand areas.
- [x ] I have made corresponding changes to the documentation.
- [x ] My changes generate no new warnings.
- [x ] The title of my pull request is a short description of my changes.
<img width="2164" height="4103" alt="PR" src="https://github.com/user-attachments/assets/bd99b350-8cd3-4285-b557-942fb4e425e3" />
<img width="2031" height="1207" alt="PR2" src="https://github.com/user-attachments/assets/68ecb2c8-daa9-4d24-baed-ef37374acb05" />

