### PR TITLE
Remove duplicate entries from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,8 +25,6 @@ defusedxml==0.7.1
 executing==0.8.3
 fastjsonschema==2.16.2
 fonttools==4.25.0
-gprMax==3.1.7
-gprMax==3.1.7
 h5py==3.12.1
 idna==3.7
 ipykernel==6.28.0
@@ -78,10 +76,8 @@ ptyprocess==0.7.0
 pur==7.3.1
 pure-eval==0.2.2
 pycparser==2.21
-Pygments==2.15.1
 pyOpenSSL==26.0.0
 Pygments==2.20.0
-pyOpenSSL==26.0.0
 pyparsing==3.0.9
 PyQt5==5.15.10
 PyQt5-sip==12.13.0


### PR DESCRIPTION
# PR Description

Removes three problematic lines from `requirements.txt`:

- Both `gprMax==3.1.7` entries — `gprMax` is not published on PyPI, so this line cannot be resolved by pip. The package is installed via `python setup.py install`, not as a pip dependency. The duplication was an artifact of a `pip freeze`-style update.
- `Pygments==2.15.1` — a stale entry; a newer `Pygments==2.20.0` line already exists from a later Dependabot bump.
- The second `pyOpenSSL==26.0.0` — an identical duplicate of an earlier line.

## 🛠️ Related Issue (Number)

Closes #685

## Verification

Tested with `pip install --dry-run -r requirements.txt` in a fresh venv.

**Before this PR** — resolution fails at line 28 with the exact error from #685:
```
ERROR: Could not find a version that satisfies the requirement gprMax==3.1.7 (from versions: none)
ERROR: No matching distribution found for gprMax==3.1.7
```
**After this PR** — resolution proceeds successfully past all the previously-duplicated entries.

The duplicates appear to have two distinct origins, both visible in git history:

- The duplicate `gprMax==3.1.7` lines were most likely a manual pip freeze dump.
- The duplicate `Pygments` and `pyOpenSSL` lines appeared in merge commit `a019e044`, where a Dependabot PR branched from stale master was merged without rebase, and the conflict resolution kept both versions of each line.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.
