### PR TITLE
Fix incorrect parameter names in docstrings

### DIFF
--- a/tools/Paraview macros/gprMax_info.py
+++ b/tools/Paraview macros/gprMax_info.py
@@ -81,7 +81,7 @@ def display_pmls(pmlthick, dx_dy_dz, nx_ny_nz):
     Args:
         pmlthick (tuple): PML thickness values for each slab (cells)
         dx_dy_dz (tuple): Spatial resolution (m)
-        nx_ny_dz (tuple): Domain size (cells)
+        nx_ny_nz (tuple): Domain size (cells)
     """
 
     pml_names = ['x0', 'y0', 'z0', 'xmax', 'ymax', 'zmax']

--- a/tools/outputfiles_merge.py
+++ b/tools/outputfiles_merge.py
@@ -68,7 +68,7 @@ def merge_files(basefilename, removefiles=False):
 
     Args:
         basefilename (string): Base name of output file series including path.
-        outputs (boolean): Flag to remove individual output files after merge.
+        removefiles (boolean): Flag to remove individual output files after merge.
     """
 
     outputfile = basefilename + '_merged.out'

--- a/tools/plot_antenna_params.py
+++ b/tools/plot_antenna_params.py
@@ -154,7 +154,7 @@ def mpl_plot(filename, time, freqs, Vinc, Vincp, Iinc, Iincp, Vref, Vrefp, Iref,
     Args:
         filename (string): Filename (including path) of output file.
         time (array): Simulation time.
-        freq (array): Frequencies for FFTs.
+        freqs (array): Frequencies for FFTs.
         Vinc, Vincp, Iinc, Iincp (array): Time and frequency domain representations of incident voltage and current.
         Vref, Vrefp, Iref, Irefp (array): Time and frequency domain representations of reflected voltage and current.
         Vtotal, Vtotalp, Itotal, Itotalp (array): Time and frequency domain representations of total voltage and current.


### PR DESCRIPTION
Several docstrings document parameter names that don't match their function signatures. This corrects them so the docs match the code:

- `merge_files` (`tools/outputfiles_merge.py`): `outputs` -> `removefiles` (the description "Flag to remove individual output files after merge" already describes the `removefiles` argument).
- `mpl_plot` (`tools/plot_antenna_params.py`): `freq` -> `freqs`.
- `display_pmls` (`tools/Paraview macros/gprMax_info.py`): `nx_ny_dz` -> `nx_ny_nz`.

Documentation-only change; no runtime behaviour is affected.
