### PR TITLE
Add A-scan post-processing dashboard and h5_reader foundation (Compon…

### DIFF
--- a/tests/test_h5_reader.py
+++ b/tests/test_h5_reader.py
@@ -1,0 +1,342 @@
+"""
+tests/test_h5_reader.py: unit tests for toolboxes/Marimo/h5_reader.py
+
+Run from repo root:
+    pytest tests/test_h5_reader.py -v
+
+Uses a synthetic HDF5 fixture built in memory — no real gprMax output
+file required. Tests cover metadata extraction, component reading,
+utility functions, and error handling.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from toolboxes.Marimo.h5_reader import (
+    build_label,
+    format_metadata_text,
+    get_time_axis,
+    get_trace,
+    get_unit_label,
+    list_components,
+    list_receivers,
+    load_file,
+    load_files,
+)
+
+# Fixtures
+
+
+DT = 4.717308673499368e-12  # seconds (from real cylinder_Ascan_2D.h5)
+ITERATIONS = 637
+NRX = 1
+NSRC = 1
+
+COMPONENTS = {
+    "Ex": np.zeros(ITERATIONS, dtype=np.float64),
+    "Ey": np.zeros(ITERATIONS, dtype=np.float64),
+    "Ez": np.linspace(-1000, 1000, ITERATIONS, dtype=np.float64),
+    "Hx": np.ones(ITERATIONS, dtype=np.float64) * 0.5,
+    "Hy": np.ones(ITERATIONS, dtype=np.float64) * -0.5,
+    "Hz": np.zeros(ITERATIONS, dtype=np.float64),
+}
+
+
+def _write_synthetic_h5(path: Path, title: str = "Test A-scan") -> None:
+    """Write a minimal valid gprMax v4 HDF5 file for testing."""
+    with h5py.File(path, "w") as f:
+        # Root attributes
+        f.attrs["Title"] = title
+        f.attrs["dt"] = DT
+        f.attrs["dx_dy_dz"] = np.array([0.002, 0.002, 0.002])
+        f.attrs["Iterations"] = ITERATIONS
+        f.attrs["nrx"] = NRX
+        f.attrs["nsrc"] = NSRC
+        f.attrs["nx_ny_nz"] = np.array([120, 105, 1])
+        f.attrs["gprMax"] = "4.0.0b0"
+
+        # Receiver
+        rx1 = f.require_group("rxs/rx1")
+        rx1.attrs["Name"] = "Rx(70,85,0)"
+        rx1.attrs["Position"] = np.array([0.14, 0.17, 0.0])
+        for comp, data in COMPONENTS.items():
+            rx1.create_dataset(comp, data=data)
+
+        # Source
+        src1 = f.require_group("srcs/src1")
+        src1.attrs["Type"] = "HertzianDipole"
+        src1.attrs["Position"] = np.array([0.10, 0.17, 0.0])
+
+
+@pytest.fixture
+def h5_file(tmp_path: Path) -> Path:
+    """Single synthetic HDF5 file."""
+    p = tmp_path / "test_ascan.h5"
+    _write_synthetic_h5(p)
+    return p
+
+
+@pytest.fixture
+def h5_file_b(tmp_path: Path) -> Path:
+    """Second synthetic HDF5 file with a different title."""
+    p = tmp_path / "test_ascan_freespace.h5"
+    _write_synthetic_h5(p, title="Free space A-scan")
+    return p
+
+
+@pytest.fixture
+def loaded(h5_file: Path):
+    """Pre-loaded FileData dict."""
+    return load_file(h5_file)
+
+
+# load_file — metadata
+
+
+class TestLoadFileMeta:
+    def test_title(self, loaded):
+        assert loaded["meta"]["title"] == "Test A-scan"
+
+    def test_dt(self, loaded):
+        assert loaded["meta"]["dt"] == pytest.approx(DT)
+
+    def test_iterations(self, loaded):
+        assert loaded["meta"]["iterations"] == ITERATIONS
+
+    def test_nrx(self, loaded):
+        assert loaded["meta"]["nrx"] == NRX
+
+    def test_nsrc(self, loaded):
+        assert loaded["meta"]["nsrc"] == NSRC
+
+    def test_dx_dy_dz(self, loaded):
+        assert loaded["meta"]["dx_dy_dz"] == pytest.approx([0.002, 0.002, 0.002])
+
+    def test_nx_ny_nz(self, loaded):
+        assert loaded["meta"]["nx_ny_nz"] == [120, 105, 1]
+
+    def test_gprmax_version(self, loaded):
+        assert loaded["meta"]["gprmax_version"] == "4.0.0b0"
+
+
+# load_file — receiver structure
+
+
+class TestLoadFileReceivers:
+    def test_receiver_keys(self, loaded):
+        assert "rx1" in loaded["receivers"]
+
+    def test_receiver_name(self, loaded):
+        assert loaded["receivers"]["rx1"]["name"] == "Rx(70,85,0)"
+
+    def test_receiver_position(self, loaded):
+        assert loaded["receivers"]["rx1"]["position"] == pytest.approx([0.14, 0.17, 0.0])
+
+    def test_all_components_present(self, loaded):
+        components = loaded["receivers"]["rx1"]["components"]
+        for comp in COMPONENTS:
+            assert comp in components
+
+    def test_component_shape(self, loaded):
+        ez = loaded["receivers"]["rx1"]["components"]["Ez"]
+        assert ez.shape == (ITERATIONS,)
+
+    def test_component_values(self, loaded):
+        ez = loaded["receivers"]["rx1"]["components"]["Ez"]
+        assert ez[0] == pytest.approx(COMPONENTS["Ez"][0])
+        assert ez[-1] == pytest.approx(COMPONENTS["Ez"][-1])
+
+
+# load_file — source structure
+
+
+class TestLoadFileSources:
+    def test_source_keys(self, loaded):
+        assert "src1" in loaded["sources"]
+
+    def test_source_type(self, loaded):
+        assert loaded["sources"]["src1"]["type"] == "HertzianDipole"
+
+    def test_source_position(self, loaded):
+        assert loaded["sources"]["src1"]["position"] == pytest.approx([0.10, 0.17, 0.0])
+
+
+# load_file — time axis
+
+
+class TestLoadFileTimeAxis:
+    def test_time_ns_length(self, loaded):
+        assert len(loaded["time_ns"]) == ITERATIONS
+
+    def test_time_ns_starts_at_zero(self, loaded):
+        assert loaded["time_ns"][0] == pytest.approx(0.0)
+
+    def test_time_ns_end_value(self, loaded):
+        expected_end = (ITERATIONS - 1) * DT * 1e9
+        assert loaded["time_ns"][-1] == pytest.approx(expected_end)
+
+
+# load_file — error handling
+
+
+class TestLoadFileErrors:
+    def test_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            load_file("/nonexistent/path/file.h5")
+
+    def test_invalid_hdf5(self, tmp_path):
+        bad = tmp_path / "bad.h5"
+        bad.write_text("not an hdf5 file")
+        with pytest.raises(OSError):
+            load_file(bad)
+
+
+# load_files — multi-file
+
+
+class TestLoadFiles:
+    def test_returns_both_files(self, h5_file, h5_file_b):
+        result = load_files([h5_file, h5_file_b])
+        assert len(result) == 2
+
+    def test_keyed_by_filename(self, h5_file):
+        result = load_files([h5_file])
+        assert "test_ascan.h5" in result
+
+    def test_collision_uses_full_path(self, tmp_path):
+        # Two files with identical names in different directories
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+        p_a = dir_a / "ascan.h5"
+        p_b = dir_b / "ascan.h5"
+        _write_synthetic_h5(p_a)
+        _write_synthetic_h5(p_b)
+        result = load_files([p_a, p_b])
+        # One entry will be the short name, one will be the full path
+        assert len(result) == 2
+
+
+# get_time_axis
+
+
+class TestGetTimeAxis:
+    def test_ns_unit(self, loaded):
+        t = get_time_axis(loaded, unit="ns")
+        assert t[-1] == pytest.approx((ITERATIONS - 1) * DT * 1e9)
+
+    def test_s_unit(self, loaded):
+        t = get_time_axis(loaded, unit="s")
+        assert t[-1] == pytest.approx((ITERATIONS - 1) * DT)
+
+    def test_iter_unit(self, loaded):
+        t = get_time_axis(loaded, unit="iter")
+        assert t[-1] == pytest.approx(ITERATIONS - 1)
+
+    def test_invalid_unit(self, loaded):
+        with pytest.raises(ValueError, match="Unknown unit"):
+            get_time_axis(loaded, unit="ms")
+
+
+# list_components
+
+
+class TestListComponents:
+    def test_returns_all_components(self, loaded):
+        comps = list_components(loaded)
+        assert set(comps) == set(COMPONENTS.keys())
+
+    def test_sorted(self, loaded):
+        comps = list_components(loaded)
+        assert comps == sorted(comps)
+
+    def test_missing_receiver_returns_empty(self, loaded):
+        comps = list_components(loaded, receiver="rx99")
+        assert comps == []
+
+
+# list_receivers
+
+
+class TestListReceivers:
+    def test_returns_rx1(self, loaded):
+        assert list_receivers(loaded) == ["rx1"]
+
+
+# get_trace
+
+
+class TestGetTrace:
+    def test_ez_values(self, loaded):
+        trace = get_trace(loaded, "Ez")
+        np.testing.assert_array_almost_equal(trace, COMPONENTS["Ez"])
+
+    def test_positive_polarity(self, loaded):
+        trace = get_trace(loaded, "Hx", polarity=1)
+        assert trace[0] == pytest.approx(COMPONENTS["Hx"][0])
+
+    def test_negative_polarity_arg(self, loaded):
+        trace = get_trace(loaded, "Hx", polarity=-1)
+        assert trace[0] == pytest.approx(-COMPONENTS["Hx"][0])
+
+    def test_negative_polarity_suffix(self, loaded):
+        trace = get_trace(loaded, "Hx-")
+        assert trace[0] == pytest.approx(-COMPONENTS["Hx"][0])
+
+    def test_missing_component_raises(self, loaded):
+        with pytest.raises(KeyError, match="Iz"):
+            get_trace(loaded, "Iz")
+
+
+# get_unit_label
+
+
+class TestGetUnitLabel:
+    def test_electric_field(self):
+        assert get_unit_label("Ez") == "V/m"
+
+    def test_magnetic_field(self):
+        assert get_unit_label("Hx") == "A/m"
+
+    def test_current(self):
+        assert get_unit_label("Ix") == "A"
+
+    def test_polarity_suffix_stripped(self):
+        assert get_unit_label("Ez-") == "V/m"
+
+
+# build_label
+
+
+class TestBuildLabel:
+    def test_label_format(self):
+        label = build_label("cylinder_Ascan_2D.h5", "rx1", "Ez")
+        assert label == "cylinder_Ascan_2D · rx1 · Ez"
+
+    def test_stem_only(self):
+        label = build_label("examples/cylinder_Ascan_2D.h5", "rx1", "Ez")
+        assert label == "cylinder_Ascan_2D · rx1 · Ez"
+
+
+# format_metadata_text
+
+
+class TestFormatMetadataText:
+    def test_contains_title(self, loaded):
+        text = format_metadata_text(loaded)
+        assert "Test A-scan" in text
+
+    def test_contains_iterations(self, loaded):
+        text = format_metadata_text(loaded)
+        assert str(ITERATIONS) in text
+
+    def test_contains_receiver_info(self, loaded):
+        text = format_metadata_text(loaded)
+        assert "rx1" in text
+        assert "Rx(70,85,0)" in text

--- a/toolboxes/Marimo/ascan_dashboard.py
+++ b/toolboxes/Marimo/ascan_dashboard.py
@@ -1,0 +1,732 @@
+import marimo
+
+__generated_with = "0.23.8"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import csv
+    import io
+    from pathlib import Path
+
+    import marimo as mo
+    import numpy as np
+    import plotly.graph_objects as go
+
+    from toolboxes.Marimo.h5_reader import (
+        build_label,
+        format_metadata_text,
+        get_time_axis,
+        get_trace,
+        get_unit_label,
+        list_components,
+        list_receivers,
+        load_files,
+    )
+
+    # Research-quality colour palette (Matplotlib tab10, colorblind-friendly)
+    PALETTE = [
+        "#1f77b4",
+        "#d62728",
+        "#2ca02c",
+        "#ff7f0e",
+        "#9467bd",
+        "#8c564b",
+        "#e377c2",
+        "#17becf",
+        "#bcbd22",
+        "#7f7f7f",
+    ]
+
+    COLOUR_NAMES = {
+        "Blue": "#1f77b4",
+        "Red": "#d62728",
+        "Green": "#2ca02c",
+        "Orange": "#ff7f0e",
+        "Purple": "#9467bd",
+        "Brown": "#8c564b",
+        "Pink": "#e377c2",
+        "Teal": "#17becf",
+        "Olive": "#bcbd22",
+        "Grey": "#7f7f7f",
+        "Cyan": "#4FC3F7",
+        "Black": "#111111",
+    }
+
+    return (
+        COLOUR_NAMES,
+        PALETTE,
+        Path,
+        build_label,
+        csv,
+        format_metadata_text,
+        get_time_axis,
+        get_trace,
+        get_unit_label,
+        go,
+        io,
+        list_components,
+        list_receivers,
+        load_files,
+        mo,
+        np,
+    )
+
+
+# ── SECTION 1: File loading ────────────────────────────────────────────────
+@app.cell
+def _(mo):
+    file_browser = mo.ui.file_browser(
+        filetypes=[".h5"],
+        label="",
+        multiple=True,
+    )
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("# gprMax A-Scan Post-Processing Dashboard"),
+                mo.md(
+                    "Load one or more `.h5` output files, select field components, "
+                    "and build publication-quality overlay plots with SVG, PDF, "
+                    "and CSV export."
+                ),
+                mo.md("---"),
+                mo.md("### Step 1 — Load output files"),
+                mo.md(
+                    "_Select one or more gprMax `.h5` output files. "
+                    "All field components (Ex, Ey, Ez, Hx, Hy, Hz) "
+                    "are detected automatically from each file._"
+                ),
+                file_browser,
+            ],
+            gap="0.4rem",
+        )
+    )
+    return (file_browser,)
+
+
+# ── SECTION 2: Data loading + metadata banner ──────────────────────────────
+@app.cell
+def _(file_browser, format_metadata_text, load_files, mo):
+    if not file_browser.value:
+        mo.stop(True, mo.md(""))
+
+    _paths = [f.path for f in file_browser.value]
+    _loaded = load_files(_paths)
+    get_data, set_data = mo.state({"files": _loaded})
+
+    _cards = [
+        mo.callout(
+            mo.md(f"**{_fname}**\n\n{format_metadata_text(_fdata)}"),
+            kind="info",
+        )
+        for _fname, _fdata in _loaded.items()
+    ]
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md(f"### {len(_loaded)} file(s) loaded"),
+                *_cards,
+                mo.md("---"),
+            ],
+            gap="0.4rem",
+        )
+    )
+    return get_data, set_data
+
+
+# ── STATE: isolated — no UI dependencies ──────────────────────────────────
+@app.cell
+def _(mo):
+    get_traces, set_traces = mo.state([])
+    return get_traces, set_traces
+
+
+# ── SECTION 3: Trace picker ────────────────────────────────────────────────
+@app.cell
+def _(
+    COLOUR_NAMES,
+    PALETTE,
+    get_data,
+    get_traces,
+    list_components,
+    list_receivers,
+    mo,
+):
+    _state = get_data()
+    _files = _state["files"]
+
+    if not _files:
+        mo.stop(True, mo.md("No files loaded."))
+
+    _file_options = list(_files.keys())
+    _first_file = _file_options[0]
+    _first_rx = list_receivers(_files[_first_file])[0]
+    _first_comps = list_components(_files[_first_file], _first_rx)
+
+    _next_hex = PALETTE[len(get_traces()) % len(PALETTE)]
+    _auto_name = next((name for name, h in COLOUR_NAMES.items() if h == _next_hex), "Blue")
+
+    file_selector = mo.ui.dropdown(
+        options=_file_options,
+        value=_first_file,
+        label="File",
+    )
+    receiver_selector = mo.ui.dropdown(
+        options=list_receivers(_files[_first_file]),
+        value=_first_rx,
+        label="Receiver",
+    )
+    component_selector = mo.ui.dropdown(
+        options=_first_comps,
+        value="Ez" if "Ez" in _first_comps else _first_comps[0],
+        label="Component",
+    )
+    colour_selector = mo.ui.dropdown(
+        options=COLOUR_NAMES,
+        value=_auto_name,
+        label="Trace colour",
+    )
+    add_button = mo.ui.run_button(label="＋  Add trace")
+    clear_button = mo.ui.run_button(label="✕  Clear all")
+
+    _traces_now = get_traces()
+    if _traces_now:
+        _remove_opts = {t["label"]: i for i, t in enumerate(_traces_now)}
+        remove_selector = mo.ui.dropdown(
+            options=_remove_opts,
+            value=list(_remove_opts.keys())[0],
+            label="Remove a trace",
+        )
+        remove_button = mo.ui.run_button(label="－  Remove selected")
+        _remove_section = mo.vstack(
+            [
+                mo.md("**Remove a trace**"),
+                mo.hstack([remove_selector, remove_button], gap="1rem"),
+            ],
+            gap="0.3rem",
+        )
+    else:
+        remove_selector = None
+        remove_button = None
+        _remove_section = mo.md("")
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 2 — Build your plot"),
+                mo.md(
+                    "_Select a file, receiver, and field component. "
+                    "Colour auto-advances through the research palette — "
+                    "override before clicking Add._"
+                ),
+                mo.md("**Select source**"),
+                mo.hstack([file_selector, receiver_selector], gap="2rem"),
+                mo.md("**Select component and colour**"),
+                mo.hstack([component_selector, colour_selector], gap="2rem"),
+                mo.hstack([add_button, clear_button], gap="1rem"),
+                mo.md("---"),
+                _remove_section,
+            ],
+            gap="0.5rem",
+        )
+    )
+    return (
+        add_button,
+        clear_button,
+        colour_selector,
+        component_selector,
+        file_selector,
+        receiver_selector,
+        remove_button,
+        remove_selector,
+    )
+
+
+# ── BUTTON HANDLER ─────────────────────────────────────────────────────────
+@app.cell
+def _(
+    add_button,
+    build_label,
+    clear_button,
+    colour_selector,
+    component_selector,
+    file_selector,
+    get_data,
+    get_traces,
+    list_components,
+    mo,
+    receiver_selector,
+    remove_button,
+    remove_selector,
+    set_traces,
+):
+    if add_button.value:
+        _fname = file_selector.value
+        _rx = receiver_selector.value
+        _comp = component_selector.value
+        _available = list_components(get_data()["files"][_fname], _rx)
+        if _comp not in _available:
+            mo.output.replace(
+                mo.callout(
+                    mo.md(
+                        f"**Component not found.** "
+                        f"`{_comp}` is not in `{_fname}` / `{_rx}`. "
+                        f"Available: {', '.join(_available)}"
+                    ),
+                    kind="danger",
+                )
+            )
+        else:
+            _new = {
+                "filename": _fname,
+                "receiver": _rx,
+                "component": _comp,
+                "colour": colour_selector.value,
+                "label": build_label(_fname, _rx, _comp),
+            }
+            _cur = get_traces()
+            _dup = any(
+                t["filename"] == _new["filename"]
+                and t["receiver"] == _new["receiver"]
+                and t["component"] == _new["component"]
+                for t in _cur
+            )
+            if not _dup:
+                set_traces(_cur + [_new])
+
+    if remove_button is not None and remove_button.value and remove_selector is not None:
+        _idx = remove_selector.value
+        set_traces([t for i, t in enumerate(get_traces()) if i != _idx])
+
+    if clear_button.value:
+        set_traces([])
+
+    _traces = get_traces()
+    if _traces:
+        _header = "| # | Colour | Component | File | Receiver |"
+        _sep = "|---|--------|-----------|------|----------|"
+        _rows = "\n".join(
+            f"| {i + 1} "
+            f"| <span style='background:{t['colour']};display:inline-block;"
+            f"width:32px;height:14px;border-radius:3px;'></span> "
+            f"| `{t['component']}` "
+            f"| `{t['filename']}` "
+            f"| `{t['receiver']}` |"
+            for i, t in enumerate(_traces)
+        )
+        mo.output.replace(
+            mo.vstack(
+                [
+                    mo.md(f"**{len(_traces)} active trace(s)**"),
+                    mo.md(f"{_header}\n{_sep}\n{_rows}"),
+                    mo.md("---"),
+                ],
+                gap="0.3rem",
+            )
+        )
+    else:
+        mo.output.replace(
+            mo.vstack(
+                [
+                    mo.callout(
+                        mo.md(
+                            "No traces added yet. "
+                            "Use the picker above and click **＋ Add trace**."
+                        ),
+                        kind="neutral",
+                    ),
+                    mo.md("---"),
+                ],
+                gap="0.25rem",
+            )
+        )
+
+
+# ── SECTION 4: Plot appearance controls ───────────────────────────────────
+@app.cell
+def _(mo):
+    bg_colour = mo.ui.dropdown(
+        options={
+            "Light": "#ffffff",
+            "Paper white": "#f8f9fa",
+            "Dark": "#0e1117",
+        },
+        value="Light",
+        label="Background",
+    )
+    line_width = mo.ui.slider(
+        start=0.5,
+        stop=4.0,
+        step=0.5,
+        value=1.5,
+        label="Line width",
+    )
+    font_size = mo.ui.slider(
+        start=10,
+        stop=22,
+        step=1,
+        value=13,
+        label="Font size",
+    )
+    show_grid = mo.ui.checkbox(label="Show grid", value=True)
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 3 — Adjust appearance"),
+                mo.hstack(
+                    [bg_colour, line_width, font_size, show_grid],
+                    gap="1.5rem",
+                    justify="start",
+                ),
+            ],
+            gap="0.5rem",
+        )
+    )
+    return bg_colour, font_size, line_width, show_grid
+
+
+# ── SECTION 5: Time zoom slider ────────────────────────────────────────────
+@app.cell
+def _(get_data, get_traces, mo):
+    if not get_traces():
+        mo.stop(True, mo.md(""))
+
+    _files = get_data()["files"]
+    _max_ns = max(
+        round(f["meta"]["iterations"] * f["meta"]["dt"] * 1e9, 4) for f in _files.values()
+    )
+    _step = round(_max_ns / 600, 4)
+
+    time_slider = mo.ui.range_slider(
+        start=0.0,
+        stop=_max_ns,
+        step=_step,
+        value=[0.0, _max_ns],
+        label="Time window (ns)",
+        full_width=True,
+    )
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 4 — Zoom time window"),
+                mo.md(
+                    "_Drag handles to focus on a specific time range. "
+                    "CSV export always contains the full unzoomed data._"
+                ),
+                time_slider,
+                mo.md("---"),
+            ],
+            gap="0.4rem",
+        )
+    )
+    return (time_slider,)
+
+
+# ── SECTION 6: Figure renderer + export ───────────────────────────────────
+@app.cell
+def _(
+    bg_colour,
+    csv,
+    font_size,
+    get_data,
+    get_time_axis,
+    get_trace,
+    get_traces,
+    get_unit_label,
+    go,
+    io,
+    line_width,
+    mo,
+    show_grid,
+    time_slider,
+):
+    _traces = get_traces()
+    if not _traces:
+        mo.stop(
+            True,
+            mo.callout(
+                mo.md("Add at least one trace using the picker above " "to render the plot."),
+                kind="warn",
+            ),
+        )
+
+    _files = get_data()["files"]
+    _bg = bg_colour.value
+    _is_dark = _bg == "#0e1117"
+    _fc = "#e8e8e8" if _is_dark else "#1a1a1a"
+    _gc = "rgba(255,255,255,0.1)" if _is_dark else "rgba(0,0,0,0.07)"
+    _lc = "rgba(255,255,255,0.25)" if _is_dark else "rgba(0,0,0,0.18)"
+
+    # ── Build figure ────────────────────────────────────────────────────────
+    _fig = go.Figure()
+    _has_e = False
+    _has_h = False
+    _comps_seen = []
+    _files_seen = []
+
+    # Store full arrays for CSV export (unaffected by zoom)
+    _csv_time: dict = {}
+    _csv_data: dict = {}
+
+    for _t in _traces:
+        _fdata = _files[_t["filename"]]
+        _arr = get_trace(_fdata, _t["component"], _t["receiver"])
+        _time = get_time_axis(_fdata, unit="ns")
+        _unit = get_unit_label(_t["component"])
+        _on_y2 = _unit == "A/m"
+
+        if _on_y2:
+            _has_h = True
+        else:
+            _has_e = True
+
+        # Track unique time axes by (n_steps, dt) tuple
+        _fmeta = _fdata["meta"]
+        _tax_key = (_fmeta["iterations"], round(_fmeta["dt"], 15))
+        if _tax_key not in _csv_time:
+            _csv_time[_tax_key] = _time
+        _csv_data[_t["label"]] = (_tax_key, _arr)
+
+        _fig.add_trace(
+            go.Scatter(
+                x=_time,
+                y=_arr,
+                mode="lines",
+                name=_t["label"],
+                line=dict(
+                    color=_t["colour"],
+                    width=line_width.value,
+                    dash="dash" if _on_y2 else "solid",
+                ),
+                yaxis="y2" if _on_y2 else "y",
+                hovertemplate=(
+                    "%{x:.4f} ns<br>%{y:.5g} " + _unit + "<extra>" + _t["label"] + "</extra>"
+                ),
+            )
+        )
+
+        if _t["component"] not in _comps_seen:
+            _comps_seen.append(_t["component"])
+        if _t["filename"] not in _files_seen:
+            _files_seen.append(_t["filename"])
+
+    _title = ", ".join(_comps_seen) + "  ·  " + "  +  ".join(_files_seen)
+    _dual = _has_e and _has_h
+
+    _axis_base = dict(
+        showgrid=show_grid.value,
+        gridcolor=_gc,
+        gridwidth=0.5,
+        showline=True,
+        linecolor=_lc,
+        linewidth=1,
+        tickfont=dict(size=font_size.value - 1, color=_fc),
+        title_font=dict(size=font_size.value, color=_fc),
+        zeroline=True,
+        zerolinecolor=_lc,
+        zerolinewidth=1,
+    )
+
+    if _dual:
+        _y1_label = "E-field [V/m]"
+    elif _has_e:
+        _y1_label = "Field strength [V/m]"
+    else:
+        _y1_label = "Field strength [A/m]"
+
+    _t_start, _t_end = time_slider.value
+
+    _layout = dict(
+        title=dict(
+            text=_title,
+            font=dict(size=font_size.value + 1, color=_fc),
+            x=0.0,
+            xanchor="left",
+        ),
+        xaxis=dict(
+            title="Time (ns)",
+            range=[_t_start, _t_end],
+            **_axis_base,
+        ),
+        yaxis=dict(title=_y1_label, **_axis_base),
+        paper_bgcolor=_bg,
+        plot_bgcolor=_bg,
+        legend=dict(
+            font=dict(size=font_size.value - 1, color=_fc),
+            bgcolor="rgba(0,0,0,0.0)",
+            bordercolor=_lc,
+            borderwidth=1,
+        ),
+        height=500,
+        margin=dict(l=72, r=80 if _dual else 32, t=55, b=60),
+        hovermode="x unified",
+    )
+
+    if _dual:
+        _layout["yaxis2"] = dict(
+            title="H-field [A/m]",
+            overlaying="y",
+            side="right",
+            showgrid=False,
+            showline=True,
+            linecolor=_lc,
+            linewidth=1,
+            tickfont=dict(size=font_size.value - 1, color=_fc),
+            title_font=dict(size=font_size.value, color=_fc),
+            zeroline=False,
+        )
+
+    _fig.update_layout(**_layout)
+
+    # ── CSV export ──────────────────────────────────────────────────────────
+    # Always exports FULL data (not the zoomed window).
+    # If all traces share the same time axis: one time column.
+    # If traces come from files with different dt/iterations: paired columns.
+    try:
+        _buf = io.StringIO()
+        _writer = csv.writer(_buf)
+
+        _single_axis = len(_csv_time) == 1
+
+        if _single_axis:
+            _shared_time = list(_csv_time.values())[0]
+            _header_row = ["time_ns"] + [t["label"] for t in _traces]
+            _writer.writerow(_header_row)
+            for _i in range(len(_shared_time)):
+                _row = [f"{_shared_time[_i]:.8g}"] + [
+                    f"{_csv_data[t['label']][1][_i]:.10g}" for t in _traces
+                ]
+                _writer.writerow(_row)
+        else:
+            # Paired time + value columns per trace
+            _header_row = []
+            for _t in _traces:
+                _header_row.extend([f"time_ns ({_t['label']})", _t["label"]])
+            _writer.writerow(_header_row)
+            _max_len = max(len(_csv_data[t["label"]][1]) for t in _traces)
+            for _i in range(_max_len):
+                _row = []
+                for _t in _traces:
+                    _tax_key, _arr = _csv_data[_t["label"]]
+                    _time = _csv_time[_tax_key]
+                    if _i < len(_arr):
+                        _row.extend([f"{_time[_i]:.8g}", f"{_arr[_i]:.10g}"])
+                    else:
+                        _row.extend(["", ""])
+                _writer.writerow(_row)
+
+        _csv_bytes = _buf.getvalue().encode("utf-8")
+        _csv_btn = mo.download(
+            data=_csv_bytes,
+            filename="gprmax_ascan.csv",
+            label="Download CSV (full data)",
+            mimetype="text/csv",
+        )
+    except Exception as _e:
+        _csv_btn = mo.md(f"_CSV export error: `{_e}`_")
+
+    # ── SVG export ──────────────────────────────────────────────────────────
+    try:
+        import plotly.io as _pio
+
+        _svg_bytes = _pio.to_image(_fig, format="svg", width=1200, height=600, scale=2)
+        _svg_btn = mo.download(
+            data=_svg_bytes,
+            filename="gprmax_ascan.svg",
+            label="Download SVG",
+            mimetype="image/svg+xml",
+        )
+    except Exception as _e:
+        _svg_btn = mo.md(
+            f"_SVG: `{type(_e).__name__}` — "
+            f"run `plotly_get_chrome` to install kaleido's Chrome, "
+            f"or use the camera icon in the plot toolbar._"
+        )
+
+    # ── PDF export ──────────────────────────────────────────────────────────
+    try:
+        import plotly.io as _pio
+
+        _pdf_bytes = _pio.to_image(_fig, format="pdf", width=1200, height=600, scale=2)
+        _pdf_btn = mo.download(
+            data=_pdf_bytes,
+            filename="gprmax_ascan.pdf",
+            label="Download PDF",
+            mimetype="application/pdf",
+        )
+    except Exception as _e:
+        _pdf_btn = mo.md(f"_PDF: `{type(_e).__name__}` — run `plotly_get_chrome` first._")
+
+    # ── Interactive HTML — no kaleido needed ────────────────────────────────
+    try:
+        _html_bytes = _fig.to_html(full_html=True, include_plotlyjs=True).encode("utf-8")
+        _html_btn = mo.download(
+            data=_html_bytes,
+            filename="gprmax_ascan.html",
+            label="Download HTML (interactive)",
+            mimetype="text/html",
+        )
+    except Exception:
+        _html_btn = mo.md("")
+
+    # ── Notes ────────────────────────────────────────────────────────────────
+    _notes = []
+    if _dual:
+        _notes.append(
+            "_Solid lines → E-field (left axis, V/m)  ·  "
+            "Dashed lines → H-field (right axis, A/m)_"
+        )
+    _notes.append(
+        "_Hover for exact values. "
+        "Camera icon in toolbar → SVG (no kaleido needed via toolbar). "
+        "Run `plotly_get_chrome` once to enable SVG/PDF download buttons._"
+    )
+
+    mo.vstack(
+        [
+            mo.md("### Plot"),
+            mo.ui.plotly(
+                _fig,
+                config={
+                    "toImageButtonOptions": {
+                        "format": "svg",
+                        "filename": "gprmax_ascan",
+                        "height": 600,
+                        "width": 1200,
+                        "scale": 2,
+                    },
+                    "displaylogo": False,
+                    "modeBarButtonsToRemove": ["lasso2d", "select2d"],
+                },
+            ),
+            mo.md("  \n".join(_notes)),
+            mo.md("**Export**"),
+            mo.hstack(
+                [_csv_btn, _html_btn, _svg_btn, _pdf_btn],
+                gap="1rem",
+                justify="start",
+            ),
+            mo.md("---"),
+            mo.callout(
+                mo.md(
+                    "**Upcoming features**\n\n"
+                    "- Background subtraction "
+                    "(target trace minus free-space trace)\n"
+                    "- FFT frequency spectrum toggle\n"
+                    "- Assemble multiple A-scan files → B-scan radargram\n"
+                    "- 3D surface viewer from multi-position A-scan data"
+                ),
+                kind="neutral",
+            ),
+        ],
+        gap="0.5rem",
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/toolboxes/Marimo/ascan_dashboard.py
+++ b/toolboxes/Marimo/ascan_dashboard.py
@@ -204,7 +204,7 @@ def _(
         _remove_section = mo.vstack(
             [
                 mo.md("**Remove a trace**"),
-                mo.hstack([remove_selector, remove_button], gap="1rem"),
+                mo.hstack([remove_selector, remove_button], gap="1rem", justify="start"),
             ],
             gap="0.3rem",
         )
@@ -223,10 +223,10 @@ def _(
                     "override before clicking Add._"
                 ),
                 mo.md("**Select source**"),
-                mo.hstack([file_selector, receiver_selector], gap="2rem"),
+                mo.hstack([file_selector, receiver_selector], gap="2rem", justify="start"),
                 mo.md("**Select component and colour**"),
-                mo.hstack([component_selector, colour_selector], gap="2rem"),
-                mo.hstack([add_button, clear_button], gap="1rem"),
+                mo.hstack([component_selector, colour_selector], gap="2rem", justify="start"),
+                mo.hstack([add_button, clear_button], gap="1rem", justify="start"),
                 mo.md("---"),
                 _remove_section,
             ],
@@ -363,6 +363,7 @@ def _(mo):
         step=0.5,
         value=1.5,
         label="Line width",
+        debounce=True,
     )
     font_size = mo.ui.slider(
         start=10,
@@ -370,6 +371,7 @@ def _(mo):
         step=1,
         value=13,
         label="Font size",
+        debounce=True,
     )
     show_grid = mo.ui.checkbox(label="Show grid", value=True)
 
@@ -408,6 +410,7 @@ def _(get_data, get_traces, mo):
         value=[0.0, _max_ns],
         label="Time window (ns)",
         full_width=True,
+        debounce=True,
     )
     mo.output.replace(
         mo.vstack(
@@ -629,49 +632,44 @@ def _(
     except Exception as _e:
         _csv_btn = mo.md(f"_CSV export error: `{_e}`_")
 
-    # ── SVG export ──────────────────────────────────────────────────────────
-    try:
+    # ── SVG/PDF export ─────────────────────────────────────────────────────
+    # Lazy on purpose: mo.download accepts a zero-arg callable and only
+    # calls it when the button is clicked. kaleido spins up headless
+    # Chrome per export, which is slow — computing it eagerly here meant
+    # this cell paid that cost twice (SVG + PDF) on every re-render, which
+    # includes every appearance-control change and every drag tick of an
+    # undebounced slider. Same bug and same fix as bscan_dashboard.py.
+    def _make_svg():
         import plotly.io as _pio
+        return _pio.to_image(_fig, format="svg", width=1200, height=600, scale=2)
 
-        _svg_bytes = _pio.to_image(_fig, format="svg", width=1200, height=600, scale=2)
-        _svg_btn = mo.download(
-            data=_svg_bytes,
-            filename="gprmax_ascan.svg",
-            label="Download SVG",
-            mimetype="image/svg+xml",
-        )
-    except Exception as _e:
-        _svg_btn = mo.md(
-            f"_SVG: `{type(_e).__name__}` — "
-            f"run `plotly_get_chrome` to install kaleido's Chrome, "
-            f"or use the camera icon in the plot toolbar._"
-        )
-
-    # ── PDF export ──────────────────────────────────────────────────────────
-    try:
+    def _make_pdf():
         import plotly.io as _pio
+        return _pio.to_image(_fig, format="pdf", width=1200, height=600, scale=2)
 
-        _pdf_bytes = _pio.to_image(_fig, format="pdf", width=1200, height=600, scale=2)
-        _pdf_btn = mo.download(
-            data=_pdf_bytes,
-            filename="gprmax_ascan.pdf",
-            label="Download PDF",
-            mimetype="application/pdf",
-        )
-    except Exception as _e:
-        _pdf_btn = mo.md(f"_PDF: `{type(_e).__name__}` — run `plotly_get_chrome` first._")
+    _svg_btn = mo.download(
+        data=_make_svg, filename="gprmax_ascan.svg", label="Download SVG", mimetype="image/svg+xml"
+    )
+    _pdf_btn = mo.download(
+        data=_make_pdf, filename="gprmax_ascan.pdf", label="Download PDF", mimetype="application/pdf"
+    )
 
-    # ── Interactive HTML — no kaleido needed ────────────────────────────────
-    try:
-        _html_bytes = _fig.to_html(full_html=True, include_plotlyjs=True).encode("utf-8")
-        _html_btn = mo.download(
-            data=_html_bytes,
-            filename="gprmax_ascan.html",
-            label="Download HTML (interactive)",
-            mimetype="text/html",
-        )
-    except Exception:
-        _html_btn = mo.md("")
+    # ── Interactive HTML — no kaleido needed, but still lazy ───────────────
+    # to_html(include_plotlyjs=True) embeds the entire Plotly.js library
+    # (several MB) as base64 into the button's data on every render,
+    # regardless of how much actual trace data there is. Not slow like
+    # kaleido since there's no external process, but still pure waste to
+    # recompute on every appearance/zoom change for a download that may
+    # never be clicked.
+    def _make_html():
+        return _fig.to_html(full_html=True, include_plotlyjs=True).encode("utf-8")
+
+    _html_btn = mo.download(
+        data=_make_html,
+        filename="gprmax_ascan.html",
+        label="Download HTML (interactive)",
+        mimetype="text/html",
+    )
 
     # ── Notes ────────────────────────────────────────────────────────────────
     _notes = []

--- a/toolboxes/Marimo/h5_reader.py
+++ b/toolboxes/Marimo/h5_reader.py
@@ -1,0 +1,371 @@
+"""
+h5_reader.py: gprMax HDF5 output file reader for the Marimo dashboard.
+
+Reads one or more gprMax v4 .h5 output files into a structured dict.
+No marimo dependency — pure h5py + numpy. Designed to be the foundation
+layer that all dashboard cells import from.
+
+Usage:
+    from toolboxes.Marimo.h5_reader import load_files, load_file
+
+    data = load_files([
+        "examples/cylinder_Ascan_2D.h5",
+        "examples/cylinder_Ascan_2D_freespace.h5",
+    ])
+
+    # Access a specific trace
+    ez = data["cylinder_Ascan_2D.h5"]["receivers"]["rx1"]["components"]["Ez"]
+    dt = data["cylinder_Ascan_2D.h5"]["meta"]["dt"]
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import h5py
+import numpy as np
+
+# ComponentMap: {"Ez": np.ndarray, "Hx": np.ndarray, ...}
+ComponentMap = dict[str, np.ndarray]
+
+# ReceiverInfo: full data for one receiver point
+ReceiverInfo = dict[str, Any]
+# {
+#   "name":       str              e.g. "Rx(70,85,0)"
+#   "position":   list[float]      e.g. [0.14, 0.17, 0.0]
+#   "components": ComponentMap
+# }
+
+# FileMeta: root-level attributes from the HDF5 file
+FileMeta = dict[str, Any]
+# {
+#   "title":       str
+#   "dt":          float           time step in seconds
+#   "dx_dy_dz":    list[float]     spatial discretisation [m, m, m]
+#   "iterations":  int
+#   "nrx":         int             number of receivers
+#   "nsrc":        int             number of sources
+#   "nx_ny_nz":    list[int]       grid dimensions in cells
+#   "gprmax_version": str
+# }
+
+# SourceInfo: metadata for one source point
+SourceInfo = dict[str, Any]
+# {
+#   "type":     str   e.g. "HertzianDipole"
+#   "position": list[float]
+# }
+
+# FileData: everything read from one .h5 file
+FileData = dict[str, Any]
+# {
+#   "path":      str               absolute path to the file
+#   "meta":      FileMeta
+#   "receivers": dict[str, ReceiverInfo]   keyed by "rx1", "rx2", ...
+#   "sources":   dict[str, SourceInfo]     keyed by "src1", "src2", ...
+#   "time_ns":   np.ndarray                time axis in nanoseconds
+# }
+
+
+# Core reader
+
+
+def load_file(path: str | Path) -> FileData:
+    """Read a single gprMax v4 HDF5 output file.
+
+    Args:
+        path: Path to the .h5 file.
+
+    Returns:
+        FileData dict containing metadata, all receiver traces, and
+        a precomputed nanosecond time axis.
+
+    Raises:
+        FileNotFoundError: if the path does not exist.
+        KeyError: if the file is missing expected gprMax structure.
+        OSError: if the file cannot be opened (not a valid HDF5 file).
+    """
+    path = Path(path).resolve()
+    if not path.exists():
+        raise FileNotFoundError(f"HDF5 file not found: {path}")
+
+    with h5py.File(path, "r") as f:
+        meta = _read_meta(f)
+        receivers = _read_receivers(f, path)
+        sources = _read_sources(f)
+
+    # Build nanosecond time axis from root dt
+    iterations = meta["iterations"]
+    dt = meta["dt"]
+    time_ns = np.arange(iterations) * dt * 1e9  # seconds → nanoseconds
+
+    return {
+        "path": str(path),
+        "meta": meta,
+        "receivers": receivers,
+        "sources": sources,
+        "time_ns": time_ns,
+    }
+
+
+def load_files(paths: list[str | Path]) -> dict[str, FileData]:
+    """Read multiple gprMax HDF5 output files.
+
+    Args:
+        paths: List of paths to .h5 files.
+
+    Returns:
+        Dict keyed by filename (not full path) mapping to FileData.
+        If two files share the same filename, the second is keyed by
+        its full path to avoid collision.
+
+    Raises:
+        FileNotFoundError: if any path does not exist.
+    """
+    result: dict[str, FileData] = {}
+    seen_names: set[str] = set()
+
+    for p in paths:
+        data = load_file(p)
+        name = Path(p).name
+
+        # Avoid key collision when two files share the same filename
+        if name in seen_names:
+            name = str(Path(p).resolve())
+        seen_names.add(name)
+
+        result[name] = data
+
+    return result
+
+
+# Time axis utility
+
+
+def get_time_axis(file_data: FileData, unit: str = "ns") -> np.ndarray:
+    """Return the time axis for a loaded file.
+
+    Args:
+        file_data: FileData dict from load_file().
+        unit: "ns" (nanoseconds, default), "s" (seconds), or "iter" (iterations).
+
+    Returns:
+        1D numpy array.
+    """
+    iterations = file_data["meta"]["iterations"]
+    dt = file_data["meta"]["dt"]
+
+    if unit == "ns":
+        return np.arange(iterations) * dt * 1e9
+    elif unit == "s":
+        return np.arange(iterations) * dt
+    elif unit == "iter":
+        return np.arange(iterations, dtype=float)
+    else:
+        raise ValueError(f"Unknown unit '{unit}'. Use 'ns', 's', or 'iter'.")
+
+
+# Component and receiver utilities
+
+
+def list_components(file_data: FileData, receiver: str = "rx1") -> list[str]:
+    """Return available field component names for a given receiver.
+
+    Args:
+        file_data: FileData dict from load_file().
+        receiver: Receiver key, e.g. "rx1".
+
+    Returns:
+        Sorted list of component names, e.g. ["Ex", "Ey", "Ez", "Hx", "Hy", "Hz"].
+    """
+    try:
+        return sorted(file_data["receivers"][receiver]["components"].keys())
+    except KeyError:
+        return []
+
+
+def list_receivers(file_data: FileData) -> list[str]:
+    """Return receiver keys available in the file.
+
+    Returns:
+        List of receiver keys, e.g. ["rx1", "rx2"].
+    """
+    return list(file_data["receivers"].keys())
+
+
+def get_trace(
+    file_data: FileData,
+    component: str,
+    receiver: str = "rx1",
+    polarity: int = 1,
+) -> np.ndarray:
+    """Return a single field component array.
+
+    Args:
+        file_data: FileData dict from load_file().
+        component: Field component name, e.g. "Ez". Append "-" for negative
+                   polarity, e.g. "Ez-".
+        receiver: Receiver key, e.g. "rx1".
+        polarity: +1 or -1. If component ends with "-", polarity is forced to -1.
+
+    Returns:
+        1D numpy array of field values.
+    """
+    # Handle polarity suffix convention from plot_Ascan.py
+    if component.endswith("-"):
+        component = component[:-1]
+        polarity = -1
+
+    try:
+        arr = file_data["receivers"][receiver]["components"][component]
+    except KeyError:
+        available = list_components(file_data, receiver)
+        raise KeyError(
+            f"Component '{component}' not found in {receiver}. "
+            f"Available: {available}"
+        )
+
+    return arr * polarity
+
+
+def get_unit_label(component: str) -> str:
+    """Return the SI unit label for a field component.
+
+    Args:
+        component: Component name, e.g. "Ez", "Hx", "Ix".
+
+    Returns:
+        Unit string for axis labelling.
+    """
+    component = component.rstrip("-")
+    if component.startswith("E"):
+        return "V/m"
+    elif component.startswith("H"):
+        return "A/m"
+    elif component.startswith("I"):
+        return "A"
+    return ""
+
+
+def build_label(filename: str, receiver: str, component: str) -> str:
+    """Build a descriptive trace label for plot legends.
+
+    Args:
+        filename: Key from load_files() dict (usually the filename).
+        receiver: Receiver key, e.g. "rx1".
+        component: Component name, e.g. "Ez".
+
+    Returns:
+        Human-readable label, e.g. "cylinder_Ascan_2D · rx1 · Ez".
+    """
+    stem = Path(filename).stem
+    return f"{stem} · {receiver} · {component}"
+
+
+# Metadata formatting
+
+
+def format_metadata_text(file_data: FileData) -> str:
+    """Format file metadata as a human-readable markdown string.
+
+    Intended for use in mo.md() metadata banners.
+
+    Args:
+        file_data: FileData dict from load_file().
+
+    Returns:
+        Markdown-formatted metadata string.
+    """
+    m = file_data["meta"]
+    dx, dy, dz = m["dx_dy_dz"]
+    nx, ny, nz = m["nx_ny_nz"]
+    dt_ps = m["dt"] * 1e12  # seconds → picoseconds
+    total_ns = m["iterations"] * m["dt"] * 1e9
+
+    lines = [
+        f"**{m['title']}**",
+        f"gprMax {m['gprmax_version']} · "
+        f"{m['iterations']} iterations · "
+        f"{total_ns:.3f} ns total window",
+        f"dt = {dt_ps:.4f} ps · "
+        f"dx/dy/dz = {dx*1000:.1f}/{dy*1000:.1f}/{dz*1000:.1f} mm · "
+        f"grid = {nx}×{ny}×{nz} cells",
+        f"{m['nrx']} receiver(s) · {m['nsrc']} source(s)",
+    ]
+
+    # Add receiver positions
+    for rx_key, rx_info in file_data["receivers"].items():
+        pos = rx_info["position"]
+        name = rx_info["name"]
+        lines.append(
+            f"  {rx_key}: {name} at "
+            f"({pos[0]:.3f}, {pos[1]:.3f}, {pos[2]:.3f}) m"
+        )
+
+    return "\n\n".join(lines[:3]) + "\n\n" + "\n".join(lines[3:])
+
+
+# Private helpers
+
+
+def _read_meta(f: h5py.File) -> FileMeta:
+    """Extract root-level metadata attributes."""
+    attrs = dict(f.attrs)
+    return {
+        "title": str(attrs.get("Title", "Untitled")),
+        "dt": float(attrs["dt"]),
+        "dx_dy_dz": list(map(float, attrs["dx_dy_dz"])),
+        "iterations": int(attrs["Iterations"]),
+        "nrx": int(attrs.get("nrx", 0)),
+        "nsrc": int(attrs.get("nsrc", 0)),
+        "nx_ny_nz": list(map(int, attrs.get("nx_ny_nz", [0, 0, 0]))),
+        "gprmax_version": str(attrs.get("gprMax", "unknown")),
+    }
+
+
+def _read_receivers(f: h5py.File, path: Path) -> dict[str, ReceiverInfo]:
+    """Read all receiver data from the HDF5 file."""
+    receivers: dict[str, ReceiverInfo] = {}
+
+    if "rxs" not in f:
+        return receivers
+
+    for rx_key in f["rxs"].keys():
+        rx_group = f["rxs"][rx_key]
+        rx_attrs = dict(rx_group.attrs)
+
+        components: ComponentMap = {}
+        for comp_name in rx_group.keys():
+            dataset = rx_group[comp_name]
+            if isinstance(dataset, h5py.Dataset):
+                components[comp_name] = dataset[:]
+
+        position = list(map(float, rx_attrs.get("Position", [0.0, 0.0, 0.0])))
+
+        receivers[rx_key] = {
+            "name": str(rx_attrs.get("Name", rx_key)),
+            "position": position,
+            "components": components,
+        }
+
+    return receivers
+
+
+def _read_sources(f: h5py.File) -> dict[str, SourceInfo]:
+    """Read all source metadata from the HDF5 file."""
+    sources: dict[str, SourceInfo] = {}
+
+    if "srcs" not in f:
+        return sources
+
+    for src_key in f["srcs"].keys():
+        src_attrs = dict(f["srcs"][src_key].attrs)
+        sources[src_key] = {
+            "type": str(src_attrs.get("Type", "unknown")),
+            "position": list(
+                map(float, src_attrs.get("Position", [0.0, 0.0, 0.0]))
+            ),
+        }
+
+    return sources

--- a/toolboxes/Marimo/requirements.txt
+++ b/toolboxes/Marimo/requirements.txt
@@ -1,0 +1,5 @@
+marimo>=0.9.0
+h5py>=3.0
+plotly>=5.0
+numpy>=1.21
+kaleido>=1.0


### PR DESCRIPTION
## Summary
This PR replaces the static `plot_Ascan.py` script with our new reactive marimo dashboard. 

To keep the architecture clean, I split the work into two distinct layers: a framework-agnostic data reader and the marimo UI. 

### 1. The Backend (`h5_reader.py` & `test_h5_reader.py`)
I deliberately kept `marimo` imports completely out of the reader. It is pure Python and `h5py`. 
* Reads any number of v4 `.h5` files into a clean dictionary structure.
* Dynamically extracts available components (no hardcoded `Ez` assumptions).
* Precomputes the time axis and handles negative polarity suffixes directly.
* Includes a suite of 47 unit tests using an in-memory mocked HDF5 fixture, so it passes CI without needing real simulation files.

### 2. The Dashboard (`ascan_dashboard.py`)
This replaces the terminal workflow with a browser UI.
* **Trace Picker:** Users can load multiple files, pick specific receivers/components, and add them to a single plot.
* **Dual Y-Axis:** Solved the scaling conflict by plotting E-field (V/m) on the left (solid lines) and H-field (A/m) on the right (dashed lines). 
* **State Management:** Isolated the trace list state into its own cell so the UI doesn't drop traces when a dropdown value changes.
* **Exports:** Added buttons for CSV (full unzoomed data) and publication-quality SVG/PDF (requires `kaleido`).

## Screenshots
[GPRMax A-Scan.pdf](https://github.com/user-attachments/files/29965975/GPRMax.A-Scan.pdf)


<img width="2880" height="5376" alt="Ascan Dashboard (6)" src="https://github.com/user-attachments/assets/15b1f06d-b085-42c6-936a-cad73aee2ba0" />
<img width="2400" height="1200" alt="GPRMax A-Scan" src="https://github.com/user-attachments/assets/c47bc75d-f93b-4f50-961d-2cb6d0a669e6" />


## How to test locally
1. `pip install -r toolboxes/Marimo/requirements.txt`
2. Run `plotly_get_chrome` in your terminal (one-time setup for the SVG export).
3. `pytest tests/test_h5_reader.py -v` (Should see 47 passes).
4. `marimo run toolboxes/Marimo/ascan_dashboard.py` and load up `examples/cylinder_Ascan_2D.h5`.

---
*Part of GSoC 2026 Component 3.*