### PR TITLE
Land magnetic material and symmetry boundary support on devel

### DIFF
--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -27,6 +27,18 @@ geometry, and imported geometry objects observe the reduced component set.
 See :ref:`input-hash-cmds` and :ref:`guidance` for the command syntax and field
 equations.
 
+PEC and PMC symmetry boundaries
+===============================
+
+PEC and PMC symmetry planes can replace the PML on selected model faces,
+reducing the simulated domain when the geometry and excitation have the
+required symmetry. PEC planes constrain the tangential electric fields,
+whereas PMC planes use an image-theory ghost-node update. Multiple symmetry
+planes may be combined. Nondispersive models are supported by the CPU, CUDA,
+OpenCL, and Metal solvers; dispersive PMC boundaries currently require the
+CPU solver. See ``#symmetry_boundary`` in :ref:`input-hash-cmds` for the
+syntax and current restrictions.
+
 Subgridding
 ===========
 
@@ -66,7 +78,7 @@ At the boundaries between different materials in a model there is the question o
 * Should the last object to be defined at that location dictate the electric and magnetic properties?
 * Should an average set of electric and magnetic properties of the materials of the objects that share that location be used?
 
-This latter option is often referred to as dielectric smoothing and has been shown to result in more accurate simulations [LUE1994]_ [BOU1996]_ [WHI2009]_. To address this question gprMax includes an option to turn dielectric smoothing on or off for volumetric object building commands. The default behaviour (if no option is specified) is for dielectric smoothing to be on. The option can be specified with a single character ``y`` (on) or ``n`` (off) given after the material identifier in each object command. When dielectric smoothing is on gprMax calculates the arithmetic mean of the electric and magnetic properties of the surrounding Yee cells, to use for the single Yee cell edge (boundary) of interest.
+This latter option is often referred to as dielectric smoothing and has been shown to result in more accurate simulations [LUE1994]_ [BOU1996]_ [WHI2009]_. To address this question gprMax includes an option to turn dielectric smoothing on or off for volumetric object building commands. The default behaviour (if no option is specified) is for dielectric smoothing to be on. The option can be specified with a single character ``y`` (on) or ``n`` (off) given after the material identifier in each object command. When dielectric smoothing is on, gprMax uses an arithmetic mean for the four cells surrounding each electric-field edge and, by default, a harmonic mean for the two cells normal to each magnetic-field edge. The harmonic magnetic average follows continuity of the normal magnetic flux density. The earlier arithmetic magnetic behaviour remains available for reproducing results from older versions; see ``#magnetic_averaging`` in :ref:`input-hash-cmds`.
 
 Perfectly Matched Layer (PML) absorbing boundary conditions
 ===========================================================

--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -122,6 +122,17 @@ Output Directory
 ----------------
 .. autoclass:: gprMax.user_objects.cmds_singleuse.OutputDir
 
+Magnetic Averaging
+------------------
+.. autoclass:: gprMax.user_objects.cmds_singleuse.MagneticAveraging
+
+The physically appropriate harmonic average is the default. Select the older
+arithmetic behaviour only when reproducing results from earlier versions:
+
+.. code-block:: python
+
+    scene.add(gprMax.MagneticAveraging(mode='arithmetic'))
+
 Material functions
 ==================
 
@@ -170,6 +181,20 @@ Cylindrical Sector
 Edge
 ----
 .. autoclass:: gprMax.user_objects.cmds_geometry.edge.Edge
+
+Magnetic Edge
+-------------
+.. autoclass:: gprMax.user_objects.cmds_geometry.magnetic_edge.MagneticEdge
+
+For example, add an x-directed perfect magnetic-conductor edge with:
+
+.. code-block:: python
+
+    scene.add(gprMax.MagneticEdge(
+        p1=(0.5, 0.5, 0.5),
+        p2=(0.7, 0.5, 0.5),
+        material_id='pmc',
+    ))
 
 Ellipsoid
 ---------
@@ -297,6 +322,16 @@ PML Formulation
 PML Thickness
 -------------
 .. autoclass:: gprMax.user_objects.cmds_singleuse.PMLThickness
+
+Symmetry Boundary
+-----------------
+.. autoclass:: gprMax.user_objects.cmds_multiuse.SymmetryBoundary
+
+For example, replace the PML on the lower x face with a PMC symmetry plane:
+
+.. code-block:: python
+
+    scene.add(gprMax.SymmetryBoundary(face='x0', type='pmc'))
 
 PML Properties
 --------------

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -238,7 +238,13 @@ Material commands
 Built-in materials
 ------------------
 
-gprMax has two builtin materials which can be used by specifying the identifiers ``pec`` and ``free_space``. These simulate a perfect electric conductor and air, i.e. a non-magnetic material with :math:`\epsilon_r = 1`, :math:`\sigma = 0`, respectively. Additionally the identifiers ``grass`` and ``water`` are currently reserved for internal use and should not be used unless you intentionally want to change their properties.
+gprMax has three built-in materials which can be used by specifying their identifiers:
+
+* ``pec`` is a perfect electric conductor (PEC), represented by infinite electric conductivity.
+* ``pmc`` is a perfect magnetic conductor (PMC), represented by infinite magnetic conductivity.
+* ``free_space`` is free space, with :math:`\epsilon_r = \mu_r = 1` and :math:`\sigma = \sigma_* = 0`.
+
+The identifiers ``grass`` and ``water`` are reserved for internal use and should not be used unless you intentionally want to change their properties.
 
 #material:
 ----------
@@ -477,6 +483,24 @@ At the boundaries between different materials in the model there is the question
     * Non-volumetric object building commands, ``#edge``, ``#plate``, and ``#triangle`` (applies to triangular patch not triangular prism) cannot have dielectric smoothing.
 
 
+#magnetic_averaging:
+---------------------
+
+Selects the mixing rule used for magnetic-field components at smoothed material interfaces. Each H component is constructed from the two cells stacked along its own axis. Because the normal component of magnetic flux density is continuous across an interface, the harmonic mean of relative permeability (:math:`\mu_r`) and magnetic loss (:math:`\sigma_*`) is used by default. Electric-field smoothing is unchanged and continues to use its arithmetic four-cell average. The syntax is:
+
+.. code-block:: none
+
+    #magnetic_averaging: str1
+
+* ``str1`` is ``harmonic`` or ``arithmetic`` (case-insensitive).
+
+.. note::
+
+    * This command is optional; the default is ``harmonic``.
+    * Earlier versions of gprMax used an arithmetic magnetic average. Add ``#magnetic_averaging: arithmetic`` when exact reproduction of those results is required.
+    * The command chooses the magnetic mixing rule only; it does not enable or disable dielectric smoothing.
+
+
 .. _geometryview:
 
 #geometry_view:
@@ -512,6 +536,25 @@ Allows you to introduce a wire with specific properties into the model. A wire i
 * ``str1`` is a material identifier that must correspond to material that has already been defined in the input file, or is one of the builtin materials.
 
 For example to specify a x-directed wire that is a perfect electric conductor, use: ``#edge: 0.5 0.5 0.5 0.7 0.5 0.5 pec``. Note that the y and z coordinates are identical.
+
+
+#magnetic_edge:
+----------------
+
+Allows you to introduce a single magnetic-field edge with specific properties into the model. It is the magnetic dual of ``#edge``. The syntax is:
+
+.. code-block:: none
+
+    #magnetic_edge: f1 f2 f3 f4 f5 f6 str1
+
+* ``f1 f2 f3`` are the starting (x,y,z) coordinates of the edge, and ``f4 f5 f6`` are its ending coordinates. The coordinates must define a single axis-aligned line.
+* ``str1`` is a material identifier that has already been defined, or one of the built-in materials.
+
+For example, an x-directed perfect magnetic conductor is specified with ``#magnetic_edge: 0.5 0.5 0.5 0.7 0.5 0.5 pmc``.
+
+.. note::
+
+    ``#magnetic_edge`` is not currently supported in 2D mode.
 
 #plate:
 -------
@@ -1182,3 +1225,30 @@ The parameters will be applied to all slabs of the PML that are switched on.
 .. tip::
 
     ``forward`` direction implies minimum parameter value at the inner boundary of the PML and maximum parameter value at the edge of computational domain, ``reverse`` is the opposite.
+
+
+#symmetry_boundary:
+--------------------
+
+Sets a PEC or PMC symmetry boundary on one face of the model domain, replacing the PML on that face. The command may be used more than once to set different faces. The syntax is:
+
+.. code-block:: none
+
+    #symmetry_boundary: str1 str2
+
+* ``str1`` is ``x0``, ``y0``, ``z0``, ``xmax``, ``ymax``, or ``zmax``.
+* ``str2`` is ``pec`` or ``pmc``.
+
+For example:
+
+.. code-block:: none
+
+    #symmetry_boundary: x0 pec
+    #symmetry_boundary: ymax pmc
+
+.. note::
+
+    * The PML thickness on a symmetry face is set to zero automatically.
+    * PEC boundaries and nondispersive PMC boundaries are supported by the CPU, CUDA, OpenCL, and Metal solvers.
+    * PMC boundaries in models containing dispersive materials are currently CPU-only.
+    * Symmetry boundaries are not currently supported in 2D mode, with MPI, or on a subgrid. They may be used on the main grid of a model that contains subgrids.

--- a/gprMax/__init__.py
+++ b/gprMax/__init__.py
@@ -45,6 +45,7 @@ from .user_objects.cmds_multiuse import (
     Rx,
     RxArray,
     SoilPeplinski,
+    SymmetryBoundary,
     TransmissionLine,
     VoltageSource,
     Waveform,

--- a/gprMax/__init__.py
+++ b/gprMax/__init__.py
@@ -24,6 +24,7 @@ from .user_objects.cmds_geometry.edge import Edge
 from .user_objects.cmds_geometry.ellipsoid import Ellipsoid
 from .user_objects.cmds_geometry.fractal_box import FractalBox
 from .user_objects.cmds_geometry.geometry_objects_read import GeometryObjectsRead
+from .user_objects.cmds_geometry.magnetic_edge import MagneticEdge
 from .user_objects.cmds_geometry.plate import Plate
 from .user_objects.cmds_geometry.sphere import Sphere
 from .user_objects.cmds_geometry.triangle import Triangle
@@ -53,6 +54,7 @@ from .user_objects.cmds_singleuse import (
     Discretisation,
     Domain,
     DomainMode,
+    MagneticAveraging,
     OMPThreads,
     OutputDir,
     PMLFormulation,

--- a/gprMax/config.py
+++ b/gprMax/config.py
@@ -97,6 +97,10 @@ class ModelConfig:
     def __init__(self, model_num):
         self.mode = "3D"
         self.requested_2d_mode = None
+        # Mixing rule for magnetic (H-field) material averaging at cell
+        # boundaries during Yee-cell smoothing. Harmonic averaging is the
+        # default; arithmetic averaging preserves results from older versions.
+        self.magnetic_averaging_mode = "harmonic"
         self.grids = []
         self.ompthreads = None
         self.model_num = model_num
@@ -204,6 +208,7 @@ class ModelConfig:
 
         self.mode = reference.mode
         self.requested_2d_mode = reference.requested_2d_mode
+        self.magnetic_averaging_mode = reference.magnetic_averaging_mode
         self.materials = dict(reference.materials)
 
     def get_scene(self):

--- a/gprMax/cuda_opencl/knl_fields_updates.py
+++ b/gprMax/cuda_opencl/knl_fields_updates.py
@@ -174,24 +174,26 @@ update_magnetic = {
     int y_ID = ((i % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) / $NZ_ID;
     int z_ID = ((i % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID)) % $NZ_ID;
 
-    // Hx component
-    if (NX != 1 && x > 0 && x < NX && y >= 0 && y < NY && z >= 0 && z < NZ) {
+    // Hx component. Include both own-axis domain walls; PMC symmetry uses
+    // the lower-wall value, while the ordinary outer-wall result remains
+    // mathematically inert because its tangential E values are zero.
+    if (NX != 1 && x >= 0 && x <= NX && y >= 0 && y < NY && z >= 0 && z < NZ) {
         int materialHx = ID[IDX4D_ID(3,x_ID,y_ID,z_ID)];
         Hx[IDX3D_FIELDS(x,y,z)] = updatecoeffsH[IDX2D_MAT(materialHx,0)] * Hx[IDX3D_FIELDS(x,y,z)] -
                                     updatecoeffsH[IDX2D_MAT(materialHx,2)] * (Ez[IDX3D_FIELDS(x,y+1,z)] - Ez[IDX3D_FIELDS(x,y,z)]) +
                                     updatecoeffsH[IDX2D_MAT(materialHx,3)] * (Ey[IDX3D_FIELDS(x,y,z+1)] - Ey[IDX3D_FIELDS(x,y,z)]);
     }
 
-    // Hy component
-    if (NY != 1 && x >= 0 && x < NX && y > 0 && y < NY && z >= 0 && z < NZ) {
+    // Hy component - include both own-axis domain walls.
+    if (NY != 1 && x >= 0 && x < NX && y >= 0 && y <= NY && z >= 0 && z < NZ) {
         int materialHy = ID[IDX4D_ID(4,x_ID,y_ID,z_ID)];
         Hy[IDX3D_FIELDS(x,y,z)] = updatecoeffsH[IDX2D_MAT(materialHy,0)] * Hy[IDX3D_FIELDS(x,y,z)] -
                                     updatecoeffsH[IDX2D_MAT(materialHy,3)] * (Ex[IDX3D_FIELDS(x,y,z+1)] - Ex[IDX3D_FIELDS(x,y,z)]) +
                                     updatecoeffsH[IDX2D_MAT(materialHy,1)] * (Ez[IDX3D_FIELDS(x+1,y,z)] - Ez[IDX3D_FIELDS(x,y,z)]);
     }
 
-    // Hz component
-    if (NZ != 1 && x >= 0 && x < NX && y >= 0 && y < NY && z > 0 && z < NZ) {
+    // Hz component - include both own-axis domain walls.
+    if (NZ != 1 && x >= 0 && x < NX && y >= 0 && y < NY && z >= 0 && z <= NZ) {
         int materialHz = ID[IDX4D_ID(5,x_ID,y_ID,z_ID)];
         Hz[IDX3D_FIELDS(x,y,z)] = updatecoeffsH[IDX2D_MAT(materialHz,0)] * Hz[IDX3D_FIELDS(x,y,z)] -
                                     updatecoeffsH[IDX2D_MAT(materialHz,1)] * (Ey[IDX3D_FIELDS(x+1,y,z)] - Ey[IDX3D_FIELDS(x,y,z)]) +

--- a/gprMax/cuda_opencl/knl_symmetry_boundaries.py
+++ b/gprMax/cuda_opencl/knl_symmetry_boundaries.py
@@ -1,0 +1,167 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+
+"""CUDA, OpenCL, and Metal PMC ghost-image boundary kernels."""
+
+from string import Template
+
+
+update_electric_pmc = {
+    "args_cuda": Template(
+        """
+__global__ void update_electric_pmc(
+    int NX, int NY, int NZ,
+    int PMC_X0, int PMC_XMAX,
+    int PMC_Y0, int PMC_YMAX,
+    int PMC_Z0, int PMC_ZMAX,
+    const unsigned int* __restrict__ ID,
+    $REAL* Ex, $REAL* Ey, $REAL* Ez,
+    const $REAL* __restrict__ Hx,
+    const $REAL* __restrict__ Hy,
+    const $REAL* __restrict__ Hz)
+"""
+    ),
+    "args_opencl": Template(
+        """
+    int NX, int NY, int NZ,
+    int PMC_X0, int PMC_XMAX,
+    int PMC_Y0, int PMC_YMAX,
+    int PMC_Z0, int PMC_ZMAX,
+    __global const unsigned int* restrict ID,
+    __global $REAL* Ex, __global $REAL* Ey, __global $REAL* Ez,
+    __global const $REAL* restrict Hx,
+    __global const $REAL* restrict Hy,
+    __global const $REAL* restrict Hz
+"""
+    ),
+    "args_metal": Template(
+        """
+kernel void update_electric_pmc(
+    device const int& NX, device const int& NY, device const int& NZ,
+    device const int& PMC_X0, device const int& PMC_XMAX,
+    device const int& PMC_Y0, device const int& PMC_YMAX,
+    device const int& PMC_Z0, device const int& PMC_ZMAX,
+    device const uint* ID,
+    device $REAL* Ex, device $REAL* Ey, device $REAL* Ez,
+    device const $REAL* Hx,
+    device const $REAL* Hy,
+    device const $REAL* Hz,
+    uint i [[thread_position_in_grid]])
+"""
+    ),
+    "func": Template(
+        r"""
+    // One work-item owns one Yee array index. A tangential E component on
+    // one or two PMC planes is updated once, so edges receive one self term
+    // plus the doubled ghost contribution from each adjoining PMC plane.
+    $CUDA_IDX
+
+    int x = i / ($NY_FIELDS * $NZ_FIELDS);
+    int y = (i % ($NY_FIELDS * $NZ_FIELDS)) / $NZ_FIELDS;
+    int z = (i % ($NY_FIELDS * $NZ_FIELDS)) % $NZ_FIELDS;
+
+    int x_ID = (i % ($NX_ID * $NY_ID * $NZ_ID)) / ($NY_ID * $NZ_ID);
+    int y_ID = ((i % ($NX_ID * $NY_ID * $NZ_ID)) %
+        ($NY_ID * $NZ_ID)) / $NZ_ID;
+    int z_ID = ((i % ($NX_ID * $NY_ID * $NZ_ID)) %
+        ($NY_ID * $NZ_ID)) % $NZ_ID;
+
+    int ex_on_pmc = (y == 0 && PMC_Y0) || (y == NY && PMC_YMAX)
+        || (z == 0 && PMC_Z0) || (z == NZ && PMC_ZMAX);
+    if (x >= 0 && x < NX && y >= 0 && y <= NY && z >= 0 && z <= NZ
+            && ex_on_pmc) {
+        int material = ID[IDX4D_ID(0,x_ID,y_ID,z_ID)];
+        $REAL dHz_dy = ($REAL)0;
+        $REAL dHy_dz = ($REAL)0;
+        if (y == 0) {
+            if (PMC_Y0) dHz_dy = ($REAL)2 * Hz[IDX3D_FIELDS(x,0,z)];
+        } else if (y == NY) {
+            if (PMC_YMAX) dHz_dy = -($REAL)2 * Hz[IDX3D_FIELDS(x,NY-1,z)];
+        } else {
+            dHz_dy = Hz[IDX3D_FIELDS(x,y,z)] - Hz[IDX3D_FIELDS(x,y-1,z)];
+        }
+        if (z == 0) {
+            if (PMC_Z0) dHy_dz = ($REAL)2 * Hy[IDX3D_FIELDS(x,y,0)];
+        } else if (z == NZ) {
+            if (PMC_ZMAX) dHy_dz = -($REAL)2 * Hy[IDX3D_FIELDS(x,y,NZ-1)];
+        } else {
+            dHy_dz = Hy[IDX3D_FIELDS(x,y,z)] - Hy[IDX3D_FIELDS(x,y,z-1)];
+        }
+        Ex[IDX3D_FIELDS(x,y,z)] =
+            updatecoeffsE[IDX2D_MAT(material,0)] * Ex[IDX3D_FIELDS(x,y,z)]
+            + updatecoeffsE[IDX2D_MAT(material,2)] * dHz_dy
+            - updatecoeffsE[IDX2D_MAT(material,3)] * dHy_dz;
+    }
+
+    int ey_on_pmc = (x == 0 && PMC_X0) || (x == NX && PMC_XMAX)
+        || (z == 0 && PMC_Z0) || (z == NZ && PMC_ZMAX);
+    if (x >= 0 && x <= NX && y >= 0 && y < NY && z >= 0 && z <= NZ
+            && ey_on_pmc) {
+        int material = ID[IDX4D_ID(1,x_ID,y_ID,z_ID)];
+        $REAL dHx_dz = ($REAL)0;
+        $REAL dHz_dx = ($REAL)0;
+        if (z == 0) {
+            if (PMC_Z0) dHx_dz = ($REAL)2 * Hx[IDX3D_FIELDS(x,y,0)];
+        } else if (z == NZ) {
+            if (PMC_ZMAX) dHx_dz = -($REAL)2 * Hx[IDX3D_FIELDS(x,y,NZ-1)];
+        } else {
+            dHx_dz = Hx[IDX3D_FIELDS(x,y,z)] - Hx[IDX3D_FIELDS(x,y,z-1)];
+        }
+        if (x == 0) {
+            if (PMC_X0) dHz_dx = ($REAL)2 * Hz[IDX3D_FIELDS(0,y,z)];
+        } else if (x == NX) {
+            if (PMC_XMAX) dHz_dx = -($REAL)2 * Hz[IDX3D_FIELDS(NX-1,y,z)];
+        } else {
+            dHz_dx = Hz[IDX3D_FIELDS(x,y,z)] - Hz[IDX3D_FIELDS(x-1,y,z)];
+        }
+        Ey[IDX3D_FIELDS(x,y,z)] =
+            updatecoeffsE[IDX2D_MAT(material,0)] * Ey[IDX3D_FIELDS(x,y,z)]
+            + updatecoeffsE[IDX2D_MAT(material,3)] * dHx_dz
+            - updatecoeffsE[IDX2D_MAT(material,1)] * dHz_dx;
+    }
+
+    int ez_on_pmc = (x == 0 && PMC_X0) || (x == NX && PMC_XMAX)
+        || (y == 0 && PMC_Y0) || (y == NY && PMC_YMAX);
+    if (x >= 0 && x <= NX && y >= 0 && y <= NY && z >= 0 && z < NZ
+            && ez_on_pmc) {
+        int material = ID[IDX4D_ID(2,x_ID,y_ID,z_ID)];
+        $REAL dHy_dx = ($REAL)0;
+        $REAL dHx_dy = ($REAL)0;
+        if (x == 0) {
+            if (PMC_X0) dHy_dx = ($REAL)2 * Hy[IDX3D_FIELDS(0,y,z)];
+        } else if (x == NX) {
+            if (PMC_XMAX) dHy_dx = -($REAL)2 * Hy[IDX3D_FIELDS(NX-1,y,z)];
+        } else {
+            dHy_dx = Hy[IDX3D_FIELDS(x,y,z)] - Hy[IDX3D_FIELDS(x-1,y,z)];
+        }
+        if (y == 0) {
+            if (PMC_Y0) dHx_dy = ($REAL)2 * Hx[IDX3D_FIELDS(x,0,z)];
+        } else if (y == NY) {
+            if (PMC_YMAX) dHx_dy = -($REAL)2 * Hx[IDX3D_FIELDS(x,NY-1,z)];
+        } else {
+            dHx_dy = Hx[IDX3D_FIELDS(x,y,z)] - Hx[IDX3D_FIELDS(x,y-1,z)];
+        }
+        Ez[IDX3D_FIELDS(x,y,z)] =
+            updatecoeffsE[IDX2D_MAT(material,0)] * Ez[IDX3D_FIELDS(x,y,z)]
+            + updatecoeffsE[IDX2D_MAT(material,1)] * dHy_dx
+            - updatecoeffsE[IDX2D_MAT(material,2)] * dHx_dy;
+    }
+"""
+    ),
+}

--- a/gprMax/cython/fields_updates_normal.pyx
+++ b/gprMax/cython/fields_updates_normal.pyx
@@ -325,3 +325,28 @@ cpdef void update_magnetic(
                     Hz[i, j, k + 1] = (updatecoeffsH[materialHz, 0] * Hz[i, j, k + 1] -
                                        updatecoeffsH[materialHz, 1] * (Ey[i + 1, j, k + 1] - Ey[i, j, k + 1]) +
                                        updatecoeffsH[materialHz, 2] * (Ex[i, j + 1, k + 1] - Ex[i, j, k + 1]))
+
+        # The main loops above update the upper own-axis walls (i=nx for Hx,
+        # j=ny for Hy, and k=nz for Hz) but not the corresponding lower walls.
+        # Updating both sides is required by the PMC ghost-node formulation
+        # and restores structural symmetry with the accelerator kernels.
+        for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+            for k in range(0, nz):
+                materialHx = ID[3, 0, j, k]
+                Hx[0, j, k] = (updatecoeffsH[materialHx, 0] * Hx[0, j, k] -
+                               updatecoeffsH[materialHx, 2] * (Ez[0, j + 1, k] - Ez[0, j, k]) +
+                               updatecoeffsH[materialHx, 3] * (Ey[0, j, k + 1] - Ey[0, j, k]))
+
+        for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+            for k in range(0, nz):
+                materialHy = ID[4, i, 0, k]
+                Hy[i, 0, k] = (updatecoeffsH[materialHy, 0] * Hy[i, 0, k] -
+                               updatecoeffsH[materialHy, 3] * (Ex[i, 0, k + 1] - Ex[i, 0, k]) +
+                               updatecoeffsH[materialHy, 1] * (Ez[i + 1, 0, k] - Ez[i, 0, k]))
+
+        for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+            for j in range(0, ny):
+                materialHz = ID[5, i, j, 0]
+                Hz[i, j, 0] = (updatecoeffsH[materialHz, 0] * Hz[i, j, 0] -
+                               updatecoeffsH[materialHz, 1] * (Ey[i + 1, j, 0] - Ey[i, j, 0]) +
+                               updatecoeffsH[materialHz, 2] * (Ex[i, j + 1, 0] - Ex[i, j, 0]))

--- a/gprMax/cython/geometry_primitives.pyx
+++ b/gprMax/cython/geometry_primitives.pyx
@@ -28,7 +28,6 @@ from gprMax.cython.yee_cell_setget_rigid cimport (
     set_rigid_Ex,
     set_rigid_Ey,
     set_rigid_Ez,
-    set_rigid_H,
     set_rigid_Hx,
     set_rigid_Hy,
     set_rigid_Hz,
@@ -242,6 +241,70 @@ cpdef void build_edge_z(
     ID[2, i, j, k] = numIDz
 
 
+cpdef void build_magnetic_edge_x(
+    int i,
+    int j,
+    int k,
+    int numIDx,
+    np.int8_t[:, :, :, ::1] rigidH,
+    np.uint32_t[:, :, :, ::1] ID
+):
+    """Set an x-orientated magnetic edge in the rigid and ID arrays - the
+    magnetic dual of build_edge_x, using the self-consistent single-position
+    Hx marker (set_rigid_Hx). Has no electric counterpart to touch, unlike
+    build_edge_x/y/z which take an (unused-by-them) rigidH parameter for
+    signature uniformity - a magnetic edge has no such relationship to E.
+
+    Args:
+        i, j, k: ints for cell coordinates of edge.
+        numIDx: int for numeric ID of material.
+        rigidH, ID: memoryviews to access rigid and ID arrays.
+    """
+
+    set_rigid_Hx(i, j, k, rigidH)
+    ID[3, i, j, k] = numIDx
+
+
+cpdef void build_magnetic_edge_y(
+    int i,
+    int j,
+    int k,
+    int numIDy,
+    np.int8_t[:, :, :, ::1] rigidH,
+    np.uint32_t[:, :, :, ::1] ID
+):
+    """Set a y-orientated magnetic edge in the rigid and ID arrays.
+
+    Args:
+        i, j, k: ints for cell coordinates of edge.
+        numIDy: int for numeric ID of material.
+        rigidH, ID: memoryviews to access rigid and ID arrays.
+    """
+
+    set_rigid_Hy(i, j, k, rigidH)
+    ID[4, i, j, k] = numIDy
+
+
+cpdef void build_magnetic_edge_z(
+    int i,
+    int j,
+    int k,
+    int numIDz,
+    np.int8_t[:, :, :, ::1] rigidH,
+    np.uint32_t[:, :, :, ::1] ID
+):
+    """Set a z-orientated magnetic edge in the rigid and ID arrays.
+
+    Args:
+        i, j, k: ints for cell coordinates of edge.
+        numIDz: int for numeric ID of material.
+        rigidH, ID: memoryviews to access rigid and ID arrays.
+    """
+
+    set_rigid_Hz(i, j, k, rigidH)
+    ID[5, i, j, k] = numIDz
+
+
 cpdef void build_face_yz(
     int i,
     int j,
@@ -335,6 +398,9 @@ cpdef void build_voxel(
     int numIDy,
     int numIDz,
     bint averaging,
+    bint pec_x,
+    bint pec_y,
+    bint pec_z,
     np.uint32_t[:, :, ::1] solid,
     np.int8_t[:, :, :, ::1] rigidE,
     np.int8_t[:, :, :, ::1] rigidH,
@@ -347,6 +413,13 @@ cpdef void build_voxel(
         numID, numIDx, numIDy, numIDz: ints for numeric ID of material.
         averaging: bint for whether material property averaging will occur for
                     the object.
+        pec_x, pec_y, pec_z: bints for whether the x/y/z-direction material is
+                    PEC (or PEC-equivalent, se=inf). PEC has no well-defined
+                    magnetic properties, so its H components are left
+                    completely untouched (ID value and rigid state both kept
+                    as whatever background was already there) rather than
+                    being set - unlike other rigid (non-averaged) materials,
+                    whose H is set at its correct 2 own-axis positions below.
         solid, rigidE, rigidH, ID: memoryviews to access solid, rigid and ID arrays.
     """
 
@@ -358,7 +431,20 @@ cpdef void build_voxel(
     else:
         solid[i, j, k] = numID
         set_rigid_E(i, j, k, rigidE)
-        set_rigid_H(i, j, k, rigidH)
+
+        # set_rigid_Hx/Hy/Hz are self-consistent single-position markers
+        # (mirroring set_rigid_Ex/Ey/Ez's shape) - a solid cell has 2 true
+        # H faces per component, so each is called twice, once per face,
+        # matching the two ID writes below exactly.
+        if not pec_x:
+            set_rigid_Hx(i, j, k, rigidH)
+            set_rigid_Hx(i + 1, j, k, rigidH)
+        if not pec_y:
+            set_rigid_Hy(i, j, k, rigidH)
+            set_rigid_Hy(i, j + 1, k, rigidH)
+        if not pec_z:
+            set_rigid_Hz(i, j, k, rigidH)
+            set_rigid_Hz(i, j, k + 1, rigidH)
 
         ID[0, i, j, k] = numIDx
         ID[0, i, j + 1, k + 1] = numIDx
@@ -375,20 +461,23 @@ cpdef void build_voxel(
         ID[2, i + 1, j, k] = numIDz
         ID[2, i, j + 1, k] = numIDz
 
-        ID[3, i, j, k] = numIDx
-        ID[3, i, j + 1, k + 1] = numIDx
-        ID[3, i, j + 1, k] = numIDx
-        ID[3, i, j, k + 1] = numIDx
+        # H components have only 2 true positions each, varying along their
+        # own dependency axis alone (tangential axes fixed to this cell) -
+        # unlike E's 4 tangential-corner positions above. This matches the
+        # established pattern in build_box(); the previous implementation
+        # incorrectly mirrored the E-component pattern. PEC axes skip this
+        # entirely - see the docstring above.
+        if not pec_x:
+            ID[3, i, j, k] = numIDx
+            ID[3, i + 1, j, k] = numIDx
 
-        ID[4, i, j, k] = numIDy
-        ID[4, i + 1, j, k + 1] = numIDy
-        ID[4, i + 1, j, k] = numIDy
-        ID[4, i, j, k + 1] = numIDy
+        if not pec_y:
+            ID[4, i, j, k] = numIDy
+            ID[4, i, j + 1, k] = numIDy
 
-        ID[5, i, j, k] = numIDz
-        ID[5, i + 1, j + 1, k] = numIDz
-        ID[5, i + 1, j, k] = numIDz
-        ID[5, i, j + 1, k] = numIDz
+        if not pec_z:
+            ID[5, i, j, k] = numIDz
+            ID[5, i, j, k + 1] = numIDz
 
 
 cpdef void build_triangle(
@@ -411,6 +500,9 @@ cpdef void build_triangle(
     int numIDy,
     int numIDz,
     bint averaging,
+    bint pec_x,
+    bint pec_y,
+    bint pec_z,
     np.uint32_t[:, :, ::1] solid,
     np.int8_t[:, :, :, ::1] rigidE,
     np.int8_t[:, :, :, ::1] rigidH,
@@ -429,6 +521,8 @@ cpdef void build_triangle(
         numID, numIDx, numIDy, numIDz: ints for numeric ID of material.
         averaging: bint for whether material property averaging will occur for
                     the object.
+        pec_x, pec_y, pec_z: bints for whether the x/y/z-direction material is
+                    PEC (or PEC-equivalent) - see build_voxel().
         solid, rigidE, rigidH, ID: memoryviews to access solid, rigid and ID arrays.
     """
 
@@ -525,13 +619,16 @@ cpdef void build_triangle(
                     for k in range(levelcells, levelcells + thicknesscells):
                         if normal == 'x':
                             build_voxel(k, i, j, numID, numIDx, numIDy, numIDz,
-                                        averaging, solid, rigidE, rigidH, ID)
+                                        averaging, pec_x, pec_y, pec_z,
+                                        solid, rigidE, rigidH, ID)
                         elif normal == 'y':
                             build_voxel(i, k, j, numID, numIDx, numIDy, numIDz,
-                                        averaging, solid, rigidE, rigidH, ID)
+                                        averaging, pec_x, pec_y, pec_z,
+                                        solid, rigidE, rigidH, ID)
                         elif normal == 'z':
                             build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
-                                        averaging, solid, rigidE, rigidH, ID)
+                                        averaging, pec_x, pec_y, pec_z,
+                                        solid, rigidE, rigidH, ID)
 
 
 cpdef void build_cylindrical_sector(
@@ -551,6 +648,9 @@ cpdef void build_cylindrical_sector(
     int numIDy,
     int numIDz,
     bint averaging,
+    bint pec_x,
+    bint pec_y,
+    bint pec_z,
     np.uint32_t[:, :, ::1] solid,
     np.int8_t[:, :, :, ::1] rigidE,
     np.int8_t[:, :, :, ::1] rigidH,
@@ -576,6 +676,8 @@ cpdef void build_cylindrical_sector(
         numID, numIDx, numIDy, numIDz: ints for numeric ID of material.
         averaging: bint for whether material property averaging will occur for
                     the object.
+        pec_x, pec_y, pec_z: bints for whether the x/y/z-direction material is
+                    PEC (or PEC-equivalent) - see build_voxel().
         solid, rigidE, rigidH, ID: memoryviews to access solid, rigid and ID arrays.
     """
 
@@ -612,7 +714,8 @@ cpdef void build_cylindrical_sector(
                     else:
                         for x in range(levelcells, levelcells + thicknesscells):
                             build_voxel(x, y, z, numID, numIDx, numIDy, numIDz,
-                                        averaging, solid, rigidE, rigidH, ID)
+                                        averaging, pec_x, pec_y, pec_z,
+                                        solid, rigidE, rigidH, ID)
 
     elif normal == 'y':
         # Angles are defined from zero degrees on the positive x-axis going
@@ -644,7 +747,8 @@ cpdef void build_cylindrical_sector(
                     else:
                         for y in range(levelcells, levelcells + thicknesscells):
                             build_voxel(x, y, z, numID, numIDx, numIDy, numIDz,
-                                        averaging, solid, rigidE, rigidH, ID)
+                                        averaging, pec_x, pec_y, pec_z,
+                                        solid, rigidE, rigidH, ID)
 
     elif normal == 'z':
         # Angles are defined from zero degrees on the positive x-axis going
@@ -676,7 +780,8 @@ cpdef void build_cylindrical_sector(
                     else:
                         for z in range(levelcells, levelcells + thicknesscells):
                             build_voxel(x, y, z, numID, numIDx, numIDy, numIDz,
-                                        averaging, solid, rigidE, rigidH, ID)
+                                        averaging, pec_x, pec_y, pec_z,
+                                        solid, rigidE, rigidH, ID)
 
 
 cpdef void build_box(
@@ -691,6 +796,9 @@ cpdef void build_box(
     int numIDy,
     int numIDz,
     bint averaging,
+    bint pec_x,
+    bint pec_y,
+    bint pec_z,
     np.uint32_t[:, :, ::1] solid,
     np.int8_t[:, :, :, ::1] rigidE,
     np.int8_t[:, :, :, ::1] rigidH,
@@ -703,6 +811,8 @@ cpdef void build_box(
         numID, numIDx, numIDy, numIDz: ints for numeric ID of material.
         averaging: bint for whether material property averaging will occur for
                     the object.
+        pec_x, pec_y, pec_z: bints for whether the x/y/z-direction material is
+                    PEC (or PEC-equivalent) - see build_voxel().
         solid, rigidE, rigidH, ID: memoryviews to access solid, rigid and ID arrays.
     """
 
@@ -721,43 +831,58 @@ cpdef void build_box(
                 for k in range(zs, zf):
                     solid[i, j, k] = numID
                     set_rigid_E(i, j, k, rigidE)
-                    set_rigid_H(i, j, k, rigidH)
+
+        # Each E/H component gets its own full-range loop. Ex/Ey/Ez are
+        # node-based on their two tangential axes, so those need the full
+        # ys..yf/zs..zf node range (+1), not just the cell range - matches
+        # the pre-2022 (pre-9c1b6f06) structure, which this restores. See
+        # project_2d_mode_framework.md for the investigation that found
+        # the regression (narrowed to single-line patches when prange was
+        # added in 9c1b6f06, and never restored when prange was later
+        # removed as a performance regression in b96ef3c1).
+        for i in range(xs, xf):
+            for j in range(ys, yf + 1):
+                for k in range(zs, zf + 1):
                     ID[0, i, j, k] = numIDx
-                    ID[1, i, j, k] = numIDy
-                    ID[2, i, j, k] = numIDz
-                    ID[3, i, j, k] = numIDx
-                    ID[4, i, j, k] = numIDy
-                    ID[5, i, j, k] = numIDz
 
-        for i in range(xs, xf):
-            j = yf
-            k = zf
-            ID[0, i, j, k] = numIDx
-
-        i = xf
-        for j in range(ys, yf):
-            for k in range(zf, zf + 1):
-                ID[1, i, j, k] = numIDy
-
-        i = xf
-        j = yf
-        for k in range(zs, zf):
-            ID[2, i, j, k] = numIDz
-
-        i = xf
-        for j in range(ys, yf):
-            for k in range(zs, zf):
-                ID[3, i, j, k] = numIDx
-
-        for i in range(xs, xf):
-            j = yf
-            for k in range(zs, zf):
-                ID[4, i, j, k] = numIDy
-
-        for i in range(xs, xf):
+        for i in range(xs, xf + 1):
             for j in range(ys, yf):
-                k = zf
-                ID[5, i, j, k] = numIDz
+                for k in range(zs, zf + 1):
+                    ID[1, i, j, k] = numIDy
+
+        for i in range(xs, xf + 1):
+            for j in range(ys, yf + 1):
+                for k in range(zs, zf):
+                    ID[2, i, j, k] = numIDz
+
+        # PEC has no well-defined magnetic properties, so a PEC axis's H is
+        # left completely untouched (background ID/rigid state kept as-is)
+        # rather than set - see build_voxel()'s docstring for the rationale.
+        # set_rigid_Hx/Hy/Hz are self-consistent single-position markers,
+        # so calling them once per position in these full-range loops
+        # (rather than once per cell in the loop above) correctly marks
+        # every position exactly once, with no redundant double-calls at
+        # shared interior boundaries.
+        if not pec_x:
+            for i in range(xs, xf + 1):
+                for j in range(ys, yf):
+                    for k in range(zs, zf):
+                        set_rigid_Hx(i, j, k, rigidH)
+                        ID[3, i, j, k] = numIDx
+
+        if not pec_y:
+            for i in range(xs, xf):
+                for j in range(ys, yf + 1):
+                    for k in range(zs, zf):
+                        set_rigid_Hy(i, j, k, rigidH)
+                        ID[4, i, j, k] = numIDy
+
+        if not pec_z:
+            for i in range(xs, xf):
+                for j in range(ys, yf):
+                    for k in range(zs, zf + 1):
+                        set_rigid_Hz(i, j, k, rigidH)
+                        ID[5, i, j, k] = numIDz
 
 
 cpdef void build_cylinder(
@@ -776,6 +901,9 @@ cpdef void build_cylinder(
     int numIDy,
     int numIDz,
     bint averaging,
+    bint pec_x,
+    bint pec_y,
+    bint pec_z,
     np.uint32_t[:, :, ::1] solid,
     np.int8_t[:, :, :, ::1] rigidE,
     np.int8_t[:, :, :, ::1] rigidH,
@@ -792,6 +920,8 @@ cpdef void build_cylinder(
         numID, numIDx, numIDy, numIDz: ints for numeric ID of material.
         averaging: bint for whether material property averaging will occur for
                     the object.
+        pec_x, pec_y, pec_z: bints for whether the x/y/z-direction material is
+                    PEC (or PEC-equivalent) - see build_voxel().
         solid, rigidE, rigidH, ID: memoryviews to access solid, rigid and ID arrays.
     """
 
@@ -884,7 +1014,8 @@ cpdef void build_cylinder(
                 if np.sqrt((j * dy + 0.5 * dy - y1)**2 + (k * dz + 0.5 * dz - z1)**2) <= r:
                     for i in range(xs, xf):
                         build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
-                                    averaging, solid, rigidE, rigidH, ID)
+                                    averaging, pec_x, pec_y, pec_z,
+                                    solid, rigidE, rigidH, ID)
     # y-aligned cylinder
     elif y_align:
         for i in range(xs, xf):
@@ -892,7 +1023,8 @@ cpdef void build_cylinder(
                 if np.sqrt((i * dx + 0.5 * dx - x1)**2 + (k * dz + 0.5 * dz - z1)**2) <= r:
                     for j in range(ys, yf):
                         build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
-                                    averaging, solid, rigidE, rigidH, ID)
+                                    averaging, pec_x, pec_y, pec_z,
+                                    solid, rigidE, rigidH, ID)
     # z-aligned cylinder
     elif z_align:
         for i in range(xs, xf):
@@ -900,7 +1032,8 @@ cpdef void build_cylinder(
                 if np.sqrt((i * dx + 0.5 * dx - x1)**2 + (j * dy + 0.5 * dy - y1)**2) <= r:
                     for k in range(zs, zf):
                         build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
-                                    averaging, solid, rigidE, rigidH, ID)
+                                    averaging, pec_x, pec_y, pec_z,
+                                    solid, rigidE, rigidH, ID)
 
     # Not aligned with any axis
     else:
@@ -954,7 +1087,8 @@ cpdef void build_cylinder(
 
                     if build:
                         build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
-                                    averaging, solid, rigidE, rigidH, ID)
+                                    averaging, pec_x, pec_y, pec_z,
+                                    solid, rigidE, rigidH, ID)
 
 
 cpdef void build_cone(
@@ -974,6 +1108,9 @@ cpdef void build_cone(
     int numIDy,
     int numIDz,
     bint averaging,
+    bint pec_x,
+    bint pec_y,
+    bint pec_z,
     np.uint32_t[:, :, ::1] solid,
     np.int8_t[:, :, :, ::1] rigidE,
     np.int8_t[:, :, :, ::1] rigidH,
@@ -991,6 +1128,8 @@ cpdef void build_cone(
         numID, numIDx, numIDy, numIDz: ints for numeric ID of material.
         averaging: bint for whether material property averaging will occur for
                     the object.
+        pec_x, pec_y, pec_z: bints for whether the x/y/z-direction material is
+                    PEC (or PEC-equivalent) - see build_voxel().
         solid, rigidE, rigidH, ID: memoryviews to access solid, rigid and ID arrays.
     """
 
@@ -1094,7 +1233,8 @@ cpdef void build_cone(
                 for i in range(xs_bound, xf_bound):
                     if np.sqrt((j * dy + 0.5 * dy - y1)**2 + (k * dz + 0.5 * dz - z1)**2) <= ((i- xs)/(xf-xs))*(r2-r1) + r1:
                         build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
-                                    averaging, solid, rigidE, rigidH, ID)
+                                    averaging, pec_x, pec_y, pec_z,
+                                    solid, rigidE, rigidH, ID)
     # y-aligned cone
     elif y_align:
         for i in range(xs_bound, xf_bound):
@@ -1102,7 +1242,8 @@ cpdef void build_cone(
                 for j in range(ys_bound, yf_bound):
                     if np.sqrt((i * dx + 0.5 * dx - x1)**2 + (k * dz + 0.5 * dz - z1)**2) <= ((j-ys)/(yf-ys))*(r2-r1) + r1:
                         build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
-                                    averaging, solid, rigidE, rigidH, ID)
+                                    averaging, pec_x, pec_y, pec_z,
+                                    solid, rigidE, rigidH, ID)
     # z-aligned cone
     elif z_align:
         for i in range(xs_bound, xf_bound):
@@ -1110,7 +1251,8 @@ cpdef void build_cone(
                 for k in range(zs_bound, zf_bound):
                     if np.sqrt((i * dx + 0.5 * dx - x1)**2 + (j * dy + 0.5 * dy - y1)**2) <= ((k-zs)/(zf-zs))*(r2-r1) + r1:
                         build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
-                                    averaging, solid, rigidE, rigidH, ID)
+                                    averaging, pec_x, pec_y, pec_z,
+                                    solid, rigidE, rigidH, ID)
 
     # Not aligned with any axis
     else:
@@ -1171,7 +1313,8 @@ cpdef void build_cone(
 
                     if build:
                         build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
-                                    averaging, solid, rigidE, rigidH, ID)
+                                    averaging, pec_x, pec_y, pec_z,
+                                    solid, rigidE, rigidH, ID)
 
 
 cpdef void build_sphere(
@@ -1187,6 +1330,9 @@ cpdef void build_sphere(
     int numIDy,
     int numIDz,
     bint averaging,
+    bint pec_x,
+    bint pec_y,
+    bint pec_z,
     np.uint32_t[:, :, ::1] solid,
     np.int8_t[:, :, :, ::1] rigidE,
     np.int8_t[:, :, :, ::1] rigidH,
@@ -1202,6 +1348,8 @@ cpdef void build_sphere(
         numID, numIDx, numIDy, numIDz: ints for numeric ID of material.
         averaging: bint for whether material property averaging will occur for
                     the object.
+        pec_x, pec_y, pec_z: bints for whether the x/y/z-direction material is
+                    PEC (or PEC-equivalent) - see build_voxel().
         solid, rigidE, rigidH, ID: memoryviews to access solid, rigid and ID arrays.
     """
 
@@ -1237,7 +1385,8 @@ cpdef void build_sphere(
                             (j + 0.5 - yc)**2 * dy**2 +
                             (k + 0.5 - zc)**2 * dz**2) <= r):
                     build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
-                                averaging, solid, rigidE, rigidH, ID)
+                                averaging, pec_x, pec_y, pec_z,
+                                solid, rigidE, rigidH, ID)
 
 
 cpdef void build_ellipsoid(
@@ -1255,6 +1404,9 @@ cpdef void build_ellipsoid(
     int numIDy,
     int numIDz,
     bint averaging,
+    bint pec_x,
+    bint pec_y,
+    bint pec_z,
     np.uint32_t[:, :, ::1] solid,
     np.int8_t[:, :, :, ::1] rigidE,
     np.int8_t[:, :, :, ::1] rigidH,
@@ -1272,6 +1424,8 @@ cpdef void build_ellipsoid(
         numID, numIDx, numIDy, numIDz: ints for numeric ID of material.
         averaging: bint for whether material property averaging will occur for
                     the object.
+        pec_x, pec_y, pec_z: bints for whether the x/y/z-direction material is
+                    PEC (or PEC-equivalent) - see build_voxel().
         solid, rigidE, rigidH, ID: memoryviews to access solid, rigid and ID arrays.
     """
 
@@ -1307,7 +1461,8 @@ cpdef void build_ellipsoid(
                             ((j + 0.5 - yc)**2 * dy**2)/yr**2 +
                             ((k + 0.5 - zc)**2 * dz**2)/zr**2 <= 1):
                     build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
-                                averaging, solid, rigidE, rigidH, ID)
+                                averaging, pec_x, pec_y, pec_z,
+                                solid, rigidE, rigidH, ID)
 
 
 cpdef void build_voxels_from_array(
@@ -1316,6 +1471,8 @@ cpdef void build_voxels_from_array(
     int zs,
     int numexistmaterials,
     bint averaging,
+    np.uint8_t[::1] is_pec_lookup,
+    np.uint8_t[::1] is_averagable_lookup,
     np.int16_t[:, :, ::1] data,
     np.uint32_t[:, :, ::1] solid,
     np.int8_t[:, :, :, ::1] rigidE,
@@ -1330,13 +1487,25 @@ cpdef void build_voxels_from_array(
         numexistmaterials: int for number of existing materials in model prior
                             to building voxels.
         averaging: bint for whether material property averaging will occur for
-                    the object.
+                    the object, requested by the user/grid default - combined
+                    per-voxel with is_averagable_lookup below, since a mixing
+                    model (e.g. #material_list/#material_range with a fractal
+                    box) may reference a non-averagable material (PEC/PMC, or
+                    any custom se=inf/sm=inf material) for only some of its
+                    bins - those voxels must always take the rigid path
+                    regardless of the requested averaging, matching how
+                    Box/Cylinder/etc. already gate on materials[0].averagable.
+        is_pec_lookup: memoryview indexed by numID, True where that material is
+                    PEC (or PEC-equivalent) - see build_voxel().
+        is_averagable_lookup: memoryview indexed by numID, True where that
+                    material permits dielectric smoothing (Material.averagable).
         data: memoryview to access array containing numeric IDs of voxels to create.
         solid, rigidE, rigidH, ID: memoryviews to access solid, rigid and ID arrays.
     """
 
     cdef Py_ssize_t i, j, k
     cdef int xf, yf, zf, numID
+    cdef bint pec, voxel_averaging
 
     # Set bounds to domain if they outside
     if xs < 0:
@@ -1366,7 +1535,10 @@ cpdef void build_voxels_from_array(
                 numID = data[i - xs, j - ys, k - zs]
                 if numID >= 0:
                     numID = numID + numexistmaterials
-                    build_voxel(i, j, k, numID, numID, numID, numID, averaging, solid, rigidE, rigidH, ID)
+                    pec = is_pec_lookup[numID]
+                    voxel_averaging = averaging and is_averagable_lookup[numID]
+                    build_voxel(i, j, k, numID, numID, numID, numID, voxel_averaging,
+                                pec, pec, pec, solid, rigidE, rigidH, ID)
 
 
 cpdef void build_voxels_from_array_mask(
@@ -1376,6 +1548,8 @@ cpdef void build_voxels_from_array_mask(
     int waternumID,
     int grassnumID,
     bint averaging,
+    np.uint8_t[::1] is_pec_lookup,
+    np.uint8_t[::1] is_averagable_lookup,
     np.int8_t[:, :, ::1] mask,
     np.int16_t[:, :, ::1] data,
     np.uint32_t[:, :, ::1] solid,
@@ -1389,7 +1563,13 @@ cpdef void build_voxels_from_array_mask(
         xs, ys, zs: ints for cell coordinates of position of start of array in domain.
         waternumID, grassnumID: ints for numeric ID of water and grass materials.
         averaging: bint for whether material property averaging will occur for
-                the object.
+                the object, requested by the user/grid default - see
+                build_voxels_from_array() for why this is combined per-voxel
+                with is_averagable_lookup rather than applied uniformly.
+        is_pec_lookup: memoryview indexed by numID, True where that material is
+                    PEC (or PEC-equivalent) - see build_voxel().
+        is_averagable_lookup: memoryview indexed by numID, True where that
+                    material permits dielectric smoothing (Material.averagable).
         data: memoryview to access array containing numeric IDs of voxels to create.
         mask: memoryview to access to array containing a mask of voxels to create.
         solid, rigidE, rigidH, ID: memoryviews to access solid, rigid and ID arrays.
@@ -1397,6 +1577,7 @@ cpdef void build_voxels_from_array_mask(
 
     cdef Py_ssize_t i, j, k
     cdef int xf, yf, zf, numID, numIDx, numIDy, numIDz
+    cdef bint pec, voxel_averaging
 
     # Set upper bounds
     xf = xs + data.shape[0]
@@ -1408,13 +1589,19 @@ cpdef void build_voxels_from_array_mask(
             for k in range(zs, zf):
                 if mask[i - xs, j - ys, k - zs] == 1:
                     numID = numIDx = numIDy = numIDz = data[i - xs, j - ys, k - zs]
+                    pec = is_pec_lookup[numID]
+                    voxel_averaging = averaging and is_averagable_lookup[numID]
                     build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
-                                averaging, solid, rigidE, rigidH, ID)
+                                voxel_averaging, pec, pec, pec, solid, rigidE, rigidH, ID)
                 elif mask[i - xs, j - ys, k - zs] == 2:
                     numID = numIDx = numIDy = numIDz = waternumID
+                    pec = is_pec_lookup[numID]
+                    voxel_averaging = averaging and is_averagable_lookup[numID]
                     build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
-                                averaging, solid, rigidE, rigidH, ID)
+                                voxel_averaging, pec, pec, pec, solid, rigidE, rigidH, ID)
                 elif mask[i - xs, j - ys, k - zs] == 3:
                     numID = numIDx = numIDy = numIDz = grassnumID
+                    pec = is_pec_lookup[numID]
+                    voxel_averaging = averaging and is_averagable_lookup[numID]
                     build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
-                                averaging, solid, rigidE, rigidH, ID)
+                                voxel_averaging, pec, pec, pec, solid, rigidE, rigidH, ID)

--- a/gprMax/cython/symmetry_boundaries.pyx
+++ b/gprMax/cython/symmetry_boundaries.pyx
@@ -1,0 +1,591 @@
+# Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+cimport numpy as np
+from cython.parallel import prange
+
+from gprMax.config cimport float_or_double
+
+
+# Per-iteration PMC ghost-node E update for the face-interior (non-edge)
+# region of a PMC symmetry boundary, standard (non-dispersive) materials
+# only. One function per domain face, mirroring the per-face convention
+# already used for PML (pml_updates_electric_HORIPML.pyx's xminus/xplus/etc.)
+#
+# Ghost-node derivation: tangential H is odd under the PMC mirror, so the
+# ghost H node just outside the domain equals minus the real interior H node
+# it mirrors. Substituting into the standard curl term collapses the missing
+# outside-neighbour difference into double one real H value. A "0" face
+# (x0/y0/z0) uses the wall's own H index with the bulk kernel's own sign; a
+# "max" face (xmax/ymax/zmax) uses the interior-adjacent H index (one cell
+# in, not the wall index) with the opposite sign.
+
+
+cpdef void update_symmetry_boundary_electric_x0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    float_or_double[:, ::1] updatecoeffsE,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Updates the Ey and Ez face-interior components on the x0 PMC face.
+
+    Args:
+        nx, ny, nz: ints for grid size in cells.
+        nthreads: int for number of threads to use.
+        updatecoeffsE, ID, E, H: memoryviews to access update coefficients,
+                                  ID and field component arrays.
+    """
+    cdef Py_ssize_t j, k
+    cdef int materialEy, materialEz
+
+    # Ey[0, 0:ny, 1:nz] - standard term Hx (dep k), ghost term Hz (dep i, doubled)
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(1, nz):
+            materialEy = ID[1, 0, j, k]
+            Ey[0, j, k] = (updatecoeffsE[materialEy, 0] * Ey[0, j, k] +
+                           updatecoeffsE[materialEy, 3] * (Hx[0, j, k] - Hx[0, j, k - 1]) -
+                           updatecoeffsE[materialEy, 1] * (2 * Hz[0, j, k]))
+
+    # Ez[0, 1:ny, 0:nz] - standard term Hx (dep j), ghost term Hy (dep i, doubled)
+    for j in prange(1, ny, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(0, nz):
+            materialEz = ID[2, 0, j, k]
+            Ez[0, j, k] = (updatecoeffsE[materialEz, 0] * Ez[0, j, k] -
+                           updatecoeffsE[materialEz, 2] * (Hx[0, j, k] - Hx[0, j - 1, k]) +
+                           updatecoeffsE[materialEz, 1] * (2 * Hy[0, j, k]))
+
+
+cpdef void update_symmetry_boundary_electric_xmax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    float_or_double[:, ::1] updatecoeffsE,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Updates the Ey and Ez face-interior components on the xmax PMC face."""
+    cdef Py_ssize_t j, k
+    cdef int materialEy, materialEz
+
+    # Ey[nx, 0:ny, 1:nz] - ghost uses interior-adjacent Hz index, flipped sign
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(1, nz):
+            materialEy = ID[1, nx, j, k]
+            Ey[nx, j, k] = (updatecoeffsE[materialEy, 0] * Ey[nx, j, k] +
+                             updatecoeffsE[materialEy, 3] * (Hx[nx, j, k] - Hx[nx, j, k - 1]) +
+                             updatecoeffsE[materialEy, 1] * (2 * Hz[nx - 1, j, k]))
+
+    # Ez[nx, 1:ny, 0:nz] - ghost uses interior-adjacent Hy index, flipped sign
+    for j in prange(1, ny, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(0, nz):
+            materialEz = ID[2, nx, j, k]
+            Ez[nx, j, k] = (updatecoeffsE[materialEz, 0] * Ez[nx, j, k] -
+                             updatecoeffsE[materialEz, 2] * (Hx[nx, j, k] - Hx[nx, j - 1, k]) -
+                             updatecoeffsE[materialEz, 1] * (2 * Hy[nx - 1, j, k]))
+
+
+cpdef void update_symmetry_boundary_electric_y0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    float_or_double[:, ::1] updatecoeffsE,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Updates the Ex and Ez face-interior components on the y0 PMC face."""
+    cdef Py_ssize_t i, k
+    cdef int materialEx, materialEz
+
+    # Ex[0:nx, 0, 1:nz] - standard term Hy (dep k), ghost term Hz (dep j, doubled)
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(1, nz):
+            materialEx = ID[0, i, 0, k]
+            Ex[i, 0, k] = (updatecoeffsE[materialEx, 0] * Ex[i, 0, k] -
+                           updatecoeffsE[materialEx, 3] * (Hy[i, 0, k] - Hy[i, 0, k - 1]) +
+                           updatecoeffsE[materialEx, 2] * (2 * Hz[i, 0, k]))
+
+    # Ez[1:nx, 0, 0:nz] - standard term Hy (dep i), ghost term Hx (dep j, doubled)
+    for i in prange(1, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(0, nz):
+            materialEz = ID[2, i, 0, k]
+            Ez[i, 0, k] = (updatecoeffsE[materialEz, 0] * Ez[i, 0, k] +
+                           updatecoeffsE[materialEz, 1] * (Hy[i, 0, k] - Hy[i - 1, 0, k]) -
+                           updatecoeffsE[materialEz, 2] * (2 * Hx[i, 0, k]))
+
+
+cpdef void update_symmetry_boundary_electric_ymax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    float_or_double[:, ::1] updatecoeffsE,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Updates the Ex and Ez face-interior components on the ymax PMC face."""
+    cdef Py_ssize_t i, k
+    cdef int materialEx, materialEz
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(1, nz):
+            materialEx = ID[0, i, ny, k]
+            Ex[i, ny, k] = (updatecoeffsE[materialEx, 0] * Ex[i, ny, k] -
+                             updatecoeffsE[materialEx, 3] * (Hy[i, ny, k] - Hy[i, ny, k - 1]) -
+                             updatecoeffsE[materialEx, 2] * (2 * Hz[i, ny - 1, k]))
+
+    for i in prange(1, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(0, nz):
+            materialEz = ID[2, i, ny, k]
+            Ez[i, ny, k] = (updatecoeffsE[materialEz, 0] * Ez[i, ny, k] +
+                             updatecoeffsE[materialEz, 1] * (Hy[i, ny, k] - Hy[i - 1, ny, k]) +
+                             updatecoeffsE[materialEz, 2] * (2 * Hx[i, ny - 1, k]))
+
+
+cpdef void update_symmetry_boundary_electric_z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    float_or_double[:, ::1] updatecoeffsE,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Updates the Ex and Ey face-interior components on the z0 PMC face."""
+    cdef Py_ssize_t i, j
+    cdef int materialEx, materialEy
+
+    # Ex[0:nx, 1:ny, 0] - standard term Hz (dep j), ghost term Hy (dep k, doubled)
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for j in range(1, ny):
+            materialEx = ID[0, i, j, 0]
+            Ex[i, j, 0] = (updatecoeffsE[materialEx, 0] * Ex[i, j, 0] +
+                           updatecoeffsE[materialEx, 2] * (Hz[i, j, 0] - Hz[i, j - 1, 0]) -
+                           updatecoeffsE[materialEx, 3] * (2 * Hy[i, j, 0]))
+
+    # Ey[1:nx, 0:ny, 0] - standard term Hz (dep i), ghost term Hx (dep k, doubled)
+    for i in prange(1, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for j in range(0, ny):
+            materialEy = ID[1, i, j, 0]
+            Ey[i, j, 0] = (updatecoeffsE[materialEy, 0] * Ey[i, j, 0] -
+                           updatecoeffsE[materialEy, 1] * (Hz[i, j, 0] - Hz[i - 1, j, 0]) +
+                           updatecoeffsE[materialEy, 3] * (2 * Hx[i, j, 0]))
+
+
+cpdef void update_symmetry_boundary_electric_zmax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    float_or_double[:, ::1] updatecoeffsE,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Updates the Ex and Ey face-interior components on the zmax PMC face."""
+    cdef Py_ssize_t i, j
+    cdef int materialEx, materialEy
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for j in range(1, ny):
+            materialEx = ID[0, i, j, nz]
+            Ex[i, j, nz] = (updatecoeffsE[materialEx, 0] * Ex[i, j, nz] +
+                             updatecoeffsE[materialEx, 2] * (Hz[i, j, nz] - Hz[i, j - 1, nz]) +
+                             updatecoeffsE[materialEx, 3] * (2 * Hy[i, j, nz - 1]))
+
+    for i in prange(1, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for j in range(0, ny):
+            materialEy = ID[1, i, j, nz]
+            Ey[i, j, nz] = (updatecoeffsE[materialEy, 0] * Ey[i, j, nz] -
+                             updatecoeffsE[materialEy, 1] * (Hz[i, j, nz] - Hz[i - 1, j, nz]) -
+                             updatecoeffsE[materialEy, 3] * (2 * Hx[i, j, nz - 1]))
+
+
+# Per-iteration PMC ghost-node E update for the 12 domain edges (where two
+# faces meet). Each edge carries exactly one tangential E component (never a
+# 3-way corner case). Named <component>_<faceA>_<faceB>, faceA/faceB in
+# canonical order (x0, y0, z0, xmax, ymax, zmax).
+#
+# Simplified per-edge scheme (no owner/increment split or execution-order
+# requirement): the self term
+# (Ca*E) is applied once if EITHER bordering face is PMC; each face then
+# separately, additively contributes its own doubled ghost term only if
+# THAT SPECIFIC face is PMC. A single-PMC-neighbour edge reduces correctly
+# to zero on its own, because the edge's ID has already been forced to pec
+# elsewhere whenever the other bordering face isn't PMC (Ca=Cb=0 there) -
+# no conditional on "is the other face PMC" is needed inside the ghost-term
+# additions themselves, only on whether THIS face is PMC.
+
+
+cpdef void update_symmetry_boundary_electric_Ez_X0_Y0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint x0_pmc,
+    bint y0_pmc,
+    float_or_double[:, ::1] updatecoeffsE,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy
+):
+    """Updates Ez along the x0-y0 edge (i=0, j=0, k free)."""
+    cdef Py_ssize_t k
+    cdef int mat
+
+    for k in prange(0, nz, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[2, 0, 0, k]
+        if x0_pmc or y0_pmc:
+            Ez[0, 0, k] = updatecoeffsE[mat, 0] * Ez[0, 0, k]
+        if x0_pmc:
+            Ez[0, 0, k] = Ez[0, 0, k] + updatecoeffsE[mat, 1] * (2 * Hy[0, 0, k])
+        if y0_pmc:
+            Ez[0, 0, k] = Ez[0, 0, k] - updatecoeffsE[mat, 2] * (2 * Hx[0, 0, k])
+
+
+cpdef void update_symmetry_boundary_electric_Ez_X0_YMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint x0_pmc,
+    bint ymax_pmc,
+    float_or_double[:, ::1] updatecoeffsE,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy
+):
+    """Updates Ez along the x0-ymax edge (i=0, j=ny, k free)."""
+    cdef Py_ssize_t k
+    cdef int mat
+
+    for k in prange(0, nz, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[2, 0, ny, k]
+        if x0_pmc or ymax_pmc:
+            Ez[0, ny, k] = updatecoeffsE[mat, 0] * Ez[0, ny, k]
+        if x0_pmc:
+            Ez[0, ny, k] = Ez[0, ny, k] + updatecoeffsE[mat, 1] * (2 * Hy[0, ny, k])
+        if ymax_pmc:
+            Ez[0, ny, k] = Ez[0, ny, k] + updatecoeffsE[mat, 2] * (2 * Hx[0, ny - 1, k])
+
+
+cpdef void update_symmetry_boundary_electric_Ez_XMax_Y0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint xmax_pmc,
+    bint y0_pmc,
+    float_or_double[:, ::1] updatecoeffsE,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy
+):
+    """Updates Ez along the xmax-y0 edge (i=nx, j=0, k free)."""
+    cdef Py_ssize_t k
+    cdef int mat
+
+    for k in prange(0, nz, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[2, nx, 0, k]
+        if xmax_pmc or y0_pmc:
+            Ez[nx, 0, k] = updatecoeffsE[mat, 0] * Ez[nx, 0, k]
+        if xmax_pmc:
+            Ez[nx, 0, k] = Ez[nx, 0, k] - updatecoeffsE[mat, 1] * (2 * Hy[nx - 1, 0, k])
+        if y0_pmc:
+            Ez[nx, 0, k] = Ez[nx, 0, k] - updatecoeffsE[mat, 2] * (2 * Hx[nx, 0, k])
+
+
+cpdef void update_symmetry_boundary_electric_Ez_XMax_YMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint xmax_pmc,
+    bint ymax_pmc,
+    float_or_double[:, ::1] updatecoeffsE,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy
+):
+    """Updates Ez along the xmax-ymax edge (i=nx, j=ny, k free)."""
+    cdef Py_ssize_t k
+    cdef int mat
+
+    for k in prange(0, nz, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[2, nx, ny, k]
+        if xmax_pmc or ymax_pmc:
+            Ez[nx, ny, k] = updatecoeffsE[mat, 0] * Ez[nx, ny, k]
+        if xmax_pmc:
+            Ez[nx, ny, k] = Ez[nx, ny, k] - updatecoeffsE[mat, 1] * (2 * Hy[nx - 1, ny, k])
+        if ymax_pmc:
+            Ez[nx, ny, k] = Ez[nx, ny, k] + updatecoeffsE[mat, 2] * (2 * Hx[nx, ny - 1, k])
+
+
+cpdef void update_symmetry_boundary_electric_Ey_X0_Z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint x0_pmc,
+    bint z0_pmc,
+    float_or_double[:, ::1] updatecoeffsE,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hz
+):
+    """Updates Ey along the x0-z0 edge (i=0, k=0, j free)."""
+    cdef Py_ssize_t j
+    cdef int mat
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[1, 0, j, 0]
+        if x0_pmc or z0_pmc:
+            Ey[0, j, 0] = updatecoeffsE[mat, 0] * Ey[0, j, 0]
+        if x0_pmc:
+            Ey[0, j, 0] = Ey[0, j, 0] - updatecoeffsE[mat, 1] * (2 * Hz[0, j, 0])
+        if z0_pmc:
+            Ey[0, j, 0] = Ey[0, j, 0] + updatecoeffsE[mat, 3] * (2 * Hx[0, j, 0])
+
+
+cpdef void update_symmetry_boundary_electric_Ey_X0_ZMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint x0_pmc,
+    bint zmax_pmc,
+    float_or_double[:, ::1] updatecoeffsE,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hz
+):
+    """Updates Ey along the x0-zmax edge (i=0, k=nz, j free)."""
+    cdef Py_ssize_t j
+    cdef int mat
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[1, 0, j, nz]
+        if x0_pmc or zmax_pmc:
+            Ey[0, j, nz] = updatecoeffsE[mat, 0] * Ey[0, j, nz]
+        if x0_pmc:
+            Ey[0, j, nz] = Ey[0, j, nz] - updatecoeffsE[mat, 1] * (2 * Hz[0, j, nz])
+        if zmax_pmc:
+            Ey[0, j, nz] = Ey[0, j, nz] - updatecoeffsE[mat, 3] * (2 * Hx[0, j, nz - 1])
+
+
+cpdef void update_symmetry_boundary_electric_Ey_XMax_Z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint xmax_pmc,
+    bint z0_pmc,
+    float_or_double[:, ::1] updatecoeffsE,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hz
+):
+    """Updates Ey along the xmax-z0 edge (i=nx, k=0, j free)."""
+    cdef Py_ssize_t j
+    cdef int mat
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[1, nx, j, 0]
+        if xmax_pmc or z0_pmc:
+            Ey[nx, j, 0] = updatecoeffsE[mat, 0] * Ey[nx, j, 0]
+        if xmax_pmc:
+            Ey[nx, j, 0] = Ey[nx, j, 0] + updatecoeffsE[mat, 1] * (2 * Hz[nx - 1, j, 0])
+        if z0_pmc:
+            Ey[nx, j, 0] = Ey[nx, j, 0] + updatecoeffsE[mat, 3] * (2 * Hx[nx, j, 0])
+
+
+cpdef void update_symmetry_boundary_electric_Ey_XMax_ZMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint xmax_pmc,
+    bint zmax_pmc,
+    float_or_double[:, ::1] updatecoeffsE,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hz
+):
+    """Updates Ey along the xmax-zmax edge (i=nx, k=nz, j free)."""
+    cdef Py_ssize_t j
+    cdef int mat
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[1, nx, j, nz]
+        if xmax_pmc or zmax_pmc:
+            Ey[nx, j, nz] = updatecoeffsE[mat, 0] * Ey[nx, j, nz]
+        if xmax_pmc:
+            Ey[nx, j, nz] = Ey[nx, j, nz] + updatecoeffsE[mat, 1] * (2 * Hz[nx - 1, j, nz])
+        if zmax_pmc:
+            Ey[nx, j, nz] = Ey[nx, j, nz] - updatecoeffsE[mat, 3] * (2 * Hx[nx, j, nz - 1])
+
+
+cpdef void update_symmetry_boundary_electric_Ex_Y0_Z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint y0_pmc,
+    bint z0_pmc,
+    float_or_double[:, ::1] updatecoeffsE,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Updates Ex along the y0-z0 edge (j=0, k=0, i free)."""
+    cdef Py_ssize_t i
+    cdef int mat
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[0, i, 0, 0]
+        if y0_pmc or z0_pmc:
+            Ex[i, 0, 0] = updatecoeffsE[mat, 0] * Ex[i, 0, 0]
+        if y0_pmc:
+            Ex[i, 0, 0] = Ex[i, 0, 0] + updatecoeffsE[mat, 2] * (2 * Hz[i, 0, 0])
+        if z0_pmc:
+            Ex[i, 0, 0] = Ex[i, 0, 0] - updatecoeffsE[mat, 3] * (2 * Hy[i, 0, 0])
+
+
+cpdef void update_symmetry_boundary_electric_Ex_Y0_ZMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint y0_pmc,
+    bint zmax_pmc,
+    float_or_double[:, ::1] updatecoeffsE,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Updates Ex along the y0-zmax edge (j=0, k=nz, i free)."""
+    cdef Py_ssize_t i
+    cdef int mat
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[0, i, 0, nz]
+        if y0_pmc or zmax_pmc:
+            Ex[i, 0, nz] = updatecoeffsE[mat, 0] * Ex[i, 0, nz]
+        if y0_pmc:
+            Ex[i, 0, nz] = Ex[i, 0, nz] + updatecoeffsE[mat, 2] * (2 * Hz[i, 0, nz])
+        if zmax_pmc:
+            Ex[i, 0, nz] = Ex[i, 0, nz] + updatecoeffsE[mat, 3] * (2 * Hy[i, 0, nz - 1])
+
+
+cpdef void update_symmetry_boundary_electric_Ex_YMax_Z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint ymax_pmc,
+    bint z0_pmc,
+    float_or_double[:, ::1] updatecoeffsE,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Updates Ex along the ymax-z0 edge (j=ny, k=0, i free)."""
+    cdef Py_ssize_t i
+    cdef int mat
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[0, i, ny, 0]
+        if ymax_pmc or z0_pmc:
+            Ex[i, ny, 0] = updatecoeffsE[mat, 0] * Ex[i, ny, 0]
+        if ymax_pmc:
+            Ex[i, ny, 0] = Ex[i, ny, 0] - updatecoeffsE[mat, 2] * (2 * Hz[i, ny - 1, 0])
+        if z0_pmc:
+            Ex[i, ny, 0] = Ex[i, ny, 0] - updatecoeffsE[mat, 3] * (2 * Hy[i, ny, 0])
+
+
+cpdef void update_symmetry_boundary_electric_Ex_YMax_ZMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint ymax_pmc,
+    bint zmax_pmc,
+    float_or_double[:, ::1] updatecoeffsE,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Updates Ex along the ymax-zmax edge (j=ny, k=nz, i free)."""
+    cdef Py_ssize_t i
+    cdef int mat
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[0, i, ny, nz]
+        if ymax_pmc or zmax_pmc:
+            Ex[i, ny, nz] = updatecoeffsE[mat, 0] * Ex[i, ny, nz]
+        if ymax_pmc:
+            Ex[i, ny, nz] = Ex[i, ny, nz] - updatecoeffsE[mat, 2] * (2 * Hz[i, ny - 1, nz])
+        if zmax_pmc:
+            Ex[i, ny, nz] = Ex[i, ny, nz] + updatecoeffsE[mat, 3] * (2 * Hy[i, ny, nz - 1])

--- a/gprMax/cython/symmetry_boundaries_dispersive.pyx
+++ b/gprMax/cython/symmetry_boundaries_dispersive.pyx
@@ -1,0 +1,1281 @@
+# Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+cimport numpy as np
+from cython.parallel import prange
+
+from gprMax.config cimport float_or_double
+
+# Dispersive (Debye) counterpart of gprMax/cython/symmetry_boundaries.pyx's
+# PMC ghost-node E update - see that file for the ghost-node derivation,
+# which is unchanged here (same doubled-H substitution, same face/edge sign
+# conventions). This file only adds the ADE polarization-current term
+# (phi/T-array bookkeeping) that the bulk dispersive kernel
+# (fields_updates_dispersive_template.jinja) already does for every other
+# cell, which the non-dispersive boundary kernel omits (it never touches
+# Tx/Ty/Tz or updatecoeffsdispersive at all).
+#
+# Two phases, mirroring the bulk kernel's own A/B split (see
+# fields_updates_dispersive_template.jinja and gprMax/updates/cpu_updates.py):
+#   Phase A ("_dispersive_"): called at the same point as the existing
+#     non-dispersive boundary update (right after update_electric_a(), before
+#     PML/sources). Accumulates phi from the OLD T, updates T from the OLD E,
+#     then assembles the new E from the ghost-doubled curl term minus
+#     updatecoeffsE[mat, 4]*phi - the same per-cell logic as the bulk kernel's
+#     Phase A, applied at wall/edge positions the bulk kernel's own loop
+#     bounds structurally exclude.
+#   Phase B ("_dispersive_b_"): called at the same point as the bulk kernel's
+#     own Phase B (right before update_electric_b(), i.e. after PML/sources
+#     have possibly further modified E - a source sitting at/adjacent to the
+#     wall, as in a center-fed dipole straddling a PMC plane, is exactly this
+#     case). Corrects T using the now-final E. No H arrays needed, matching
+#     the bulk Phase B's own signature.
+#
+# maxpoles is always looped unconditionally (no 1-pole specialisation, unlike
+# the bulk kernel's separate "1pole" functions) - boundary cells are a
+# vanishing fraction of total domain cells, so the loop-unrolling
+# optimisation that matters at bulk (O(n^3)) scale is immaterial here.
+#
+# Edges: no explicit PEC-transparency branch is needed for the phi/T block,
+# unlike you might expect - it is computed unconditionally (not gated by
+# a_pmc/b_pmc) for the same reason the non-dispersive edge kernels don't
+# need one for their self term: when only one bordering face is PMC, the
+# other face has already forced this edge's material to "pec" at build time
+# (FDTDGrid._terminate_pmls_with_pec/_force_pec_tangential_e), and a pec
+# material's updatecoeffsdispersive row is never written (stays zero,
+# since it's a plain Material, not a DispersiveMaterial) - phi and the T
+# recursion both correctly evaluate to zero for free. When both bordering
+# faces are PMC, the phi/T machinery runs for real, correctly, on whatever
+# genuinely dispersive material occupies the corner.
+
+
+###############################################
+# Phase A - face-interior, one function/face #
+###############################################
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_x0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tx,
+    float_or_double[:, :, :, ::1] Ty,
+    float_or_double[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_x0()."""
+    cdef Py_ssize_t j, k, pole
+    cdef int materialEy, materialEz
+    cdef float_or_double phi
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(1, nz):
+            materialEy = ID[1, 0, j, k]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEy, pole * 3] * Ty[pole, 0, j, k]
+                Ty[pole, 0, j, k] = (updatecoeffsdispersive[materialEy, 1 + (pole * 3)] * Ty[pole, 0, j, k]
+                                     + updatecoeffsdispersive[materialEy, 2 + (pole * 3)] * Ey[0, j, k])
+            Ey[0, j, k] = (updatecoeffsE[materialEy, 0] * Ey[0, j, k] +
+                           updatecoeffsE[materialEy, 3] * (Hx[0, j, k] - Hx[0, j, k - 1]) -
+                           updatecoeffsE[materialEy, 1] * (2 * Hz[0, j, k]) -
+                           updatecoeffsE[materialEy, 4] * phi)
+
+    for j in prange(1, ny, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(0, nz):
+            materialEz = ID[2, 0, j, k]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEz, pole * 3] * Tz[pole, 0, j, k]
+                Tz[pole, 0, j, k] = (updatecoeffsdispersive[materialEz, 1 + (pole * 3)] * Tz[pole, 0, j, k]
+                                     + updatecoeffsdispersive[materialEz, 2 + (pole * 3)] * Ez[0, j, k])
+            Ez[0, j, k] = (updatecoeffsE[materialEz, 0] * Ez[0, j, k] -
+                           updatecoeffsE[materialEz, 2] * (Hx[0, j, k] - Hx[0, j - 1, k]) +
+                           updatecoeffsE[materialEz, 1] * (2 * Hy[0, j, k]) -
+                           updatecoeffsE[materialEz, 4] * phi)
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_xmax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tx,
+    float_or_double[:, :, :, ::1] Ty,
+    float_or_double[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_xmax()."""
+    cdef Py_ssize_t j, k, pole
+    cdef int materialEy, materialEz
+    cdef float_or_double phi
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(1, nz):
+            materialEy = ID[1, nx, j, k]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEy, pole * 3] * Ty[pole, nx, j, k]
+                Ty[pole, nx, j, k] = (updatecoeffsdispersive[materialEy, 1 + (pole * 3)] * Ty[pole, nx, j, k]
+                                      + updatecoeffsdispersive[materialEy, 2 + (pole * 3)] * Ey[nx, j, k])
+            Ey[nx, j, k] = (updatecoeffsE[materialEy, 0] * Ey[nx, j, k] +
+                             updatecoeffsE[materialEy, 3] * (Hx[nx, j, k] - Hx[nx, j, k - 1]) +
+                             updatecoeffsE[materialEy, 1] * (2 * Hz[nx - 1, j, k]) -
+                             updatecoeffsE[materialEy, 4] * phi)
+
+    for j in prange(1, ny, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(0, nz):
+            materialEz = ID[2, nx, j, k]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEz, pole * 3] * Tz[pole, nx, j, k]
+                Tz[pole, nx, j, k] = (updatecoeffsdispersive[materialEz, 1 + (pole * 3)] * Tz[pole, nx, j, k]
+                                      + updatecoeffsdispersive[materialEz, 2 + (pole * 3)] * Ez[nx, j, k])
+            Ez[nx, j, k] = (updatecoeffsE[materialEz, 0] * Ez[nx, j, k] -
+                             updatecoeffsE[materialEz, 2] * (Hx[nx, j, k] - Hx[nx, j - 1, k]) -
+                             updatecoeffsE[materialEz, 1] * (2 * Hy[nx - 1, j, k]) -
+                             updatecoeffsE[materialEz, 4] * phi)
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_y0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tx,
+    float_or_double[:, :, :, ::1] Ty,
+    float_or_double[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_y0()."""
+    cdef Py_ssize_t i, k, pole
+    cdef int materialEx, materialEz
+    cdef float_or_double phi
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(1, nz):
+            materialEx = ID[0, i, 0, k]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEx, pole * 3] * Tx[pole, i, 0, k]
+                Tx[pole, i, 0, k] = (updatecoeffsdispersive[materialEx, 1 + (pole * 3)] * Tx[pole, i, 0, k]
+                                     + updatecoeffsdispersive[materialEx, 2 + (pole * 3)] * Ex[i, 0, k])
+            Ex[i, 0, k] = (updatecoeffsE[materialEx, 0] * Ex[i, 0, k] -
+                           updatecoeffsE[materialEx, 3] * (Hy[i, 0, k] - Hy[i, 0, k - 1]) +
+                           updatecoeffsE[materialEx, 2] * (2 * Hz[i, 0, k]) -
+                           updatecoeffsE[materialEx, 4] * phi)
+
+    for i in prange(1, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(0, nz):
+            materialEz = ID[2, i, 0, k]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEz, pole * 3] * Tz[pole, i, 0, k]
+                Tz[pole, i, 0, k] = (updatecoeffsdispersive[materialEz, 1 + (pole * 3)] * Tz[pole, i, 0, k]
+                                     + updatecoeffsdispersive[materialEz, 2 + (pole * 3)] * Ez[i, 0, k])
+            Ez[i, 0, k] = (updatecoeffsE[materialEz, 0] * Ez[i, 0, k] +
+                           updatecoeffsE[materialEz, 1] * (Hy[i, 0, k] - Hy[i - 1, 0, k]) -
+                           updatecoeffsE[materialEz, 2] * (2 * Hx[i, 0, k]) -
+                           updatecoeffsE[materialEz, 4] * phi)
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_ymax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tx,
+    float_or_double[:, :, :, ::1] Ty,
+    float_or_double[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_ymax()."""
+    cdef Py_ssize_t i, k, pole
+    cdef int materialEx, materialEz
+    cdef float_or_double phi
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(1, nz):
+            materialEx = ID[0, i, ny, k]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEx, pole * 3] * Tx[pole, i, ny, k]
+                Tx[pole, i, ny, k] = (updatecoeffsdispersive[materialEx, 1 + (pole * 3)] * Tx[pole, i, ny, k]
+                                      + updatecoeffsdispersive[materialEx, 2 + (pole * 3)] * Ex[i, ny, k])
+            Ex[i, ny, k] = (updatecoeffsE[materialEx, 0] * Ex[i, ny, k] -
+                             updatecoeffsE[materialEx, 3] * (Hy[i, ny, k] - Hy[i, ny, k - 1]) -
+                             updatecoeffsE[materialEx, 2] * (2 * Hz[i, ny - 1, k]) -
+                             updatecoeffsE[materialEx, 4] * phi)
+
+    for i in prange(1, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(0, nz):
+            materialEz = ID[2, i, ny, k]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEz, pole * 3] * Tz[pole, i, ny, k]
+                Tz[pole, i, ny, k] = (updatecoeffsdispersive[materialEz, 1 + (pole * 3)] * Tz[pole, i, ny, k]
+                                      + updatecoeffsdispersive[materialEz, 2 + (pole * 3)] * Ez[i, ny, k])
+            Ez[i, ny, k] = (updatecoeffsE[materialEz, 0] * Ez[i, ny, k] +
+                             updatecoeffsE[materialEz, 1] * (Hy[i, ny, k] - Hy[i - 1, ny, k]) +
+                             updatecoeffsE[materialEz, 2] * (2 * Hx[i, ny - 1, k]) -
+                             updatecoeffsE[materialEz, 4] * phi)
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tx,
+    float_or_double[:, :, :, ::1] Ty,
+    float_or_double[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_z0()."""
+    cdef Py_ssize_t i, j, pole
+    cdef int materialEx, materialEy
+    cdef float_or_double phi
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for j in range(1, ny):
+            materialEx = ID[0, i, j, 0]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEx, pole * 3] * Tx[pole, i, j, 0]
+                Tx[pole, i, j, 0] = (updatecoeffsdispersive[materialEx, 1 + (pole * 3)] * Tx[pole, i, j, 0]
+                                     + updatecoeffsdispersive[materialEx, 2 + (pole * 3)] * Ex[i, j, 0])
+            Ex[i, j, 0] = (updatecoeffsE[materialEx, 0] * Ex[i, j, 0] +
+                           updatecoeffsE[materialEx, 2] * (Hz[i, j, 0] - Hz[i, j - 1, 0]) -
+                           updatecoeffsE[materialEx, 3] * (2 * Hy[i, j, 0]) -
+                           updatecoeffsE[materialEx, 4] * phi)
+
+    for i in prange(1, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for j in range(0, ny):
+            materialEy = ID[1, i, j, 0]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEy, pole * 3] * Ty[pole, i, j, 0]
+                Ty[pole, i, j, 0] = (updatecoeffsdispersive[materialEy, 1 + (pole * 3)] * Ty[pole, i, j, 0]
+                                     + updatecoeffsdispersive[materialEy, 2 + (pole * 3)] * Ey[i, j, 0])
+            Ey[i, j, 0] = (updatecoeffsE[materialEy, 0] * Ey[i, j, 0] -
+                           updatecoeffsE[materialEy, 1] * (Hz[i, j, 0] - Hz[i - 1, j, 0]) +
+                           updatecoeffsE[materialEy, 3] * (2 * Hx[i, j, 0]) -
+                           updatecoeffsE[materialEy, 4] * phi)
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_zmax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tx,
+    float_or_double[:, :, :, ::1] Ty,
+    float_or_double[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_zmax()."""
+    cdef Py_ssize_t i, j, pole
+    cdef int materialEx, materialEy
+    cdef float_or_double phi
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for j in range(1, ny):
+            materialEx = ID[0, i, j, nz]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEx, pole * 3] * Tx[pole, i, j, nz]
+                Tx[pole, i, j, nz] = (updatecoeffsdispersive[materialEx, 1 + (pole * 3)] * Tx[pole, i, j, nz]
+                                      + updatecoeffsdispersive[materialEx, 2 + (pole * 3)] * Ex[i, j, nz])
+            Ex[i, j, nz] = (updatecoeffsE[materialEx, 0] * Ex[i, j, nz] +
+                             updatecoeffsE[materialEx, 2] * (Hz[i, j, nz] - Hz[i, j - 1, nz]) +
+                             updatecoeffsE[materialEx, 3] * (2 * Hy[i, j, nz - 1]) -
+                             updatecoeffsE[materialEx, 4] * phi)
+
+    for i in prange(1, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for j in range(0, ny):
+            materialEy = ID[1, i, j, nz]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEy, pole * 3] * Ty[pole, i, j, nz]
+                Ty[pole, i, j, nz] = (updatecoeffsdispersive[materialEy, 1 + (pole * 3)] * Ty[pole, i, j, nz]
+                                      + updatecoeffsdispersive[materialEy, 2 + (pole * 3)] * Ey[i, j, nz])
+            Ey[i, j, nz] = (updatecoeffsE[materialEy, 0] * Ey[i, j, nz] -
+                             updatecoeffsE[materialEy, 1] * (Hz[i, j, nz] - Hz[i - 1, j, nz]) -
+                             updatecoeffsE[materialEy, 3] * (2 * Hx[i, j, nz - 1]) -
+                             updatecoeffsE[materialEy, 4] * phi)
+
+
+######################################################
+# Phase A - domain edges, one function/edge (12 total) #
+######################################################
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ez_X0_Y0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint x0_pmc,
+    bint y0_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ez_X0_Y0()."""
+    cdef Py_ssize_t k, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for k in prange(0, nz, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[2, 0, 0, k]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3] * Tz[pole, 0, 0, k]
+            Tz[pole, 0, 0, k] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tz[pole, 0, 0, k]
+                                 + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ez[0, 0, k])
+        if x0_pmc or y0_pmc:
+            Ez[0, 0, k] = updatecoeffsE[mat, 0] * Ez[0, 0, k] - updatecoeffsE[mat, 4] * phi
+        if x0_pmc:
+            Ez[0, 0, k] = Ez[0, 0, k] + updatecoeffsE[mat, 1] * (2 * Hy[0, 0, k])
+        if y0_pmc:
+            Ez[0, 0, k] = Ez[0, 0, k] - updatecoeffsE[mat, 2] * (2 * Hx[0, 0, k])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ez_X0_YMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint x0_pmc,
+    bint ymax_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ez_X0_YMax()."""
+    cdef Py_ssize_t k, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for k in prange(0, nz, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[2, 0, ny, k]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3] * Tz[pole, 0, ny, k]
+            Tz[pole, 0, ny, k] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tz[pole, 0, ny, k]
+                                  + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ez[0, ny, k])
+        if x0_pmc or ymax_pmc:
+            Ez[0, ny, k] = updatecoeffsE[mat, 0] * Ez[0, ny, k] - updatecoeffsE[mat, 4] * phi
+        if x0_pmc:
+            Ez[0, ny, k] = Ez[0, ny, k] + updatecoeffsE[mat, 1] * (2 * Hy[0, ny, k])
+        if ymax_pmc:
+            Ez[0, ny, k] = Ez[0, ny, k] + updatecoeffsE[mat, 2] * (2 * Hx[0, ny - 1, k])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ez_XMax_Y0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint xmax_pmc,
+    bint y0_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ez_XMax_Y0()."""
+    cdef Py_ssize_t k, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for k in prange(0, nz, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[2, nx, 0, k]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3] * Tz[pole, nx, 0, k]
+            Tz[pole, nx, 0, k] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tz[pole, nx, 0, k]
+                                  + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ez[nx, 0, k])
+        if xmax_pmc or y0_pmc:
+            Ez[nx, 0, k] = updatecoeffsE[mat, 0] * Ez[nx, 0, k] - updatecoeffsE[mat, 4] * phi
+        if xmax_pmc:
+            Ez[nx, 0, k] = Ez[nx, 0, k] - updatecoeffsE[mat, 1] * (2 * Hy[nx - 1, 0, k])
+        if y0_pmc:
+            Ez[nx, 0, k] = Ez[nx, 0, k] - updatecoeffsE[mat, 2] * (2 * Hx[nx, 0, k])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ez_XMax_YMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint xmax_pmc,
+    bint ymax_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ez_XMax_YMax()."""
+    cdef Py_ssize_t k, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for k in prange(0, nz, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[2, nx, ny, k]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3] * Tz[pole, nx, ny, k]
+            Tz[pole, nx, ny, k] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tz[pole, nx, ny, k]
+                                   + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ez[nx, ny, k])
+        if xmax_pmc or ymax_pmc:
+            Ez[nx, ny, k] = updatecoeffsE[mat, 0] * Ez[nx, ny, k] - updatecoeffsE[mat, 4] * phi
+        if xmax_pmc:
+            Ez[nx, ny, k] = Ez[nx, ny, k] - updatecoeffsE[mat, 1] * (2 * Hy[nx - 1, ny, k])
+        if ymax_pmc:
+            Ez[nx, ny, k] = Ez[nx, ny, k] + updatecoeffsE[mat, 2] * (2 * Hx[nx, ny - 1, k])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ey_X0_Z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint x0_pmc,
+    bint z0_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Ty,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ey_X0_Z0()."""
+    cdef Py_ssize_t j, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[1, 0, j, 0]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3] * Ty[pole, 0, j, 0]
+            Ty[pole, 0, j, 0] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Ty[pole, 0, j, 0]
+                                 + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ey[0, j, 0])
+        if x0_pmc or z0_pmc:
+            Ey[0, j, 0] = updatecoeffsE[mat, 0] * Ey[0, j, 0] - updatecoeffsE[mat, 4] * phi
+        if x0_pmc:
+            Ey[0, j, 0] = Ey[0, j, 0] - updatecoeffsE[mat, 1] * (2 * Hz[0, j, 0])
+        if z0_pmc:
+            Ey[0, j, 0] = Ey[0, j, 0] + updatecoeffsE[mat, 3] * (2 * Hx[0, j, 0])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ey_X0_ZMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint x0_pmc,
+    bint zmax_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Ty,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ey_X0_ZMax()."""
+    cdef Py_ssize_t j, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[1, 0, j, nz]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3] * Ty[pole, 0, j, nz]
+            Ty[pole, 0, j, nz] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Ty[pole, 0, j, nz]
+                                  + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ey[0, j, nz])
+        if x0_pmc or zmax_pmc:
+            Ey[0, j, nz] = updatecoeffsE[mat, 0] * Ey[0, j, nz] - updatecoeffsE[mat, 4] * phi
+        if x0_pmc:
+            Ey[0, j, nz] = Ey[0, j, nz] - updatecoeffsE[mat, 1] * (2 * Hz[0, j, nz])
+        if zmax_pmc:
+            Ey[0, j, nz] = Ey[0, j, nz] - updatecoeffsE[mat, 3] * (2 * Hx[0, j, nz - 1])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ey_XMax_Z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint xmax_pmc,
+    bint z0_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Ty,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ey_XMax_Z0()."""
+    cdef Py_ssize_t j, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[1, nx, j, 0]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3] * Ty[pole, nx, j, 0]
+            Ty[pole, nx, j, 0] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Ty[pole, nx, j, 0]
+                                  + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ey[nx, j, 0])
+        if xmax_pmc or z0_pmc:
+            Ey[nx, j, 0] = updatecoeffsE[mat, 0] * Ey[nx, j, 0] - updatecoeffsE[mat, 4] * phi
+        if xmax_pmc:
+            Ey[nx, j, 0] = Ey[nx, j, 0] + updatecoeffsE[mat, 1] * (2 * Hz[nx - 1, j, 0])
+        if z0_pmc:
+            Ey[nx, j, 0] = Ey[nx, j, 0] + updatecoeffsE[mat, 3] * (2 * Hx[nx, j, 0])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ey_XMax_ZMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint xmax_pmc,
+    bint zmax_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Ty,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ey_XMax_ZMax()."""
+    cdef Py_ssize_t j, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[1, nx, j, nz]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3] * Ty[pole, nx, j, nz]
+            Ty[pole, nx, j, nz] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Ty[pole, nx, j, nz]
+                                   + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ey[nx, j, nz])
+        if xmax_pmc or zmax_pmc:
+            Ey[nx, j, nz] = updatecoeffsE[mat, 0] * Ey[nx, j, nz] - updatecoeffsE[mat, 4] * phi
+        if xmax_pmc:
+            Ey[nx, j, nz] = Ey[nx, j, nz] + updatecoeffsE[mat, 1] * (2 * Hz[nx - 1, j, nz])
+        if zmax_pmc:
+            Ey[nx, j, nz] = Ey[nx, j, nz] - updatecoeffsE[mat, 3] * (2 * Hx[nx, j, nz - 1])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ex_Y0_Z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint y0_pmc,
+    bint z0_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tx,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ex_Y0_Z0()."""
+    cdef Py_ssize_t i, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[0, i, 0, 0]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3] * Tx[pole, i, 0, 0]
+            Tx[pole, i, 0, 0] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tx[pole, i, 0, 0]
+                                 + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ex[i, 0, 0])
+        if y0_pmc or z0_pmc:
+            Ex[i, 0, 0] = updatecoeffsE[mat, 0] * Ex[i, 0, 0] - updatecoeffsE[mat, 4] * phi
+        if y0_pmc:
+            Ex[i, 0, 0] = Ex[i, 0, 0] + updatecoeffsE[mat, 2] * (2 * Hz[i, 0, 0])
+        if z0_pmc:
+            Ex[i, 0, 0] = Ex[i, 0, 0] - updatecoeffsE[mat, 3] * (2 * Hy[i, 0, 0])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ex_Y0_ZMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint y0_pmc,
+    bint zmax_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tx,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ex_Y0_ZMax()."""
+    cdef Py_ssize_t i, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[0, i, 0, nz]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3] * Tx[pole, i, 0, nz]
+            Tx[pole, i, 0, nz] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tx[pole, i, 0, nz]
+                                  + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ex[i, 0, nz])
+        if y0_pmc or zmax_pmc:
+            Ex[i, 0, nz] = updatecoeffsE[mat, 0] * Ex[i, 0, nz] - updatecoeffsE[mat, 4] * phi
+        if y0_pmc:
+            Ex[i, 0, nz] = Ex[i, 0, nz] + updatecoeffsE[mat, 2] * (2 * Hz[i, 0, nz])
+        if zmax_pmc:
+            Ex[i, 0, nz] = Ex[i, 0, nz] + updatecoeffsE[mat, 3] * (2 * Hy[i, 0, nz - 1])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ex_YMax_Z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint ymax_pmc,
+    bint z0_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tx,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ex_YMax_Z0()."""
+    cdef Py_ssize_t i, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[0, i, ny, 0]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3] * Tx[pole, i, ny, 0]
+            Tx[pole, i, ny, 0] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tx[pole, i, ny, 0]
+                                  + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ex[i, ny, 0])
+        if ymax_pmc or z0_pmc:
+            Ex[i, ny, 0] = updatecoeffsE[mat, 0] * Ex[i, ny, 0] - updatecoeffsE[mat, 4] * phi
+        if ymax_pmc:
+            Ex[i, ny, 0] = Ex[i, ny, 0] - updatecoeffsE[mat, 2] * (2 * Hz[i, ny - 1, 0])
+        if z0_pmc:
+            Ex[i, ny, 0] = Ex[i, ny, 0] - updatecoeffsE[mat, 3] * (2 * Hy[i, ny, 0])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ex_YMax_ZMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint ymax_pmc,
+    bint zmax_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tx,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ex_YMax_ZMax()."""
+    cdef Py_ssize_t i, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[0, i, ny, nz]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3] * Tx[pole, i, ny, nz]
+            Tx[pole, i, ny, nz] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tx[pole, i, ny, nz]
+                                   + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ex[i, ny, nz])
+        if ymax_pmc or zmax_pmc:
+            Ex[i, ny, nz] = updatecoeffsE[mat, 0] * Ex[i, ny, nz] - updatecoeffsE[mat, 4] * phi
+        if ymax_pmc:
+            Ex[i, ny, nz] = Ex[i, ny, nz] - updatecoeffsE[mat, 2] * (2 * Hz[i, ny - 1, nz])
+        if zmax_pmc:
+            Ex[i, ny, nz] = Ex[i, ny, nz] + updatecoeffsE[mat, 3] * (2 * Hy[i, ny, nz - 1])
+
+
+###########################################################
+# Phase B - face-interior, T-array correction only (6 total) #
+###########################################################
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_x0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tx,
+    float_or_double[:, :, :, ::1] Ty,
+    float_or_double[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez
+):
+    """Phase-B (post-PML/source T-array correction) counterpart of
+    update_symmetry_boundary_electric_dispersive_x0()."""
+    cdef Py_ssize_t j, k, pole
+    cdef int materialEy, materialEz
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(1, nz):
+            materialEy = ID[1, 0, j, k]
+            for pole in range(maxpoles):
+                Ty[pole, 0, j, k] = (Ty[pole, 0, j, k]
+                                     - updatecoeffsdispersive[materialEy, 2 + (pole * 3)] * Ey[0, j, k])
+
+    for j in prange(1, ny, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(0, nz):
+            materialEz = ID[2, 0, j, k]
+            for pole in range(maxpoles):
+                Tz[pole, 0, j, k] = (Tz[pole, 0, j, k]
+                                     - updatecoeffsdispersive[materialEz, 2 + (pole * 3)] * Ez[0, j, k])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_xmax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tx,
+    float_or_double[:, :, :, ::1] Ty,
+    float_or_double[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_xmax()."""
+    cdef Py_ssize_t j, k, pole
+    cdef int materialEy, materialEz
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(1, nz):
+            materialEy = ID[1, nx, j, k]
+            for pole in range(maxpoles):
+                Ty[pole, nx, j, k] = (Ty[pole, nx, j, k]
+                                      - updatecoeffsdispersive[materialEy, 2 + (pole * 3)] * Ey[nx, j, k])
+
+    for j in prange(1, ny, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(0, nz):
+            materialEz = ID[2, nx, j, k]
+            for pole in range(maxpoles):
+                Tz[pole, nx, j, k] = (Tz[pole, nx, j, k]
+                                      - updatecoeffsdispersive[materialEz, 2 + (pole * 3)] * Ez[nx, j, k])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_y0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tx,
+    float_or_double[:, :, :, ::1] Ty,
+    float_or_double[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_y0()."""
+    cdef Py_ssize_t i, k, pole
+    cdef int materialEx, materialEz
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(1, nz):
+            materialEx = ID[0, i, 0, k]
+            for pole in range(maxpoles):
+                Tx[pole, i, 0, k] = (Tx[pole, i, 0, k]
+                                     - updatecoeffsdispersive[materialEx, 2 + (pole * 3)] * Ex[i, 0, k])
+
+    for i in prange(1, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(0, nz):
+            materialEz = ID[2, i, 0, k]
+            for pole in range(maxpoles):
+                Tz[pole, i, 0, k] = (Tz[pole, i, 0, k]
+                                     - updatecoeffsdispersive[materialEz, 2 + (pole * 3)] * Ez[i, 0, k])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_ymax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tx,
+    float_or_double[:, :, :, ::1] Ty,
+    float_or_double[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_ymax()."""
+    cdef Py_ssize_t i, k, pole
+    cdef int materialEx, materialEz
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(1, nz):
+            materialEx = ID[0, i, ny, k]
+            for pole in range(maxpoles):
+                Tx[pole, i, ny, k] = (Tx[pole, i, ny, k]
+                                      - updatecoeffsdispersive[materialEx, 2 + (pole * 3)] * Ex[i, ny, k])
+
+    for i in prange(1, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(0, nz):
+            materialEz = ID[2, i, ny, k]
+            for pole in range(maxpoles):
+                Tz[pole, i, ny, k] = (Tz[pole, i, ny, k]
+                                      - updatecoeffsdispersive[materialEz, 2 + (pole * 3)] * Ez[i, ny, k])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tx,
+    float_or_double[:, :, :, ::1] Ty,
+    float_or_double[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_z0()."""
+    cdef Py_ssize_t i, j, pole
+    cdef int materialEx, materialEy
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for j in range(1, ny):
+            materialEx = ID[0, i, j, 0]
+            for pole in range(maxpoles):
+                Tx[pole, i, j, 0] = (Tx[pole, i, j, 0]
+                                     - updatecoeffsdispersive[materialEx, 2 + (pole * 3)] * Ex[i, j, 0])
+
+    for i in prange(1, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for j in range(0, ny):
+            materialEy = ID[1, i, j, 0]
+            for pole in range(maxpoles):
+                Ty[pole, i, j, 0] = (Ty[pole, i, j, 0]
+                                     - updatecoeffsdispersive[materialEy, 2 + (pole * 3)] * Ey[i, j, 0])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_zmax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tx,
+    float_or_double[:, :, :, ::1] Ty,
+    float_or_double[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_zmax()."""
+    cdef Py_ssize_t i, j, pole
+    cdef int materialEx, materialEy
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for j in range(1, ny):
+            materialEx = ID[0, i, j, nz]
+            for pole in range(maxpoles):
+                Tx[pole, i, j, nz] = (Tx[pole, i, j, nz]
+                                      - updatecoeffsdispersive[materialEx, 2 + (pole * 3)] * Ex[i, j, nz])
+
+    for i in prange(1, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for j in range(0, ny):
+            materialEy = ID[1, i, j, nz]
+            for pole in range(maxpoles):
+                Ty[pole, i, j, nz] = (Ty[pole, i, j, nz]
+                                      - updatecoeffsdispersive[materialEy, 2 + (pole * 3)] * Ey[i, j, nz])
+
+
+##############################################################
+# Phase B - domain edges, T-array correction only (12 total) #
+##############################################################
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ez_X0_Y0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ez
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ez_X0_Y0()."""
+    cdef Py_ssize_t k, pole
+    cdef int mat
+
+    for k in prange(0, nz, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[2, 0, 0, k]
+        for pole in range(maxpoles):
+            Tz[pole, 0, 0, k] = Tz[pole, 0, 0, k] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ez[0, 0, k]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ez_X0_YMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ez
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ez_X0_YMax()."""
+    cdef Py_ssize_t k, pole
+    cdef int mat
+
+    for k in prange(0, nz, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[2, 0, ny, k]
+        for pole in range(maxpoles):
+            Tz[pole, 0, ny, k] = Tz[pole, 0, ny, k] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ez[0, ny, k]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ez_XMax_Y0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ez
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ez_XMax_Y0()."""
+    cdef Py_ssize_t k, pole
+    cdef int mat
+
+    for k in prange(0, nz, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[2, nx, 0, k]
+        for pole in range(maxpoles):
+            Tz[pole, nx, 0, k] = Tz[pole, nx, 0, k] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ez[nx, 0, k]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ez_XMax_YMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ez
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ez_XMax_YMax()."""
+    cdef Py_ssize_t k, pole
+    cdef int mat
+
+    for k in prange(0, nz, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[2, nx, ny, k]
+        for pole in range(maxpoles):
+            Tz[pole, nx, ny, k] = Tz[pole, nx, ny, k] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ez[nx, ny, k]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ey_X0_Z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Ty,
+    float_or_double[:, :, ::1] Ey
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ey_X0_Z0()."""
+    cdef Py_ssize_t j, pole
+    cdef int mat
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[1, 0, j, 0]
+        for pole in range(maxpoles):
+            Ty[pole, 0, j, 0] = Ty[pole, 0, j, 0] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ey[0, j, 0]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ey_X0_ZMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Ty,
+    float_or_double[:, :, ::1] Ey
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ey_X0_ZMax()."""
+    cdef Py_ssize_t j, pole
+    cdef int mat
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[1, 0, j, nz]
+        for pole in range(maxpoles):
+            Ty[pole, 0, j, nz] = Ty[pole, 0, j, nz] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ey[0, j, nz]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ey_XMax_Z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Ty,
+    float_or_double[:, :, ::1] Ey
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ey_XMax_Z0()."""
+    cdef Py_ssize_t j, pole
+    cdef int mat
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[1, nx, j, 0]
+        for pole in range(maxpoles):
+            Ty[pole, nx, j, 0] = Ty[pole, nx, j, 0] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ey[nx, j, 0]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ey_XMax_ZMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Ty,
+    float_or_double[:, :, ::1] Ey
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ey_XMax_ZMax()."""
+    cdef Py_ssize_t j, pole
+    cdef int mat
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[1, nx, j, nz]
+        for pole in range(maxpoles):
+            Ty[pole, nx, j, nz] = Ty[pole, nx, j, nz] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ey[nx, j, nz]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ex_Y0_Z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tx,
+    float_or_double[:, :, ::1] Ex
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ex_Y0_Z0()."""
+    cdef Py_ssize_t i, pole
+    cdef int mat
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[0, i, 0, 0]
+        for pole in range(maxpoles):
+            Tx[pole, i, 0, 0] = Tx[pole, i, 0, 0] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ex[i, 0, 0]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ex_Y0_ZMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tx,
+    float_or_double[:, :, ::1] Ex
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ex_Y0_ZMax()."""
+    cdef Py_ssize_t i, pole
+    cdef int mat
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[0, i, 0, nz]
+        for pole in range(maxpoles):
+            Tx[pole, i, 0, nz] = Tx[pole, i, 0, nz] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ex[i, 0, nz]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ex_YMax_Z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tx,
+    float_or_double[:, :, ::1] Ex
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ex_YMax_Z0()."""
+    cdef Py_ssize_t i, pole
+    cdef int mat
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[0, i, ny, 0]
+        for pole in range(maxpoles):
+            Tx[pole, i, ny, 0] = Tx[pole, i, ny, 0] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ex[i, ny, 0]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ex_YMax_ZMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double[:, :, :, ::1] Tx,
+    float_or_double[:, :, ::1] Ex
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ex_YMax_ZMax()."""
+    cdef Py_ssize_t i, pole
+    cdef int mat
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[0, i, ny, nz]
+        for pole in range(maxpoles):
+            Tx[pole, i, ny, nz] = Tx[pole, i, ny, nz] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ex[i, ny, nz]

--- a/gprMax/cython/symmetry_boundaries_dispersive_complex.pyx
+++ b/gprMax/cython/symmetry_boundaries_dispersive_complex.pyx
@@ -1,0 +1,1294 @@
+# Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+cimport numpy as np
+from cython.parallel import prange
+
+from gprMax.config cimport float_or_double
+from gprMax.config cimport float_or_double_complex
+
+# Complex-pole dispersive (Lorentz/Drude) counterpart of
+# gprMax/cython/symmetry_boundaries.pyx's PMC ghost-node E update and of
+# symmetry_boundaries_dispersive.pyx's real-pole (Debye) counterpart - see
+# those files for the ghost-node derivation and the ADE phi/T-array
+# bookkeeping this file adds, both unchanged here. The only difference from
+# the real-pole file is the phi accumulation: Tx/Ty/Tz and
+# updatecoeffsdispersive are complex (float_or_double_complex) here, so phi
+# (which must stay real - it feeds directly into a real E-field update)
+# accumulates Real(updatecoeffsdispersive[...]) * Real(T[...]) per pole,
+# exactly matching fields_updates_dispersive_template.jinja's own complex
+# branch (`{{ item.real_part }}(updatecoeffsdispersive[...]) *
+# {{ item.real_part }}(Tx[...])`) - the real part of each factor
+# individually, not the real part of their complex product. This is the
+# same formula the bulk kernel already uses; replicating it exactly here
+# (rather than "fixing" it to Re(a*b)) is what keeps the boundary correction
+# consistent with the bulk kernel's own (already-established) numerics.
+# The T-array recursion itself (Tx[pole,i,j,k] = beta*Tx_old + gamma*E_old)
+# and Phase B's correction are unchanged in form from the real-pole file -
+# ordinary complex arithmetic (complex*complex, complex*real, complex-complex)
+# handles them directly, with no real-part extraction needed there.
+#
+# Two phases, mirroring the bulk kernel's own A/B split (see
+# fields_updates_dispersive_template.jinja and gprMax/updates/cpu_updates.py):
+#   Phase A ("_dispersive_"): called at the same point as the existing
+#     non-dispersive boundary update (right after update_electric_a(), before
+#     PML/sources). Accumulates phi from the OLD T, updates T from the OLD E,
+#     then assembles the new E from the ghost-doubled curl term minus
+#     updatecoeffsE[mat, 4]*phi - the same per-cell logic as the bulk kernel's
+#     Phase A, applied at wall/edge positions the bulk kernel's own loop
+#     bounds structurally exclude.
+#   Phase B ("_dispersive_b_"): called at the same point as the bulk kernel's
+#     own Phase B (right before update_electric_b(), i.e. after PML/sources
+#     have possibly further modified E - a source sitting at/adjacent to the
+#     wall, as in a center-fed dipole straddling a PMC plane, is exactly this
+#     case). Corrects T using the now-final E. No H arrays needed, matching
+#     the bulk Phase B's own signature.
+#
+# maxpoles is always looped unconditionally (no 1-pole specialisation, unlike
+# the bulk kernel's separate "1pole" functions) - boundary cells are a
+# vanishing fraction of total domain cells, so the loop-unrolling
+# optimisation that matters at bulk (O(n^3)) scale is immaterial here.
+#
+# Edges: no explicit PEC-transparency branch is needed for the phi/T block,
+# unlike you might expect - it is computed unconditionally (not gated by
+# a_pmc/b_pmc) for the same reason the non-dispersive edge kernels don't
+# need one for their self term: when only one bordering face is PMC, the
+# other face has already forced this edge's material to "pec" at build time
+# (FDTDGrid._terminate_pmls_with_pec/_force_pec_tangential_e), and a pec
+# material's updatecoeffsdispersive row is never written (stays zero,
+# since it's a plain Material, not a DispersiveMaterial) - phi and the T
+# recursion both correctly evaluate to zero for free. When both bordering
+# faces are PMC, the phi/T machinery runs for real, correctly, on whatever
+# genuinely dispersive material occupies the corner.
+
+
+###############################################
+# Phase A - face-interior, one function/face #
+###############################################
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_x0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tx,
+    float_or_double_complex[:, :, :, ::1] Ty,
+    float_or_double_complex[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_x0()."""
+    cdef Py_ssize_t j, k, pole
+    cdef int materialEy, materialEz
+    cdef float_or_double phi
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(1, nz):
+            materialEy = ID[1, 0, j, k]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEy, pole * 3].real * Ty[pole, 0, j, k].real
+                Ty[pole, 0, j, k] = (updatecoeffsdispersive[materialEy, 1 + (pole * 3)] * Ty[pole, 0, j, k]
+                                     + updatecoeffsdispersive[materialEy, 2 + (pole * 3)] * Ey[0, j, k])
+            Ey[0, j, k] = (updatecoeffsE[materialEy, 0] * Ey[0, j, k] +
+                           updatecoeffsE[materialEy, 3] * (Hx[0, j, k] - Hx[0, j, k - 1]) -
+                           updatecoeffsE[materialEy, 1] * (2 * Hz[0, j, k]) -
+                           updatecoeffsE[materialEy, 4] * phi)
+
+    for j in prange(1, ny, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(0, nz):
+            materialEz = ID[2, 0, j, k]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEz, pole * 3].real * Tz[pole, 0, j, k].real
+                Tz[pole, 0, j, k] = (updatecoeffsdispersive[materialEz, 1 + (pole * 3)] * Tz[pole, 0, j, k]
+                                     + updatecoeffsdispersive[materialEz, 2 + (pole * 3)] * Ez[0, j, k])
+            Ez[0, j, k] = (updatecoeffsE[materialEz, 0] * Ez[0, j, k] -
+                           updatecoeffsE[materialEz, 2] * (Hx[0, j, k] - Hx[0, j - 1, k]) +
+                           updatecoeffsE[materialEz, 1] * (2 * Hy[0, j, k]) -
+                           updatecoeffsE[materialEz, 4] * phi)
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_xmax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tx,
+    float_or_double_complex[:, :, :, ::1] Ty,
+    float_or_double_complex[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_xmax()."""
+    cdef Py_ssize_t j, k, pole
+    cdef int materialEy, materialEz
+    cdef float_or_double phi
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(1, nz):
+            materialEy = ID[1, nx, j, k]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEy, pole * 3].real * Ty[pole, nx, j, k].real
+                Ty[pole, nx, j, k] = (updatecoeffsdispersive[materialEy, 1 + (pole * 3)] * Ty[pole, nx, j, k]
+                                      + updatecoeffsdispersive[materialEy, 2 + (pole * 3)] * Ey[nx, j, k])
+            Ey[nx, j, k] = (updatecoeffsE[materialEy, 0] * Ey[nx, j, k] +
+                             updatecoeffsE[materialEy, 3] * (Hx[nx, j, k] - Hx[nx, j, k - 1]) +
+                             updatecoeffsE[materialEy, 1] * (2 * Hz[nx - 1, j, k]) -
+                             updatecoeffsE[materialEy, 4] * phi)
+
+    for j in prange(1, ny, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(0, nz):
+            materialEz = ID[2, nx, j, k]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEz, pole * 3].real * Tz[pole, nx, j, k].real
+                Tz[pole, nx, j, k] = (updatecoeffsdispersive[materialEz, 1 + (pole * 3)] * Tz[pole, nx, j, k]
+                                      + updatecoeffsdispersive[materialEz, 2 + (pole * 3)] * Ez[nx, j, k])
+            Ez[nx, j, k] = (updatecoeffsE[materialEz, 0] * Ez[nx, j, k] -
+                             updatecoeffsE[materialEz, 2] * (Hx[nx, j, k] - Hx[nx, j - 1, k]) -
+                             updatecoeffsE[materialEz, 1] * (2 * Hy[nx - 1, j, k]) -
+                             updatecoeffsE[materialEz, 4] * phi)
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_y0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tx,
+    float_or_double_complex[:, :, :, ::1] Ty,
+    float_or_double_complex[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_y0()."""
+    cdef Py_ssize_t i, k, pole
+    cdef int materialEx, materialEz
+    cdef float_or_double phi
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(1, nz):
+            materialEx = ID[0, i, 0, k]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEx, pole * 3].real * Tx[pole, i, 0, k].real
+                Tx[pole, i, 0, k] = (updatecoeffsdispersive[materialEx, 1 + (pole * 3)] * Tx[pole, i, 0, k]
+                                     + updatecoeffsdispersive[materialEx, 2 + (pole * 3)] * Ex[i, 0, k])
+            Ex[i, 0, k] = (updatecoeffsE[materialEx, 0] * Ex[i, 0, k] -
+                           updatecoeffsE[materialEx, 3] * (Hy[i, 0, k] - Hy[i, 0, k - 1]) +
+                           updatecoeffsE[materialEx, 2] * (2 * Hz[i, 0, k]) -
+                           updatecoeffsE[materialEx, 4] * phi)
+
+    for i in prange(1, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(0, nz):
+            materialEz = ID[2, i, 0, k]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEz, pole * 3].real * Tz[pole, i, 0, k].real
+                Tz[pole, i, 0, k] = (updatecoeffsdispersive[materialEz, 1 + (pole * 3)] * Tz[pole, i, 0, k]
+                                     + updatecoeffsdispersive[materialEz, 2 + (pole * 3)] * Ez[i, 0, k])
+            Ez[i, 0, k] = (updatecoeffsE[materialEz, 0] * Ez[i, 0, k] +
+                           updatecoeffsE[materialEz, 1] * (Hy[i, 0, k] - Hy[i - 1, 0, k]) -
+                           updatecoeffsE[materialEz, 2] * (2 * Hx[i, 0, k]) -
+                           updatecoeffsE[materialEz, 4] * phi)
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_ymax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tx,
+    float_or_double_complex[:, :, :, ::1] Ty,
+    float_or_double_complex[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_ymax()."""
+    cdef Py_ssize_t i, k, pole
+    cdef int materialEx, materialEz
+    cdef float_or_double phi
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(1, nz):
+            materialEx = ID[0, i, ny, k]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEx, pole * 3].real * Tx[pole, i, ny, k].real
+                Tx[pole, i, ny, k] = (updatecoeffsdispersive[materialEx, 1 + (pole * 3)] * Tx[pole, i, ny, k]
+                                      + updatecoeffsdispersive[materialEx, 2 + (pole * 3)] * Ex[i, ny, k])
+            Ex[i, ny, k] = (updatecoeffsE[materialEx, 0] * Ex[i, ny, k] -
+                             updatecoeffsE[materialEx, 3] * (Hy[i, ny, k] - Hy[i, ny, k - 1]) -
+                             updatecoeffsE[materialEx, 2] * (2 * Hz[i, ny - 1, k]) -
+                             updatecoeffsE[materialEx, 4] * phi)
+
+    for i in prange(1, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(0, nz):
+            materialEz = ID[2, i, ny, k]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEz, pole * 3].real * Tz[pole, i, ny, k].real
+                Tz[pole, i, ny, k] = (updatecoeffsdispersive[materialEz, 1 + (pole * 3)] * Tz[pole, i, ny, k]
+                                      + updatecoeffsdispersive[materialEz, 2 + (pole * 3)] * Ez[i, ny, k])
+            Ez[i, ny, k] = (updatecoeffsE[materialEz, 0] * Ez[i, ny, k] +
+                             updatecoeffsE[materialEz, 1] * (Hy[i, ny, k] - Hy[i - 1, ny, k]) +
+                             updatecoeffsE[materialEz, 2] * (2 * Hx[i, ny - 1, k]) -
+                             updatecoeffsE[materialEz, 4] * phi)
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tx,
+    float_or_double_complex[:, :, :, ::1] Ty,
+    float_or_double_complex[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_z0()."""
+    cdef Py_ssize_t i, j, pole
+    cdef int materialEx, materialEy
+    cdef float_or_double phi
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for j in range(1, ny):
+            materialEx = ID[0, i, j, 0]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEx, pole * 3].real * Tx[pole, i, j, 0].real
+                Tx[pole, i, j, 0] = (updatecoeffsdispersive[materialEx, 1 + (pole * 3)] * Tx[pole, i, j, 0]
+                                     + updatecoeffsdispersive[materialEx, 2 + (pole * 3)] * Ex[i, j, 0])
+            Ex[i, j, 0] = (updatecoeffsE[materialEx, 0] * Ex[i, j, 0] +
+                           updatecoeffsE[materialEx, 2] * (Hz[i, j, 0] - Hz[i, j - 1, 0]) -
+                           updatecoeffsE[materialEx, 3] * (2 * Hy[i, j, 0]) -
+                           updatecoeffsE[materialEx, 4] * phi)
+
+    for i in prange(1, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for j in range(0, ny):
+            materialEy = ID[1, i, j, 0]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEy, pole * 3].real * Ty[pole, i, j, 0].real
+                Ty[pole, i, j, 0] = (updatecoeffsdispersive[materialEy, 1 + (pole * 3)] * Ty[pole, i, j, 0]
+                                     + updatecoeffsdispersive[materialEy, 2 + (pole * 3)] * Ey[i, j, 0])
+            Ey[i, j, 0] = (updatecoeffsE[materialEy, 0] * Ey[i, j, 0] -
+                           updatecoeffsE[materialEy, 1] * (Hz[i, j, 0] - Hz[i - 1, j, 0]) +
+                           updatecoeffsE[materialEy, 3] * (2 * Hx[i, j, 0]) -
+                           updatecoeffsE[materialEy, 4] * phi)
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_zmax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tx,
+    float_or_double_complex[:, :, :, ::1] Ty,
+    float_or_double_complex[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_zmax()."""
+    cdef Py_ssize_t i, j, pole
+    cdef int materialEx, materialEy
+    cdef float_or_double phi
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for j in range(1, ny):
+            materialEx = ID[0, i, j, nz]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEx, pole * 3].real * Tx[pole, i, j, nz].real
+                Tx[pole, i, j, nz] = (updatecoeffsdispersive[materialEx, 1 + (pole * 3)] * Tx[pole, i, j, nz]
+                                      + updatecoeffsdispersive[materialEx, 2 + (pole * 3)] * Ex[i, j, nz])
+            Ex[i, j, nz] = (updatecoeffsE[materialEx, 0] * Ex[i, j, nz] +
+                             updatecoeffsE[materialEx, 2] * (Hz[i, j, nz] - Hz[i, j - 1, nz]) +
+                             updatecoeffsE[materialEx, 3] * (2 * Hy[i, j, nz - 1]) -
+                             updatecoeffsE[materialEx, 4] * phi)
+
+    for i in prange(1, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for j in range(0, ny):
+            materialEy = ID[1, i, j, nz]
+            phi = 0
+            for pole in range(maxpoles):
+                phi = phi + updatecoeffsdispersive[materialEy, pole * 3].real * Ty[pole, i, j, nz].real
+                Ty[pole, i, j, nz] = (updatecoeffsdispersive[materialEy, 1 + (pole * 3)] * Ty[pole, i, j, nz]
+                                      + updatecoeffsdispersive[materialEy, 2 + (pole * 3)] * Ey[i, j, nz])
+            Ey[i, j, nz] = (updatecoeffsE[materialEy, 0] * Ey[i, j, nz] -
+                             updatecoeffsE[materialEy, 1] * (Hz[i, j, nz] - Hz[i - 1, j, nz]) -
+                             updatecoeffsE[materialEy, 3] * (2 * Hx[i, j, nz - 1]) -
+                             updatecoeffsE[materialEy, 4] * phi)
+
+
+######################################################
+# Phase A - domain edges, one function/edge (12 total) #
+######################################################
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ez_X0_Y0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint x0_pmc,
+    bint y0_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ez_X0_Y0()."""
+    cdef Py_ssize_t k, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for k in prange(0, nz, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[2, 0, 0, k]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Tz[pole, 0, 0, k].real
+            Tz[pole, 0, 0, k] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tz[pole, 0, 0, k]
+                                 + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ez[0, 0, k])
+        if x0_pmc or y0_pmc:
+            Ez[0, 0, k] = updatecoeffsE[mat, 0] * Ez[0, 0, k] - updatecoeffsE[mat, 4] * phi
+        if x0_pmc:
+            Ez[0, 0, k] = Ez[0, 0, k] + updatecoeffsE[mat, 1] * (2 * Hy[0, 0, k])
+        if y0_pmc:
+            Ez[0, 0, k] = Ez[0, 0, k] - updatecoeffsE[mat, 2] * (2 * Hx[0, 0, k])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ez_X0_YMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint x0_pmc,
+    bint ymax_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ez_X0_YMax()."""
+    cdef Py_ssize_t k, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for k in prange(0, nz, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[2, 0, ny, k]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Tz[pole, 0, ny, k].real
+            Tz[pole, 0, ny, k] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tz[pole, 0, ny, k]
+                                  + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ez[0, ny, k])
+        if x0_pmc or ymax_pmc:
+            Ez[0, ny, k] = updatecoeffsE[mat, 0] * Ez[0, ny, k] - updatecoeffsE[mat, 4] * phi
+        if x0_pmc:
+            Ez[0, ny, k] = Ez[0, ny, k] + updatecoeffsE[mat, 1] * (2 * Hy[0, ny, k])
+        if ymax_pmc:
+            Ez[0, ny, k] = Ez[0, ny, k] + updatecoeffsE[mat, 2] * (2 * Hx[0, ny - 1, k])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ez_XMax_Y0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint xmax_pmc,
+    bint y0_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ez_XMax_Y0()."""
+    cdef Py_ssize_t k, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for k in prange(0, nz, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[2, nx, 0, k]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Tz[pole, nx, 0, k].real
+            Tz[pole, nx, 0, k] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tz[pole, nx, 0, k]
+                                  + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ez[nx, 0, k])
+        if xmax_pmc or y0_pmc:
+            Ez[nx, 0, k] = updatecoeffsE[mat, 0] * Ez[nx, 0, k] - updatecoeffsE[mat, 4] * phi
+        if xmax_pmc:
+            Ez[nx, 0, k] = Ez[nx, 0, k] - updatecoeffsE[mat, 1] * (2 * Hy[nx - 1, 0, k])
+        if y0_pmc:
+            Ez[nx, 0, k] = Ez[nx, 0, k] - updatecoeffsE[mat, 2] * (2 * Hx[nx, 0, k])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ez_XMax_YMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint xmax_pmc,
+    bint ymax_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ez,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hy
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ez_XMax_YMax()."""
+    cdef Py_ssize_t k, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for k in prange(0, nz, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[2, nx, ny, k]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Tz[pole, nx, ny, k].real
+            Tz[pole, nx, ny, k] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tz[pole, nx, ny, k]
+                                   + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ez[nx, ny, k])
+        if xmax_pmc or ymax_pmc:
+            Ez[nx, ny, k] = updatecoeffsE[mat, 0] * Ez[nx, ny, k] - updatecoeffsE[mat, 4] * phi
+        if xmax_pmc:
+            Ez[nx, ny, k] = Ez[nx, ny, k] - updatecoeffsE[mat, 1] * (2 * Hy[nx - 1, ny, k])
+        if ymax_pmc:
+            Ez[nx, ny, k] = Ez[nx, ny, k] + updatecoeffsE[mat, 2] * (2 * Hx[nx, ny - 1, k])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ey_X0_Z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint x0_pmc,
+    bint z0_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Ty,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ey_X0_Z0()."""
+    cdef Py_ssize_t j, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[1, 0, j, 0]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Ty[pole, 0, j, 0].real
+            Ty[pole, 0, j, 0] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Ty[pole, 0, j, 0]
+                                 + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ey[0, j, 0])
+        if x0_pmc or z0_pmc:
+            Ey[0, j, 0] = updatecoeffsE[mat, 0] * Ey[0, j, 0] - updatecoeffsE[mat, 4] * phi
+        if x0_pmc:
+            Ey[0, j, 0] = Ey[0, j, 0] - updatecoeffsE[mat, 1] * (2 * Hz[0, j, 0])
+        if z0_pmc:
+            Ey[0, j, 0] = Ey[0, j, 0] + updatecoeffsE[mat, 3] * (2 * Hx[0, j, 0])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ey_X0_ZMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint x0_pmc,
+    bint zmax_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Ty,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ey_X0_ZMax()."""
+    cdef Py_ssize_t j, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[1, 0, j, nz]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Ty[pole, 0, j, nz].real
+            Ty[pole, 0, j, nz] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Ty[pole, 0, j, nz]
+                                  + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ey[0, j, nz])
+        if x0_pmc or zmax_pmc:
+            Ey[0, j, nz] = updatecoeffsE[mat, 0] * Ey[0, j, nz] - updatecoeffsE[mat, 4] * phi
+        if x0_pmc:
+            Ey[0, j, nz] = Ey[0, j, nz] - updatecoeffsE[mat, 1] * (2 * Hz[0, j, nz])
+        if zmax_pmc:
+            Ey[0, j, nz] = Ey[0, j, nz] - updatecoeffsE[mat, 3] * (2 * Hx[0, j, nz - 1])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ey_XMax_Z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint xmax_pmc,
+    bint z0_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Ty,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ey_XMax_Z0()."""
+    cdef Py_ssize_t j, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[1, nx, j, 0]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Ty[pole, nx, j, 0].real
+            Ty[pole, nx, j, 0] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Ty[pole, nx, j, 0]
+                                  + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ey[nx, j, 0])
+        if xmax_pmc or z0_pmc:
+            Ey[nx, j, 0] = updatecoeffsE[mat, 0] * Ey[nx, j, 0] - updatecoeffsE[mat, 4] * phi
+        if xmax_pmc:
+            Ey[nx, j, 0] = Ey[nx, j, 0] + updatecoeffsE[mat, 1] * (2 * Hz[nx - 1, j, 0])
+        if z0_pmc:
+            Ey[nx, j, 0] = Ey[nx, j, 0] + updatecoeffsE[mat, 3] * (2 * Hx[nx, j, 0])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ey_XMax_ZMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint xmax_pmc,
+    bint zmax_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Ty,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Hx,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ey_XMax_ZMax()."""
+    cdef Py_ssize_t j, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[1, nx, j, nz]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Ty[pole, nx, j, nz].real
+            Ty[pole, nx, j, nz] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Ty[pole, nx, j, nz]
+                                   + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ey[nx, j, nz])
+        if xmax_pmc or zmax_pmc:
+            Ey[nx, j, nz] = updatecoeffsE[mat, 0] * Ey[nx, j, nz] - updatecoeffsE[mat, 4] * phi
+        if xmax_pmc:
+            Ey[nx, j, nz] = Ey[nx, j, nz] + updatecoeffsE[mat, 1] * (2 * Hz[nx - 1, j, nz])
+        if zmax_pmc:
+            Ey[nx, j, nz] = Ey[nx, j, nz] - updatecoeffsE[mat, 3] * (2 * Hx[nx, j, nz - 1])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ex_Y0_Z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint y0_pmc,
+    bint z0_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tx,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ex_Y0_Z0()."""
+    cdef Py_ssize_t i, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[0, i, 0, 0]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Tx[pole, i, 0, 0].real
+            Tx[pole, i, 0, 0] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tx[pole, i, 0, 0]
+                                 + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ex[i, 0, 0])
+        if y0_pmc or z0_pmc:
+            Ex[i, 0, 0] = updatecoeffsE[mat, 0] * Ex[i, 0, 0] - updatecoeffsE[mat, 4] * phi
+        if y0_pmc:
+            Ex[i, 0, 0] = Ex[i, 0, 0] + updatecoeffsE[mat, 2] * (2 * Hz[i, 0, 0])
+        if z0_pmc:
+            Ex[i, 0, 0] = Ex[i, 0, 0] - updatecoeffsE[mat, 3] * (2 * Hy[i, 0, 0])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ex_Y0_ZMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint y0_pmc,
+    bint zmax_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tx,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ex_Y0_ZMax()."""
+    cdef Py_ssize_t i, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[0, i, 0, nz]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Tx[pole, i, 0, nz].real
+            Tx[pole, i, 0, nz] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tx[pole, i, 0, nz]
+                                  + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ex[i, 0, nz])
+        if y0_pmc or zmax_pmc:
+            Ex[i, 0, nz] = updatecoeffsE[mat, 0] * Ex[i, 0, nz] - updatecoeffsE[mat, 4] * phi
+        if y0_pmc:
+            Ex[i, 0, nz] = Ex[i, 0, nz] + updatecoeffsE[mat, 2] * (2 * Hz[i, 0, nz])
+        if zmax_pmc:
+            Ex[i, 0, nz] = Ex[i, 0, nz] + updatecoeffsE[mat, 3] * (2 * Hy[i, 0, nz - 1])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ex_YMax_Z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint ymax_pmc,
+    bint z0_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tx,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ex_YMax_Z0()."""
+    cdef Py_ssize_t i, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[0, i, ny, 0]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Tx[pole, i, ny, 0].real
+            Tx[pole, i, ny, 0] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tx[pole, i, ny, 0]
+                                  + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ex[i, ny, 0])
+        if ymax_pmc or z0_pmc:
+            Ex[i, ny, 0] = updatecoeffsE[mat, 0] * Ex[i, ny, 0] - updatecoeffsE[mat, 4] * phi
+        if ymax_pmc:
+            Ex[i, ny, 0] = Ex[i, ny, 0] - updatecoeffsE[mat, 2] * (2 * Hz[i, ny - 1, 0])
+        if z0_pmc:
+            Ex[i, ny, 0] = Ex[i, ny, 0] - updatecoeffsE[mat, 3] * (2 * Hy[i, ny, 0])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_Ex_YMax_ZMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    bint ymax_pmc,
+    bint zmax_pmc,
+    int maxpoles,
+    float_or_double[:, ::1] updatecoeffsE,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tx,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Hy,
+    float_or_double[:, :, ::1] Hz
+):
+    """Dispersive counterpart of update_symmetry_boundary_electric_Ex_YMax_ZMax()."""
+    cdef Py_ssize_t i, pole
+    cdef int mat
+    cdef float_or_double phi
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[0, i, ny, nz]
+        phi = 0
+        for pole in range(maxpoles):
+            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Tx[pole, i, ny, nz].real
+            Tx[pole, i, ny, nz] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tx[pole, i, ny, nz]
+                                   + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ex[i, ny, nz])
+        if ymax_pmc or zmax_pmc:
+            Ex[i, ny, nz] = updatecoeffsE[mat, 0] * Ex[i, ny, nz] - updatecoeffsE[mat, 4] * phi
+        if ymax_pmc:
+            Ex[i, ny, nz] = Ex[i, ny, nz] - updatecoeffsE[mat, 2] * (2 * Hz[i, ny - 1, nz])
+        if zmax_pmc:
+            Ex[i, ny, nz] = Ex[i, ny, nz] + updatecoeffsE[mat, 3] * (2 * Hy[i, ny, nz - 1])
+
+
+###########################################################
+# Phase B - face-interior, T-array correction only (6 total) #
+###########################################################
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_x0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tx,
+    float_or_double_complex[:, :, :, ::1] Ty,
+    float_or_double_complex[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez
+):
+    """Phase-B (post-PML/source T-array correction) counterpart of
+    update_symmetry_boundary_electric_dispersive_x0()."""
+    cdef Py_ssize_t j, k, pole
+    cdef int materialEy, materialEz
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(1, nz):
+            materialEy = ID[1, 0, j, k]
+            for pole in range(maxpoles):
+                Ty[pole, 0, j, k] = (Ty[pole, 0, j, k]
+                                     - updatecoeffsdispersive[materialEy, 2 + (pole * 3)] * Ey[0, j, k])
+
+    for j in prange(1, ny, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(0, nz):
+            materialEz = ID[2, 0, j, k]
+            for pole in range(maxpoles):
+                Tz[pole, 0, j, k] = (Tz[pole, 0, j, k]
+                                     - updatecoeffsdispersive[materialEz, 2 + (pole * 3)] * Ez[0, j, k])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_xmax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tx,
+    float_or_double_complex[:, :, :, ::1] Ty,
+    float_or_double_complex[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_xmax()."""
+    cdef Py_ssize_t j, k, pole
+    cdef int materialEy, materialEz
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(1, nz):
+            materialEy = ID[1, nx, j, k]
+            for pole in range(maxpoles):
+                Ty[pole, nx, j, k] = (Ty[pole, nx, j, k]
+                                      - updatecoeffsdispersive[materialEy, 2 + (pole * 3)] * Ey[nx, j, k])
+
+    for j in prange(1, ny, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(0, nz):
+            materialEz = ID[2, nx, j, k]
+            for pole in range(maxpoles):
+                Tz[pole, nx, j, k] = (Tz[pole, nx, j, k]
+                                      - updatecoeffsdispersive[materialEz, 2 + (pole * 3)] * Ez[nx, j, k])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_y0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tx,
+    float_or_double_complex[:, :, :, ::1] Ty,
+    float_or_double_complex[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_y0()."""
+    cdef Py_ssize_t i, k, pole
+    cdef int materialEx, materialEz
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(1, nz):
+            materialEx = ID[0, i, 0, k]
+            for pole in range(maxpoles):
+                Tx[pole, i, 0, k] = (Tx[pole, i, 0, k]
+                                     - updatecoeffsdispersive[materialEx, 2 + (pole * 3)] * Ex[i, 0, k])
+
+    for i in prange(1, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(0, nz):
+            materialEz = ID[2, i, 0, k]
+            for pole in range(maxpoles):
+                Tz[pole, i, 0, k] = (Tz[pole, i, 0, k]
+                                     - updatecoeffsdispersive[materialEz, 2 + (pole * 3)] * Ez[i, 0, k])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_ymax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tx,
+    float_or_double_complex[:, :, :, ::1] Ty,
+    float_or_double_complex[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_ymax()."""
+    cdef Py_ssize_t i, k, pole
+    cdef int materialEx, materialEz
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(1, nz):
+            materialEx = ID[0, i, ny, k]
+            for pole in range(maxpoles):
+                Tx[pole, i, ny, k] = (Tx[pole, i, ny, k]
+                                      - updatecoeffsdispersive[materialEx, 2 + (pole * 3)] * Ex[i, ny, k])
+
+    for i in prange(1, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for k in range(0, nz):
+            materialEz = ID[2, i, ny, k]
+            for pole in range(maxpoles):
+                Tz[pole, i, ny, k] = (Tz[pole, i, ny, k]
+                                      - updatecoeffsdispersive[materialEz, 2 + (pole * 3)] * Ez[i, ny, k])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tx,
+    float_or_double_complex[:, :, :, ::1] Ty,
+    float_or_double_complex[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_z0()."""
+    cdef Py_ssize_t i, j, pole
+    cdef int materialEx, materialEy
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for j in range(1, ny):
+            materialEx = ID[0, i, j, 0]
+            for pole in range(maxpoles):
+                Tx[pole, i, j, 0] = (Tx[pole, i, j, 0]
+                                     - updatecoeffsdispersive[materialEx, 2 + (pole * 3)] * Ex[i, j, 0])
+
+    for i in prange(1, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for j in range(0, ny):
+            materialEy = ID[1, i, j, 0]
+            for pole in range(maxpoles):
+                Ty[pole, i, j, 0] = (Ty[pole, i, j, 0]
+                                     - updatecoeffsdispersive[materialEy, 2 + (pole * 3)] * Ey[i, j, 0])
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_zmax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tx,
+    float_or_double_complex[:, :, :, ::1] Ty,
+    float_or_double_complex[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ex,
+    float_or_double[:, :, ::1] Ey,
+    float_or_double[:, :, ::1] Ez
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_zmax()."""
+    cdef Py_ssize_t i, j, pole
+    cdef int materialEx, materialEy
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for j in range(1, ny):
+            materialEx = ID[0, i, j, nz]
+            for pole in range(maxpoles):
+                Tx[pole, i, j, nz] = (Tx[pole, i, j, nz]
+                                      - updatecoeffsdispersive[materialEx, 2 + (pole * 3)] * Ex[i, j, nz])
+
+    for i in prange(1, nx, nogil=True, schedule='static', num_threads=nthreads):
+        for j in range(0, ny):
+            materialEy = ID[1, i, j, nz]
+            for pole in range(maxpoles):
+                Ty[pole, i, j, nz] = (Ty[pole, i, j, nz]
+                                      - updatecoeffsdispersive[materialEy, 2 + (pole * 3)] * Ey[i, j, nz])
+
+
+##############################################################
+# Phase B - domain edges, T-array correction only (12 total) #
+##############################################################
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ez_X0_Y0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ez
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ez_X0_Y0()."""
+    cdef Py_ssize_t k, pole
+    cdef int mat
+
+    for k in prange(0, nz, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[2, 0, 0, k]
+        for pole in range(maxpoles):
+            Tz[pole, 0, 0, k] = Tz[pole, 0, 0, k] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ez[0, 0, k]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ez_X0_YMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ez
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ez_X0_YMax()."""
+    cdef Py_ssize_t k, pole
+    cdef int mat
+
+    for k in prange(0, nz, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[2, 0, ny, k]
+        for pole in range(maxpoles):
+            Tz[pole, 0, ny, k] = Tz[pole, 0, ny, k] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ez[0, ny, k]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ez_XMax_Y0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ez
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ez_XMax_Y0()."""
+    cdef Py_ssize_t k, pole
+    cdef int mat
+
+    for k in prange(0, nz, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[2, nx, 0, k]
+        for pole in range(maxpoles):
+            Tz[pole, nx, 0, k] = Tz[pole, nx, 0, k] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ez[nx, 0, k]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ez_XMax_YMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tz,
+    float_or_double[:, :, ::1] Ez
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ez_XMax_YMax()."""
+    cdef Py_ssize_t k, pole
+    cdef int mat
+
+    for k in prange(0, nz, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[2, nx, ny, k]
+        for pole in range(maxpoles):
+            Tz[pole, nx, ny, k] = Tz[pole, nx, ny, k] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ez[nx, ny, k]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ey_X0_Z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Ty,
+    float_or_double[:, :, ::1] Ey
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ey_X0_Z0()."""
+    cdef Py_ssize_t j, pole
+    cdef int mat
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[1, 0, j, 0]
+        for pole in range(maxpoles):
+            Ty[pole, 0, j, 0] = Ty[pole, 0, j, 0] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ey[0, j, 0]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ey_X0_ZMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Ty,
+    float_or_double[:, :, ::1] Ey
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ey_X0_ZMax()."""
+    cdef Py_ssize_t j, pole
+    cdef int mat
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[1, 0, j, nz]
+        for pole in range(maxpoles):
+            Ty[pole, 0, j, nz] = Ty[pole, 0, j, nz] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ey[0, j, nz]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ey_XMax_Z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Ty,
+    float_or_double[:, :, ::1] Ey
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ey_XMax_Z0()."""
+    cdef Py_ssize_t j, pole
+    cdef int mat
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[1, nx, j, 0]
+        for pole in range(maxpoles):
+            Ty[pole, nx, j, 0] = Ty[pole, nx, j, 0] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ey[nx, j, 0]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ey_XMax_ZMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Ty,
+    float_or_double[:, :, ::1] Ey
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ey_XMax_ZMax()."""
+    cdef Py_ssize_t j, pole
+    cdef int mat
+
+    for j in prange(0, ny, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[1, nx, j, nz]
+        for pole in range(maxpoles):
+            Ty[pole, nx, j, nz] = Ty[pole, nx, j, nz] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ey[nx, j, nz]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ex_Y0_Z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tx,
+    float_or_double[:, :, ::1] Ex
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ex_Y0_Z0()."""
+    cdef Py_ssize_t i, pole
+    cdef int mat
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[0, i, 0, 0]
+        for pole in range(maxpoles):
+            Tx[pole, i, 0, 0] = Tx[pole, i, 0, 0] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ex[i, 0, 0]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ex_Y0_ZMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tx,
+    float_or_double[:, :, ::1] Ex
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ex_Y0_ZMax()."""
+    cdef Py_ssize_t i, pole
+    cdef int mat
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[0, i, 0, nz]
+        for pole in range(maxpoles):
+            Tx[pole, i, 0, nz] = Tx[pole, i, 0, nz] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ex[i, 0, nz]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ex_YMax_Z0(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tx,
+    float_or_double[:, :, ::1] Ex
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ex_YMax_Z0()."""
+    cdef Py_ssize_t i, pole
+    cdef int mat
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[0, i, ny, 0]
+        for pole in range(maxpoles):
+            Tx[pole, i, ny, 0] = Tx[pole, i, ny, 0] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ex[i, ny, 0]
+
+
+cpdef void update_symmetry_boundary_electric_dispersive_b_Ex_YMax_ZMax(
+    int nx,
+    int ny,
+    int nz,
+    int nthreads,
+    int maxpoles,
+    float_or_double_complex[:, ::1] updatecoeffsdispersive,
+    np.uint32_t[:, :, :, ::1] ID,
+    float_or_double_complex[:, :, :, ::1] Tx,
+    float_or_double[:, :, ::1] Ex
+):
+    """Phase-B counterpart of update_symmetry_boundary_electric_dispersive_Ex_YMax_ZMax()."""
+    cdef Py_ssize_t i, pole
+    cdef int mat
+
+    for i in prange(0, nx, nogil=True, schedule='static', num_threads=nthreads):
+        mat = ID[0, i, ny, nz]
+        for pole in range(maxpoles):
+            Tx[pole, i, ny, nz] = Tx[pole, i, ny, nz] - updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ex[i, ny, nz]

--- a/gprMax/cython/yee_cell_build.pyx
+++ b/gprMax/cython/yee_cell_build.pyx
@@ -19,6 +19,7 @@
 
 import numpy as np
 
+cimport cython
 cimport numpy as np
 
 from gprMax.cython.yee_cell_setget_rigid cimport (
@@ -31,6 +32,29 @@ from gprMax.cython.yee_cell_setget_rigid cimport (
 )
 
 from gprMax.materials import Material
+
+
+@cython.cdivision(True)
+cdef inline double harmonic_mean2(double a, double b) noexcept nogil:
+    """Harmonic mean of two values.
+
+    Uses the reciprocal-sum form (not the algebraically equivalent
+    2*a*b/(a+b)) so that the physically-relevant boundary values 0 and
+    inf - both reachable for magnetic loss (sigma*), e.g. free_space
+    (0) next to a custom sm=inf/builtin pmc material (inf) - resolve to
+    their correct limits (0 and 2*finite value respectively) via ordinary
+    IEEE-754 semantics, instead of the 0*inf / inf-inf indeterminate forms
+    the product form would hit.
+
+    Needs cython.cdivision(True): Cython's default division checks for a
+    zero denominator and raises ZeroDivisionError to match Python
+    semantics, even for floats (unlike plain C) - which would defeat the
+    reciprocal-sum trick above, since a=0 is the common case (any
+    non-magnetically-lossy material). cdivision(True) switches to plain
+    IEEE-754 float division, where 1.0/0.0 is +inf rather than an
+    exception.
+    """
+    return 2.0 / (1.0 / a + 1.0 / b)
 
 
 cpdef void create_electric_average(
@@ -92,20 +116,45 @@ cpdef void create_magnetic_average(
     int numID1,
     int numID2,
     int componentID,
-    G
+    G,
+    bint harmonic
 ):
-    """Creates a new material by averaging the dielectric properties of the
-        surrounding cells.
+    """Creates a new material by averaging the properties of the
+        surrounding cells for a magnetic (H) field component.
 
     Args:
         i, j, k: ints for cell coordinates.
         numID: ints for numeric IDs for materials in surrounding cells.
         componentID: int for numeric ID for magnetic field component.
         G: FDTDGrid class describing a grid in a model.
+        harmonic: bool, True to combine mu_r/sigma* with a harmonic mean
+            (default, physically correct for the field-normal direction
+            these two cells are stacked in - see #magnetic_averaging),
+            False for the legacy arithmetic mean.
     """
 
-    # Make an ID composed of the names of the two materials that will be averaged
+    # Make an ID composed of the names of the two materials that will be
+    # averaged. Material.create_compound_id() duplicates a 2-material call
+    # into a 4-part name ("A+A+B+B") specifically so it collides with (and
+    # reuses) a 4-cell electric average of the same 2 materials - correct
+    # only as long as both use the same mixing rule, since arithmetic mean
+    # of {A,A,B,B} equals arithmetic mean of {A,B}. With harmonic H
+    # averaging that equivalence no longer holds, so the harmonic case
+    # gets its own "Hmag_" namespace to avoid silently reusing an
+    # arithmetic-mean electric material for mu_r/sigma*. The arithmetic
+    # case is left exactly as before (byte-for-byte, including the
+    # electric/magnetic reuse) for backwards compatibility.
+    #
+    # Must not use ':' here (or any other character that could appear only
+    # once elsewhere) - hash_cmds_file.py's command-line parser does a bare
+    # `line.split(":")` and keeps only cmd[1], so a second ':' anywhere in
+    # a material ID (e.g. from a round-trip through #geometry_objects_write
+    # / #geometry_objects_read, which writes material.ID verbatim into a
+    # #material: line) silently truncates the name there. '_' is already
+    # used elsewhere in material IDs (e.g. "free_space") and is safe.
     requiredID = Material.create_compound_id(G.materials[numID1], G.materials[numID2])
+    if harmonic:
+        requiredID = "Hmag_" + requiredID
 
     # Check if this material already exists
     material = [x for x in G.materials if x.ID == requiredID]
@@ -117,11 +166,18 @@ cpdef void create_magnetic_average(
         newNumID = len(G.materials)
         m = Material(newNumID, requiredID)
         m.type = 'dielectric-smoothed'
-        # Create averaged constituents for material
+        # er/se are not used by the H-field update coefficients (only
+        # mr/sm are - see Material.calculate_update_coeffsH()), so they
+        # are always arithmetic-averaged here regardless of "harmonic",
+        # purely for display/reporting consistency.
         m.er = np.mean((G.materials[numID1].er, G.materials[numID2].er), axis=0)
         m.se = np.mean((G.materials[numID1].se, G.materials[numID2].se), axis=0)
-        m.mr = np.mean((G.materials[numID1].mr, G.materials[numID2].mr), axis=0)
-        m.sm = np.mean((G.materials[numID1].sm, G.materials[numID2].sm), axis=0)
+        if harmonic:
+            m.mr = harmonic_mean2(<double>G.materials[numID1].mr, <double>G.materials[numID2].mr)
+            m.sm = harmonic_mean2(<double>G.materials[numID1].sm, <double>G.materials[numID2].sm)
+        else:
+            m.mr = np.mean((G.materials[numID1].mr, G.materials[numID2].mr), axis=0)
+            m.sm = np.mean((G.materials[numID1].sm, G.materials[numID2].sm), axis=0)
 
         # Append the new material object to the materials list
         G.materials.append(m)
@@ -137,32 +193,56 @@ cpdef void build_electric_components(
 ):
     """Builds the electric field components in the ID array.
 
+    Each E component has one "own" axis (no material dependency, full range
+    0..n-1) and two "dependency" axes (need the cell at index v and v-1, full
+    range 0..n to cover the ID array's n+1 sized dependency dimensions). At a
+    dependency-axis wall (v=0 or v=n) the missing out-of-domain neighbour is
+    clamped onto the cell that does exist, which collapses the usual 4-cell
+    average to the correct 2-cell (edge) or 1-cell (corner) result via the
+    existing "if all equal" fast path - no special-casing needed here.
+
+    Note (MPI): for an MPIGrid rank, a "dependency-axis wall" reached here may
+    be an internal partition seam rather than a true global-domain wall, in
+    which case this clamp is a placeholder like before this fix (inert for
+    the main FDTD update, which never reads these components). Code adding a
+    boundary-plane update (e.g. PMC symmetry planes) must gate on
+    has_neighbour(dim, dir) and only trust this ID at genuine global walls.
+
     Args:
         solid, rigid, ID: memoryviews to access solid, rigid and ID arrays.
         G: FDTDGrid class describing a grid in a model.
     """
 
     cdef Py_ssize_t i, j, k
+    cdef Py_ssize_t i_hi, i_lo, j_hi, j_lo, k_hi, k_lo
+    cdef Py_ssize_t nx, ny, nz
     cdef int numID1, numID2, numID3, numID4, IDEx, IDEy, IDEz
 
     IDEx = G.IDlookup['Ex']
     IDEy = G.IDlookup['Ey']
     IDEz = G.IDlookup['Ez']
 
-    # Loops common for all electric components
-    for i in range(1, G.nx):
-        for j in range(1, G.ny):
-            for k in range(1, G.nz):
+    nx = G.nx
+    ny = G.ny
+    nz = G.nz
 
-                # Ex component
+    # Ex: own axis i; dependency axes j, k
+    for i in range(nx):
+        for j in range(ny + 1):
+            j_hi = j if j < ny else ny - 1
+            j_lo = j - 1 if j > 0 else 0
+            for k in range(nz + 1):
+                k_hi = k if k < nz else nz - 1
+                k_lo = k - 1 if k > 0 else 0
+
                 # If rigid is True do not average
                 if get_rigid_Ex(i, j, k, rigidE):
                     pass
                 else:
-                    numID1 = solid[i, j, k]
-                    numID2 = solid[i, j - 1, k]
-                    numID3 = solid[i, j - 1, k - 1]
-                    numID4 = solid[i, j, k - 1]
+                    numID1 = solid[i, j_hi, k_hi]
+                    numID2 = solid[i, j_lo, k_hi]
+                    numID3 = solid[i, j_lo, k_lo]
+                    numID4 = solid[i, j_hi, k_lo]
 
                     # If all values are the same no need to average
                     if numID1 == numID2 and numID1 == numID3 and numID1 == numID4:
@@ -172,15 +252,23 @@ cpdef void build_electric_components(
                         create_electric_average(i, j, k, numID1, numID2,
                                                 numID3, numID4, IDEx, G)
 
-                # Ey component
+    # Ey: own axis j; dependency axes i, k
+    for i in range(nx + 1):
+        i_hi = i if i < nx else nx - 1
+        i_lo = i - 1 if i > 0 else 0
+        for j in range(ny):
+            for k in range(nz + 1):
+                k_hi = k if k < nz else nz - 1
+                k_lo = k - 1 if k > 0 else 0
+
                 # If rigid is True do not average
                 if get_rigid_Ey(i, j, k, rigidE):
                     pass
                 else:
-                    numID1 = solid[i, j, k]
-                    numID2 = solid[i - 1, j, k]
-                    numID3 = solid[i - 1, j, k - 1]
-                    numID4 = solid[i, j, k - 1]
+                    numID1 = solid[i_hi, j, k_hi]
+                    numID2 = solid[i_lo, j, k_hi]
+                    numID3 = solid[i_lo, j, k_lo]
+                    numID4 = solid[i_hi, j, k_lo]
 
                     # If all values are the same no need to average
                     if numID1 == numID2 and numID1 == numID3 and numID1 == numID4:
@@ -190,15 +278,23 @@ cpdef void build_electric_components(
                         create_electric_average(i, j, k, numID1, numID2,
                                                 numID3, numID4, IDEy, G)
 
-                # Ez component
+    # Ez: own axis k; dependency axes i, j
+    for i in range(nx + 1):
+        i_hi = i if i < nx else nx - 1
+        i_lo = i - 1 if i > 0 else 0
+        for j in range(ny + 1):
+            j_hi = j if j < ny else ny - 1
+            j_lo = j - 1 if j > 0 else 0
+            for k in range(nz):
+
                 # If rigid is True do not average
                 if get_rigid_Ez(i, j, k, rigidE):
                     pass
                 else:
-                    numID1 = solid[i, j, k]
-                    numID2 = solid[i - 1, j, k]
-                    numID3 = solid[i - 1, j - 1, k]
-                    numID4 = solid[i, j - 1, k]
+                    numID1 = solid[i_hi, j_hi, k]
+                    numID2 = solid[i_lo, j_hi, k]
+                    numID3 = solid[i_lo, j_lo, k]
+                    numID4 = solid[i_hi, j_lo, k]
 
                     # If all values are the same no need to average
                     if numID1 == numID2 and numID1 == numID3 and numID1 == numID4:
@@ -208,190 +304,148 @@ cpdef void build_electric_components(
                         create_electric_average(i, j, k, numID1, numID2,
                                                 numID3, numID4, IDEz, G)
 
-    # Extra loops for Ex component
-    i = 0
-    for j in range(1, G.ny):
-        for k in range(1, G.nz):
-            # If rigid is True do not average
-            if get_rigid_Ex(i, j, k, rigidE):
-                pass
-            else:
-                numID1 = solid[i, j, k]
-                numID2 = solid[i, j - 1, k]
-                numID3 = solid[i, j - 1, k - 1]
-                numID4 = solid[i, j, k - 1]
-
-                # If all values are the same no need to average
-                if numID1 == numID2 and numID1 == numID3 and numID1 == numID4:
-                    ID[IDEx, i, j, k] = numID1
-                else:
-                    # Averaging is required
-                    create_electric_average(i, j, k, numID1, numID2,
-                                            numID3, numID4, IDEx, G)
-
-    # Extra loops for Ey component
-    for i in range(1, G.nx):
-        j = 0
-        for k in range(1, G.nz):
-            # If rigid is True do not average
-            if get_rigid_Ey(i, j, k, rigidE):
-                pass
-            else:
-                numID1 = solid[i, j, k]
-                numID2 = solid[i - 1, j, k]
-                numID3 = solid[i - 1, j, k - 1]
-                numID4 = solid[i, j, k - 1]
-
-                # If all values are the same no need to average
-                if numID1 == numID2 and numID1 == numID3 and numID1 == numID4:
-                    ID[IDEy, i, j, k] = numID1
-                else:
-                    # Averaging is required
-                    create_electric_average(i, j, k, numID1, numID2,
-                                            numID3, numID4, IDEy, G)
-
-   # Extra loops for Ez component
-    for i in range(1, G.nx):
-        for j in range(1, G.ny):
-            k = 0
-            # If rigid is True do not average
-            if get_rigid_Ez(i, j, k, rigidE):
-                pass
-            else:
-                numID1 = solid[i, j, k]
-                numID2 = solid[i - 1, j, k]
-                numID3 = solid[i - 1, j - 1, k]
-                numID4 = solid[i, j - 1, k]
-
-                # If all values are the same no need to average
-                if numID1 == numID2 and numID1 == numID3 and numID1 == numID4:
-                    ID[IDEz, i, j, k] = numID1
-                else:
-                    # Averaging is required
-                    create_electric_average(i, j, k, numID1, numID2,
-                                            numID3, numID4, IDEz, G)
-
 
 cpdef void build_magnetic_components(
     np.uint32_t[:, :, ::1] solid,
     np.int8_t[:, :, :, ::1] rigidH,
     np.uint32_t[:, :, :, ::1] ID,
-    G
+    G,
+    bint harmonic=True
 ):
     """Builds the magnetic field components in the ID array.
+
+    Each H component has two "own" axes (no material dependency, full range
+    0..n-1 each) and one "dependency" axis (needs the cell at index v and
+    v-1, full range 0..n to cover the ID array's n+1 sized dependency
+    dimension). At a dependency-axis wall (v=0 or v=n) the missing
+    out-of-domain neighbour is clamped onto the cell that does exist, which
+    collapses the 2-cell average to a direct single-cell assignment via the
+    existing "if equal" fast path - no special-casing needed here.
+
+    Note (MPI): see build_electric_components - the same caveat about
+    internal partition seams vs. genuine global-domain walls applies here.
+
+    PEC transparency: PEC has no well-defined magnetic properties (Part A of
+    the PMC-boundary groundwork already stops build_voxel/build_box from
+    forcing/rigid-marking H directly at a PEC location) - but solid[] still
+    (correctly) shows PEC's numID there, so without this check the averaging
+    below would blend PEC's meaningless mr=1/sm=0 placeholder into a real
+    neighbour's properties. A PEC neighbour is instead treated as transparent:
+    if exactly one of the two neighbours is PEC, the real neighbour's numID is
+    used directly (no averaging, matching what a model without the PEC object
+    would produce there); if both are PEC, there is no real medium left to
+    reference (solid[] no longer remembers what was there before the PEC
+    object was placed) so the position is left untouched, consistent with
+    Part A's "don't force anything" philosophy.
 
     Args:
         solid, rigid, ID: memoryviews to access solid, rigid and ID arrays.
         G: FDTDGrid class describing a grid in a model.
+        harmonic: bool, see create_magnetic_average(). Resolved once by the
+            caller (from #magnetic_averaging) rather than per averaged
+            cell; defaults to True (the harmonic-mean default) so direct
+            callers that don't care about this setting (e.g. low-level
+            tests building a bare grid without full simulation config)
+            still get sensible behaviour without needing config set up.
     """
 
     cdef Py_ssize_t i, j, k
+    cdef Py_ssize_t i_hi, i_lo, j_hi, j_lo, k_hi, k_lo
+    cdef Py_ssize_t nx, ny, nz
     cdef int numID1, numID2, IDHx, IDHy, IDHz
+    cdef bint pec1, pec2
+    cdef np.uint8_t[::1] is_pec_lookup
 
     IDHx = G.IDlookup['Hx']
     IDHy = G.IDlookup['Hy']
     IDHz = G.IDlookup['Hz']
 
-    # Loops common for all electric components
-    for i in range(1, G.nx):
-        for j in range(1, G.ny):
-            for k in range(1, G.nz):
+    nx = G.nx
+    ny = G.ny
+    nz = G.nz
 
-                # Hx component
+    is_pec_lookup = np.array([m.is_pec for m in G.materials], dtype=np.uint8)
+
+    # Hx: own axes j, k; dependency axis i
+    for i in range(nx + 1):
+        i_hi = i if i < nx else nx - 1
+        i_lo = i - 1 if i > 0 else 0
+        for j in range(ny):
+            for k in range(nz):
+
                 # If rigid is True do not average
                 if get_rigid_Hx(i, j, k, rigidH):
                     pass
                 else:
-                    numID1 = solid[i, j, k]
-                    numID2 = solid[i - 1, j, k]
+                    numID1 = solid[i_hi, j, k]
+                    numID2 = solid[i_lo, j, k]
+                    pec1 = is_pec_lookup[numID1]
+                    pec2 = is_pec_lookup[numID2]
 
-                    # If all values are the same no need to average
-                    if numID1 == numID2:
+                    if pec1 and pec2:
+                        pass
+                    elif pec1:
+                        ID[IDHx, i, j, k] = numID2
+                    elif pec2:
+                        ID[IDHx, i, j, k] = numID1
+                    elif numID1 == numID2:
                         ID[IDHx, i, j, k] = numID1
                     else:
                         # Averaging is required
-                        create_magnetic_average(i, j, k, numID1, numID2, IDHx, G)
+                        create_magnetic_average(i, j, k, numID1, numID2, IDHx, G, harmonic)
 
-                # Hy component
+    # Hy: own axes i, k; dependency axis j
+    for i in range(nx):
+        for j in range(ny + 1):
+            j_hi = j if j < ny else ny - 1
+            j_lo = j - 1 if j > 0 else 0
+            for k in range(nz):
+
                 # If rigid is True do not average
                 if get_rigid_Hy(i, j, k, rigidH):
                     pass
                 else:
-                    numID1 = solid[i, j, k]
-                    numID2 = solid[i, j - 1, k]
+                    numID1 = solid[i, j_hi, k]
+                    numID2 = solid[i, j_lo, k]
+                    pec1 = is_pec_lookup[numID1]
+                    pec2 = is_pec_lookup[numID2]
 
-                    # If all values are the same no need to average
-                    if numID1 == numID2:
+                    if pec1 and pec2:
+                        pass
+                    elif pec1:
+                        ID[IDHy, i, j, k] = numID2
+                    elif pec2:
+                        ID[IDHy, i, j, k] = numID1
+                    elif numID1 == numID2:
                         ID[IDHy, i, j, k] = numID1
                     else:
                         # Averaging is required
-                        create_magnetic_average(i, j, k, numID1, numID2, IDHy, G)
+                        create_magnetic_average(i, j, k, numID1, numID2, IDHy, G, harmonic)
 
-                # Hz component
+    # Hz: own axes i, j; dependency axis k
+    for i in range(nx):
+        for j in range(ny):
+            for k in range(nz + 1):
+                k_hi = k if k < nz else nz - 1
+                k_lo = k - 1 if k > 0 else 0
+
                 # If rigid is True do not average
                 if get_rigid_Hz(i, j, k, rigidH):
                     pass
                 else:
-                    numID1 = solid[i, j, k]
-                    numID2 = solid[i, j, k - 1]
+                    numID1 = solid[i, j, k_hi]
+                    numID2 = solid[i, j, k_lo]
+                    pec1 = is_pec_lookup[numID1]
+                    pec2 = is_pec_lookup[numID2]
 
-                    # If all values are the same no need to average
-                    if numID1 == numID2:
+                    if pec1 and pec2:
+                        pass
+                    elif pec1:
+                        ID[IDHz, i, j, k] = numID2
+                    elif pec2:
+                        ID[IDHz, i, j, k] = numID1
+                    elif numID1 == numID2:
                         ID[IDHz, i, j, k] = numID1
                     else:
                         # Averaging is required
-                        create_magnetic_average(i, j, k, numID1, numID2, IDHz, G)
-
-    # Extra loops for Hx component
-    for i in range(1, G.nx):
-        j = 0
-        k = 0
-        # If rigid is True do not average
-        if get_rigid_Hx(i, j, k, rigidH):
-            pass
-        else:
-            numID1 = solid[i, j, k]
-            numID2 = solid[i - 1, j, k]
-
-            # If all values are the same no need to average
-            if numID1 == numID2:
-                ID[IDHx, i, j, k] = numID1
-            else:
-                # Averaging is required
-                create_magnetic_average(i, j, k, numID1, numID2, IDHx, G)
-
-    # Extra loops for Hy component
-    i = 0
-    k = 0
-    for j in range(1, G.ny):
-            # If rigid is True do not average
-            if get_rigid_Hy(i, j, k, rigidH):
-                pass
-            else:
-                numID1 = solid[i, j, k]
-                numID2 = solid[i, j - 1, k]
-
-                # If all values are the same no need to average
-                if numID1 == numID2:
-                    ID[IDHy, i, j, k] = numID1
-                else:
-                    # Averaging is required
-                    create_magnetic_average(i, j, k, numID1, numID2, IDHy, G)
-
-    # Extra loops for Hz component
-    i = 0
-    j = 0
-    for k in range(1, G.nz):
-        # If rigid is True do not average
-        if get_rigid_Hz(i, j, k, rigidH):
-            pass
-        else:
-            numID1 = solid[i, j, k]
-            numID2 = solid[i, j, k - 1]
-
-            # If all values are the same no need to average
-            if numID1 == numID2:
-                ID[IDHz, i, j, k] = numID1
-            else:
-                # Averaging is required
-                create_magnetic_average(i, j, k, numID1, numID2, IDHz, G)
+                        create_magnetic_average(i, j, k, numID1, numID2, IDHz, G, harmonic)

--- a/gprMax/cython/yee_cell_setget_rigid.pyx
+++ b/gprMax/cython/yee_cell_setget_rigid.pyx
@@ -30,15 +30,19 @@ cdef bint get_rigid_Ex(
     int k,
     np.int8_t[:, :, :, ::1] rigidE
 ) nogil:
-
+    # j, k may run to rigidE.shape[2]/[3] (Ex's dependency-axis far wall),
+    # one past the last valid cell index - guard the "own corner" reads
+    # (which use the raw j/k) the same way the "neighbour corner" reads
+    # already guard j-1/k-1.
     cdef bint result
     result = False
-    if rigidE[0, i, j, k]:
-        result = True
-    if j != 0:
+    if j < rigidE.shape[2] and k < rigidE.shape[3]:
+        if rigidE[0, i, j, k]:
+            result = True
+    if j != 0 and k < rigidE.shape[3]:
         if rigidE[1, i, j - 1, k]:
             result = True
-    if k != 0:
+    if k != 0 and j < rigidE.shape[2]:
         if rigidE[3, i, j, k - 1]:
             result = True
     if j != 0 and k != 0:
@@ -53,14 +57,16 @@ cdef bint get_rigid_Ey(
     int k,
     np.int8_t[:, :, :, ::1] rigidE
 ) nogil:
+    # i, k may run to rigidE.shape[1]/[3] (Ey's dependency-axis far wall).
     cdef bint result
     result = False
-    if rigidE[4, i, j, k]:
-        result = True
-    if i != 0:
+    if i < rigidE.shape[1] and k < rigidE.shape[3]:
+        if rigidE[4, i, j, k]:
+            result = True
+    if i != 0 and k < rigidE.shape[3]:
         if rigidE[7, i - 1, j, k]:
             result = True
-    if k != 0:
+    if k != 0 and i < rigidE.shape[1]:
         if rigidE[5, i, j, k - 1]:
             result = True
     if i != 0 and k != 0:
@@ -75,14 +81,16 @@ cdef bint get_rigid_Ez(
     int k,
     np.int8_t[:, :, :, ::1] rigidE
 ) nogil:
+    # i, j may run to rigidE.shape[1]/[2] (Ez's dependency-axis far wall).
     cdef bint result
     result = False
-    if rigidE[8, i, j, k]:
-        result = True
-    if i != 0:
+    if i < rigidE.shape[1] and j < rigidE.shape[2]:
+        if rigidE[8, i, j, k]:
+            result = True
+    if i != 0 and j < rigidE.shape[2]:
         if rigidE[9, i - 1, j, k]:
             result = True
-    if j != 0:
+    if j != 0 and i < rigidE.shape[1]:
         if rigidE[11, i, j - 1, k]:
             result = True
     if i != 0 and j != 0:
@@ -97,10 +105,18 @@ cdef void set_rigid_Ex(
     int k,
     np.int8_t[:, :, :, ::1] rigidE
 ) nogil:
-    rigidE[0, i, j, k] = True
-    if j != 0:
+    # j, k may run to rigidE.shape[2]/[3] (Ex's dependency-axis far wall,
+    # e.g. an x-directed #edge lying exactly on the y=ny or z=nz domain
+    # boundary) - guard the "own corner" writes (which use the raw j/k)
+    # the same way get_rigid_Ex already guards its "own corner" reads,
+    # mirroring it term-for-term. Without this, boundscheck=False (set
+    # globally in setup.py) means an out-of-range write here silently
+    # corrupts adjacent memory instead of raising an IndexError.
+    if j < rigidE.shape[2] and k < rigidE.shape[3]:
+        rigidE[0, i, j, k] = True
+    if j != 0 and k < rigidE.shape[3]:
         rigidE[1, i, j - 1, k] = True
-    if k != 0:
+    if k != 0 and j < rigidE.shape[2]:
         rigidE[3, i, j, k - 1] = True
     if j != 0 and k != 0:
         rigidE[2, i, j - 1, k - 1] = True
@@ -112,10 +128,13 @@ cdef void set_rigid_Ey(
     int k,
     np.int8_t[:, :, :, ::1] rigidE
 ) nogil:
-    rigidE[4, i, j, k] = True
-    if i != 0:
+    # i, k may run to rigidE.shape[1]/[3] (Ey's dependency-axis far wall)
+    # - see set_rigid_Ex's comment; mirrors get_rigid_Ey term-for-term.
+    if i < rigidE.shape[1] and k < rigidE.shape[3]:
+        rigidE[4, i, j, k] = True
+    if i != 0 and k < rigidE.shape[3]:
         rigidE[7, i - 1, j, k] = True
-    if k != 0:
+    if k != 0 and i < rigidE.shape[1]:
         rigidE[5, i, j, k - 1] = True
     if i != 0 and k != 0:
         rigidE[6, i - 1, j, k - 1] = True
@@ -127,10 +146,13 @@ cdef void set_rigid_Ez(
     int k,
     np.int8_t[:, :, :, ::1] rigidE
 ) nogil:
-    rigidE[8, i, j, k] = True
-    if i != 0:
+    # i, j may run to rigidE.shape[1]/[2] (Ez's dependency-axis far wall)
+    # - see set_rigid_Ex's comment; mirrors get_rigid_Ez term-for-term.
+    if i < rigidE.shape[1] and j < rigidE.shape[2]:
+        rigidE[8, i, j, k] = True
+    if i != 0 and j < rigidE.shape[2]:
         rigidE[9, i - 1, j, k] = True
-    if j != 0:
+    if j != 0 and i < rigidE.shape[1]:
         rigidE[11, i, j - 1, k] = True
     if i != 0 and j != 0:
         rigidE[10, i - 1, j - 1, k] = True
@@ -162,10 +184,20 @@ cdef bint get_rigid_Hx(
     int k,
     np.int8_t[:, :, :, ::1] rigidH
 ) nogil:
+    # i may run to rigidH.shape[1] (Hx's dependency-axis far wall). j, k
+    # (transverse to Hx's own axis) are only ever iterated safely within
+    # bounds by the one existing caller today (yee_cell_build.pyx's
+    # material-averaging loops), but a #magnetic_edge lying on the y=ny
+    # or z=nz domain boundary calls the corresponding set_rigid_Hx with
+    # j/k at exactly that wall - guarded here too for symmetry with that
+    # write path and to avoid a latent trap for any future caller.
     cdef bint result
     result = False
-    if rigidH[0, i, j, k]:
-        result = True
+    if j >= rigidH.shape[2] or k >= rigidH.shape[3]:
+        return result
+    if i < rigidH.shape[1]:
+        if rigidH[0, i, j, k]:
+            result = True
     if i != 0:
         if rigidH[1, i - 1, j, k]:
             result = True
@@ -178,10 +210,15 @@ cdef bint get_rigid_Hy(
     int k,
     np.int8_t[:, :, :, ::1] rigidH
 ) nogil:
+    # j may run to rigidH.shape[2] (Hy's dependency-axis far wall) - see
+    # get_rigid_Hx's comment for why i, k (transverse) are also guarded.
     cdef bint result
     result = False
-    if rigidH[2, i, j, k]:
-        result = True
+    if i >= rigidH.shape[1] or k >= rigidH.shape[3]:
+        return result
+    if j < rigidH.shape[2]:
+        if rigidH[2, i, j, k]:
+            result = True
     if j != 0:
         if rigidH[3, i, j - 1, k]:
             result = True
@@ -194,10 +231,15 @@ cdef bint get_rigid_Hz(
     int k,
     np.int8_t[:, :, :, ::1] rigidH
 ) nogil:
+    # k may run to rigidH.shape[3] (Hz's dependency-axis far wall) - see
+    # get_rigid_Hx's comment for why i, j (transverse) are also guarded.
     cdef bint result
     result = False
-    if rigidH[4, i, j, k]:
-        result = True
+    if i >= rigidH.shape[1] or j >= rigidH.shape[2]:
+        return result
+    if k < rigidH.shape[3]:
+        if rigidH[4, i, j, k]:
+            result = True
     if k != 0:
         if rigidH[5, i, j, k - 1]:
             result = True
@@ -210,7 +252,24 @@ cdef void set_rigid_Hx(
     int k,
     np.int8_t[:, :, :, ::1] rigidH
 ) nogil:
-    rigidH[0, i, j, k] = True
+    # Self-consistent single-position marker, mirroring set_rigid_Ex's own
+    # own-position/neighbour-offset shape (just one dependency axis instead
+    # of two): a single call here only ever satisfies get_rigid_Hx queried
+    # at this SAME (i,j,k) - it never leaks into i-1 or i+1. Callers that
+    # need to mark BOTH of a cell's two true H faces (build_voxel/build_box)
+    # call this twice, once at each face position.
+    #
+    # j, k (transverse to Hx's own axis) are used raw with no neighbour
+    # offset at all, so - unlike i - they need a plain upper-bound guard,
+    # not a get_rigid_Ex-style split across multiple terms: a
+    # #magnetic_edge lying exactly on the y=ny or z=nz domain boundary
+    # passes j/k == that wall directly (unlike i, which the edge-building
+    # loop in geometry_primitives.pyx never lets reach nx, matching
+    # get_rigid_Hx's own i < rigidH.shape[1] guard below).
+    if j >= rigidH.shape[2] or k >= rigidH.shape[3]:
+        return
+    if i < rigidH.shape[1]:
+        rigidH[0, i, j, k] = True
     if i != 0:
         rigidH[1, i - 1, j, k] = True
 
@@ -221,7 +280,11 @@ cdef void set_rigid_Hy(
     int k,
     np.int8_t[:, :, :, ::1] rigidH
 ) nogil:
-    rigidH[2, i, j, k] = True
+    # i, k (transverse to Hy's own axis) - see set_rigid_Hx's comment.
+    if i >= rigidH.shape[1] or k >= rigidH.shape[3]:
+        return
+    if j < rigidH.shape[2]:
+        rigidH[2, i, j, k] = True
     if j != 0:
         rigidH[3, i, j - 1, k] = True
 
@@ -232,7 +295,11 @@ cdef void set_rigid_Hz(
     int k,
     np.int8_t[:, :, :, ::1] rigidH
 ) nogil:
-    rigidH[4, i, j, k] = True
+    # i, j (transverse to Hz's own axis) - see set_rigid_Hx's comment.
+    if i >= rigidH.shape[1] or j >= rigidH.shape[2]:
+        return
+    if k < rigidH.shape[3]:
+        rigidH[4, i, j, k] = True
     if k != 0:
         rigidH[5, i, j, k - 1] = True
 

--- a/gprMax/grid/fdtd_grid.py
+++ b/gprMax/grid/fdtd_grid.py
@@ -55,6 +55,11 @@ from gprMax.sources import (
     TransmissionLine,
     VoltageSource,
 )
+from gprMax.symmetry_boundaries import (
+    build_symmetry_boundary_edges,
+    build_symmetry_boundary_edges_dispersive,
+    build_symmetry_boundary_edges_dispersive_b,
+)
 from gprMax.utilities.utilities import fft_power, get_terminal_width, round_value
 from gprMax.waveforms import Waveform
 
@@ -118,6 +123,13 @@ class FDTDGrid:
         # corrections will be different.
         self.pmls["thickness"] = OrderedDict()
         self.set_pml_thickness(10)
+
+        # PEC/PMC symmetry boundaries, keyed by domain face. Edge dispatch
+        # is resolved once after geometry and material IDs are finalised.
+        self.symmetry_boundaries: dict = {}
+        self.symmetry_boundary_edges: list = []
+        self.symmetry_boundary_edges_dispersive: list = []
+        self.symmetry_boundary_edges_dispersive_b: list = []
 
         # Materials used by this grid
         self.materials: List[Material] = []
@@ -258,6 +270,8 @@ class FDTDGrid:
         if self.averagevolumeobjects:
             self._build_components()
         self._2d_mode_grid_update()
+        self._terminate_pmls_with_pec()
+        self._build_symmetry_boundaries()
         self._create_voltage_source_materials()
         self.initialise_field_arrays()
         self.initialise_std_update_coeff_arrays()
@@ -479,6 +493,61 @@ class FDTDGrid:
             self.tey()
         elif mode == "2D TEz":
             self.tez()
+
+    def _terminate_pmls_with_pec(self) -> None:
+        """Mark the tangential E components at active PML outer faces as PEC.
+
+        The existing field-update bounds already make the outer PML wall a
+        PEC termination. Updating the material IDs makes that termination
+        explicit for inspection and for edges shared with a PMC symmetry
+        face. This must run after geometry and component averaging.
+        """
+        pml_faces = [face for face, thickness in self.pmls["thickness"].items() if thickness > 0]
+        if not pml_faces:
+            return
+
+        pec_numid = next(m.numID for m in self.materials if m.ID == "pec")
+        for face in pml_faces:
+            self._force_pec_tangential_e(face, pec_numid)
+
+    def _build_symmetry_boundaries(self) -> None:
+        """Apply PEC faces and resolve the per-iteration PMC edge dispatch."""
+        if not self.symmetry_boundaries:
+            return
+
+        pec_numid = next(m.numID for m in self.materials if m.ID == "pec")
+        for face, boundary_type in self.symmetry_boundaries.items():
+            if boundary_type == "pec":
+                self._force_pec_tangential_e(face, pec_numid)
+
+        self.symmetry_boundary_edges = build_symmetry_boundary_edges(self)
+        self.symmetry_boundary_edges_dispersive = build_symmetry_boundary_edges_dispersive(self)
+        self.symmetry_boundary_edges_dispersive_b = build_symmetry_boundary_edges_dispersive_b(self)
+
+    def _force_pec_tangential_e(self, face: str, pec_numid: int) -> None:
+        """Force the two tangential E-component IDs on a domain face to PEC."""
+        idx_ex, idx_ey, idx_ez = 0, 1, 2
+
+        if face == "x0":
+            self.ID[idx_ey, 0, 0 : self.ny, 0 : self.nz + 1] = pec_numid
+            self.ID[idx_ez, 0, 0 : self.ny + 1, 0 : self.nz] = pec_numid
+        elif face == "xmax":
+            self.ID[idx_ey, self.nx, 0 : self.ny, 0 : self.nz + 1] = pec_numid
+            self.ID[idx_ez, self.nx, 0 : self.ny + 1, 0 : self.nz] = pec_numid
+        elif face == "y0":
+            self.ID[idx_ex, 0 : self.nx, 0, 0 : self.nz + 1] = pec_numid
+            self.ID[idx_ez, 0 : self.nx + 1, 0, 0 : self.nz] = pec_numid
+        elif face == "ymax":
+            self.ID[idx_ex, 0 : self.nx, self.ny, 0 : self.nz + 1] = pec_numid
+            self.ID[idx_ez, 0 : self.nx + 1, self.ny, 0 : self.nz] = pec_numid
+        elif face == "z0":
+            self.ID[idx_ex, 0 : self.nx, 0 : self.ny + 1, 0] = pec_numid
+            self.ID[idx_ey, 0 : self.nx + 1, 0 : self.ny, 0] = pec_numid
+        elif face == "zmax":
+            self.ID[idx_ex, 0 : self.nx, 0 : self.ny + 1, self.nz] = pec_numid
+            self.ID[idx_ey, 0 : self.nx + 1, 0 : self.ny, self.nz] = pec_numid
+        else:
+            raise ValueError(f"Unknown symmetry boundary face '{face}'")
 
     def _create_voltage_source_materials(self):
         """Create materials for voltage sources.

--- a/gprMax/grid/fdtd_grid.py
+++ b/gprMax/grid/fdtd_grid.py
@@ -459,7 +459,8 @@ class FDTDGrid:
         )
         build_electric_components(self.solid, self.rigidE, self.ID, self)
         pbar.update()
-        build_magnetic_components(self.solid, self.rigidH, self.ID, self)
+        harmonic = config.get_model_config().magnetic_averaging_mode == "harmonic"
+        build_magnetic_components(self.solid, self.rigidH, self.ID, self, harmonic)
         pbar.update()
         pbar.close()
 

--- a/gprMax/hash_cmds_file.py
+++ b/gprMax/hash_cmds_file.py
@@ -217,6 +217,7 @@ def check_cmd_names(processedlines, checkessential=True):
         [
             "#domain",
             "#domain_mode",
+            "#magnetic_averaging",
             "#dx_dy_dz",
             "#time_window",
             "#title",
@@ -267,6 +268,7 @@ def check_cmd_names(processedlines, checkessential=True):
     geometrycmds = [
         "#geometry_objects_read",
         "#edge",
+        "#magnetic_edge",
         "#plate",
         "#triangle",
         "#box",

--- a/gprMax/hash_cmds_file.py
+++ b/gprMax/hash_cmds_file.py
@@ -259,6 +259,7 @@ def check_cmd_names(processedlines, checkessential=True):
             "#rx_array",
             "#snapshot",
             "#pml_cfs",
+            "#symmetry_boundary",
             "#include_file",
         ]
     }

--- a/gprMax/hash_cmds_geometry.py
+++ b/gprMax/hash_cmds_geometry.py
@@ -31,6 +31,7 @@ from .user_objects.cmds_geometry.cylindrical_sector import CylindricalSector
 from .user_objects.cmds_geometry.edge import Edge
 from .user_objects.cmds_geometry.ellipsoid import Ellipsoid
 from .user_objects.cmds_geometry.fractal_box import FractalBox
+from .user_objects.cmds_geometry.magnetic_edge import MagneticEdge
 from .user_objects.cmds_geometry.plate import Plate
 from .user_objects.cmds_geometry.sphere import Sphere
 from .user_objects.cmds_geometry.triangle import Triangle
@@ -80,6 +81,18 @@ def process_geometrycmds(geometry):
             )
 
             scene_objects.append(edge)
+
+        elif tmp[0] == "#magnetic_edge:":
+            if len(tmp) != 8:
+                logger.exception("'" + " ".join(tmp) + "'" + " requires exactly seven parameters")
+                raise ValueError
+
+            magnetic_edge = MagneticEdge(
+                p1=(float(tmp[1]), float(tmp[2]), float(tmp[3])),
+                p2=(float(tmp[4]), float(tmp[5]), float(tmp[6])),
+                material_id=tmp[7],
+            )
+            scene_objects.append(magnetic_edge)
 
         elif tmp[0] == "#plate:":
             if len(tmp) < 8:

--- a/gprMax/hash_cmds_multiuse.py
+++ b/gprMax/hash_cmds_multiuse.py
@@ -36,6 +36,7 @@ from .user_objects.cmds_multiuse import (
     Rx,
     RxArray,
     SoilPeplinski,
+    SymmetryBoundary,
     TransmissionLine,
     VoltageSource,
     Waveform,
@@ -694,5 +695,19 @@ def process_multicmds(multicmds):
             )
 
             scene_objects.append(pml_cfs)
+
+    cmdname = "#symmetry_boundary"
+    if multicmds[cmdname] is not None:
+        for cmdinstance in multicmds[cmdname]:
+            tmp = cmdinstance.split()
+
+            if len(tmp) != 2:
+                logger.exception(
+                    "'" + cmdname + ": " + " ".join(tmp) + "'" + " requires exactly two parameters"
+                )
+                raise ValueError
+
+            symmetry_boundary = SymmetryBoundary(face=tmp[0].lower(), type=tmp[1].lower())
+            scene_objects.append(symmetry_boundary)
 
     return scene_objects

--- a/gprMax/hash_cmds_singleuse.py
+++ b/gprMax/hash_cmds_singleuse.py
@@ -23,6 +23,7 @@ from .user_objects.cmds_singleuse import (
     Discretisation,
     Domain,
     DomainMode,
+    MagneticAveraging,
     OMPThreads,
     OutputDir,
     PMLFormulation,
@@ -94,6 +95,16 @@ def process_singlecmds(singlecmds):
 
         domain_mode = DomainMode(mode=tmp[0])
         scene_objects.append(domain_mode)
+
+    cmd = "#magnetic_averaging"
+    if singlecmds[cmd] is not None:
+        tmp = singlecmds[cmd].split()
+        if len(tmp) != 1:
+            logger.exception(f"{cmd} requires exactly one parameter, either 'harmonic' or 'arithmetic'")
+            raise ValueError
+
+        magnetic_averaging = MagneticAveraging(mode=tmp[0])
+        scene_objects.append(magnetic_averaging)
 
     cmd = "#domain"
     if singlecmds[cmd] is not None:

--- a/gprMax/model.py
+++ b/gprMax/model.py
@@ -400,6 +400,7 @@ class Model:
 
         self._check_stateful_sources_with_geometry_fixed(grids)
         self._check_for_dispersive_materials(grids)
+        self._check_accelerator_symmetry_boundaries(grids)
         self._check_memory_requirements(grids)
 
         for grid in grids:
@@ -481,6 +482,19 @@ class Model:
             # kernel-selection code (e.g. CPUUpdates.set_dispersive_updates(),
             # the CUDA/OpenCL/Metal equivalents) to read the owning grid's
             # own flag rather than the global one.
+
+    def _check_accelerator_symmetry_boundaries(self, grids: Sequence[FDTDGrid]):
+        """Reject accelerator PMC after material dispersion is resolved."""
+        solver = config.sim_config.general["solver"]
+        maxpoles = config.get_model_config().materials["maxpoles"]
+        has_pmc = any("pmc" in grid.symmetry_boundaries.values() for grid in grids)
+
+        if solver in ("cuda", "opencl", "metal") and maxpoles > 0 and has_pmc:
+            raise ValueError(
+                "Dispersive PMC symmetry boundaries currently require the CPU "
+                "solver. PEC and nondispersive PMC symmetry are supported by "
+                "CUDA, OpenCL, and Apple Metal."
+            )
 
     def _check_memory_requirements(self, grids: Sequence[FDTDGrid]):
         # Check memory requirements to build model/scene (different to memory

--- a/gprMax/solvers.py
+++ b/gprMax/solvers.py
@@ -81,6 +81,10 @@ class Solver:
 
             #time loop at this point is still at working on fields updated to be at n+1  
             self.updates.update_electric_a()
+            # Apply the PMC ghost-image correction on the active local
+            # backend. MPI symmetry is deliberately unsupported.
+            if not isinstance(self.updates, MPIUpdates):
+                self.updates.update_symmetry_boundaries_electric()
             self.updates.update_electric_pml()
             self.updates.update_electric_sources(iteration)
             if isinstance(self.updates, CPUUpdates):
@@ -89,6 +93,11 @@ class Solver:
            # TODO: Increment iteration here if add Model to Solver
             if isinstance(self.updates, SubgridUpdates):
                 self.updates.hsg_1()
+
+            # Complete the dispersive PMC correction after PML and sources,
+            # mirroring the bulk dispersive update's A/B split.
+            if not isinstance(self.updates, MPIUpdates):
+                self.updates.update_symmetry_boundaries_electric_b()
                          
             self.updates.update_electric_b()
 

--- a/gprMax/symmetry_boundaries.py
+++ b/gprMax/symmetry_boundaries.py
@@ -1,0 +1,585 @@
+# Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Per-iteration field updates for PMC (magnetic-wall/ghost-node) symmetry
+boundaries. PEC symmetry boundaries need no per-iteration code at all - their
+tangential E is already correctly forced to pec's zero coefficients at build
+time (FDTDGrid._force_pec_tangential_e). Only PMC needs a runtime update,
+since its on-wall tangential E is otherwise never touched by the ordinary
+bulk update loop.
+
+Covers both the face-interior region of each PMC face (trimmed by one cell
+on every side, so it never touches a domain edge) and the 12 domain edges
+(where two faces meet). Two material regimes, each with its own dispatch:
+
+- Standard (non-dispersive) materials: `update_symmetry_boundaries_electric_normal()`,
+  a single per-iteration call using only `updatecoeffsE`.
+- Dispersive materials (Debye - real poles, or Lorentz/Drude - complex
+  poles): `update_symmetry_boundaries_electric_dispersive()`/
+  `update_symmetry_boundaries_electric_dispersive_b()`, a two-phase call
+  mirroring the bulk dispersive kernel's own A/B split (see
+  gprMax/cython/fields_updates_dispersive_template.jinja and
+  gprMax/updates/cpu_updates.py's update_electric_a()/update_electric_b()) -
+  phase A computes the ADE polarisation-current term (phi) from the T-array
+  and updates T from the pre-iteration E, phase B corrects T using the final
+  (post-PML, post-source) E. Which Cython module's functions actually run
+  (gprMax.cython.symmetry_boundaries_dispersive for Debye,
+  gprMax.cython.symmetry_boundaries_dispersive_complex for Lorentz/Drude) is
+  chosen per-iteration from config.get_model_config().materials["drudelorentz"]
+  - the same flag config.py itself uses to pick updatecoeffsdispersive's
+  dtype (real vs complex), so the Cython functions called always match the
+  actual dtype of grid.updatecoeffsdispersive/Tx/Ty/Tz.
+
+Ghost-node derivation: tangential H is
+odd under the PMC mirror, so the "ghost" H node just outside the domain
+equals minus the real interior H node it mirrors. Substituting into the
+standard curl term used by the bulk kernel collapses the missing
+outside-neighbour difference into double one real H value - no ghost array
+needed, just a modified update formula. For a face at the "0" end of its
+axis (x0/y0/z0), the doubled term uses the wall's own H index with the same
+sign the bulk kernel's own formula already has; for a "max" end
+(xmax/ymax/zmax), it uses the interior-adjacent H index (one cell in, not
+the wall index) with the opposite sign. This part is identical between the
+non-dispersive and dispersive kernels.
+
+At an edge (where two faces meet), the self term (Ca*E, or Ca*E - Ce*phi for
+the dispersive variant) applies once if EITHER bordering face is PMC; each
+face then separately, additively, contributes its own doubled ghost term
+only if THAT SPECIFIC face is PMC - no owner/increment distinction needed.
+Both flags are resolved once here, at build time (they never change once
+#symmetry_boundary commands are processed), and edges where NEITHER
+bordering face is PMC are dropped entirely - not called every iteration with
+both flags False, which would still pay for a wasted loop-and-branch pass.
+This keeps the feature's cost at zero for any model that doesn't use
+#symmetry_boundary at all, and proportional only to the faces/edges actually
+declared PMC otherwise. For the dispersive edge kernels, the phi/T
+bookkeeping itself runs unconditionally (not gated by the a_pmc/b_pmc
+flags) - see gprMax/cython/symmetry_boundaries_dispersive.pyx's module
+docstring for why no explicit PEC-transparency branch is needed there.
+
+The actual per-position math is implemented in Cython
+(gprMax/cython/symmetry_boundaries.pyx for non-dispersive,
+gprMax/cython/symmetry_boundaries_dispersive.pyx for dispersive), one
+function per domain face and one per domain edge, mirroring the per-face
+convention already used for PML (pml_updates_electric_HORIPML.pyx) - this
+module is the build-time resolution (which faces/edges are active) and the
+thin per-iteration dispatch layer, matching how cpu_updates.py calls into
+fields_updates_normal.pyx.
+"""
+
+from gprMax import config
+from gprMax.cython.symmetry_boundaries import (
+    update_symmetry_boundary_electric_Ex_Y0_Z0,
+    update_symmetry_boundary_electric_Ex_Y0_ZMax,
+    update_symmetry_boundary_electric_Ex_YMax_Z0,
+    update_symmetry_boundary_electric_Ex_YMax_ZMax,
+    update_symmetry_boundary_electric_Ey_X0_Z0,
+    update_symmetry_boundary_electric_Ey_X0_ZMax,
+    update_symmetry_boundary_electric_Ey_XMax_Z0,
+    update_symmetry_boundary_electric_Ey_XMax_ZMax,
+    update_symmetry_boundary_electric_Ez_X0_Y0,
+    update_symmetry_boundary_electric_Ez_X0_YMax,
+    update_symmetry_boundary_electric_Ez_XMax_Y0,
+    update_symmetry_boundary_electric_Ez_XMax_YMax,
+    update_symmetry_boundary_electric_x0,
+    update_symmetry_boundary_electric_xmax,
+    update_symmetry_boundary_electric_y0,
+    update_symmetry_boundary_electric_ymax,
+    update_symmetry_boundary_electric_z0,
+    update_symmetry_boundary_electric_zmax,
+)
+from gprMax.cython.symmetry_boundaries_dispersive import (
+    update_symmetry_boundary_electric_dispersive_b_Ex_Y0_Z0,
+    update_symmetry_boundary_electric_dispersive_b_Ex_Y0_ZMax,
+    update_symmetry_boundary_electric_dispersive_b_Ex_YMax_Z0,
+    update_symmetry_boundary_electric_dispersive_b_Ex_YMax_ZMax,
+    update_symmetry_boundary_electric_dispersive_b_Ey_X0_Z0,
+    update_symmetry_boundary_electric_dispersive_b_Ey_X0_ZMax,
+    update_symmetry_boundary_electric_dispersive_b_Ey_XMax_Z0,
+    update_symmetry_boundary_electric_dispersive_b_Ey_XMax_ZMax,
+    update_symmetry_boundary_electric_dispersive_b_Ez_X0_Y0,
+    update_symmetry_boundary_electric_dispersive_b_Ez_X0_YMax,
+    update_symmetry_boundary_electric_dispersive_b_Ez_XMax_Y0,
+    update_symmetry_boundary_electric_dispersive_b_Ez_XMax_YMax,
+    update_symmetry_boundary_electric_dispersive_b_x0,
+    update_symmetry_boundary_electric_dispersive_b_xmax,
+    update_symmetry_boundary_electric_dispersive_b_y0,
+    update_symmetry_boundary_electric_dispersive_b_ymax,
+    update_symmetry_boundary_electric_dispersive_b_z0,
+    update_symmetry_boundary_electric_dispersive_b_zmax,
+    update_symmetry_boundary_electric_dispersive_Ex_Y0_Z0,
+    update_symmetry_boundary_electric_dispersive_Ex_Y0_ZMax,
+    update_symmetry_boundary_electric_dispersive_Ex_YMax_Z0,
+    update_symmetry_boundary_electric_dispersive_Ex_YMax_ZMax,
+    update_symmetry_boundary_electric_dispersive_Ey_X0_Z0,
+    update_symmetry_boundary_electric_dispersive_Ey_X0_ZMax,
+    update_symmetry_boundary_electric_dispersive_Ey_XMax_Z0,
+    update_symmetry_boundary_electric_dispersive_Ey_XMax_ZMax,
+    update_symmetry_boundary_electric_dispersive_Ez_X0_Y0,
+    update_symmetry_boundary_electric_dispersive_Ez_X0_YMax,
+    update_symmetry_boundary_electric_dispersive_Ez_XMax_Y0,
+    update_symmetry_boundary_electric_dispersive_Ez_XMax_YMax,
+    update_symmetry_boundary_electric_dispersive_x0,
+    update_symmetry_boundary_electric_dispersive_xmax,
+    update_symmetry_boundary_electric_dispersive_y0,
+    update_symmetry_boundary_electric_dispersive_ymax,
+    update_symmetry_boundary_electric_dispersive_z0,
+    update_symmetry_boundary_electric_dispersive_zmax,
+)
+from gprMax.cython.symmetry_boundaries_dispersive_complex import (
+    update_symmetry_boundary_electric_dispersive_b_Ex_Y0_Z0 as _c_update_symmetry_boundary_electric_dispersive_b_Ex_Y0_Z0,
+    update_symmetry_boundary_electric_dispersive_b_Ex_Y0_ZMax as _c_update_symmetry_boundary_electric_dispersive_b_Ex_Y0_ZMax,
+    update_symmetry_boundary_electric_dispersive_b_Ex_YMax_Z0 as _c_update_symmetry_boundary_electric_dispersive_b_Ex_YMax_Z0,
+    update_symmetry_boundary_electric_dispersive_b_Ex_YMax_ZMax as _c_update_symmetry_boundary_electric_dispersive_b_Ex_YMax_ZMax,
+    update_symmetry_boundary_electric_dispersive_b_Ey_X0_Z0 as _c_update_symmetry_boundary_electric_dispersive_b_Ey_X0_Z0,
+    update_symmetry_boundary_electric_dispersive_b_Ey_X0_ZMax as _c_update_symmetry_boundary_electric_dispersive_b_Ey_X0_ZMax,
+    update_symmetry_boundary_electric_dispersive_b_Ey_XMax_Z0 as _c_update_symmetry_boundary_electric_dispersive_b_Ey_XMax_Z0,
+    update_symmetry_boundary_electric_dispersive_b_Ey_XMax_ZMax as _c_update_symmetry_boundary_electric_dispersive_b_Ey_XMax_ZMax,
+    update_symmetry_boundary_electric_dispersive_b_Ez_X0_Y0 as _c_update_symmetry_boundary_electric_dispersive_b_Ez_X0_Y0,
+    update_symmetry_boundary_electric_dispersive_b_Ez_X0_YMax as _c_update_symmetry_boundary_electric_dispersive_b_Ez_X0_YMax,
+    update_symmetry_boundary_electric_dispersive_b_Ez_XMax_Y0 as _c_update_symmetry_boundary_electric_dispersive_b_Ez_XMax_Y0,
+    update_symmetry_boundary_electric_dispersive_b_Ez_XMax_YMax as _c_update_symmetry_boundary_electric_dispersive_b_Ez_XMax_YMax,
+    update_symmetry_boundary_electric_dispersive_b_x0 as _c_update_symmetry_boundary_electric_dispersive_b_x0,
+    update_symmetry_boundary_electric_dispersive_b_xmax as _c_update_symmetry_boundary_electric_dispersive_b_xmax,
+    update_symmetry_boundary_electric_dispersive_b_y0 as _c_update_symmetry_boundary_electric_dispersive_b_y0,
+    update_symmetry_boundary_electric_dispersive_b_ymax as _c_update_symmetry_boundary_electric_dispersive_b_ymax,
+    update_symmetry_boundary_electric_dispersive_b_z0 as _c_update_symmetry_boundary_electric_dispersive_b_z0,
+    update_symmetry_boundary_electric_dispersive_b_zmax as _c_update_symmetry_boundary_electric_dispersive_b_zmax,
+    update_symmetry_boundary_electric_dispersive_Ex_Y0_Z0 as _c_update_symmetry_boundary_electric_dispersive_Ex_Y0_Z0,
+    update_symmetry_boundary_electric_dispersive_Ex_Y0_ZMax as _c_update_symmetry_boundary_electric_dispersive_Ex_Y0_ZMax,
+    update_symmetry_boundary_electric_dispersive_Ex_YMax_Z0 as _c_update_symmetry_boundary_electric_dispersive_Ex_YMax_Z0,
+    update_symmetry_boundary_electric_dispersive_Ex_YMax_ZMax as _c_update_symmetry_boundary_electric_dispersive_Ex_YMax_ZMax,
+    update_symmetry_boundary_electric_dispersive_Ey_X0_Z0 as _c_update_symmetry_boundary_electric_dispersive_Ey_X0_Z0,
+    update_symmetry_boundary_electric_dispersive_Ey_X0_ZMax as _c_update_symmetry_boundary_electric_dispersive_Ey_X0_ZMax,
+    update_symmetry_boundary_electric_dispersive_Ey_XMax_Z0 as _c_update_symmetry_boundary_electric_dispersive_Ey_XMax_Z0,
+    update_symmetry_boundary_electric_dispersive_Ey_XMax_ZMax as _c_update_symmetry_boundary_electric_dispersive_Ey_XMax_ZMax,
+    update_symmetry_boundary_electric_dispersive_Ez_X0_Y0 as _c_update_symmetry_boundary_electric_dispersive_Ez_X0_Y0,
+    update_symmetry_boundary_electric_dispersive_Ez_X0_YMax as _c_update_symmetry_boundary_electric_dispersive_Ez_X0_YMax,
+    update_symmetry_boundary_electric_dispersive_Ez_XMax_Y0 as _c_update_symmetry_boundary_electric_dispersive_Ez_XMax_Y0,
+    update_symmetry_boundary_electric_dispersive_Ez_XMax_YMax as _c_update_symmetry_boundary_electric_dispersive_Ez_XMax_YMax,
+    update_symmetry_boundary_electric_dispersive_x0 as _c_update_symmetry_boundary_electric_dispersive_x0,
+    update_symmetry_boundary_electric_dispersive_xmax as _c_update_symmetry_boundary_electric_dispersive_xmax,
+    update_symmetry_boundary_electric_dispersive_y0 as _c_update_symmetry_boundary_electric_dispersive_y0,
+    update_symmetry_boundary_electric_dispersive_ymax as _c_update_symmetry_boundary_electric_dispersive_ymax,
+    update_symmetry_boundary_electric_dispersive_z0 as _c_update_symmetry_boundary_electric_dispersive_z0,
+    update_symmetry_boundary_electric_dispersive_zmax as _c_update_symmetry_boundary_electric_dispersive_zmax,
+)
+
+_FACE_UPDATE_FUNCS = {
+    "x0": update_symmetry_boundary_electric_x0,
+    "xmax": update_symmetry_boundary_electric_xmax,
+    "y0": update_symmetry_boundary_electric_y0,
+    "ymax": update_symmetry_boundary_electric_ymax,
+    "z0": update_symmetry_boundary_electric_z0,
+    "zmax": update_symmetry_boundary_electric_zmax,
+}
+
+_FACE_UPDATE_FUNCS_DISPERSIVE = {
+    "x0": update_symmetry_boundary_electric_dispersive_x0,
+    "xmax": update_symmetry_boundary_electric_dispersive_xmax,
+    "y0": update_symmetry_boundary_electric_dispersive_y0,
+    "ymax": update_symmetry_boundary_electric_dispersive_ymax,
+    "z0": update_symmetry_boundary_electric_dispersive_z0,
+    "zmax": update_symmetry_boundary_electric_dispersive_zmax,
+}
+
+_FACE_UPDATE_FUNCS_DISPERSIVE_B = {
+    "x0": update_symmetry_boundary_electric_dispersive_b_x0,
+    "xmax": update_symmetry_boundary_electric_dispersive_b_xmax,
+    "y0": update_symmetry_boundary_electric_dispersive_b_y0,
+    "ymax": update_symmetry_boundary_electric_dispersive_b_ymax,
+    "z0": update_symmetry_boundary_electric_dispersive_b_z0,
+    "zmax": update_symmetry_boundary_electric_dispersive_b_zmax,
+}
+
+# Complex-pole (Lorentz/Drude) counterparts of the two dicts above -
+# structurally identical, functions from symmetry_boundaries_dispersive_complex
+# instead of symmetry_boundaries_dispersive.
+_FACE_UPDATE_FUNCS_DISPERSIVE_COMPLEX = {
+    "x0": _c_update_symmetry_boundary_electric_dispersive_x0,
+    "xmax": _c_update_symmetry_boundary_electric_dispersive_xmax,
+    "y0": _c_update_symmetry_boundary_electric_dispersive_y0,
+    "ymax": _c_update_symmetry_boundary_electric_dispersive_ymax,
+    "z0": _c_update_symmetry_boundary_electric_dispersive_z0,
+    "zmax": _c_update_symmetry_boundary_electric_dispersive_zmax,
+}
+
+_FACE_UPDATE_FUNCS_DISPERSIVE_B_COMPLEX = {
+    "x0": _c_update_symmetry_boundary_electric_dispersive_b_x0,
+    "xmax": _c_update_symmetry_boundary_electric_dispersive_b_xmax,
+    "y0": _c_update_symmetry_boundary_electric_dispersive_b_y0,
+    "ymax": _c_update_symmetry_boundary_electric_dispersive_b_ymax,
+    "z0": _c_update_symmetry_boundary_electric_dispersive_b_z0,
+    "zmax": _c_update_symmetry_boundary_electric_dispersive_b_zmax,
+}
+
+_ALL_FACES = ("x0", "y0", "z0", "xmax", "ymax", "zmax")
+
+# The 12 domain edges: (face_a, face_b, cython function, E component
+# attribute, H1/H2 attributes in the function's own positional order).
+_EDGE_TABLE = (
+    ("x0", "y0", update_symmetry_boundary_electric_Ez_X0_Y0, "Ez", "Hx", "Hy"),
+    ("x0", "ymax", update_symmetry_boundary_electric_Ez_X0_YMax, "Ez", "Hx", "Hy"),
+    ("xmax", "y0", update_symmetry_boundary_electric_Ez_XMax_Y0, "Ez", "Hx", "Hy"),
+    ("xmax", "ymax", update_symmetry_boundary_electric_Ez_XMax_YMax, "Ez", "Hx", "Hy"),
+    ("x0", "z0", update_symmetry_boundary_electric_Ey_X0_Z0, "Ey", "Hx", "Hz"),
+    ("x0", "zmax", update_symmetry_boundary_electric_Ey_X0_ZMax, "Ey", "Hx", "Hz"),
+    ("xmax", "z0", update_symmetry_boundary_electric_Ey_XMax_Z0, "Ey", "Hx", "Hz"),
+    ("xmax", "zmax", update_symmetry_boundary_electric_Ey_XMax_ZMax, "Ey", "Hx", "Hz"),
+    ("y0", "z0", update_symmetry_boundary_electric_Ex_Y0_Z0, "Ex", "Hy", "Hz"),
+    ("y0", "zmax", update_symmetry_boundary_electric_Ex_Y0_ZMax, "Ex", "Hy", "Hz"),
+    ("ymax", "z0", update_symmetry_boundary_electric_Ex_YMax_Z0, "Ex", "Hy", "Hz"),
+    ("ymax", "zmax", update_symmetry_boundary_electric_Ex_YMax_ZMax, "Ex", "Hy", "Hz"),
+)
+
+# Same 12 edges, dispersive Phase-A functions (same table shape as
+# _EDGE_TABLE - only the function differs).
+_EDGE_TABLE_DISPERSIVE = (
+    ("x0", "y0", update_symmetry_boundary_electric_dispersive_Ez_X0_Y0, "Ez", "Hx", "Hy"),
+    ("x0", "ymax", update_symmetry_boundary_electric_dispersive_Ez_X0_YMax, "Ez", "Hx", "Hy"),
+    ("xmax", "y0", update_symmetry_boundary_electric_dispersive_Ez_XMax_Y0, "Ez", "Hx", "Hy"),
+    ("xmax", "ymax", update_symmetry_boundary_electric_dispersive_Ez_XMax_YMax, "Ez", "Hx", "Hy"),
+    ("x0", "z0", update_symmetry_boundary_electric_dispersive_Ey_X0_Z0, "Ey", "Hx", "Hz"),
+    ("x0", "zmax", update_symmetry_boundary_electric_dispersive_Ey_X0_ZMax, "Ey", "Hx", "Hz"),
+    ("xmax", "z0", update_symmetry_boundary_electric_dispersive_Ey_XMax_Z0, "Ey", "Hx", "Hz"),
+    ("xmax", "zmax", update_symmetry_boundary_electric_dispersive_Ey_XMax_ZMax, "Ey", "Hx", "Hz"),
+    ("y0", "z0", update_symmetry_boundary_electric_dispersive_Ex_Y0_Z0, "Ex", "Hy", "Hz"),
+    ("y0", "zmax", update_symmetry_boundary_electric_dispersive_Ex_Y0_ZMax, "Ex", "Hy", "Hz"),
+    ("ymax", "z0", update_symmetry_boundary_electric_dispersive_Ex_YMax_Z0, "Ex", "Hy", "Hz"),
+    ("ymax", "zmax", update_symmetry_boundary_electric_dispersive_Ex_YMax_ZMax, "Ex", "Hy", "Hz"),
+)
+
+# Same 12 edges, dispersive Phase-B functions - no H arrays needed (matches
+# the bulk Phase-B kernel's own signature), so only (face_a, face_b, func,
+# e_attr) is needed.
+_EDGE_TABLE_DISPERSIVE_B = (
+    ("x0", "y0", update_symmetry_boundary_electric_dispersive_b_Ez_X0_Y0, "Ez"),
+    ("x0", "ymax", update_symmetry_boundary_electric_dispersive_b_Ez_X0_YMax, "Ez"),
+    ("xmax", "y0", update_symmetry_boundary_electric_dispersive_b_Ez_XMax_Y0, "Ez"),
+    ("xmax", "ymax", update_symmetry_boundary_electric_dispersive_b_Ez_XMax_YMax, "Ez"),
+    ("x0", "z0", update_symmetry_boundary_electric_dispersive_b_Ey_X0_Z0, "Ey"),
+    ("x0", "zmax", update_symmetry_boundary_electric_dispersive_b_Ey_X0_ZMax, "Ey"),
+    ("xmax", "z0", update_symmetry_boundary_electric_dispersive_b_Ey_XMax_Z0, "Ey"),
+    ("xmax", "zmax", update_symmetry_boundary_electric_dispersive_b_Ey_XMax_ZMax, "Ey"),
+    ("y0", "z0", update_symmetry_boundary_electric_dispersive_b_Ex_Y0_Z0, "Ex"),
+    ("y0", "zmax", update_symmetry_boundary_electric_dispersive_b_Ex_Y0_ZMax, "Ex"),
+    ("ymax", "z0", update_symmetry_boundary_electric_dispersive_b_Ex_YMax_Z0, "Ex"),
+    ("ymax", "zmax", update_symmetry_boundary_electric_dispersive_b_Ex_YMax_ZMax, "Ex"),
+)
+
+# Complex-pole (Lorentz/Drude) counterparts of the two edge tables above -
+# same shape, functions from symmetry_boundaries_dispersive_complex.
+_EDGE_TABLE_DISPERSIVE_COMPLEX = (
+    ("x0", "y0", _c_update_symmetry_boundary_electric_dispersive_Ez_X0_Y0, "Ez", "Hx", "Hy"),
+    ("x0", "ymax", _c_update_symmetry_boundary_electric_dispersive_Ez_X0_YMax, "Ez", "Hx", "Hy"),
+    ("xmax", "y0", _c_update_symmetry_boundary_electric_dispersive_Ez_XMax_Y0, "Ez", "Hx", "Hy"),
+    ("xmax", "ymax", _c_update_symmetry_boundary_electric_dispersive_Ez_XMax_YMax, "Ez", "Hx", "Hy"),
+    ("x0", "z0", _c_update_symmetry_boundary_electric_dispersive_Ey_X0_Z0, "Ey", "Hx", "Hz"),
+    ("x0", "zmax", _c_update_symmetry_boundary_electric_dispersive_Ey_X0_ZMax, "Ey", "Hx", "Hz"),
+    ("xmax", "z0", _c_update_symmetry_boundary_electric_dispersive_Ey_XMax_Z0, "Ey", "Hx", "Hz"),
+    ("xmax", "zmax", _c_update_symmetry_boundary_electric_dispersive_Ey_XMax_ZMax, "Ey", "Hx", "Hz"),
+    ("y0", "z0", _c_update_symmetry_boundary_electric_dispersive_Ex_Y0_Z0, "Ex", "Hy", "Hz"),
+    ("y0", "zmax", _c_update_symmetry_boundary_electric_dispersive_Ex_Y0_ZMax, "Ex", "Hy", "Hz"),
+    ("ymax", "z0", _c_update_symmetry_boundary_electric_dispersive_Ex_YMax_Z0, "Ex", "Hy", "Hz"),
+    ("ymax", "zmax", _c_update_symmetry_boundary_electric_dispersive_Ex_YMax_ZMax, "Ex", "Hy", "Hz"),
+)
+
+_EDGE_TABLE_DISPERSIVE_B_COMPLEX = (
+    ("x0", "y0", _c_update_symmetry_boundary_electric_dispersive_b_Ez_X0_Y0, "Ez"),
+    ("x0", "ymax", _c_update_symmetry_boundary_electric_dispersive_b_Ez_X0_YMax, "Ez"),
+    ("xmax", "y0", _c_update_symmetry_boundary_electric_dispersive_b_Ez_XMax_Y0, "Ez"),
+    ("xmax", "ymax", _c_update_symmetry_boundary_electric_dispersive_b_Ez_XMax_YMax, "Ez"),
+    ("x0", "z0", _c_update_symmetry_boundary_electric_dispersive_b_Ey_X0_Z0, "Ey"),
+    ("x0", "zmax", _c_update_symmetry_boundary_electric_dispersive_b_Ey_X0_ZMax, "Ey"),
+    ("xmax", "z0", _c_update_symmetry_boundary_electric_dispersive_b_Ey_XMax_Z0, "Ey"),
+    ("xmax", "zmax", _c_update_symmetry_boundary_electric_dispersive_b_Ey_XMax_ZMax, "Ey"),
+    ("y0", "z0", _c_update_symmetry_boundary_electric_dispersive_b_Ex_Y0_Z0, "Ex"),
+    ("y0", "zmax", _c_update_symmetry_boundary_electric_dispersive_b_Ex_Y0_ZMax, "Ex"),
+    ("ymax", "z0", _c_update_symmetry_boundary_electric_dispersive_b_Ex_YMax_Z0, "Ex"),
+    ("ymax", "zmax", _c_update_symmetry_boundary_electric_dispersive_b_Ex_YMax_ZMax, "Ex"),
+)
+
+
+def _t_attr(e_attr: str) -> str:
+    """Maps an E-field grid attribute name to its matching T-array
+    attribute name, e.g. "Ez" -> "Tz"."""
+    return "T" + e_attr[1:]
+
+
+def build_symmetry_boundary_edges(grid) -> list:
+    """Resolves, once at grid-build time, which of the 12 domain edges need
+    a per-iteration PMC update, and with which (fixed) flags, for standard
+    (non-dispersive) materials.
+
+    An edge is included only if at least one of its two bordering faces is
+    a declared PMC symmetry boundary - an edge where neither face is PMC is
+    dropped entirely, not included with both flags False, so the
+    per-iteration dispatcher never even calls into it.
+
+    Args:
+        grid: FDTDGrid class describing a grid in a model.
+
+    Returns:
+        edges: list of (cython_func, a_pmc, b_pmc, e_attr, h1_attr, h2_attr)
+            tuples for FDTDGrid.symmetry_boundary_edges.
+    """
+    face_is_pmc = {face: grid.symmetry_boundaries.get(face) == "pmc" for face in _ALL_FACES}
+
+    edges = []
+    for face_a, face_b, func, e_attr, h1_attr, h2_attr in _EDGE_TABLE:
+        a_pmc = face_is_pmc[face_a]
+        b_pmc = face_is_pmc[face_b]
+        if a_pmc or b_pmc:
+            edges.append((func, a_pmc, b_pmc, e_attr, h1_attr, h2_attr))
+
+    return edges
+
+
+def build_symmetry_boundary_edges_dispersive(grid) -> list:
+    """Dispersive Phase-A counterpart of build_symmetry_boundary_edges().
+
+    Picks the real-pole (Debye) or complex-pole (Lorentz/Drude) edge table
+    once here, at build time, from materials["drudelorentz"] - already set
+    by Model._check_for_dispersive_materials() before grid.build() (and
+    hence this method) runs for every grid. This matches
+    grid.updatecoeffsdispersive/Tx/Ty/Tz's own dtype, chosen from the same
+    flag in config.py's _set_precision()/set_dispersive_material_types(), so
+    the functions returned here always match the arrays they'll be called
+    with.
+
+    Returns:
+        edges: list of (cython_func, a_pmc, b_pmc, t_attr, e_attr, h1_attr,
+            h2_attr) tuples for FDTDGrid.symmetry_boundary_edges_dispersive.
+    """
+    table = (
+        _EDGE_TABLE_DISPERSIVE_COMPLEX
+        if config.get_model_config().materials["drudelorentz"]
+        else _EDGE_TABLE_DISPERSIVE
+    )
+    face_is_pmc = {face: grid.symmetry_boundaries.get(face) == "pmc" for face in _ALL_FACES}
+
+    edges = []
+    for face_a, face_b, func, e_attr, h1_attr, h2_attr in table:
+        a_pmc = face_is_pmc[face_a]
+        b_pmc = face_is_pmc[face_b]
+        if a_pmc or b_pmc:
+            edges.append((func, a_pmc, b_pmc, _t_attr(e_attr), e_attr, h1_attr, h2_attr))
+
+    return edges
+
+
+def build_symmetry_boundary_edges_dispersive_b(grid) -> list:
+    """Dispersive Phase-B counterpart of build_symmetry_boundary_edges().
+
+    See build_symmetry_boundary_edges_dispersive() for the real/complex
+    table selection.
+
+    Returns:
+        edges: list of (cython_func, t_attr, e_attr) tuples for
+            FDTDGrid.symmetry_boundary_edges_dispersive_b.
+    """
+    table = (
+        _EDGE_TABLE_DISPERSIVE_B_COMPLEX
+        if config.get_model_config().materials["drudelorentz"]
+        else _EDGE_TABLE_DISPERSIVE_B
+    )
+    face_is_pmc = {face: grid.symmetry_boundaries.get(face) == "pmc" for face in _ALL_FACES}
+
+    edges = []
+    for face_a, face_b, func, e_attr in table:
+        a_pmc = face_is_pmc[face_a]
+        b_pmc = face_is_pmc[face_b]
+        if a_pmc or b_pmc:
+            edges.append((func, _t_attr(e_attr), e_attr))
+
+    return edges
+
+
+def update_symmetry_boundaries_electric_normal(grid) -> None:
+    """Applies the per-iteration PMC ghost-node E update to every declared
+    PMC symmetry boundary's face-interior region and, for domain edges
+    touching at least one PMC face, the edge itself - for standard
+    (non-dispersive) materials.
+
+    Args:
+        grid: FDTDGrid class describing a grid in a model.
+    """
+    if not grid.symmetry_boundaries:
+        return
+
+    nthreads = config.get_model_config().ompthreads
+
+    for face, kind in grid.symmetry_boundaries.items():
+        if kind != "pmc":
+            continue
+
+        _FACE_UPDATE_FUNCS[face](
+            grid.nx,
+            grid.ny,
+            grid.nz,
+            nthreads,
+            grid.updatecoeffsE,
+            grid.ID,
+            grid.Ex,
+            grid.Ey,
+            grid.Ez,
+            grid.Hx,
+            grid.Hy,
+            grid.Hz,
+        )
+
+    for func, a_pmc, b_pmc, e_attr, h1_attr, h2_attr in grid.symmetry_boundary_edges:
+        func(
+            grid.nx,
+            grid.ny,
+            grid.nz,
+            nthreads,
+            a_pmc,
+            b_pmc,
+            grid.updatecoeffsE,
+            grid.ID,
+            getattr(grid, e_attr),
+            getattr(grid, h1_attr),
+            getattr(grid, h2_attr),
+        )
+
+
+def update_symmetry_boundaries_electric_dispersive(grid) -> None:
+    """Dispersive Phase-A counterpart of update_symmetry_boundaries_electric_normal().
+
+    Called at the same point in the solve loop as the non-dispersive
+    version (right after update_electric_a(), before PML/sources). Picks
+    the real-pole (Debye) or complex-pole (Lorentz/Drude) face dict from
+    materials["drudelorentz"] - see build_symmetry_boundary_edges_dispersive()
+    for why this matches grid.updatecoeffsdispersive/Tx/Ty/Tz's own dtype.
+    A plain dict lookup, done once per iteration (not per cell), so the
+    cost is negligible either way.
+
+    Args:
+        grid: FDTDGrid class describing a grid in a model.
+    """
+    if not grid.symmetry_boundaries:
+        return
+
+    nthreads = config.get_model_config().ompthreads
+    maxpoles = config.get_model_config().materials["maxpoles"]
+    face_funcs = (
+        _FACE_UPDATE_FUNCS_DISPERSIVE_COMPLEX
+        if config.get_model_config().materials["drudelorentz"]
+        else _FACE_UPDATE_FUNCS_DISPERSIVE
+    )
+
+    for face, kind in grid.symmetry_boundaries.items():
+        if kind != "pmc":
+            continue
+
+        face_funcs[face](
+            grid.nx,
+            grid.ny,
+            grid.nz,
+            nthreads,
+            maxpoles,
+            grid.updatecoeffsE,
+            grid.updatecoeffsdispersive,
+            grid.ID,
+            grid.Tx,
+            grid.Ty,
+            grid.Tz,
+            grid.Ex,
+            grid.Ey,
+            grid.Ez,
+            grid.Hx,
+            grid.Hy,
+            grid.Hz,
+        )
+
+    for func, a_pmc, b_pmc, t_attr, e_attr, h1_attr, h2_attr in grid.symmetry_boundary_edges_dispersive:
+        func(
+            grid.nx,
+            grid.ny,
+            grid.nz,
+            nthreads,
+            a_pmc,
+            b_pmc,
+            maxpoles,
+            grid.updatecoeffsE,
+            grid.updatecoeffsdispersive,
+            grid.ID,
+            getattr(grid, t_attr),
+            getattr(grid, e_attr),
+            getattr(grid, h1_attr),
+            getattr(grid, h2_attr),
+        )
+
+
+def update_symmetry_boundaries_electric_dispersive_b(grid) -> None:
+    """Dispersive Phase-B counterpart of update_symmetry_boundaries_electric_normal().
+
+    Called at the same point in the solve loop as the bulk dispersive
+    kernel's own Phase B (right before update_electric_b(), i.e. after PML
+    and sources have possibly further modified E). See
+    update_symmetry_boundaries_electric_dispersive() for the real/complex
+    face dict selection.
+
+    Args:
+        grid: FDTDGrid class describing a grid in a model.
+    """
+    if not grid.symmetry_boundaries:
+        return
+
+    nthreads = config.get_model_config().ompthreads
+    maxpoles = config.get_model_config().materials["maxpoles"]
+    face_funcs = (
+        _FACE_UPDATE_FUNCS_DISPERSIVE_B_COMPLEX
+        if config.get_model_config().materials["drudelorentz"]
+        else _FACE_UPDATE_FUNCS_DISPERSIVE_B
+    )
+
+    for face, kind in grid.symmetry_boundaries.items():
+        if kind != "pmc":
+            continue
+
+        face_funcs[face](
+            grid.nx,
+            grid.ny,
+            grid.nz,
+            nthreads,
+            maxpoles,
+            grid.updatecoeffsdispersive,
+            grid.ID,
+            grid.Tx,
+            grid.Ty,
+            grid.Tz,
+            grid.Ex,
+            grid.Ey,
+            grid.Ez,
+        )
+
+    for func, t_attr, e_attr in grid.symmetry_boundary_edges_dispersive_b:
+        func(
+            grid.nx,
+            grid.ny,
+            grid.nz,
+            nthreads,
+            maxpoles,
+            grid.updatecoeffsdispersive,
+            grid.ID,
+            getattr(grid, t_attr),
+            getattr(grid, e_attr),
+        )

--- a/gprMax/updates/cpu_updates.py
+++ b/gprMax/updates/cpu_updates.py
@@ -25,6 +25,11 @@ from gprMax import config
 from gprMax.cython.fields_updates_normal import update_electric as update_electric_cpu
 from gprMax.cython.fields_updates_normal import update_magnetic as update_magnetic_cpu
 from gprMax.fields_outputs import store_outputs as store_outputs_cpu
+from gprMax.symmetry_boundaries import (
+    update_symmetry_boundaries_electric_dispersive,
+    update_symmetry_boundaries_electric_dispersive_b,
+    update_symmetry_boundaries_electric_normal,
+)
 from gprMax.updates.updates import GridType, Updates
 from gprMax.utilities.utilities import timer
 
@@ -200,6 +205,18 @@ class CPUUpdates(Updates[GridType]):
                 self.grid.Hy,
                 self.grid.Hz,
             )
+
+    def update_symmetry_boundaries_electric(self):
+        """Apply the PMC ghost-node E update on CPU symmetry faces."""
+        if config.get_model_config().materials["maxpoles"] == 0:
+            update_symmetry_boundaries_electric_normal(self.grid)
+        else:
+            update_symmetry_boundaries_electric_dispersive(self.grid)
+
+    def update_symmetry_boundaries_electric_b(self):
+        """Complete the dispersive PMC ghost-node update's second phase."""
+        if config.get_model_config().materials["maxpoles"] > 0:
+            update_symmetry_boundaries_electric_dispersive_b(self.grid)
 
     def update_electric_pml(self):
         """Updates electric field components with the PML correction."""

--- a/gprMax/updates/cuda_updates.py
+++ b/gprMax/updates/cuda_updates.py
@@ -30,6 +30,7 @@ from gprMax.cuda_opencl import (
     knl_snapshots,
     knl_source_updates,
     knl_store_outputs,
+    knl_symmetry_boundaries,
 )
 from gprMax.grid.cuda_grid import CUDAGrid
 from gprMax.receivers import dtoh_rx_array, htod_rx_arrays
@@ -96,6 +97,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
         # Initialise arrays on GPU, prepare kernels, and get kernel functions
         self._set_macros()
         self._set_field_knls()
+        if "pmc" in self.grid.symmetry_boundaries.values():
+            self._set_symmetry_boundary_knl()
         if self.grid.pmls["slabs"]:
             self._set_pml_knls()
         if self.grid.rxs:
@@ -227,6 +230,24 @@ class CUDAUpdates(Updates[CUDAGrid]):
         self.grid.htod_field_arrays()
         if config.get_model_config().materials["maxpoles"] > 0:
             self.grid.htod_dispersive_arrays()
+
+    def _set_symmetry_boundary_knl(self):
+        """Build the nondispersive PMC ghost-image boundary kernel."""
+        source = self._build_knl(
+            knl_symmetry_boundaries.update_electric_pmc,
+            self.subs_name_args,
+            self.subs_func,
+        )
+        module = self.source_module(source, options=config.sim_config.devices["nvcc_opts"])
+        self.update_electric_pmc_dev = module.get_function("update_electric_pmc")
+        self._copy_mat_coeffs(module, module)
+
+    def _pmc_flags(self):
+        boundaries = self.grid.symmetry_boundaries
+        return tuple(
+            np.int32(boundaries.get(face) == "pmc")
+            for face in ("x0", "xmax", "y0", "ymax", "z0", "zmax")
+        )
 
     def _set_pml_knls(self):
         """PMLS - prepares kernels and gets kernel functions."""
@@ -526,6 +547,27 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 block=self.grid.tpb,
                 grid=self.grid.bpg,
             )
+
+    def update_symmetry_boundaries_electric(self):
+        """Apply the nondispersive PMC ghost-image correction on CUDA."""
+        if "pmc" not in self.grid.symmetry_boundaries.values():
+            return
+
+        self.update_electric_pmc_dev(
+            np.int32(self.grid.nx),
+            np.int32(self.grid.ny),
+            np.int32(self.grid.nz),
+            *self._pmc_flags(),
+            self.grid.ID_dev.gpudata,
+            self.grid.Ex_dev.gpudata,
+            self.grid.Ey_dev.gpudata,
+            self.grid.Ez_dev.gpudata,
+            self.grid.Hx_dev.gpudata,
+            self.grid.Hy_dev.gpudata,
+            self.grid.Hz_dev.gpudata,
+            block=self.grid.tpb,
+            grid=self.grid.bpg,
+        )
 
     def update_electric_pml(self):
         """Updates electric field components with the PML correction."""

--- a/gprMax/updates/metal_updates.py
+++ b/gprMax/updates/metal_updates.py
@@ -29,6 +29,7 @@ from gprMax.cuda_opencl import (
     knl_snapshots,
     knl_source_updates,
     knl_store_outputs,
+    knl_symmetry_boundaries,
 )
 from gprMax.receivers import dtoh_rx_array, htod_rx_arrays
 from gprMax.snapshots import (
@@ -92,6 +93,8 @@ class MetalUpdates:
         # Initialise arrays on device, prepare kernels, and get kernel functions
         self._set_macros()
         self._set_field_knls()
+        if "pmc" in self.grid.symmetry_boundaries.values():
+            self._set_symmetry_boundary_knl()
         if self.grid.pmls["slabs"]:
             self._set_pml_knls()
         if self.grid.rxs:
@@ -269,6 +272,28 @@ class MetalUpdates:
         self.grid.htod_geometry_arrays(self.dev)
         self.grid.htod_field_arrays(self.dev)
         self.grid.htod_material_arrays(self.dev)
+
+    def _set_symmetry_boundary_knl(self):
+        """Build the nondispersive PMC ghost-image boundary kernel."""
+        source = self._build_knl(
+            knl_symmetry_boundaries.update_electric_pmc,
+            self.subs_name_args,
+            self.subs_func,
+        )
+        library, error = self.dev.newLibraryWithSource_options_error_(source, self.opts, None)
+        if library is None:
+            raise RuntimeError(f"Failed to compile Metal PMC kernel: {error}")
+        function = library.newFunctionWithName_("update_electric_pmc")
+        self.pso_electric_pmc = self.dev.newComputePipelineStateWithFunction_error_(
+            function, None
+        )[0]
+
+    def _pmc_flags(self):
+        boundaries = self.grid.symmetry_boundaries
+        return tuple(
+            np.int32(boundaries.get(face) == "pmc")
+            for face in ("x0", "xmax", "y0", "ymax", "z0", "zmax")
+        )
 
     def _set_pml_knls(self):
         """PMLS - prepares kernels and gets kernel functions."""
@@ -825,6 +850,45 @@ class MetalUpdates:
             cmdbuffer.commit()
             cmdbuffer.waitUntilCompleted()
 
+    def update_symmetry_boundaries_electric(self):
+        """Apply the nondispersive PMC ghost-image correction on Metal."""
+        if "pmc" not in self.grid.symmetry_boundaries.values():
+            return
+
+        command = self.cmdqueue.commandBuffer()
+        encoder = command.computeCommandEncoder()
+        encoder.setComputePipelineState_(self.pso_electric_pmc)
+        scalars = (
+            np.int32(self.grid.nx),
+            np.int32(self.grid.ny),
+            np.int32(self.grid.nz),
+            *self._pmc_flags(),
+        )
+        for index, value in enumerate(scalars):
+            encoder.setBytes_length_atIndex_(value.tobytes(), 4, index)
+
+        buffers = (
+            self.grid.ID_dev,
+            self.grid.Ex_dev,
+            self.grid.Ey_dev,
+            self.grid.Ez_dev,
+            self.grid.Hx_dev,
+            self.grid.Hy_dev,
+            self.grid.Hz_dev,
+        )
+        for index, buffer in enumerate(buffers, start=9):
+            encoder.setBuffer_offset_atIndex_(buffer, 0, index)
+
+        encoder.dispatchThreads_threadsPerThreadgroup_(
+            self.grid.tptg,
+            self.metal.MTLSizeMake(
+                self.pso_electric_pmc.maxTotalThreadsPerThreadgroup(), 1, 1
+            ),
+        )
+        encoder.endEncoding()
+        command.commit()
+        command.waitUntilCompleted()
+
     def update_electric_pml(self):
         """Updates electric field components with the PML correction."""
         for pml in self.grid.pmls["slabs"]:
@@ -1046,6 +1110,11 @@ class MetalUpdates:
             cmpencoder.endEncoding()
             cmdbuffer.commit()
             cmdbuffer.waitUntilCompleted()
+
+    def update_symmetry_boundaries_electric_b(self):
+        """No-op because dispersive PMC symmetry is rejected for Metal."""
+
+        pass
 
     def time_start(self):
         """Starts event timers used to calculate solving time for model."""

--- a/gprMax/updates/opencl_updates.py
+++ b/gprMax/updates/opencl_updates.py
@@ -29,6 +29,7 @@ from gprMax.cuda_opencl import (
     knl_snapshots,
     knl_source_updates,
     knl_store_outputs,
+    knl_symmetry_boundaries,
 )
 from gprMax.grid.opencl_grid import OpenCLGrid
 from gprMax.receivers import dtoh_rx_array, htod_rx_arrays
@@ -78,6 +79,8 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
         # Initialise arrays on device, prepare kernels, and get kernel functions
         self._set_macros()
         self._set_field_knls()
+        if "pmc" in self.grid.symmetry_boundaries.values():
+            self._set_symmetry_boundary_knl()
         if self.grid.pmls["slabs"]:
             self._set_pml_knls()
         if self.grid.rxs:
@@ -221,6 +224,36 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
         self.grid.htod_field_arrays(self.queue)
         if config.get_model_config().materials["maxpoles"] > 0:
             self.grid.htod_dispersive_arrays(self.queue)
+
+    def _set_symmetry_boundary_knl(self):
+        """Build the nondispersive PMC ghost-image boundary kernel."""
+        substitutions = {
+            "CUDA_IDX": "",
+            "REAL": config.sim_config.dtypes["C_float_or_double"],
+            "NX_FIELDS": self.grid.nx + 1,
+            "NY_FIELDS": self.grid.ny + 1,
+            "NZ_FIELDS": self.grid.nz + 1,
+            "NX_ID": self.grid.ID.shape[1],
+            "NY_ID": self.grid.ID.shape[2],
+            "NZ_ID": self.grid.ID.shape[3],
+        }
+        self.update_electric_pmc_dev = self.elwiseknl(
+            self.ctx,
+            knl_symmetry_boundaries.update_electric_pmc["args_opencl"].substitute(
+                {"REAL": config.sim_config.dtypes["C_float_or_double"]}
+            ),
+            knl_symmetry_boundaries.update_electric_pmc["func"].substitute(substitutions),
+            "update_electric_pmc",
+            preamble=self.knl_common,
+            options=config.sim_config.devices["compiler_opts"],
+        )
+
+    def _pmc_flags(self):
+        boundaries = self.grid.symmetry_boundaries
+        return tuple(
+            np.int32(boundaries.get(face) == "pmc")
+            for face in ("x0", "xmax", "y0", "ymax", "z0", "zmax")
+        )
 
     def _set_pml_knls(self):
         """PMLS - prepares kernels and gets kernel functions."""
@@ -520,6 +553,25 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
                 self.grid.Ty_dev,
                 self.grid.Tz_dev,
             )
+
+    def update_symmetry_boundaries_electric(self):
+        """Apply the nondispersive PMC ghost-image correction on OpenCL."""
+        if "pmc" not in self.grid.symmetry_boundaries.values():
+            return
+
+        self.update_electric_pmc_dev(
+            np.int32(self.grid.nx),
+            np.int32(self.grid.ny),
+            np.int32(self.grid.nz),
+            *self._pmc_flags(),
+            self.grid.ID_dev,
+            self.grid.Ex_dev,
+            self.grid.Ey_dev,
+            self.grid.Ez_dev,
+            self.grid.Hx_dev,
+            self.grid.Hy_dev,
+            self.grid.Hz_dev,
+        )
 
     def update_electric_pml(self):
         """Updates electric field components with the PML correction."""

--- a/gprMax/updates/updates.py
+++ b/gprMax/updates/updates.py
@@ -71,6 +71,11 @@ class Updates(Generic[GridType], ABC):
         """Updates electric field components."""
         pass
 
+    def update_symmetry_boundaries_electric(self) -> None:
+        """Apply any PMC ghost-image electric boundary correction."""
+
+        pass
+
     @abstractmethod
     def update_electric_pml(self) -> None:
         """Updates electric field components with the PML correction."""
@@ -91,6 +96,11 @@ class Updates(Generic[GridType], ABC):
         updated after the electric field has been updated by the PML and
         source updates.
         """
+        pass
+
+    def update_symmetry_boundaries_electric_b(self) -> None:
+        """Apply phase B of any dispersive PMC boundary correction."""
+
         pass
 
     @abstractmethod

--- a/gprMax/user_objects/cmds_geometry/box.py
+++ b/gprMax/user_objects/cmds_geometry/box.py
@@ -119,6 +119,7 @@ class Box(RotatableMixin, GeometryUserObject):
         if len(materials) == 1:
             averaging = materials[0].averagable and averagebox
             numID = numIDx = numIDy = numIDz = materials[0].numID
+            pec_x = pec_y = pec_z = materials[0].is_pec
 
         # Uniaxial anisotropic case
         elif len(materials) == 3:
@@ -126,6 +127,9 @@ class Box(RotatableMixin, GeometryUserObject):
             numIDx = materials[0].numID
             numIDy = materials[1].numID
             numIDz = materials[2].numID
+            pec_x = materials[0].is_pec
+            pec_y = materials[1].is_pec
+            pec_z = materials[2].is_pec
             requiredID = Material.create_compound_id(materials[0], materials[1], materials[2])
             averagedmaterial = [x for x in grid.materials if x.ID == requiredID]
             if averagedmaterial:
@@ -155,6 +159,9 @@ class Box(RotatableMixin, GeometryUserObject):
             numIDy,
             numIDz,
             averaging,
+            pec_x,
+            pec_y,
+            pec_z,
             grid.solid,
             grid.rigidE,
             grid.rigidH,

--- a/gprMax/user_objects/cmds_geometry/cone.py
+++ b/gprMax/user_objects/cmds_geometry/cone.py
@@ -130,6 +130,7 @@ class Cone(GeometryUserObject):
         if len(materials) == 1:
             averaging = materials[0].averagable and averagecone
             numID = numIDx = numIDy = numIDz = materials[0].numID
+            pec_x = pec_y = pec_z = materials[0].is_pec
 
         # Uniaxial anisotropic case
         elif len(materials) == 3:
@@ -137,6 +138,9 @@ class Cone(GeometryUserObject):
             numIDx = materials[0].numID
             numIDy = materials[1].numID
             numIDz = materials[2].numID
+            pec_x = materials[0].is_pec
+            pec_y = materials[1].is_pec
+            pec_z = materials[2].is_pec
             requiredID = Material.create_compound_id(materials[0], materials[1], materials[2])
             averagedmaterial = [x for x in grid.materials if x.ID == requiredID]
             if averagedmaterial:
@@ -171,6 +175,9 @@ class Cone(GeometryUserObject):
             numIDy,
             numIDz,
             averaging,
+            pec_x,
+            pec_y,
+            pec_z,
             grid.solid,
             grid.rigidE,
             grid.rigidH,

--- a/gprMax/user_objects/cmds_geometry/cylinder.py
+++ b/gprMax/user_objects/cmds_geometry/cylinder.py
@@ -106,6 +106,7 @@ class Cylinder(GeometryUserObject):
         if len(materials) == 1:
             averaging = materials[0].averagable and averagecylinder
             numID = numIDx = numIDy = numIDz = materials[0].numID
+            pec_x = pec_y = pec_z = materials[0].is_pec
 
         # Uniaxial anisotropic case
         elif len(materials) == 3:
@@ -113,6 +114,9 @@ class Cylinder(GeometryUserObject):
             numIDx = materials[0].numID
             numIDy = materials[1].numID
             numIDz = materials[2].numID
+            pec_x = materials[0].is_pec
+            pec_y = materials[1].is_pec
+            pec_z = materials[2].is_pec
             requiredID = Material.create_compound_id(materials[0], materials[1], materials[2])
             averagedmaterial = [x for x in grid.materials if x.ID == requiredID]
             if averagedmaterial:
@@ -146,6 +150,9 @@ class Cylinder(GeometryUserObject):
             numIDy,
             numIDz,
             averaging,
+            pec_x,
+            pec_y,
+            pec_z,
             grid.solid,
             grid.rigidE,
             grid.rigidH,

--- a/gprMax/user_objects/cmds_geometry/cylindrical_sector.py
+++ b/gprMax/user_objects/cmds_geometry/cylindrical_sector.py
@@ -194,12 +194,16 @@ class CylindricalSector(GeometryUserObject):
             if len(materials) == 1:
                 averaging = materials[0].averagable and averagecylindricalsector
                 numID = numIDx = numIDy = numIDz = materials[0].numID
+                pec_x = pec_y = pec_z = materials[0].is_pec
 
             elif len(materials) == 3:
                 averaging = False
                 numIDx = materials[0].numID
                 numIDy = materials[1].numID
                 numIDz = materials[2].numID
+                pec_x = materials[0].is_pec
+                pec_y = materials[1].is_pec
+                pec_z = materials[2].is_pec
                 requiredID = Material.create_compound_id(materials[0], materials[1], materials[2])
                 averagedmaterial = [x for x in grid.materials if x.ID == requiredID]
                 if averagedmaterial:
@@ -221,6 +225,7 @@ class CylindricalSector(GeometryUserObject):
             # Isotropic case
             if len(materials) == 1:
                 numID = numIDx = numIDy = numIDz = materials[0].numID
+                pec_x = pec_y = pec_z = materials[0].is_pec
 
             # Uniaxial anisotropic case
             elif len(materials) == 3:
@@ -229,6 +234,9 @@ class CylindricalSector(GeometryUserObject):
                 numIDx = materials[0].numID
                 numIDy = materials[1].numID
                 numIDz = materials[2].numID
+                pec_x = materials[0].is_pec
+                pec_y = materials[1].is_pec
+                pec_z = materials[2].is_pec
 
         build_cylindrical_sector(
             ctr1,
@@ -247,6 +255,9 @@ class CylindricalSector(GeometryUserObject):
             numIDy,
             numIDz,
             averaging,
+            pec_x,
+            pec_y,
+            pec_z,
             grid.solid,
             grid.rigidE,
             grid.rigidH,

--- a/gprMax/user_objects/cmds_geometry/ellipsoid.py
+++ b/gprMax/user_objects/cmds_geometry/ellipsoid.py
@@ -99,6 +99,7 @@ class Ellipsoid(GeometryUserObject):
         if len(materials) == 1:
             averaging = materials[0].averagable and averageellipsoid
             numID = numIDx = numIDy = numIDz = materials[0].numID
+            pec_x = pec_y = pec_z = materials[0].is_pec
 
         # Uniaxial anisotropic case
         elif len(materials) == 3:
@@ -106,6 +107,9 @@ class Ellipsoid(GeometryUserObject):
             numIDx = materials[0].numID
             numIDy = materials[1].numID
             numIDz = materials[2].numID
+            pec_x = materials[0].is_pec
+            pec_y = materials[1].is_pec
+            pec_z = materials[2].is_pec
             requiredID = Material.create_compound_id(materials[0], materials[1], materials[2])
             averagedmaterial = [x for x in grid.materials if x.ID == requiredID]
             if averagedmaterial:
@@ -138,6 +142,9 @@ class Ellipsoid(GeometryUserObject):
             numIDy,
             numIDz,
             averaging,
+            pec_x,
+            pec_y,
+            pec_z,
             grid.solid,
             grid.rigidE,
             grid.rigidH,

--- a/gprMax/user_objects/cmds_geometry/fractal_box.py
+++ b/gprMax/user_objects/cmds_geometry/fractal_box.py
@@ -737,6 +737,10 @@ class FractalBox(RotatableMixin, GeometryUserObject):
                 grassnumID = next((x.numID for x in grid.materials if x.ID == "grass"), 0)
                 data = self.volume.fractalvolume.astype("int16", order="C")
                 mask = self.volume.mask.copy(order="C")
+                is_pec_lookup = np.array([m.is_pec for m in grid.materials], dtype=np.uint8)
+                is_averagable_lookup = np.array(
+                    [m.averagable for m in grid.materials], dtype=np.uint8
+                )
                 build_voxels_from_array_mask(
                     self.volume.xs,
                     self.volume.ys,
@@ -744,6 +748,8 @@ class FractalBox(RotatableMixin, GeometryUserObject):
                     waternumID,
                     grassnumID,
                     self.volume.averaging,
+                    is_pec_lookup,
+                    is_averagable_lookup,
                     mask,
                     data,
                     grid.solid,
@@ -771,12 +777,18 @@ class FractalBox(RotatableMixin, GeometryUserObject):
                                 ]
 
                 data = self.volume.fractalvolume.astype("int16", order="C")
+                is_pec_lookup = np.array([m.is_pec for m in grid.materials], dtype=np.uint8)
+                is_averagable_lookup = np.array(
+                    [m.averagable for m in grid.materials], dtype=np.uint8
+                )
                 build_voxels_from_array(
                     self.volume.xs,
                     self.volume.ys,
                     self.volume.zs,
                     0,
                     self.volume.averaging,
+                    is_pec_lookup,
+                    is_averagable_lookup,
                     data,
                     grid.solid,
                     grid.rigidE,

--- a/gprMax/user_objects/cmds_geometry/geometry_objects_read.py
+++ b/gprMax/user_objects/cmds_geometry/geometry_objects_read.py
@@ -221,12 +221,20 @@ class GeometryObjectsRead(GeometryUserObject):
                 data = f.get_data()
                 if data is not None:
                     averaging = False
+                    is_pec_lookup = np.array(
+                        [m.is_pec for m in grid.materials], dtype=np.uint8
+                    )
+                    is_averagable_lookup = np.array(
+                        [m.averagable for m in grid.materials], dtype=np.uint8
+                    )
                     build_voxels_from_array(
                         discretised_p1[0],
                         discretised_p1[1],
                         discretised_p1[2],
                         0,
                         averaging,
+                        is_pec_lookup,
+                        is_averagable_lookup,
                         data,
                         grid.solid,
                         grid.rigidE,

--- a/gprMax/user_objects/cmds_geometry/magnetic_edge.py
+++ b/gprMax/user_objects/cmds_geometry/magnetic_edge.py
@@ -1,0 +1,136 @@
+# Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+import numpy as np
+
+import gprMax.config as config
+from gprMax.cython.geometry_primitives import (
+    build_magnetic_edge_x,
+    build_magnetic_edge_y,
+    build_magnetic_edge_z,
+)
+from gprMax.grid.fdtd_grid import FDTDGrid
+from gprMax.user_objects.rotatable import RotatableMixin
+from gprMax.user_objects.user_objects import GeometryUserObject
+
+from .cmds_geometry import rotate_2point_object
+
+logger = logging.getLogger(__name__)
+
+
+class MagneticEdge(RotatableMixin, GeometryUserObject):
+    """Introduces a single magnetic (H) edge with specific properties into
+        the model - the magnetic dual of #edge.
+
+    Attributes:
+        p1: list of the coordinates (x,y,z) of the starting point of the edge.
+        p2: list of the coordinates (x,y,z) of the ending point of the edge.
+        material_id: string for the material identifier that must correspond
+                        to material that has already been defined.
+    """
+
+    @property
+    def hash(self):
+        return "#magnetic_edge"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def _do_rotate(self, grid: FDTDGrid):
+        """Performs rotation."""
+        pts = np.array([self.kwargs["p1"], self.kwargs["p2"]])
+        rot_pts = rotate_2point_object(pts, self.axis, self.angle, self.origin)
+        self.kwargs["p1"] = tuple(rot_pts[0, :])
+        self.kwargs["p2"] = tuple(rot_pts[1, :])
+
+    def build(self, grid: FDTDGrid):
+        """Creates a magnetic edge and adds it to the grid."""
+        try:
+            p1 = self.kwargs["p1"]
+            p2 = self.kwargs["p2"]
+            material_id = self.kwargs["material_id"]
+        except KeyError:
+            logger.exception(f"{self.__str__()} requires exactly 3 parameters")
+            raise
+
+        if config.get_model_config().mode.startswith("2D"):
+            raise ValueError(
+                f"{self.__str__()} is not yet supported in 2D mode - which axis "
+                "is physically meaningful for a magnetic edge differs from "
+                "#edge's own 2D rule and has not yet been verified."
+            )
+
+        if self.do_rotate:
+            self._do_rotate(grid)
+
+        uip = self._create_uip(grid)
+
+        p1 = uip.resolve_inf_point(p1, role="lower")
+        p2 = uip.resolve_inf_point(p2, role="upper")
+
+        edge_within_grid, discretised_p1, discretised_p2 = uip.check_box_points(
+            p1, p2, self.__str__()
+        )
+
+        # Exit early if none of the edge is in this grid as there is
+        # nothing else to do.
+        if not edge_within_grid:
+            return
+
+        xs, ys, zs = discretised_p1
+        xf, yf, zf = discretised_p2
+
+        material = next((x for x in grid.materials if x.ID == material_id), None)
+
+        if not material:
+            logger.exception(f"Material with ID {material_id} does not exist")
+            raise ValueError
+
+        # Check for valid orientations
+        if (
+            (xs != xf and (ys != yf or zs != zf))
+            or (ys != yf and (xs != xf or zs != zf))
+            or (zs != zf and (xs != xf or ys != yf))
+            or (xs == xf and ys == yf and zs == zf)
+        ):
+            logger.exception(f"{self.__str__()} the edge is not specified correctly")
+            raise ValueError
+
+        if xs != xf:
+            for i in range(xs, xf):
+                build_magnetic_edge_x(i, ys, zs, material.numID, grid.rigidH, grid.ID)
+
+        elif ys != yf:
+            for j in range(ys, yf):
+                build_magnetic_edge_y(xs, j, zs, material.numID, grid.rigidH, grid.ID)
+
+        elif zs != zf:
+            for k in range(zs, zf):
+                build_magnetic_edge_z(xs, ys, k, material.numID, grid.rigidH, grid.ID)
+
+        p3 = uip.round_to_grid_static_point(p1)
+        p4 = uip.round_to_grid_static_point(p2)
+
+        logger.info(
+            f"{self.grid_name(grid)}Magnetic edge from {p3[0]:g}m, {p3[1]:g}m, "
+            f"{p3[2]:g}m, to {p4[0]:g}m, {p4[1]:g}m, {p4[2]:g}m of "
+            f"material {material_id} created."
+        )

--- a/gprMax/user_objects/cmds_geometry/sphere.py
+++ b/gprMax/user_objects/cmds_geometry/sphere.py
@@ -94,6 +94,7 @@ class Sphere(GeometryUserObject):
         if len(materials) == 1:
             averaging = materials[0].averagable and averagesphere
             numID = numIDx = numIDy = numIDz = materials[0].numID
+            pec_x = pec_y = pec_z = materials[0].is_pec
 
         # Uniaxial anisotropic case
         elif len(materials) == 3:
@@ -101,6 +102,9 @@ class Sphere(GeometryUserObject):
             numIDx = materials[0].numID
             numIDy = materials[1].numID
             numIDz = materials[2].numID
+            pec_x = materials[0].is_pec
+            pec_y = materials[1].is_pec
+            pec_z = materials[2].is_pec
             requiredID = Material.create_compound_id(materials[0], materials[1], materials[2])
             averagedmaterial = [x for x in grid.materials if x.ID == requiredID]
             if averagedmaterial:
@@ -131,6 +135,9 @@ class Sphere(GeometryUserObject):
             numIDy,
             numIDz,
             averaging,
+            pec_x,
+            pec_y,
+            pec_z,
             grid.solid,
             grid.rigidE,
             grid.rigidH,

--- a/gprMax/user_objects/cmds_geometry/triangle.py
+++ b/gprMax/user_objects/cmds_geometry/triangle.py
@@ -167,6 +167,7 @@ class Triangle(RotatableMixin, GeometryUserObject):
             if len(materials) == 1:
                 averaging = materials[0].averagable and averagetriangularprism
                 numID = numIDx = numIDy = numIDz = materials[0].numID
+                pec_x = pec_y = pec_z = materials[0].is_pec
 
             # Uniaxial anisotropic case
             elif len(materials) == 3:
@@ -174,6 +175,9 @@ class Triangle(RotatableMixin, GeometryUserObject):
                 numIDx = materials[0].numID
                 numIDy = materials[1].numID
                 numIDz = materials[2].numID
+                pec_x = materials[0].is_pec
+                pec_y = materials[1].is_pec
+                pec_z = materials[2].is_pec
                 requiredID = Material.create_compound_id(materials[0], materials[1], materials[2])
                 averagedmaterial = [x for x in grid.materials if x.ID == requiredID]
                 if averagedmaterial:
@@ -195,6 +199,7 @@ class Triangle(RotatableMixin, GeometryUserObject):
             # Isotropic case
             if len(materials) == 1:
                 numID = numIDx = numIDy = numIDz = materials[0].numID
+                pec_x = pec_y = pec_z = materials[0].is_pec
 
             # Uniaxial anisotropic case
             elif len(materials) == 3:
@@ -203,6 +208,9 @@ class Triangle(RotatableMixin, GeometryUserObject):
                 numIDx = materials[0].numID
                 numIDy = materials[1].numID
                 numIDz = materials[2].numID
+                pec_x = materials[0].is_pec
+                pec_y = materials[1].is_pec
+                pec_z = materials[2].is_pec
 
         build_triangle(
             x1,
@@ -224,6 +232,9 @@ class Triangle(RotatableMixin, GeometryUserObject):
             numIDy,
             numIDz,
             averaging,
+            pec_x,
+            pec_y,
+            pec_z,
             grid.solid,
             grid.rigidE,
             grid.rigidH,

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -1927,8 +1927,9 @@ class Material(GridUserObject):
         m.mr = mr
         m.sm = sm
 
-        # Set material averaging to False if infinite conductivity, i.e. pec
-        if m.se == float("inf"):
+        # Perfect electric and magnetic conductors cannot participate in
+        # dielectric smoothing at a material interface.
+        if m.se == float("inf") or m.sm == float("inf"):
             m.averagable = False
 
         m.er = er

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -42,6 +42,7 @@ from gprMax.sources import HertzianDipole as HertzianDipoleUser
 from gprMax.sources import MagneticDipole as MagneticDipoleUser
 from gprMax.sources import TransmissionLine as TransmissionLineUser
 from gprMax.sources import VoltageSource as VoltageSourceUser
+from gprMax.subgrids.grid import SubGridBaseGrid
 from gprMax.user_objects.cmds_geometry.cmds_geometry import (
     rotate_2point_object,
     rotate_polarisation,
@@ -2578,6 +2579,96 @@ class PMLCFS(GridUserObject):
                 f"{self.params_str()} can only be used up to two times, for up to a 2nd order PML."
             )
             raise ValueError
+
+
+class SymmetryBoundary(GridUserObject):
+    """Sets a PEC or PMC symmetry boundary condition on a model-domain face.
+
+    The selected boundary replaces the PML on that face. A PEC boundary
+    forces the tangential electric-field component IDs to the built-in PEC
+    material during grid construction. A PMC boundary uses an image-theory
+    ghost-node update for the on-wall tangential electric fields.
+
+    Nondispersive PMC boundaries are supported by the CPU, CUDA, OpenCL, and
+    Metal solvers. Dispersive PMC boundaries are currently CPU-only.
+    Symmetry boundaries are not supported in 2D mode, with MPI, or on a
+    subgrid, although they may be used on the main grid of a model that
+    contains subgrids.
+
+    Attributes:
+        face: One of ``x0``, ``y0``, ``z0``, ``xmax``, ``ymax``, or ``zmax``.
+        type: Either ``pec`` or ``pmc``.
+    """
+
+    VALID_FACES = ("x0", "y0", "z0", "xmax", "ymax", "zmax")
+    VALID_TYPES = ("pec", "pmc")
+
+    @property
+    def order(self):
+        # Build before sources and receivers so their PML-position checks see
+        # the symmetry face's disabled PML thickness.
+        return 0
+
+    @property
+    def hash(self):
+        return "#symmetry_boundary"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def build(self, grid: FDTDGrid):
+        try:
+            face = self.kwargs["face"]
+            boundary_type = self.kwargs["type"]
+        except KeyError:
+            logger.exception(f"{self.params_str()} requires a face and a boundary type.")
+            raise
+
+        if face not in self.VALID_FACES:
+            logger.exception(
+                f"{self.params_str()} face must be one of {', '.join(self.VALID_FACES)}."
+            )
+            raise ValueError
+
+        if boundary_type not in self.VALID_TYPES:
+            logger.exception(
+                f"{self.params_str()} type must be one of {', '.join(self.VALID_TYPES)}."
+            )
+            raise ValueError
+
+        if config.sim_config.mpi:
+            logger.exception(f"{self.params_str()} cannot currently be used with MPI.")
+            raise ValueError
+
+        if config.get_model_config().mode.startswith("2D"):
+            logger.exception(f"{self.params_str()} cannot currently be used in 2D mode.")
+            raise ValueError
+
+        if isinstance(grid, SubGridBaseGrid):
+            logger.exception(
+                f"{self.params_str()} cannot be used on a subgrid. It may still be "
+                "used on the main grid of a model that contains subgrids."
+            )
+            raise ValueError
+
+        if face in grid.symmetry_boundaries:
+            logger.exception(
+                f"{self.params_str()} a symmetry boundary has already been set on face '{face}'."
+            )
+            raise ValueError
+
+        grid.symmetry_boundaries[face] = boundary_type
+        overridden_thickness = grid.pmls["thickness"][face]
+        grid.pmls["thickness"][face] = 0
+
+        logger.info(
+            f"Symmetry boundary ({boundary_type}) set on face '{face}'"
+            + (
+                f"; PML thickness on that face (was {overridden_thickness}) disabled."
+                if overridden_thickness
+                else "; PML on that face disabled."
+            )
+        )
 
 
 """

--- a/gprMax/user_objects/cmds_singleuse.py
+++ b/gprMax/user_objects/cmds_singleuse.py
@@ -138,6 +138,55 @@ class DomainMode(ModelUserObject):
         logger.info(f"Requested domain mode: {self.requested_mode}")
 
 
+class MagneticAveraging(ModelUserObject):
+    """Sets the mixing rule used to combine the relative magnetic
+    permeability (mu_r) and magnetic loss (sigma*) of two different
+    materials when a magnetic (H) field component's Yee-cell smoothing
+    needs to average across a material boundary.
+
+    Optional. Defaults to 'harmonic'. Each H component (Hx, Hy, Hz) is
+    averaged from the two neighbouring cells stacked along the component's
+    own axis, i.e. normal to any interface between them. The normal
+    component of B is continuous across a material interface, so the
+    harmonic mean of mu_r (and, for consistency, sigma*) is the physically
+    correct mixing rule for this direction - unlike the tangential 4-cell
+    average used for E-field smoothing, where the arithmetic mean already
+    used remains correct and is unaffected by this command.
+
+    Versions of gprMax prior to the introduction of this command always
+    used a simple arithmetic mean here instead. Set this command to
+    'arithmetic' to reproduce that older behaviour exactly, e.g. to
+    reproduce results generated with an older version of gprMax.
+
+    Attributes:
+        mode (str): 'harmonic' (default) or 'arithmetic'.
+    """
+
+    @property
+    def order(self):
+        return 2
+
+    @property
+    def hash(self):
+        return "#magnetic_averaging"
+
+    def __init__(self, mode: str = "harmonic"):
+        """Create a MagneticAveraging user object.
+
+        Args:
+            mode: 'harmonic' (default) or 'arithmetic' (case-insensitive).
+        """
+        super().__init__(mode=mode)
+        self.mode = mode.lower()
+
+    def build(self, model: Model):
+        if self.mode not in ("harmonic", "arithmetic"):
+            raise ValueError(f"{self} requires the mode to be 'harmonic' or 'arithmetic'")
+
+        config.get_model_config().magnetic_averaging_mode = self.mode
+        logger.info(f"Magnetic (H-field) averaging mixing rule: {self.mode}")
+
+
 class Domain(ModelUserObject):
     """Size of the model.
 

--- a/tests/cmds_geometry/test_edge_boundary_rigid_arrays.py
+++ b/tests/cmds_geometry/test_edge_boundary_rigid_arrays.py
@@ -1,0 +1,330 @@
+"""Regression tests for Edge/MagneticEdge writing outside the rigid arrays
+(Codex-reported, "Need to make sure we can build the edges properly"):
+
+Grid coordinates are allowed to equal the far domain boundary (e.g. an
+x-directed #magnetic_edge at y == ny is a legitimate, physically
+meaningful position - a wire running along the domain's far edge).
+MagneticEdge.build() then calls build_magnetic_edge_x(i, ny, k, ...),
+whose set_rigid_Hx() (gprMax/cython/yee_cell_setget_rigid.pyx) wrote
+directly to rigidH[0, i, j, k] with NO bounds guard at all. rigidH has
+purely cell-centred dimensions (nx, ny, nz) (gprMax/grid/fdtd_grid.py),
+so j == ny is one past the last valid index. Cython is compiled with
+boundscheck=False globally (setup.py), so this was not a clean exception
+but an out-of-bounds memory WRITE - undefined behaviour, potentially
+silent heap corruption rather than a crash.
+
+The regular electric Edge has the identical problem via
+set_rigid_Ex/Ey/Ez - except those already had a "j, k may run to
+rigidE.shape[2]/[3]" comment and correct guards on the READ side
+(get_rigid_Ex/Ey/Ez), just not on the WRITE side. The H-component read
+functions (get_rigid_Hx/Hy/Hz) had the identical latent gap too (only
+guarded their own axis, not the transverse ones) - unexploited by any
+current caller (yee_cell_build.pyx's material-averaging loops always
+iterate the transverse axes safely within [0, n)), but fixed for
+symmetry with the now-fixed write path.
+
+Fixed by adding upper-bound guards on the transverse axis/axes to all
+six set_rigid_{E,H}{x,y,z} functions (and the three get_rigid_H{x,y,z}
+functions), mirroring the guards get_rigid_Ex/Ey/Ez already had.
+
+This file tests two things:
+1. Unit-level, directly against the compiled Cython functions with
+   minimally-sized (no slack/padding) arrays: a transverse coordinate at
+   the far wall must not write anything (the guard fires), and ordinary
+   interior coordinates must still behave exactly as before (no
+   regression in normal geometry building).
+2. End-to-end, via real Edge/#edge and MagneticEdge/#magnetic_edge
+   commands positioned exactly on each of the 6 domain faces, for every
+   run-axis/transverse-boundary combination - confirming the model
+   builds without exception and the ID array reflects the intended
+   material assignment.
+"""
+import numpy as np
+import pytest
+
+import gprMax
+from gprMax.cython.geometry_primitives import (
+    build_edge_x,
+    build_edge_y,
+    build_edge_z,
+    build_magnetic_edge_x,
+    build_magnetic_edge_y,
+    build_magnetic_edge_z,
+)
+
+NX, NY, NZ = 5, 6, 7  # deliberately asymmetric to catch axis-mixups
+SHAPE3 = (NX, NY, NZ)
+
+
+def _make_arrays():
+    rigidE = np.zeros((12, NX, NY, NZ), dtype=np.int8)
+    rigidH = np.zeros((6, NX, NY, NZ), dtype=np.int8)
+    ID = np.zeros((6, NX + 1, NY + 1, NZ + 1), dtype=np.uint32)
+    return rigidE, rigidH, ID
+
+
+def _expected_e_writes(own_idx, tr1_idx, tr2_idx, offsets, i, j, k, shape):
+    """Reference re-implementation (independent of the Cython fix, but
+    mirroring its exact guard logic) of which of set_rigid_E{x,y,z}'s 4
+    write terms are valid for the fixed axis-role mapping of a specific
+    component. own_idx/tr1_idx/tr2_idx are which of (i,j,k) plays the
+    "own" (undecremented) vs the two transverse roles for this component
+    (e.g. for Ex, own=i, transverse pair=(j,k)). `offsets` is the
+    (own, tr1_decrement, tr2_decrement, both_decrement) component-index
+    offsets - Ex/Ez use (0,1,3,2), but Ey's real (pre-existing, correct)
+    layout swaps the two transverse terms' indices: (0,3,1,2).
+
+    Returns a set of (component, i, j, k) tuples that must be True.
+    """
+    own_off, tr1_off, tr2_off, both_off = offsets
+    coords = [i, j, k]
+    own = coords[own_idx]
+    t1 = coords[tr1_idx]
+    t2 = coords[tr2_idx]
+    s1 = shape[tr1_idx]
+    s2 = shape[tr2_idx]
+
+    def make(own_v, t1_v, t2_v):
+        c = [0, 0, 0]
+        c[own_idx] = own_v
+        c[tr1_idx] = t1_v
+        c[tr2_idx] = t2_v
+        return tuple(c)
+
+    expected = set()
+    if t1 < s1 and t2 < s2:
+        expected.add((own_off,) + make(own, t1, t2))
+    if t1 != 0 and t2 < s2:
+        expected.add((tr1_off,) + make(own, t1 - 1, t2))
+    if t2 != 0 and t1 < s1:
+        expected.add((tr2_off,) + make(own, t1, t2 - 1))
+    if t1 != 0 and t2 != 0:
+        expected.add((both_off,) + make(own, t1 - 1, t2 - 1))
+    return expected
+
+
+def _actual_true_positions(rigid):
+    return {tuple(pos) for pos in np.argwhere(rigid != 0)}
+
+
+# --- Electric edges (build_edge_x/y/z): own axis / transverse pair / component offsets ---
+# offsets = (own, tr1_decrement, tr2_decrement, both_decrement) - see
+# set_rigid_Ex/Ey/Ez in yee_cell_setget_rigid.pyx. Ex/Ez use (0,1,3,2);
+# Ey's pre-existing (correct, unchanged) layout swaps the two transverse
+# terms to (0,3,1,2) - see _expected_e_writes' docstring.
+_E_CASES = [
+    (build_edge_x, 0, 1, 2, (0, 1, 3, 2)),  # Ex: own=i, transverse=(j,k)
+    (build_edge_y, 1, 0, 2, (4, 7, 5, 6)),  # Ey: own=j, transverse=(i,k)
+    (build_edge_z, 2, 0, 1, (8, 9, 11, 10)),  # Ez: own=k, transverse=(i,j)
+]
+
+
+@pytest.mark.parametrize("builder,own_idx,tr1_idx,tr2_idx,offsets", _E_CASES)
+@pytest.mark.parametrize("t1_at_max", [False, True])
+@pytest.mark.parametrize("t2_at_max", [False, True])
+def test_electric_edge_transverse_boundary_matches_reference(
+    builder, own_idx, tr1_idx, tr2_idx, offsets, t1_at_max, t2_at_max
+):
+    """No exception/crash, and the resulting rigidE state EXACTLY matches
+    an independent, guard-mirroring reference computation - not just
+    "stays zero" (some neighbour-offset terms remain valid even when one
+    transverse coordinate is at the far wall)."""
+    rigidE, rigidH, ID = _make_arrays()
+    coords = [1, 1, 1]
+    coords[own_idx] = 1  # interior, safe
+    coords[tr1_idx] = SHAPE3[tr1_idx] if t1_at_max else 1
+    coords[tr2_idx] = SHAPE3[tr2_idx] if t2_at_max else 1
+    i, j, k = coords
+
+    builder(i, j, k, 9, rigidE, rigidH, ID)
+
+    expected = _expected_e_writes(own_idx, tr1_idx, tr2_idx, offsets, i, j, k, SHAPE3)
+    assert _actual_true_positions(rigidE) == expected
+
+
+@pytest.mark.parametrize("builder", [build_edge_x, build_edge_y, build_edge_z])
+def test_electric_edge_interior_position_still_sets_rigid_flag(builder):
+    rigidE, rigidH, ID = _make_arrays()
+    builder(1, 1, 1, 9, rigidE, rigidH, ID)
+    assert np.any(rigidE != 0)
+
+
+# --- Magnetic edges (build_magnetic_edge_x/y/z): own axis / two transverse axes ---
+_H_CASES = [
+    (build_magnetic_edge_x, 0, 1, 2, 0),  # Hx: own=i, transverse=(j,k), components 0-1
+    (build_magnetic_edge_y, 1, 0, 2, 2),  # Hy: own=j, transverse=(i,k), components 2-3
+    (build_magnetic_edge_z, 2, 0, 1, 4),  # Hz: own=k, transverse=(i,j), components 4-5
+]
+
+
+@pytest.mark.parametrize("builder,own_idx,tr1_idx,tr2_idx,comp_base", _H_CASES)
+@pytest.mark.parametrize("t1_at_max", [False, True])
+@pytest.mark.parametrize("t2_at_max", [False, True])
+def test_magnetic_edge_transverse_boundary_matches_reference(
+    builder, own_idx, tr1_idx, tr2_idx, comp_base, t1_at_max, t2_at_max
+):
+    """Unlike E components, H's transverse axes have no neighbour-offset
+    term at all - both writes use the SAME raw transverse coordinates,
+    so if EITHER is at the far wall, the guard must block BOTH writes
+    entirely (there's no partially-valid case here, unlike E)."""
+    rigidH_arrays_zero = np.zeros((6, NX, NY, NZ), dtype=np.int8)
+    rigidE, rigidH, ID = _make_arrays()
+    coords = [1, 1, 1]
+    coords[own_idx] = 1
+    coords[tr1_idx] = SHAPE3[tr1_idx] if t1_at_max else 1
+    coords[tr2_idx] = SHAPE3[tr2_idx] if t2_at_max else 1
+    i, j, k = coords
+
+    builder(i, j, k, 9, rigidH, ID)
+
+    if t1_at_max or t2_at_max:
+        assert np.array_equal(rigidH, rigidH_arrays_zero)
+    else:
+        assert np.any(rigidH != 0)
+
+
+@pytest.mark.parametrize(
+    "builder,run_axis_size",
+    [
+        (build_magnetic_edge_x, NX),
+        (build_magnetic_edge_y, NY),
+        (build_magnetic_edge_z, NZ),
+    ],
+)
+def test_magnetic_edge_interior_position_still_sets_rigid_flag(builder, run_axis_size):
+    """No regression: an ordinary interior edge position must still set
+    the expected rigid flag exactly as before."""
+    rigidE, rigidH, ID = _make_arrays()
+    builder(1, 1, 1, 9, rigidH, ID)
+    assert np.any(rigidH != 0)
+
+
+# --- End-to-end: real #edge / #magnetic_edge commands at each domain face ---
+
+
+def _base_scene(domain=(0.02, 0.02, 0.02), dl=1e-3):
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=domain))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=1e-12))
+    scene.add(gprMax.Material(er=1, se=1, mr=1, sm=0, id="wire"))
+    return scene
+
+
+def _build_and_capture(monkeypatch, scene):
+    import gprMax.model as model_mod
+
+    captured = {}
+    orig_build = model_mod.Model.build
+
+    def patched(self):
+        orig_build(self)
+        captured["ID"] = self.G.ID.copy()
+        captured["rigidE"] = self.G.rigidE.copy()
+        captured["rigidH"] = self.G.rigidH.copy()
+        captured["wire_numID"] = next(m.numID for m in self.G.materials if m.ID == "wire")
+
+    monkeypatch.setattr(model_mod.Model, "build", patched)
+    return captured
+
+
+@pytest.mark.parametrize("axis", ["x", "y", "z"])
+@pytest.mark.parametrize("boundary", ["near", "far"])
+def test_magnetic_edge_builds_at_every_transverse_boundary(monkeypatch, tmp_path, axis, boundary):
+    dl = 1e-3
+    domain = (0.02, 0.02, 0.02)
+    n = 20  # cells per axis (0.02 / 1e-3)
+    scene = _base_scene(domain, dl)
+
+    # Run the edge along `axis`; place it at the near (0) or far (n) wall
+    # on BOTH transverse axes simultaneously - the worst case, since it
+    # exercises both fixed coordinates at the boundary at once.
+    coord = 0.0 if boundary == "near" else n * dl
+    p1 = [0.005, 0.005, 0.005]
+    p2 = [0.005, 0.005, 0.005]
+    run_index = "xyz".index(axis)
+    p1[run_index] = 0.005
+    p2[run_index] = 0.015
+    for i in range(3):
+        if i != run_index:
+            p1[i] = coord
+            p2[i] = coord
+
+    scene.add(gprMax.MagneticEdge(p1=tuple(p1), p2=tuple(p2), material_id="wire"))
+
+    captured = _build_and_capture(monkeypatch, scene)
+    # Must not raise/crash - the previously vulnerable code path.
+    gprMax.run(
+        scenes=[scene], n=1, geometry_only=True,
+        outputfile=tmp_path / f"medge_{axis}_{boundary}", hide_progress_bars=True,
+    )
+
+    # ID (padded nx+1/ny+1/nz+1, so a boundary coordinate is always a
+    # valid index there) must reflect the material assignment along the
+    # whole run of the edge - confirms the edge was genuinely built at
+    # the boundary, not silently skipped as "outside the grid".
+    id_component = 3 + run_index  # Hx/Hy/Hz -> ID indices 3/4/5
+    lo_cell, hi_cell = 5, 14  # 0.005m..0.015m at dl=1e-3
+    fixed = n if boundary == "far" else 0
+    id_slice = [slice(None)] * 3
+    id_slice[run_index] = slice(lo_cell, hi_cell + 1)
+    for i in range(3):
+        if i != run_index:
+            id_slice[i] = fixed
+    assert np.all(captured["ID"][id_component][tuple(id_slice)] == captured["wire_numID"])
+
+    # rigidH must never contain a flag at a transverse coordinate that
+    # equals the array's own far-wall size (out of range for a purely
+    # cell-centred (nx,ny,nz) array) - the guard must have prevented any
+    # write there, for every one of the 6 magnetic-edge flag planes.
+    assert captured["rigidH"].shape == (6, n, n, n)
+    if boundary == "far":
+        assert np.count_nonzero(captured["rigidH"]) == 0
+
+
+@pytest.mark.parametrize("axis", ["x", "y", "z"])
+@pytest.mark.parametrize("boundary", ["near", "far"])
+def test_electric_edge_builds_at_every_transverse_boundary(monkeypatch, tmp_path, axis, boundary):
+    dl = 1e-3
+    domain = (0.02, 0.02, 0.02)
+    n = 20
+    scene = _base_scene(domain, dl)
+
+    coord = 0.0 if boundary == "near" else n * dl
+    p1 = [0.005, 0.005, 0.005]
+    p2 = [0.005, 0.005, 0.005]
+    run_index = "xyz".index(axis)
+    p1[run_index] = 0.005
+    p2[run_index] = 0.015
+    for i in range(3):
+        if i != run_index:
+            p1[i] = coord
+            p2[i] = coord
+
+    scene.add(gprMax.Edge(p1=tuple(p1), p2=tuple(p2), material_id="wire"))
+
+    captured = _build_and_capture(monkeypatch, scene)
+    gprMax.run(
+        scenes=[scene], n=1, geometry_only=True,
+        outputfile=tmp_path / f"edge_{axis}_{boundary}", hide_progress_bars=True,
+    )
+
+    id_component = run_index  # Ex/Ey/Ez -> ID indices 0/1/2
+    lo_cell, hi_cell = 5, 14
+    fixed = n if boundary == "far" else 0
+    id_slice = [slice(None)] * 3
+    id_slice[run_index] = slice(lo_cell, hi_cell + 1)
+    for i in range(3):
+        if i != run_index:
+            id_slice[i] = fixed
+    assert np.all(captured["ID"][id_component][tuple(id_slice)] == captured["wire_numID"])
+
+    # Unlike MagneticEdge/rigidH, rigidE's "both transverse coordinates
+    # decremented" term (see test_electric_edge_transverse_boundary_
+    # matches_reference) stays genuinely valid even when both transverse
+    # coordinates are at the far wall, so rigidE is NOT expected to be
+    # all-zero here - the array shape itself (no resize/corruption) and
+    # the correct ID assignment above are what matter; the unit-level
+    # reference test above already covers the exact expected pattern.
+    assert captured["rigidE"].shape == (12, n, n, n)

--- a/tests/cmds_geometry/test_magnetic_edge.py
+++ b/tests/cmds_geometry/test_magnetic_edge.py
@@ -1,0 +1,121 @@
+"""Tests for the #magnetic_edge command / MagneticEdge class - the magnetic
+dual of #edge, added alongside the reversion of set_rigid_Hx/Hy/Hz to the
+self-consistent single-position formula (see
+tests/materials/test_pec_h_components.py for the underlying rigid-flag
+mechanics tests).
+"""
+from pathlib import Path
+
+import pytest
+
+import gprMax
+import gprMax.model as model_mod
+
+INF = float("inf")
+
+
+def _capture_grid(monkeypatch):
+    captured = {}
+    orig_build = model_mod.Model.build
+
+    def patched_build(self):
+        orig_build(self)
+        captured["grid"] = self.G
+
+    monkeypatch.setattr(model_mod.Model, "build", patched_build)
+    return captured
+
+
+def _scene(dl=1e-3):
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(0.01, 0.01, 0.01)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=1e-12))
+    return scene
+
+
+def test_magnetic_edge_sets_single_hx_edge(monkeypatch, tmp_path):
+    # p1->p2 spans x=2mm to 4mm at 1mm resolution: 2 cells, i=2 and i=3
+    # (matching exactly how #edge spans multiple cells for the same span).
+    scene = _scene()
+    scene.add(gprMax.MagneticEdge(p1=(0.002, 0.001, 0.001), p2=(0.004, 0.001, 0.001), material_id="pmc"))
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+    grid = captured["grid"]
+
+    pmc_numid = next(m.numID for m in grid.materials if m.ID == "pmc")
+    idHx = grid.IDlookup["Hx"]
+    assert grid.ID[idHx, 2, 1, 1] == pmc_numid
+    assert grid.ID[idHx, 3, 1, 1] == pmc_numid
+    # Doesn't leak to neighbouring Hx positions outside the specified span.
+    assert grid.ID[idHx, 1, 1, 1] != pmc_numid
+    assert grid.ID[idHx, 4, 1, 1] != pmc_numid
+
+
+def test_magnetic_edge_multi_cell_wire(monkeypatch, tmp_path):
+    """A magnetic edge spanning multiple cells sets every cell along the
+    run axis, like #edge does for a multi-cell wire."""
+    scene = _scene()
+    scene.add(gprMax.MagneticEdge(p1=(0.001, 0.002, 0.002), p2=(0.006, 0.002, 0.002), material_id="pmc"))
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+    grid = captured["grid"]
+
+    pmc_numid = next(m.numID for m in grid.materials if m.ID == "pmc")
+    idHx = grid.IDlookup["Hx"]
+    for i in range(1, 6):
+        assert grid.ID[idHx, i, 2, 2] == pmc_numid
+
+
+def test_magnetic_edge_invalid_orientation_rejected(monkeypatch, tmp_path):
+    scene = _scene()
+    scene.add(gprMax.MagneticEdge(p1=(0.002, 0.002, 0.002), p2=(0.004, 0.004, 0.002), material_id="pmc"))
+
+    with pytest.raises(ValueError):
+        gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+
+
+def test_magnetic_edge_missing_material_rejected(monkeypatch, tmp_path):
+    scene = _scene()
+    scene.add(gprMax.MagneticEdge(p1=(0.002, 0.001, 0.001), p2=(0.004, 0.001, 0.001), material_id="doesnotexist"))
+
+    with pytest.raises(ValueError):
+        gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+
+
+def test_magnetic_edge_rejected_in_2d_mode(monkeypatch, tmp_path):
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(1e-3, 1e-3, 1e-3)))
+    scene.add(gprMax.TimeWindow(time=1e-12))
+    scene.add(gprMax.DomainMode(mode="TM"))
+    scene.add(gprMax.Domain(p1=(0.01, 0.01, INF)))
+    scene.add(gprMax.MagneticEdge(p1=(0.002, 0.001, INF), p2=(0.004, 0.001, INF), material_id="pmc"))
+
+    with pytest.raises(ValueError, match="not yet supported in 2D mode"):
+        gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+
+
+def test_magnetic_edge_text_command_parses_correctly(monkeypatch, tmp_path: Path):
+    """Exercises the hash_cmds_geometry.py text-parsing path specifically
+    (the #magnetic_edge: line -> MagneticEdge construction), not just the
+    Python Scene API used by the other tests in this file."""
+    infile = tmp_path / "magnetic_edge.in"
+    infile.write_text(
+        "#title: magnetic edge text parsing\n"
+        "#dx_dy_dz: 0.001 0.001 0.001\n"
+        "#domain: 0.01 0.01 0.01\n"
+        "#pml_cells: 0\n"
+        "#time_window: 1e-12\n"
+        "#magnetic_edge: 0.002 0.001 0.001 0.004 0.001 0.001 pmc\n"
+    )
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(inputfile=str(infile), n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+    grid = captured["grid"]
+
+    pmc_numid = next(m.numID for m in grid.materials if m.ID == "pmc")
+    idHx = grid.IDlookup["Hx"]
+    assert grid.ID[idHx, 2, 1, 1] == pmc_numid

--- a/tests/cmds_multiuse/test_symmetry_boundary.py
+++ b/tests/cmds_multiuse/test_symmetry_boundary.py
@@ -1,0 +1,253 @@
+"""Tests for the #symmetry_boundary command / SymmetryBoundary class - PEC
+and PMC symmetry-plane boundaries that replace the PML on a domain face.
+
+Covers the command-structure/registration parts of the feature (face
+registration, PML thickness disabling, PEC-ID forcing at build time), and
+confirms all three material regimes (non-dispersive, Debye, Lorentz/Drude)
+are accepted at a PMC face without error - the per-iteration PMC ghost-node
+field update itself is tested separately under
+tests/materials/test_symmetry_boundary_pmc_*.py and
+tests/updates/test_symmetry_boundary_solve_loop.py.
+"""
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import gprMax
+import gprMax.model as model_mod
+
+INF = float("inf")
+
+
+def _capture_grid(monkeypatch):
+    captured = {}
+    orig_build = model_mod.Model.build
+
+    def patched_build(self):
+        orig_build(self)
+        captured["grid"] = self.G
+
+    monkeypatch.setattr(model_mod.Model, "build", patched_build)
+    return captured
+
+
+def _scene(dl=1e-3, pml_thickness=10):
+    # Domain is sized to 25 cells/axis (not 10) so that the default PML
+    # thickness (10 cells/side) fits without tripping FDTDGrid's
+    # "PML has too many cells for the domain size" check on the faces
+    # that are NOT under test (i.e. that keep their default thickness) -
+    # see test_pec_face_registers_and_disables_pml, which explicitly
+    # asserts those faces stay at the default 10.
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(0.025, 0.025, 0.025)))
+    scene.add(gprMax.TimeWindow(time=1e-12))
+    if pml_thickness != 10:
+        scene.add(gprMax.PMLThickness(thickness=pml_thickness))
+    return scene
+
+
+def test_pec_face_registers_and_disables_pml(monkeypatch, tmp_path):
+    scene = _scene()
+    scene.add(gprMax.SymmetryBoundary(face="x0", type="pec"))
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+    grid = captured["grid"]
+
+    assert grid.symmetry_boundaries == {"x0": "pec"}
+    assert grid.pmls["thickness"]["x0"] == 0
+    # Other faces keep their default PML thickness.
+    for face in ("y0", "z0", "xmax", "ymax", "zmax"):
+        assert grid.pmls["thickness"][face] == 10
+
+
+def test_pmc_face_registers_and_disables_pml_but_no_id_changes(monkeypatch, tmp_path):
+    """PML disabled on every other face so this test isolates the pmc face's
+    own (lack of) ID forcing from the separate PML-termination-with-pec
+    behaviour, which would otherwise also force pec at the other, still-PML
+    -active faces this slice's border touches."""
+    scene = _scene(pml_thickness=0)
+    scene.add(gprMax.SymmetryBoundary(face="ymax", type="pmc"))
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+    grid = captured["grid"]
+
+    assert grid.symmetry_boundaries == {"ymax": "pmc"}
+    assert grid.pmls["thickness"]["ymax"] == 0
+
+    pec_numid = next(m.numID for m in grid.materials if m.ID == "pec")
+    nx, ny, nz = grid.nx, grid.ny, grid.nz
+    ex_ymax = grid.ID[0, 0:nx, ny, 0 : nz + 1]
+    ez_ymax = grid.ID[2, 0 : nx + 1, ny, 0:nz]
+    assert not np.any(ex_ymax == pec_numid)
+    assert not np.any(ez_ymax == pec_numid)
+
+
+def test_pec_face_forces_tangential_e_ids_to_pec(monkeypatch, tmp_path):
+    """x0 is x-normal, so its tangential components are Ey and Ez - both
+    should be forced to pec across the full face; Ex (normal to the face)
+    must be untouched, and the adjacent x=1 plane must be untouched. PML
+    disabled on every other face so this test isolates the symmetry
+    boundary's own ID forcing from the separate PML-termination-with-pec
+    behaviour, which would otherwise also force pec at the other, still-PML
+    -active faces these slices' borders touch."""
+    scene = _scene(pml_thickness=0)
+    scene.add(gprMax.SymmetryBoundary(face="x0", type="pec"))
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+    grid = captured["grid"]
+
+    pec_numid = next(m.numID for m in grid.materials if m.ID == "pec")
+    nx, ny, nz = grid.nx, grid.ny, grid.nz
+
+    ey_x0 = grid.ID[1, 0, 0:ny, 0 : nz + 1]
+    ez_x0 = grid.ID[2, 0, 0 : ny + 1, 0:nz]
+    assert np.all(ey_x0 == pec_numid)
+    assert np.all(ez_x0 == pec_numid)
+
+    ex_x0 = grid.ID[0, 0, 0 : ny + 1, 0 : nz + 1]
+    assert not np.any(ex_x0 == pec_numid)
+
+    ey_x1 = grid.ID[1, 1, 0:ny, 0 : nz + 1]
+    assert not np.any(ey_x1 == pec_numid)
+
+
+def test_pec_and_pmc_sharing_an_edge_forces_shared_e_component_pec(monkeypatch, tmp_path):
+    """x0 (pec) and ymax (pmc) share the edge x=0,y=ny. Ez is tangential to
+    both faces, so the pec face's own forcing must reach that shared edge -
+    this is the safeguard the feature is specifically for (a PMC ghost-node
+    update must never see a live value where E has to stay exactly zero).
+    PML disabled on every other face so this test isolates the symmetry
+    boundaries' own ID forcing from the separate PML-termination-with-pec
+    behaviour, which would otherwise also force pec at the other, still-PML
+    -active faces this slice's border touches."""
+    scene = _scene(pml_thickness=0)
+    scene.add(gprMax.SymmetryBoundary(face="x0", type="pec"))
+    scene.add(gprMax.SymmetryBoundary(face="ymax", type="pmc"))
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+    grid = captured["grid"]
+
+    pec_numid = next(m.numID for m in grid.materials if m.ID == "pec")
+    nx, ny, nz = grid.nx, grid.ny, grid.nz
+
+    ez_ymax = grid.ID[2, 0 : nx + 1, ny, 0:nz]
+    pec_mask = ez_ymax == pec_numid
+    # Only the i=0 shared-edge line is pec, not the rest of the ymax face.
+    assert np.all(np.where(pec_mask)[0] == 0)
+    assert pec_mask.sum() == nz
+
+
+def test_duplicate_face_declaration_rejected(monkeypatch, tmp_path):
+    scene = _scene()
+    scene.add(gprMax.SymmetryBoundary(face="x0", type="pec"))
+    scene.add(gprMax.SymmetryBoundary(face="x0", type="pmc"))
+
+    with pytest.raises(ValueError):
+        gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+
+
+def test_invalid_face_rejected(monkeypatch, tmp_path):
+    scene = _scene()
+    scene.add(gprMax.SymmetryBoundary(face="w0", type="pec"))
+
+    with pytest.raises(ValueError):
+        gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+
+
+def test_invalid_type_rejected(monkeypatch, tmp_path):
+    scene = _scene()
+    scene.add(gprMax.SymmetryBoundary(face="x0", type="foo"))
+
+    with pytest.raises(ValueError):
+        gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+
+
+def test_rejected_in_2d_mode(monkeypatch, tmp_path):
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(1e-3, 1e-3, 1e-3)))
+    scene.add(gprMax.DomainMode(mode="TM"))
+    scene.add(gprMax.Domain(p1=(0.01, 0.01, INF)))
+    scene.add(gprMax.TimeWindow(time=1e-12))
+    scene.add(gprMax.SymmetryBoundary(face="x0", type="pec"))
+
+    with pytest.raises(ValueError):
+        gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+
+
+def test_lorentz_material_at_pmc_face_is_allowed(monkeypatch, tmp_path):
+    """Lorentz/Drude (complex-pole) dispersive materials ARE supported by
+    the per-iteration PMC ghost-node update - see
+    gprMax/cython/symmetry_boundaries_dispersive_complex.pyx. An earlier
+    version of this feature rejected this combination with a build-time
+    guard (Stage 1 of the PMC-dispersive work); Stage 2 added the
+    complex-pole Cython path and lifted it."""
+    scene = _scene()
+    scene.add(gprMax.SymmetryBoundary(face="x0", type="pmc"))
+    scene.add(gprMax.Material(er=3, se=0, mr=1, sm=0, id="metal"))
+    scene.add(
+        gprMax.AddLorentzDispersion(
+            poles=1, er_delta=[2.0], omega=[1e9], delta=[1e8], material_ids=["metal"]
+        )
+    )
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+    assert captured["grid"].symmetry_boundaries == {"x0": "pmc"}
+
+
+def test_debye_material_at_pmc_face_is_allowed(monkeypatch, tmp_path):
+    """Debye (real-pole) dispersive materials are also supported at a PMC
+    face, via the separate real-pole Cython path."""
+    scene = _scene()
+    scene.add(gprMax.SymmetryBoundary(face="x0", type="pmc"))
+    scene.add(gprMax.Material(er=3, se=0, mr=1, sm=0, id="soil"))
+    scene.add(gprMax.AddDebyeDispersion(poles=1, er_delta=[2.0], tau=[1e-10], material_ids=["soil"]))
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+    assert captured["grid"].symmetry_boundaries == {"x0": "pmc"}
+
+
+def test_lorentz_material_with_pec_symmetry_boundary_is_allowed(monkeypatch, tmp_path):
+    """PEC symmetry boundaries need no per-iteration code at all (dispersive
+    or otherwise), so a Lorentz/Drude material present elsewhere in the
+    model must not be rejected there either."""
+    scene = _scene()
+    scene.add(gprMax.SymmetryBoundary(face="x0", type="pec"))
+    scene.add(gprMax.Material(er=3, se=0, mr=1, sm=0, id="metal"))
+    scene.add(
+        gprMax.AddLorentzDispersion(
+            poles=1, er_delta=[2.0], omega=[1e9], delta=[1e8], material_ids=["metal"]
+        )
+    )
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+    assert captured["grid"].symmetry_boundaries == {"x0": "pec"}
+
+
+def test_text_command_parses_correctly(monkeypatch, tmp_path: Path):
+    """Exercises the hash_cmds_multiuse.py text-parsing path specifically."""
+    infile = tmp_path / "symmetry_boundary.in"
+    infile.write_text(
+        "#title: symmetry boundary text parsing\n"
+        "#dx_dy_dz: 0.001 0.001 0.001\n"
+        "#domain: 0.025 0.025 0.025\n"
+        "#time_window: 1e-12\n"
+        "#symmetry_boundary: x0 pec\n"
+        "#symmetry_boundary: ymax pmc\n"
+    )
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(inputfile=str(infile), n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+    grid = captured["grid"]
+
+    assert grid.symmetry_boundaries == {"x0": "pec", "ymax": "pmc"}
+    assert grid.pmls["thickness"]["x0"] == 0
+    assert grid.pmls["thickness"]["ymax"] == 0

--- a/tests/cmds_multiuse/test_symmetry_boundary_edge_resolution.py
+++ b/tests/cmds_multiuse/test_symmetry_boundary_edge_resolution.py
@@ -1,0 +1,114 @@
+"""Tests for FDTDGrid.symmetry_boundary_edges - the build-time resolution of
+which of the 12 domain edges need a per-iteration PMC update, and with which
+fixed flags (gprMax.symmetry_boundaries.build_symmetry_boundary_edges).
+
+An edge is included only if at least one of its two bordering faces is a
+declared PMC symmetry boundary; an edge where neither face is PMC is
+dropped entirely, so the per-iteration dispatcher never calls into it.
+"""
+import gprMax
+import gprMax.model as model_mod
+
+
+def _capture_grid(monkeypatch):
+    captured = {}
+    orig_build = model_mod.Model.build
+
+    def patched_build(self):
+        orig_build(self)
+        captured["grid"] = self.G
+
+    monkeypatch.setattr(model_mod.Model, "build", patched_build)
+    return captured
+
+
+def _scene(dl=1e-3):
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(0.01, 0.01, 0.01)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=1e-12))
+    return scene
+
+
+def _edge_flags(grid):
+    """Returns {cython_func_name: (a_pmc, b_pmc)} for easy assertions."""
+    return {func.__name__: (a, b) for func, a, b, *_ in grid.symmetry_boundary_edges}
+
+
+def test_no_symmetry_boundaries_gives_no_edges(monkeypatch, tmp_path):
+    scene = _scene()
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+    grid = captured["grid"]
+
+    assert grid.symmetry_boundary_edges == []
+
+
+def test_single_pmc_face_resolves_its_four_edges_single_sided(monkeypatch, tmp_path):
+    scene = _scene()
+    scene.add(gprMax.SymmetryBoundary(face="x0", type="pmc"))
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+    grid = captured["grid"]
+
+    flags = _edge_flags(grid)
+    assert len(flags) == 4
+    assert flags["update_symmetry_boundary_electric_Ez_X0_Y0"] == (True, False)
+    assert flags["update_symmetry_boundary_electric_Ez_X0_YMax"] == (True, False)
+    assert flags["update_symmetry_boundary_electric_Ey_X0_Z0"] == (True, False)
+    assert flags["update_symmetry_boundary_electric_Ey_X0_ZMax"] == (True, False)
+
+
+def test_two_adjacent_pmc_faces_resolve_shared_edge_both_true(monkeypatch, tmp_path):
+    """x0 and y0 share the Ez_X0_Y0 edge - both flags should be True there,
+    while their other (non-shared) edges stay single-sided."""
+    scene = _scene()
+    scene.add(gprMax.SymmetryBoundary(face="x0", type="pmc"))
+    scene.add(gprMax.SymmetryBoundary(face="y0", type="pmc"))
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+    grid = captured["grid"]
+
+    flags = _edge_flags(grid)
+    # x0 touches 4 edges, y0 touches 4 edges, one (X0_Y0) is shared -> 7 total.
+    assert len(flags) == 7
+    assert flags["update_symmetry_boundary_electric_Ez_X0_Y0"] == (True, True)
+    assert flags["update_symmetry_boundary_electric_Ez_X0_YMax"] == (True, False)
+    assert flags["update_symmetry_boundary_electric_Ez_XMax_Y0"] == (False, True)
+    assert flags["update_symmetry_boundary_electric_Ey_X0_Z0"] == (True, False)
+    assert flags["update_symmetry_boundary_electric_Ey_X0_ZMax"] == (True, False)
+    assert flags["update_symmetry_boundary_electric_Ex_Y0_Z0"] == (True, False)
+    assert flags["update_symmetry_boundary_electric_Ex_Y0_ZMax"] == (True, False)
+    # Edges not touching either x0 or y0 must not appear at all.
+    assert "update_symmetry_boundary_electric_Ez_XMax_YMax" not in flags
+
+
+def test_pec_face_contributes_no_edges(monkeypatch, tmp_path):
+    """A pec-type symmetry boundary needs no per-iteration edge update at
+    all - only pmc faces populate symmetry_boundary_edges."""
+    scene = _scene()
+    scene.add(gprMax.SymmetryBoundary(face="x0", type="pec"))
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+    grid = captured["grid"]
+
+    assert grid.symmetry_boundary_edges == []
+
+
+def test_all_six_faces_pmc_resolves_all_twelve_edges_both_true(monkeypatch, tmp_path):
+    scene = _scene()
+    for face in ("x0", "y0", "z0", "xmax", "ymax", "zmax"):
+        scene.add(gprMax.SymmetryBoundary(face=face, type="pmc"))
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+    grid = captured["grid"]
+
+    flags = _edge_flags(grid)
+    assert len(flags) == 12
+    assert all(a and b for a, b in flags.values())

--- a/tests/grid/test_pml_pec_termination.py
+++ b/tests/grid/test_pml_pec_termination.py
@@ -1,0 +1,156 @@
+"""Tests for FDTDGrid._terminate_pmls_with_pec - a PML is always implicitly
+backed by a PEC wall at the domain's outer edge (the existing non-update of
+tangential E there already gives the correct physics); this makes that
+explicit in the ID array, purely for bookkeeping/inspection (e.g. fine
+geometry views), the same way a `#symmetry_boundary ... pec` face's ID is
+forced. A face with neither an active PML nor a symmetry boundary is
+deliberately left unforced, to leave room for a future non-PEC termination
+there.
+"""
+import numpy as np
+
+import gprMax
+import gprMax.model as model_mod
+
+FACES = ("x0", "y0", "z0", "xmax", "ymax", "zmax")
+
+# (component index, tangential-component name) pairs per face, matching
+# FDTDGrid._force_pec_tangential_e's own face -> tangential-component map.
+TANGENTIAL = {
+    "x0": (1, 2),
+    "xmax": (1, 2),
+    "y0": (0, 2),
+    "ymax": (0, 2),
+    "z0": (0, 1),
+    "zmax": (0, 1),
+}
+NORMAL = {"x0": 0, "xmax": 0, "y0": 1, "ymax": 1, "z0": 2, "zmax": 2}
+
+
+def _capture_grid(monkeypatch):
+    captured = {}
+    orig_build = model_mod.Model.build
+
+    def patched_build(self):
+        orig_build(self)
+        captured["grid"] = self.G
+
+    monkeypatch.setattr(model_mod.Model, "build", patched_build)
+    return captured
+
+
+def _scene():
+    # Domain sized to 30 cells/axis (dl=1e-3) so the default 10-cell PML
+    # comfortably fits (2*10 < 30) on every face - this file specifically
+    # exercises real PML-driven PEC termination, so the domain must be
+    # large enough for genuine PML physics rather than disabling PML.
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(1e-3, 1e-3, 1e-3)))
+    scene.add(gprMax.Domain(p1=(0.03, 0.03, 0.03)))
+    scene.add(gprMax.TimeWindow(time=1e-12))
+    return scene
+
+
+def _face_slice(grid, comp_idx, face):
+    """Exactly mirrors the valid-range slices FDTDGrid._force_pec_tangential_e
+    writes (component's own dependency-axis range only, not the padded
+    array's full shape - e.g. Ey's j only spans 0:ny, not 0:ny+1)."""
+    nx, ny, nz = grid.nx, grid.ny, grid.nz
+    slices = {
+        ("x0", 1): grid.ID[1, 0, 0:ny, 0 : nz + 1],
+        ("x0", 2): grid.ID[2, 0, 0 : ny + 1, 0:nz],
+        ("xmax", 1): grid.ID[1, nx, 0:ny, 0 : nz + 1],
+        ("xmax", 2): grid.ID[2, nx, 0 : ny + 1, 0:nz],
+        ("y0", 0): grid.ID[0, 0:nx, 0, 0 : nz + 1],
+        ("y0", 2): grid.ID[2, 0 : nx + 1, 0, 0:nz],
+        ("ymax", 0): grid.ID[0, 0:nx, ny, 0 : nz + 1],
+        ("ymax", 2): grid.ID[2, 0 : nx + 1, ny, 0:nz],
+        ("z0", 0): grid.ID[0, 0:nx, 0 : ny + 1, 0],
+        ("z0", 1): grid.ID[1, 0 : nx + 1, 0:ny, 0],
+        ("zmax", 0): grid.ID[0, 0:nx, 0 : ny + 1, nz],
+        ("zmax", 1): grid.ID[1, 0 : nx + 1, 0:ny, nz],
+        # Normal component at (or nearest to, for an upper wall - E has no
+        # own-axis position exactly on an upper wall) this face - must never
+        # be forced by this face's own mechanism. Restricted to the interior
+        # of the perpendicular axes (excluding this plane's own edges, which
+        # are legitimately tangential-forced by the *other* four faces they
+        # border) so this check isn't confounded by that separate, correct
+        # forcing.
+        ("x0", 0): grid.ID[0, 0, 1:ny, 1:nz],
+        ("xmax", 0): grid.ID[0, nx - 1, 1:ny, 1:nz],
+        ("y0", 1): grid.ID[1, 1:nx, 0, 1:nz],
+        ("ymax", 1): grid.ID[1, 1:nx, ny - 1, 1:nz],
+        ("z0", 2): grid.ID[2, 1:nx, 1:ny, 0],
+        ("zmax", 2): grid.ID[2, 1:nx, 1:ny, nz - 1],
+    }
+    return slices[(face, comp_idx)]
+
+
+def test_default_pml_on_all_faces_forces_tangential_e_to_pec(monkeypatch, tmp_path):
+    """Default domain (PML active on all 6 faces, no symmetry boundaries):
+    every face's two tangential E components must be forced to pec across
+    their whole plane; the normal component must be untouched."""
+    scene = _scene()
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+    grid = captured["grid"]
+
+    pec_numid = next(m.numID for m in grid.materials if m.ID == "pec")
+
+    for face in FACES:
+        for comp_idx in TANGENTIAL[face]:
+            assert np.all(_face_slice(grid, comp_idx, face) == pec_numid), face
+        assert not np.any(_face_slice(grid, NORMAL[face], face) == pec_numid), face
+
+
+def test_no_pml_no_symmetry_boundary_leaves_face_unforced(monkeypatch, tmp_path):
+    """PML disabled everywhere, no symmetry boundary declared: the physics
+    at the domain wall is still silently PEC-like (unchanged, established
+    elsewhere), but the ID array must NOT be explicitly forced to pec -
+    leaving room for a future non-PEC termination there."""
+    scene = _scene()
+    scene.add(gprMax.PMLThickness(thickness=0))
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+    grid = captured["grid"]
+
+    pec_numid = next(m.numID for m in grid.materials if m.ID == "pec")
+
+    for face in FACES:
+        for comp_idx in TANGENTIAL[face]:
+            assert not np.any(_face_slice(grid, comp_idx, face) == pec_numid), face
+
+
+def test_pml_termination_coexists_with_symmetry_boundary_on_other_faces(monkeypatch, tmp_path):
+    """A pec/pmc symmetry boundary on some faces must not stop the other,
+    still-PML-active faces from getting their own independent PEC
+    termination."""
+    scene = _scene()
+    scene.add(gprMax.SymmetryBoundary(face="x0", type="pec"))
+    scene.add(gprMax.SymmetryBoundary(face="ymax", type="pmc"))
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=tmp_path / "run", hide_progress_bars=True)
+    grid = captured["grid"]
+
+    pec_numid = next(m.numID for m in grid.materials if m.ID == "pec")
+
+    # x0 has its own explicit pec symmetry boundary (already covered by
+    # test_symmetry_boundary.py); ymax is pmc, so untouched. The remaining
+    # faces (y0, z0, xmax, zmax) still have their default active PML and
+    # must be independently PEC-terminated by this new mechanism.
+    for face in ("y0", "z0", "xmax", "zmax"):
+        for comp_idx in TANGENTIAL[face]:
+            assert np.all(_face_slice(grid, comp_idx, face) == pec_numid), face
+
+    # ymax (pmc, PML disabled there) must still have no ID forcing of its
+    # own - checked on the interior only, since its own face slice's edges
+    # are legitimately forced by the bordering x0 (pec symmetry boundary)
+    # and z0/zmax (still-PML-active) faces, not by ymax itself.
+    nx, nz = grid.nx, grid.nz
+    ex_ymax_interior = grid.ID[0, 1:nx, grid.ny, 1:nz]
+    ez_ymax_interior = grid.ID[2, 1:nx, grid.ny, 1:nz]
+    assert not np.any(ex_ymax_interior == pec_numid)
+    assert not np.any(ez_ymax_interior == pec_numid)

--- a/tests/materials/test_array_based_averaging_gate.py
+++ b/tests/materials/test_array_based_averaging_gate.py
@@ -1,0 +1,130 @@
+"""Regression tests for per-voxel averaging gating in build_voxels_from_array
+and build_voxels_from_array_mask (used by FractalBox and GeometryObjectsRead).
+
+Bug: unlike Box/Cylinder/etc. (which compute
+`averaging = materials[0].averagable and user_flag`, forcing the rigid path
+whenever the material is non-averagable, e.g. PEC/PMC or any custom
+se=inf/sm=inf material), FractalBox.build() set `self.volume.averaging`
+purely from the user/grid default flag, never checking whether any of its
+mixing model's constituent materials (resolvable since the 2023-04-21
+#material_list/#material_range mixing models let a fractal box reference
+arbitrary predefined materials by name) are non-averagable. This let a PEC
+"bin" in a fractal box's mixing model get its E properties blended with a
+real neighbour's via the ordinary averaging pass, producing a physically
+meaningless compound material with se=inf.
+
+Fixed by gating averaging per-voxel inside build_voxels_from_array/_mask:
+`voxel_averaging = averaging and is_averagable_lookup[numID]`, so a
+non-averagable bin always takes the rigid path (with the existing PEC/H
+carve-out still applying there) regardless of the object-level averaging
+request, while other (averagable) bins continue to be smoothed normally with
+each other.
+"""
+import numpy as np
+
+from gprMax.cython.geometry_primitives import build_voxels_from_array
+from gprMax.grid.fdtd_grid import FDTDGrid
+from gprMax.materials import Material, create_built_in_materials
+
+
+def _grid(nx, ny, nz, extra_materials=()):
+    grid = FDTDGrid()
+    grid.nx, grid.ny, grid.nz = nx, ny, nz
+    create_built_in_materials(grid)
+    grid.materials += list(extra_materials)
+    grid.initialise_geometry_arrays()
+    return grid
+
+
+PEC_NUMID = 0
+
+
+def test_pec_voxel_in_array_takes_rigid_path_even_when_averaging_requested():
+    """A PEC-numID voxel in the data array must be rigid (E marked rigid,
+    solid[] set directly) even though averaging=True was requested for the
+    whole call - the per-voxel gate must override it for this one voxel."""
+    grid = _grid(2, 1, 1)
+    data = np.array([[[PEC_NUMID]], [[PEC_NUMID]]], dtype=np.int16).reshape(2, 1, 1)
+    is_pec_lookup = np.array([m.is_pec for m in grid.materials], dtype=np.uint8)
+    is_averagable_lookup = np.array([m.averagable for m in grid.materials], dtype=np.uint8)
+
+    build_voxels_from_array(
+        0, 0, 0, 0, True, is_pec_lookup, is_averagable_lookup, data,
+        grid.solid, grid.rigidE, grid.rigidH, grid.ID,
+    )
+
+    # Rigid path was taken despite averaging=True: E is marked rigid.
+    assert grid.rigidE[0, 0, 0, 0]
+    assert grid.rigidE[0, 1, 0, 0]
+
+
+def test_averagable_voxel_in_array_still_averages_when_requested():
+    """An ordinary averagable material in the same call must still take the
+    averaging path (E unmarked rigid, deferred to the general averaging
+    pass) - the PEC gate must not disable averaging for everything."""
+    grid = _grid(2, 1, 1)
+    matA = Material(3, "matA")
+    matA.se = 5.0
+    grid.materials.append(matA)
+
+    data = np.full((2, 1, 1), matA.numID, dtype=np.int16)
+    is_pec_lookup = np.array([m.is_pec for m in grid.materials], dtype=np.uint8)
+    is_averagable_lookup = np.array([m.averagable for m in grid.materials], dtype=np.uint8)
+
+    build_voxels_from_array(
+        0, 0, 0, 0, True, is_pec_lookup, is_averagable_lookup, data,
+        grid.solid, grid.rigidE, grid.rigidH, grid.ID,
+    )
+
+    assert not grid.rigidE[0, 0, 0, 0]
+    assert not grid.rigidE[0, 1, 0, 0]
+
+
+def test_fractal_box_with_pec_in_mixing_model_creates_no_infinite_conductivity_compound(tmp_path):
+    """End-to-end regression for the exact scenario that surfaced this bug:
+    a FractalBox using a #material_list mixing model that includes 'pec'
+    must not create any compound material with se=inf, regardless of the
+    requested averaging setting - while ordinary averaging between the
+    other (real) materials in the mixing model must still occur normally.
+    """
+    import gprMax
+    import gprMax.model as model_mod
+
+    def _capture(scene, outfile):
+        captured = {}
+        orig_build = model_mod.Model.build
+
+        def patched_build(self):
+            orig_build(self)
+            captured["grid"] = self.G
+
+        import unittest.mock as mock
+        with mock.patch.object(model_mod.Model, "build", patched_build):
+            gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=outfile, hide_progress_bars=True)
+        return captured["grid"]
+
+    dl = 2e-3
+    scene = gprMax.Scene()
+    scene.add(gprMax.Title(name="fractal_pec_averaging_gate"))
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(0.02, 0.02, 0.02)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=1e-12))
+    scene.add(gprMax.Material(er=6, se=0.01, mr=3, sm=0.02, id="matA"))
+    scene.add(gprMax.Material(er=10, se=0.02, mr=1, sm=0, id="matB"))
+    scene.add(gprMax.MaterialList(id="mymix", list_of_materials=["matA", "matB", "pec"]))
+    scene.add(gprMax.FractalBox(
+        p1=(0, 0, 0), p2=(0.02, 0.02, 0.02),
+        frac_dim=1.5, weighting=(1, 1, 1), n_materials=3,
+        mixing_model_id="mymix", id="myfractalbox", seed=1,
+        averaging="y",
+    ))
+
+    grid = _capture(scene, tmp_path / "fractal_pec_averaging_gate")
+
+    inf_compounds = [m.ID for m in grid.materials if "+" in m.ID and m.se == float("inf")]
+    assert inf_compounds == [], f"found infinite-conductivity compound material(s): {inf_compounds}"
+
+    # Ordinary averaging between the two real materials must still work.
+    normal_compounds = [m.ID for m in grid.materials if "+" in m.ID and "pec" not in m.ID]
+    assert normal_compounds, "expected ordinary matA/matB averaging to still produce compound materials"

--- a/tests/materials/test_boundary_id_averaging.py
+++ b/tests/materials/test_boundary_id_averaging.py
@@ -1,0 +1,196 @@
+"""Regression tests for domain-boundary-plane material IDs produced by the
+dielectric-smoothing (averaging) geometry build.
+
+Bug: build_electric_components()/build_magnetic_components()
+(gprMax/cython/yee_cell_build.pyx) only ever computed each field component's
+ID over the interior of its material-dependency axis/axes. The tangential E
+(and corresponding H) components that sit exactly on a domain-boundary plane
+(e.g. Ex at j=0/j=ny) were never written by either the main loop or the
+per-component "extra loop" patches, regardless of what material a primitive
+(box, cylinder, etc.) actually placed there in the averaging/dielectric-
+smoothed build path - they were silently left at the array's free_space
+default. This is inert for the standard FDTD update (which never reads those
+same boundary planes), but is wrong for geometry inspection/export and for
+any future feature (e.g. PMC symmetry boundaries) that reads ID at those
+positions. The fix uses a "clamp to edge" scheme: a missing out-of-domain
+neighbour is clamped onto the cell that does exist, collapsing the usual
+4-cell/2-cell average to the correct reduced-neighbour result.
+"""
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from gprMax.cython.geometry_primitives import build_voxel
+from gprMax.cython.yee_cell_build import (
+    build_electric_components,
+    build_magnetic_components,
+)
+from gprMax.grid.fdtd_grid import FDTDGrid
+from gprMax.materials import Material
+
+
+def _build_grid(nx, ny, nz, materials):
+    grid = FDTDGrid()
+    grid.nx, grid.ny, grid.nz = nx, ny, nz
+    grid.materials = materials
+    grid.initialise_geometry_arrays()
+    return grid
+
+
+def _run_build(grid):
+    build_electric_components(grid.solid, grid.rigidE, grid.ID, grid)
+    build_magnetic_components(grid.solid, grid.rigidH, grid.ID, grid)
+
+
+def _valid_region(component, nx, ny, nz):
+    """The ID array is uniformly (6, nx+1, ny+1, nz+1), but each component
+    is only ever written over its own valid sub-range: full range on its
+    dependency axis/axes, but only 0..n-1 (not n) on its own/free axis/axes
+    (e.g. Ex's own axis i spans 0..nx-1, never nx). Slots outside a
+    component's valid range are never written and stay at whatever
+    initialise_geometry_arrays() filled them with - comparing the raw,
+    uniformly-shaped array directly against an expected uniform value would
+    incorrectly include those untouched slots.
+    """
+    ranges = {
+        "Ex": (nx, ny + 1, nz + 1),
+        "Ey": (nx + 1, ny, nz + 1),
+        "Ez": (nx + 1, ny + 1, nz),
+        "Hx": (nx + 1, ny, nz),
+        "Hy": (nx, ny + 1, nz),
+        "Hz": (nx, ny, nz + 1),
+    }
+    ni, nj, nk = ranges[component]
+    return np.s_[:ni, :nj, :nk]
+
+
+def test_uniform_material_reaches_every_boundary_plane():
+    """A single material filling the whole grid must produce that material's
+    ID everywhere in every component's array, including both the near (0)
+    and far (n) domain-boundary plane of every dependency axis - previously
+    those boundary entries were left at free_space instead.
+    """
+    free_space = Material(0, "free_space")
+    matA = Material(1, "matA")
+    matA.er = 3.0
+
+    grid = _build_grid(3, 3, 3, [free_space, matA])
+    grid.solid[:, :, :] = matA.numID
+    _run_build(grid)
+
+    for component in ("Ex", "Ey", "Ez", "Hx", "Hy", "Hz"):
+        idx = grid.IDlookup[component]
+        region = _valid_region(component, grid.nx, grid.ny, grid.nz)
+        actual = np.asarray(grid.ID[idx])[region]
+        assert_array_equal(
+            actual,
+            np.full(actual.shape, matA.numID, dtype=np.uint32),
+            err_msg=f"{component} ID not uniform across its valid range (including boundary planes)",
+        )
+
+
+def test_thin_axis_degenerate_boundary_planes_collapse_correctly():
+    """When a dependency axis has only 1 cell (as on a 2D-mode grid's
+    invariant axis), the near (0) and far (1) boundary planes both clamp
+    onto that same single cell. Must not crash and must still produce the
+    correct material, not free_space.
+    """
+    free_space = Material(0, "free_space")
+    matA = Material(1, "matA")
+    matA.er = 5.0
+
+    grid = _build_grid(2, 1, 2, [free_space, matA])
+    grid.solid[:, :, :] = matA.numID
+    _run_build(grid)
+
+    for component in ("Ex", "Hy"):
+        idx = grid.IDlookup[component]
+        region = _valid_region(component, grid.nx, grid.ny, grid.nz)
+        actual = np.asarray(grid.ID[idx])[region]
+        assert_array_equal(
+            actual, np.full(actual.shape, matA.numID, dtype=np.uint32)
+        )
+
+
+def test_ez_boundary_plane_averages_across_its_non_clamped_dependency_axis():
+    """Ez depends on i and j. At the j=0 (and j=ny) wall, the j-side of the
+    average collapses (no cell exists across that wall), but the i-side
+    does not - two different materials sitting side-by-side along x, both
+    at the wall, must still be genuinely averaged there (a reduced 2-way
+    average, not free_space and not an arbitrary pick of one).
+    """
+    free_space = Material(0, "free_space")
+    matA = Material(1, "matA")
+    matA.er = 3.0
+    matB = Material(2, "matB")
+    matB.er = 6.0
+
+    grid = _build_grid(2, 2, 1, [free_space, matA, matB])
+    grid.solid[0, :, :] = matA.numID
+    grid.solid[1, :, :] = matB.numID
+    _run_build(grid)
+
+    idEz = grid.IDlookup["Ez"]
+    for j in (0, grid.ny):
+        compound_numid = grid.ID[idEz, 1, j, 0]
+        compound = next(m for m in grid.materials if m.numID == compound_numid)
+        assert compound.er == np.mean([matA.er, matB.er]), (
+            f"Ez at wall j={j} should be the 2-way average of matA/matB across x, "
+            f"got material {compound.ID!r} with er={compound.er}"
+        )
+
+
+def test_hx_boundary_plane_preserves_distinct_values_along_its_own_axes():
+    """Hx depends only on i. At the i=0 wall there is no averaging (nothing
+    exists across that wall), but Hx's own (non-dependency) axes j, k must
+    still each get their own distinct, correctly-assigned material - not
+    merged together and not left at free_space.
+    """
+    free_space = Material(0, "free_space")
+    matA = Material(1, "matA")
+    matB = Material(2, "matB")
+
+    grid = _build_grid(2, 2, 1, [free_space, matA, matB])
+    grid.solid[:, 0, :] = matA.numID
+    grid.solid[:, 1, :] = matB.numID
+    _run_build(grid)
+
+    idHx = grid.IDlookup["Hx"]
+    for i in (0, grid.nx):
+        assert grid.ID[idHx, i, 0, 0] == matA.numID
+        assert grid.ID[idHx, i, 1, 0] == matB.numID
+
+
+def test_rigid_material_at_extreme_corner_is_not_overwritten_by_averaging():
+    """Regression guard for the get_rigid_* bounds-guard fix
+    (yee_cell_setget_rigid.pyx): on a 1-cell grid, every ID position is a
+    dependency-axis far-wall (n=1) for at least one component. Whatever
+    build_voxel wrote for a rigid (non-averaged) material must be preserved
+    exactly by the averaging pass - and querying get_rigid_* at these
+    extreme positions must not crash (out-of-bounds read) or incorrectly
+    report "not rigid" and overwrite it.
+
+    Compares a before/after snapshot rather than an expected value - this
+    keeps the test agnostic to build_voxel's own exact H/E placement
+    (covered precisely by tests/materials/test_pec_h_components.py), and
+    focused purely on what's in scope here: the averaging pass must never
+    touch a position build_voxel already marked rigid.
+    """
+    free_space = Material(0, "free_space")
+    matA = Material(1, "matA")
+
+    grid = _build_grid(1, 1, 1, [free_space, matA])
+    build_voxel(
+        0, 0, 0,
+        matA.numID, matA.numID, matA.numID, matA.numID,
+        False, False, False, False,
+        grid.solid, grid.rigidE, grid.rigidH, grid.ID,
+    )
+    before = np.array(grid.ID, copy=True)
+
+    _run_build(grid)
+
+    assert_array_equal(
+        np.asarray(grid.ID),
+        before,
+        err_msg="averaging pass modified ID values already set by a rigid build_voxel call",
+    )

--- a/tests/materials/test_magnetic_averaging_mode.py
+++ b/tests/materials/test_magnetic_averaging_mode.py
@@ -1,0 +1,234 @@
+"""Regression tests for #magnetic_averaging (harmonic vs. arithmetic mixing
+of mu_r/sigma* at Yee-cell H-component boundaries).
+
+Each H component (Hx, Hy, Hz) is averaged from the two neighbouring cells
+stacked along the component's own axis - i.e. normal to any interface
+between them. Normal B is continuous across a material interface, so the
+harmonic mean of mu_r (and, for consistency, sigma*) is the physically
+correct mixing rule there, unlike the tangential 4-cell average used for
+E-field smoothing (arithmetic mean, unaffected by this command).
+
+New default (this change): harmonic. 'arithmetic' is available via
+#magnetic_averaging for byte-for-byte backwards compatibility with older
+gprMax versions.
+
+Implementation note this file guards against: Material.create_compound_id()
+deliberately duplicates a 2-material call into a 4-part name ("A+A+B+B")
+so a 2-cell magnetic average collides with (and reuses) a 4-cell electric
+average of the same 2 materials - correct only because both used the same
+(arithmetic) mixing rule before this change. Harmonic magnetic averages now
+use a distinct "Hmag_" prefix to avoid silently reusing the electric
+material's arithmetic-mean mu_r/sigma*. That prefix must never be or
+contain ':' - hash_cmds_file.py's command-line parser does a bare
+`line.split(":")` and keeps only cmd[1], so a second ':' anywhere in a
+material ID (reachable via a #geometry_objects_write / #geometry_objects_read
+round-trip, which writes material.ID verbatim into a #material: line)
+silently truncates the name there.
+"""
+import numpy as np
+import pytest
+
+import gprMax
+import gprMax.config as config
+import gprMax.model as model_mod
+from gprMax.cython.yee_cell_build import build_magnetic_components
+from gprMax.grid.fdtd_grid import FDTDGrid
+from gprMax.materials import Material, create_built_in_materials
+from gprMax.user_objects.cmds_singleuse import MagneticAveraging
+
+
+def _grid(nx, ny, nz, extra_materials=()):
+    grid = FDTDGrid()
+    grid.nx, grid.ny, grid.nz = nx, ny, nz
+    create_built_in_materials(grid)
+    grid.materials += list(extra_materials)
+    grid.initialise_geometry_arrays()
+    return grid
+
+
+def _capture_built_grid(monkeypatch):
+    captured = {}
+    orig_build = model_mod.Model.build
+
+    def patched_build(self):
+        orig_build(self)
+        captured["grid"] = self.G
+
+    monkeypatch.setattr(model_mod.Model, "build", patched_build)
+    return captured
+
+
+def test_default_mode_is_harmonic(tmp_path, monkeypatch):
+    """No #magnetic_averaging command present - config must default to
+    'harmonic', not the old 'arithmetic'."""
+    captured = {}
+    orig_build = model_mod.Model.build
+
+    def patched_build(self):
+        orig_build(self)
+        captured["mode"] = config.get_model_config().magnetic_averaging_mode
+
+    monkeypatch.setattr(model_mod.Model, "build", patched_build)
+
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(0.01, 0.01, 0.01)))
+    scene.add(gprMax.Domain(p1=(0.05, 0.05, 0.05)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=1e-11))
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        outputfile=tmp_path / "default_mode",
+        geometry_only=True,
+        hide_progress_bars=True,
+    )
+
+    assert captured["mode"] == "harmonic"
+
+
+def test_magnetic_averaging_command_rejects_invalid_mode():
+    grid = _grid(2, 2, 2)
+    with pytest.raises(ValueError, match="harmonic.*arithmetic"):
+        MagneticAveraging(mode="bogus").build(grid)
+
+
+@pytest.mark.parametrize("mode", ["harmonic", "HARMONIC", "Arithmetic"])
+def test_magnetic_averaging_command_accepts_case_insensitive_valid_modes(tmp_path, monkeypatch, mode):
+    # Routed through a real gprMax.run() (like test_default_mode_is_harmonic)
+    # rather than calling .build() on a bare grid: MagneticAveraging.build()
+    # reads/writes config.get_model_config(), which only exists once a full
+    # SimulationConfig has been created - i.e. inside an actual run, not for
+    # a hand-built grid in isolation.
+    captured = {}
+    orig_build = model_mod.Model.build
+
+    def patched_build(self):
+        orig_build(self)
+        captured["mode"] = config.get_model_config().magnetic_averaging_mode
+
+    monkeypatch.setattr(model_mod.Model, "build", patched_build)
+
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(0.01, 0.01, 0.01)))
+    scene.add(gprMax.Domain(p1=(0.05, 0.05, 0.05)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=1e-11))
+    scene.add(gprMax.MagneticAveraging(mode=mode))
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        outputfile=tmp_path / f"mode_{mode}",
+        geometry_only=True,
+        hide_progress_bars=True,
+    )
+
+    assert captured["mode"] == mode.lower()
+
+
+def test_harmonic_mean_matches_hand_computed_value_including_zero_sigma_star():
+    """mr=(1,4) -> harmonic mean 1.6 (not the arithmetic 2.5). sm=(0,0.4) ->
+    harmonic mean 0, not a ZeroDivisionError/NaN - free_space (sm=0) next to
+    any ordinary lossy magnetic material is the common case this must
+    handle cleanly.
+    """
+    matA = Material(3, "matA")
+    matA.mr, matA.sm = 1.0, 0.0
+    matB = Material(4, "matB")
+    matB.mr, matB.sm = 4.0, 0.4
+    grid = _grid(2, 2, 2, extra_materials=[matA, matB])
+    grid.solid[0, :, :] = matA.numID
+    grid.solid[1, :, :] = matB.numID
+
+    build_magnetic_components(grid.solid, grid.rigidH, grid.ID, grid, True)
+
+    idHx = grid.IDlookup["Hx"]
+    numid = grid.ID[idHx, 1, 0, 0]
+    averaged = next(m for m in grid.materials if m.numID == numid)
+    assert averaged.mr == pytest.approx(1.6)
+    assert averaged.sm == pytest.approx(0.0)
+    assert ":" not in averaged.ID
+
+
+def test_arithmetic_mean_still_available_and_matches_old_formula():
+    matA = Material(3, "matA")
+    matA.mr, matA.sm = 1.0, 0.0
+    matB = Material(4, "matB")
+    matB.mr, matB.sm = 4.0, 0.4
+    grid = _grid(2, 2, 2, extra_materials=[matA, matB])
+    grid.solid[0, :, :] = matA.numID
+    grid.solid[1, :, :] = matB.numID
+
+    build_magnetic_components(grid.solid, grid.rigidH, grid.ID, grid, False)
+
+    idHx = grid.IDlookup["Hx"]
+    numid = grid.ID[idHx, 1, 0, 0]
+    averaged = next(m for m in grid.materials if m.numID == numid)
+    assert averaged.mr == np.mean([matA.mr, matB.mr])
+    assert averaged.sm == np.mean([matA.sm, matB.sm])
+
+
+def test_harmonic_and_arithmetic_use_independent_materials_not_stale_reuse():
+    """Building the same 2-material boundary once in each mode must not
+    let one mode's material leak into the other via the compound-ID
+    lookup (the exact bug this change had to fix: harmonic silently
+    reusing the arithmetic-mean electric-average material)."""
+    matA = Material(3, "matA")
+    matA.mr = 2.0
+    matB = Material(4, "matB")
+    matB.mr = 8.0
+    grid = _grid(2, 2, 2, extra_materials=[matA, matB])
+    grid.solid[0, :, :] = matA.numID
+    grid.solid[1, :, :] = matB.numID
+
+    build_magnetic_components(grid.solid, grid.rigidH, grid.ID, grid, True)
+    harmonic_numid = grid.ID[grid.IDlookup["Hx"], 1, 0, 0]
+    harmonic_mat = next(m for m in grid.materials if m.numID == harmonic_numid)
+    assert harmonic_mat.mr == pytest.approx(3.2)  # 2*2*8/10
+
+    # Reset the Hx ID at this position and rebuild in arithmetic mode -
+    # must produce (or reuse) a *different* material with the arithmetic value.
+    grid.ID[grid.IDlookup["Hx"], 1, 0, 0] = 0
+    build_magnetic_components(grid.solid, grid.rigidH, grid.ID, grid, False)
+    arithmetic_numid = grid.ID[grid.IDlookup["Hx"], 1, 0, 0]
+    arithmetic_mat = next(m for m in grid.materials if m.numID == arithmetic_numid)
+    assert arithmetic_mat.mr == pytest.approx(5.0)  # (2+8)/2
+    assert arithmetic_mat.numID != harmonic_mat.numID
+
+
+def test_end_to_end_default_harmonic_differs_from_explicit_arithmetic(tmp_path, monkeypatch):
+    """A real Box boundary, built through the full gprMax.run() pipeline,
+    must give different (correct, harmonic) mu_r by default and reproduce
+    the old arithmetic value when #magnetic_averaging: arithmetic is set.
+    """
+
+    def _run(mode):
+        captured = _capture_built_grid(monkeypatch)
+        scene = gprMax.Scene()
+        scene.add(gprMax.Discretisation(p1=(0.01, 0.01, 0.01)))
+        scene.add(gprMax.Domain(p1=(0.1, 0.1, 0.1)))
+        scene.add(gprMax.PMLThickness(thickness=0))
+        scene.add(gprMax.TimeWindow(time=1e-11))
+        if mode is not None:
+            scene.add(gprMax.MagneticAveraging(mode=mode))
+        scene.add(gprMax.Material(er=1, se=0, mr=4, sm=0.4, id="mag"))
+        scene.add(gprMax.Box(p1=(0.0, 0.0, 0.0), p2=(0.05, 0.1, 0.1), material_id="mag"))
+        gprMax.run(
+            scenes=[scene],
+            n=1,
+            outputfile=tmp_path / f"end_to_end_{mode}",
+            geometry_only=True,
+            hide_progress_bars=True,
+        )
+        grid = captured["grid"]
+        idHx = grid.IDlookup["Hx"]
+        numid = grid.ID[idHx, 5, 0, 0]
+        return next(m for m in grid.materials if m.numID == numid)
+
+    default_mat = _run(None)
+    harmonic_mat = _run("harmonic")
+    arithmetic_mat = _run("arithmetic")
+
+    assert default_mat.mr == pytest.approx(1.6)  # harmonic mean of (1, 4)
+    assert harmonic_mat.mr == pytest.approx(1.6)
+    assert arithmetic_mat.mr == pytest.approx(2.5)  # (1 + 4) / 2, the old behaviour
+    assert ":" not in harmonic_mat.ID

--- a/tests/materials/test_material_averaging.py
+++ b/tests/materials/test_material_averaging.py
@@ -1,0 +1,88 @@
+"""Regression tests for dielectric-smoothing eligibility on user-defined
+materials.
+
+Bug: Material.build() (gprMax/user_objects/cmds_multiuse.py) only disabled
+`averagable` for infinite electric conductivity (se == inf, i.e. a
+PEC-like material). There was no equivalent check for infinite magnetic
+loss (sm == inf, i.e. a PMC-like material) - built-in `pmc` is protected by
+a separate hardcoded `averagable = False` in create_built_in_materials(),
+but a user-defined material with sm=inf was not, and would silently
+participate in dielectric smoothing at geometry boundaries (e.g. a Box),
+producing physically meaningless "smoothed" compound materials at what
+should be a sharp perfect-magnetic-conductor boundary.
+"""
+from pathlib import Path
+
+import gprMax
+import gprMax.model as model_mod
+from gprMax.grid.fdtd_grid import FDTDGrid
+from gprMax.materials import create_built_in_materials
+from gprMax.user_objects.cmds_multiuse import Material
+
+
+def _build_custom_material(**kwargs):
+    grid = FDTDGrid()
+    create_built_in_materials(grid)
+    material = Material(**kwargs)
+    material.build(grid)
+    return next(m for m in grid.materials if m.ID == kwargs["id"])
+
+
+def test_custom_pmc_like_material_is_not_averagable():
+    m = _build_custom_material(er=1, se=0, mr=1, sm=float("inf"), id="myPMC")
+    assert m.averagable is False
+
+
+def test_custom_pec_like_material_is_not_averagable():
+    m = _build_custom_material(er=1, se=float("inf"), mr=1, sm=0, id="myPEC")
+    assert m.averagable is False
+
+
+def test_ordinary_dielectric_material_is_averagable():
+    m = _build_custom_material(er=3, se=0.01, mr=1, sm=0, id="dielectric")
+    assert m.averagable is True
+
+
+def _capture_built_grid(monkeypatch):
+    captured = {}
+    orig_build = model_mod.Model.build
+
+    def patched_build(self):
+        orig_build(self)
+        captured["grid"] = self.G
+
+    monkeypatch.setattr(model_mod.Model, "build", patched_build)
+    return captured
+
+
+def test_pmc_like_box_produces_no_smoothed_boundary_material(tmp_path: Path, monkeypatch):
+    """End-to-end: a Box filled with a custom sm=inf material must not
+    produce any dielectric-smoothed compound material at its boundary,
+    exactly like a Box filled with a custom se=inf material doesn't.
+    """
+    dl = 1e-3
+    scene = gprMax.Scene()
+    scene.add(gprMax.Title(name="pmc_like_box"))
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(0.02, 0.02, 0.02)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=1e-12))
+    scene.add(gprMax.Material(er=1, se=0, mr=1, sm=float("inf"), id="myPMC"))
+    scene.add(gprMax.Box(p1=(0.005, 0.005, 0.005), p2=(0.009, 0.009, 0.009), material_id="myPMC"))
+
+    captured = _capture_built_grid(monkeypatch)
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        geometry_only=True,
+        outputfile=tmp_path / "pmc_like_box",
+        hide_progress_bars=True,
+    )
+    grid = captured["grid"]
+
+    my_pmc = next(m for m in grid.materials if m.ID == "myPMC")
+    assert my_pmc.averagable is False
+    assert not any("+" in m.ID for m in grid.materials), (
+        "no compound/smoothed material should have been created at the "
+        f"myPMC box boundary, found: {[m.ID for m in grid.materials if '+' in m.ID]}"
+    )

--- a/tests/materials/test_pec_h_components.py
+++ b/tests/materials/test_pec_h_components.py
@@ -1,0 +1,434 @@
+"""Regression tests for H-component handling in the rigid (non-averaged)
+geometry build path.
+
+Bug 3 (fixed): build_voxel() wrote Hx/Hy/Hz using the same 4-tangential-
+corner pattern as Ex/Ey/Ez, instead of H's correct 2-position own-axis
+pattern (already correct in build_box()).
+
+New behaviour (this session): PEC specifically (matched via
+Material.is_pec - the builtin 'pec' material, or any user-defined material
+with se=inf) must not touch H at all - no ID write, no rigid flag - leaving
+whatever background value/state was already there, since PEC has no
+well-defined magnetic properties. This is PEC-specific, not applied to other
+rigid (non-averaged) materials such as PMC or a non-averagable anisotropic
+material, which still get the corrected 2-position H write.
+"""
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from gprMax.cython.geometry_primitives import (
+    build_box,
+    build_magnetic_edge_x,
+    build_voxel,
+    build_voxels_from_array,
+)
+from gprMax.cython.yee_cell_build import build_electric_components, build_magnetic_components
+from gprMax.grid.fdtd_grid import FDTDGrid
+from gprMax.materials import Material, create_built_in_materials
+
+
+def _grid(nx, ny, nz, extra_materials=()):
+    grid = FDTDGrid()
+    grid.nx, grid.ny, grid.nz = nx, ny, nz
+    create_built_in_materials(grid)
+    grid.materials += list(extra_materials)
+    grid.initialise_geometry_arrays()
+    return grid
+
+
+PEC_NUMID = 0  # builtin pec is always created first by create_built_in_materials
+
+
+def test_pec_voxel_leaves_h_untouched():
+    """A PEC voxel must not write H ID values or mark H rigid - both must
+    remain exactly as they were before the call (the "background")."""
+    grid = _grid(3, 3, 3)
+    before_ID = np.array(grid.ID, copy=True)
+    before_rigidH = np.array(grid.rigidH, copy=True)
+
+    build_voxel(
+        1, 1, 1, PEC_NUMID, PEC_NUMID, PEC_NUMID, PEC_NUMID,
+        False, True, True, True,
+        grid.solid, grid.rigidE, grid.rigidH, grid.ID,
+    )
+
+    idHx, idHy, idHz = grid.IDlookup["Hx"], grid.IDlookup["Hy"], grid.IDlookup["Hz"]
+    assert_array_equal(np.asarray(grid.ID[idHx]), before_ID[idHx])
+    assert_array_equal(np.asarray(grid.ID[idHy]), before_ID[idHy])
+    assert_array_equal(np.asarray(grid.ID[idHz]), before_ID[idHz])
+    assert_array_equal(np.asarray(grid.rigidH), before_rigidH)
+
+    # E must still be correctly rigid at all 4 corners - unaffected by PEC's
+    # H carve-out.
+    idEx = grid.IDlookup["Ex"]
+    assert grid.ID[idEx, 1, 1, 1] == PEC_NUMID
+    assert grid.ID[idEx, 1, 2, 2] == PEC_NUMID
+    assert grid.ID[idEx, 1, 2, 1] == PEC_NUMID
+    assert grid.ID[idEx, 1, 1, 2] == PEC_NUMID
+
+
+def test_non_pec_rigid_voxel_writes_h_at_correct_two_positions():
+    """A non-PEC rigid (non-averaged) material must get the corrected
+    2-position H write (own axis only), not the old broken 4-corner copy,
+    and must be marked rigid there."""
+    grid = _grid(3, 3, 3)
+    matA = Material(3, "matA")
+    matA.se = 5.0
+    grid.materials.append(matA)
+
+    build_voxel(
+        1, 1, 1, matA.numID, matA.numID, matA.numID, matA.numID,
+        False, False, False, False,
+        grid.solid, grid.rigidE, grid.rigidH, grid.ID,
+    )
+
+    idHx, idHy, idHz = grid.IDlookup["Hx"], grid.IDlookup["Hy"], grid.IDlookup["Hz"]
+    # The 2 true positions for each component.
+    assert grid.ID[idHx, 1, 1, 1] == matA.numID
+    assert grid.ID[idHx, 2, 1, 1] == matA.numID
+    assert grid.ID[idHy, 1, 1, 1] == matA.numID
+    assert grid.ID[idHy, 1, 2, 1] == matA.numID
+    assert grid.ID[idHz, 1, 1, 1] == matA.numID
+    assert grid.ID[idHz, 1, 1, 2] == matA.numID
+
+    # The old (buggy) tangential-corner positions must NOT have been written.
+    assert grid.ID[idHx, 1, 2, 2] != matA.numID
+    assert grid.ID[idHy, 2, 1, 2] != matA.numID
+    assert grid.ID[idHz, 2, 2, 1] != matA.numID
+
+    # Rigid flags set (own-corner flag, index 0/2/4 per component).
+    assert grid.rigidH[0, 1, 1, 1]
+    assert grid.rigidH[2, 1, 1, 1]
+    assert grid.rigidH[4, 1, 1, 1]
+
+
+def test_anisotropic_pec_on_one_axis_only_skips_only_that_axis():
+    """An anisotropic voxel with a PEC x-material but ordinary non-averaged
+    y/z materials must only skip Hx - Hy/Hz get the correct 2-position
+    write as normal."""
+    grid = _grid(3, 3, 3)
+    matY = Material(3, "matY")
+    matY.se = 2.0
+    matZ = Material(4, "matZ")
+    matZ.se = 3.0
+    grid.materials += [matY, matZ]
+    before_ID = np.array(grid.ID, copy=True)
+
+    build_voxel(
+        1, 1, 1, PEC_NUMID, PEC_NUMID, matY.numID, matZ.numID,
+        False, True, False, False,
+        grid.solid, grid.rigidE, grid.rigidH, grid.ID,
+    )
+
+    idHx, idHy, idHz = grid.IDlookup["Hx"], grid.IDlookup["Hy"], grid.IDlookup["Hz"]
+    # Hx (PEC axis) untouched.
+    assert_array_equal(np.asarray(grid.ID[idHx]), before_ID[idHx])
+    assert not grid.rigidH[0, 1, 1, 1]
+    # Hy, Hz (non-PEC axes) correctly written and rigid.
+    assert grid.ID[idHy, 1, 1, 1] == matY.numID
+    assert grid.ID[idHy, 1, 2, 1] == matY.numID
+    assert grid.ID[idHz, 1, 1, 1] == matZ.numID
+    assert grid.ID[idHz, 1, 1, 2] == matZ.numID
+    assert grid.rigidH[2, 1, 1, 1]
+    assert grid.rigidH[4, 1, 1, 1]
+
+
+def test_pec_box_leaves_h_untouched():
+    """Same PEC/H behaviour as build_voxel, via build_box's own (separately
+    hand-written) loops."""
+    grid = _grid(4, 4, 4)
+    before_ID = np.array(grid.ID, copy=True)
+    before_rigidH = np.array(grid.rigidH, copy=True)
+
+    build_box(
+        1, 3, 1, 3, 1, 3, PEC_NUMID, PEC_NUMID, PEC_NUMID, PEC_NUMID,
+        False, True, True, True,
+        grid.solid, grid.rigidE, grid.rigidH, grid.ID,
+    )
+
+    idHx, idHy, idHz = grid.IDlookup["Hx"], grid.IDlookup["Hy"], grid.IDlookup["Hz"]
+    assert_array_equal(np.asarray(grid.ID[idHx]), before_ID[idHx])
+    assert_array_equal(np.asarray(grid.ID[idHy]), before_ID[idHy])
+    assert_array_equal(np.asarray(grid.ID[idHz]), before_ID[idHz])
+    assert_array_equal(np.asarray(grid.rigidH), before_rigidH)
+
+    idEx = grid.IDlookup["Ex"]
+    assert grid.ID[idEx, 1, 1, 1] == PEC_NUMID
+
+
+def test_non_pec_box_writes_h_at_correct_positions():
+    """build_box with a non-PEC rigid material writes H at the correct
+    2-position own-axis pattern and marks it rigid."""
+    grid = _grid(4, 4, 4)
+    matA = Material(3, "matA")
+    matA.se = 5.0
+    grid.materials.append(matA)
+
+    build_box(
+        1, 3, 1, 3, 1, 3, matA.numID, matA.numID, matA.numID, matA.numID,
+        False, False, False, False,
+        grid.solid, grid.rigidE, grid.rigidH, grid.ID,
+    )
+
+    idHx = grid.IDlookup["Hx"]
+    assert grid.ID[idHx, 1, 1, 1] == matA.numID
+    assert grid.ID[idHx, 3, 1, 1] == matA.numID
+    assert grid.rigidH[0, 1, 1, 1]
+
+
+def test_build_voxels_from_array_skips_h_for_pec_numid():
+    """The is_pec_lookup threading for build_voxels_from_array (used by
+    FractalBox/GeometryObjectsRead) must skip H for a PEC-numID voxel."""
+    grid = _grid(3, 3, 3)
+    before_ID = np.array(grid.ID, copy=True)
+
+    data = np.full((1, 1, 1), PEC_NUMID, dtype=np.int16)
+    is_pec_lookup = np.array([m.is_pec for m in grid.materials], dtype=np.uint8)
+    is_averagable_lookup = np.array([m.averagable for m in grid.materials], dtype=np.uint8)
+
+    build_voxels_from_array(
+        1, 1, 1, 0, False, is_pec_lookup, is_averagable_lookup, data,
+        grid.solid, grid.rigidE, grid.rigidH, grid.ID,
+    )
+
+    idHx, idHy, idHz = grid.IDlookup["Hx"], grid.IDlookup["Hy"], grid.IDlookup["Hz"]
+    assert_array_equal(np.asarray(grid.ID[idHx]), before_ID[idHx])
+    assert_array_equal(np.asarray(grid.ID[idHy]), before_ID[idHy])
+    assert_array_equal(np.asarray(grid.ID[idHz]), before_ID[idHz])
+
+    idEx = grid.IDlookup["Ex"]
+    assert grid.ID[idEx, 1, 1, 1] == PEC_NUMID
+
+
+def test_pec_box_end_to_end_leaves_h_at_background(tmp_path):
+    """End-to-end: a real PEC Box built via gprMax.run() must leave H at
+    the domain's background material (free_space), not overwritten with
+    the PEC's placeholder magnetic properties."""
+    import gprMax
+    import gprMax.model as model_mod
+
+    captured = {}
+    orig_build = model_mod.Model.build
+
+    def patched_build(self):
+        orig_build(self)
+        captured["grid"] = self.G
+
+    import unittest.mock as mock
+    with mock.patch.object(model_mod.Model, "build", patched_build):
+        dl = 1e-3
+        scene = gprMax.Scene()
+        scene.add(gprMax.Title(name="pec_box_h_background"))
+        scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+        scene.add(gprMax.Domain(p1=(0.02, 0.02, 0.02)))
+        scene.add(gprMax.PMLThickness(thickness=0))
+        scene.add(gprMax.TimeWindow(time=1e-12))
+        scene.add(gprMax.Box(p1=(0.005, 0.005, 0.005), p2=(0.015, 0.015, 0.015), material_id="pec"))
+        gprMax.run(
+            scenes=[scene],
+            n=1,
+            geometry_only=True,
+            outputfile=tmp_path / "pec_box_h_background",
+            hide_progress_bars=True,
+        )
+
+    grid = captured["grid"]
+    # H must never be marked rigid anywhere inside the PEC box's footprint -
+    # confirming build_box's PEC carve-out took effect through the real
+    # object-building pipeline (Scene -> Model.build()), not just a raw
+    # build_box() call. The resulting ID value itself is intentionally not
+    # asserted here: since solid[] is still (correctly) set to PEC's numID
+    # throughout the box regardless of this fix, the ordinary averaging
+    # pass - now free to run since H isn't rigid - naturally recomputes a
+    # deep-interior point as PEC's numID too (both its neighbours are PEC),
+    # which is the expected "let the general mechanism decide" outcome, not
+    # a specific frozen background value.
+    assert not grid.rigidH[0, 10, 10, 10]
+    assert not grid.rigidH[2, 10, 10, 10]
+    assert not grid.rigidH[4, 10, 10, 10]
+
+    # E must still be correctly rigid throughout the box - unaffected by
+    # the H carve-out.
+    assert grid.rigidE[0, 10, 10, 10]
+
+
+def test_build_magnetic_components_treats_pec_as_transparent_at_boundary():
+    """The general averaging pass (build_magnetic_components) must not blend
+    PEC's meaningless mr=1/sm=0 placeholder into a real neighbour's magnetic
+    properties - at a boundary between a real material and PEC, H must take
+    the real material's numID directly (no averaging, no compound material),
+    matching what a model without the PEC object would produce there.
+
+    A single 2x2x2 grid with solid[0,:,:]=matA (real) and solid[1,:,:]=PEC
+    exercises all three cases for Hx (dependency axis i) in one pass:
+    i=0 (both sides matA - ordinary equal case), i=1 (boundary - one PEC, one
+    real - must resolve to matA directly), i=2 (both sides PEC - left
+    untouched, see test_build_magnetic_components_leaves_both_pec_untouched).
+    """
+    grid = _grid(2, 2, 2)
+    matA = Material(3, "matA")
+    matA.mr = 3.0
+    matA.sm = 0.02
+    grid.materials.append(matA)
+
+    grid.solid[0, :, :] = matA.numID
+    grid.solid[1, :, :] = PEC_NUMID
+
+    build_magnetic_components(grid.solid, grid.rigidH, grid.ID, grid)
+
+    idHx = grid.IDlookup["Hx"]
+    # i=0: both neighbours matA - ordinary case, unaffected by this fix.
+    assert grid.ID[idHx, 0, 0, 0] == matA.numID
+    # i=1: boundary - PEC is transparent, real neighbour used directly.
+    assert grid.ID[idHx, 1, 0, 0] == matA.numID
+    # No compound "matA+...+pec+pec"-style material should exist at all.
+    assert not any("pec" in m.ID and "+" in m.ID for m in grid.materials)
+
+
+def test_build_magnetic_components_leaves_both_pec_neighbours_untouched():
+    """When both neighbours of an H position are PEC, there is no real
+    medium left to reference (solid[] no longer remembers what was there
+    before PEC was placed) - the position must be left exactly as it was
+    before this call, not forced to PEC's own numID nor anything else."""
+    grid = _grid(2, 2, 2)
+    grid.solid[:, :, :] = PEC_NUMID
+    before = np.array(grid.ID, copy=True)
+
+    build_magnetic_components(grid.solid, grid.rigidH, grid.ID, grid)
+
+    assert_array_equal(np.asarray(grid.ID), before)
+
+
+def test_build_magnetic_components_unchanged_for_two_real_materials():
+    """Sanity check: ordinary averaging between two non-PEC materials is
+    completely unaffected by the PEC-transparency logic.
+
+    Explicitly requests harmonic=False (arithmetic mean) here because that's
+    what this test is actually checking (that PEC-transparency doesn't
+    perturb an ordinary average) - it doesn't care which mixing rule
+    #magnetic_averaging defaults to. See test_magnetic_averaging_mode.py for
+    coverage of the harmonic/arithmetic mixing rules themselves.
+    """
+    grid = _grid(2, 2, 2)
+    matA = Material(3, "matA")
+    matA.mr = 3.0
+    matB = Material(4, "matB")
+    matB.mr = 5.0
+    grid.materials += [matA, matB]
+
+    grid.solid[0, :, :] = matA.numID
+    grid.solid[1, :, :] = matB.numID
+
+    build_magnetic_components(grid.solid, grid.rigidH, grid.ID, grid, False)
+
+    idHx = grid.IDlookup["Hx"]
+    compound_numid = grid.ID[idHx, 1, 0, 0]
+    compound = next(m for m in grid.materials if m.numID == compound_numid)
+    assert compound.mr == np.mean([matA.mr, matB.mr])
+
+
+def test_pec_cylinder_and_box_in_magnetic_half_space_leave_h_at_boundary_unchanged(tmp_path):
+    """End-to-end regression for the exact scenario that surfaced this bug:
+    a half-space with magnetic properties different from free space
+    (mr=3, sm=0.02) embedding a PEC cylinder and a PEC box must not create
+    any PEC-blended compound material - H at the object boundaries must
+    resolve directly to half_space's own numID, not an averaged placeholder.
+    """
+    import gprMax
+    import gprMax.model as model_mod
+
+    def _capture(scene, outfile):
+        captured = {}
+        orig_build = model_mod.Model.build
+
+        def patched_build(self):
+            orig_build(self)
+            captured["grid"] = self.G
+
+        import unittest.mock as mock
+        with mock.patch.object(model_mod.Model, "build", patched_build):
+            gprMax.run(scenes=[scene], n=1, geometry_only=True, outputfile=outfile, hide_progress_bars=True)
+        return captured["grid"]
+
+    dl = 2e-3
+    scene = gprMax.Scene()
+    scene.add(gprMax.Title(name="pec_h_invariance"))
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(0.040, 0.040, 0.040)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=1e-12))
+    scene.add(gprMax.Material(er=6, se=0.01, mr=3, sm=0.02, id="half_space"))
+    scene.add(gprMax.Box(p1=(0, 0, 0), p2=(0.040, 0.040, 0.020), material_id="half_space"))
+    scene.add(gprMax.Cylinder(p1=(0.020, 0, 0.010), p2=(0.020, 0.040, 0.010), r=0.006, material_id="pec"))
+    scene.add(gprMax.Box(p1=(0.005, 0.005, 0.002), p2=(0.015, 0.015, 0.012), material_id="pec"))
+
+    grid = _capture(scene, tmp_path / "pec_h_invariance")
+
+    assert not any("pec" in m.ID and "+" in m.ID for m in grid.materials), (
+        "no PEC-blended compound material should have been created at the "
+        f"cylinder/box boundaries, found: {[m.ID for m in grid.materials if '+' in m.ID]}"
+    )
+
+
+def test_magnetic_edge_sets_exact_self_consistent_rigid_bits():
+    """set_rigid_Hx was reverted to the self-consistent formula (mirroring
+    set_rigid_Ex/Ey/Ez's own-position/neighbour-offset shape) so a
+    standalone magnetic edge marks exactly one H position, not two - a
+    single build_magnetic_edge_x call at position i must set plane0@i and
+    plane1@(i-1) (if i!=0), and nothing else."""
+    grid = _grid(4, 3, 3)
+    matA = Material(3, "matA")
+    grid.materials.append(matA)
+
+    build_magnetic_edge_x(2, 1, 1, matA.numID, grid.rigidH, grid.ID)
+
+    rigidH = np.asarray(grid.rigidH)
+    expected = np.zeros_like(rigidH)
+    expected[0, 2, 1, 1] = True  # plane0 at the edge's own position
+    expected[1, 1, 1, 1] = True  # plane1 at position-1 (i!=0, so guard passes)
+    assert_array_equal(rigidH, expected)
+
+    idHx = grid.IDlookup["Hx"]
+    assert grid.ID[idHx, 2, 1, 1] == matA.numID
+
+
+def test_hole_carving_preserves_neighbouring_cells_rigid_h_faces():
+    """Overwriting one rigid cell in a multi-cell rigid block must not
+    orphan the H faces still legitimately claimed by its untouched
+    neighbours - the same safety property #edge/#box already rely on for
+    E, now confirmed for H's 2-owner-per-position sharing too."""
+    grid = _grid(4, 3, 3)
+    matA = Material(3, "matA")
+    matA.se = 5.0
+    grid.materials.append(matA)
+
+    # Two adjacent rigid cells at i=1 and i=2, sharing Hx position 2.
+    build_voxel(
+        1, 1, 1, matA.numID, matA.numID, matA.numID, matA.numID,
+        False, False, False, False,
+        grid.solid, grid.rigidE, grid.rigidH, grid.ID,
+    )
+    build_voxel(
+        2, 1, 1, matA.numID, matA.numID, matA.numID, matA.numID,
+        False, False, False, False,
+        grid.solid, grid.rigidE, grid.rigidH, grid.ID,
+    )
+
+    idHx = grid.IDlookup["Hx"]
+    assert grid.ID[idHx, 2, 1, 1] == matA.numID
+
+    # Overwrite cell 2 with an averaging (non-rigid) material.
+    free_space_numid = next(m.numID for m in grid.materials if m.ID == "free_space")
+    build_voxel(
+        2, 1, 1, free_space_numid, free_space_numid, free_space_numid, free_space_numid,
+        True, False, False, False,
+        grid.solid, grid.rigidE, grid.rigidH, grid.ID,
+    )
+
+    # Shared position 2 must still be rigid, via cell 1's independent claim.
+    build_electric_components(grid.solid, grid.rigidE, grid.ID, grid)
+    build_magnetic_components(grid.solid, grid.rigidH, grid.ID, grid)
+    assert grid.ID[idHx, 2, 1, 1] == matA.numID, (
+        "cell 1's independent rigid claim on the shared Hx face at position 2 "
+        "should have survived cell 2 being overwritten"
+    )

--- a/tests/materials/test_symmetry_boundary_pmc_dispersive_complex_edges.py
+++ b/tests/materials/test_symmetry_boundary_pmc_dispersive_complex_edges.py
@@ -1,0 +1,221 @@
+"""Tests for the complex-pole dispersive (Lorentz/Drude) per-iteration PMC
+ghost-node E update on the 12 domain edges
+(gprMax.cython.symmetry_boundaries_dispersive_complex), the edge counterpart
+of test_symmetry_boundary_pmc_dispersive_complex_updates.py, mirroring
+test_symmetry_boundary_pmc_dispersive_edges.py's (Debye/real-pole)
+structure.
+
+Same design decision under test as the real-pole edge file (see
+gprMax/cython/symmetry_boundaries_dispersive_complex.pyx's module
+docstring): phi/T bookkeeping runs unconditionally regardless of the
+a_pmc/b_pmc flags; only phi's accumulation formula differs from the
+real-pole case (Real(coeff)*Real(T) per pole, not the full complex
+product's real part - matching the bulk dispersive kernel's own complex
+branch exactly).
+"""
+import numpy as np
+import pytest
+
+from gprMax.cython import symmetry_boundaries_dispersive_complex as sbdc
+
+nx, ny, nz = 6, 5, 4
+maxpoles = 2
+ca, cb1, cb2, cb3, ce = 0.7, 0.11, 0.22, 0.33, 0.15
+alpha = [0.05 + 0.09j, 0.03 - 0.06j]
+beta = [0.9 - 0.2j, 0.8 + 0.15j]
+gamma = [0.02 + 0.01j, 0.01 - 0.03j]
+
+_CALL_H_ORDER = {"Ez": ("Hx", "Hy"), "Ey": ("Hx", "Hz"), "Ex": ("Hy", "Hz")}
+_T_FOR_E = {"Ez": "Tz", "Ey": "Ty", "Ex": "Tx"}
+
+
+def _make_arrays():
+    ID = np.ones((6, nx + 1, ny + 1, nz + 1), dtype=np.uint32)
+    C = np.array([[0.0, 0.0, 0.0, 0.0, 0.0], [ca, cb1, cb2, cb3, ce]])
+    D = np.array(
+        [[0.0] * (3 * maxpoles), [alpha[0], beta[0], gamma[0], alpha[1], beta[1], gamma[1]]],
+        dtype=np.complex128,
+    )
+
+    def field(offset, shape=(nx + 1, ny + 1, nz + 1), dtype=np.float64):
+        arr = np.zeros(shape, dtype=dtype)
+        it = np.nditer(arr, flags=["multi_index", "refs_ok"])
+        for _ in it:
+            idx = it.multi_index
+            arr[idx] = sum(1000**p * v for p, v in enumerate(idx)) + offset
+        return arr
+
+    Ex, Ey, Ez = field(1), field(2), field(3)
+    Hx, Hy, Hz = field(4), field(5), field(6)
+    tshape = (maxpoles, nx + 1, ny + 1, nz + 1)
+    Tx = field(7, tshape, dtype=np.complex128) + 0.5j * field(0.7, tshape, dtype=np.complex128)
+    Ty = field(8, tshape, dtype=np.complex128) + 0.5j * field(0.8, tshape, dtype=np.complex128)
+    Tz = field(9, tshape, dtype=np.complex128) + 0.5j * field(0.9, tshape, dtype=np.complex128)
+    return ID, C, D, {"Ex": Ex, "Ey": Ey, "Ez": Ez}, {"Hx": Hx, "Hy": Hy, "Hz": Hz}, {"Tx": Tx, "Ty": Ty, "Tz": Tz}
+
+
+def _phi_and_new_t(t_old_poles, e_old):
+    phi = 0.0
+    t_new = []
+    for p in range(maxpoles):
+        phi += alpha[p].real * t_old_poles[p].real
+        t_new.append(beta[p] * t_old_poles[p] + gamma[p] * e_old)
+    return phi, t_new
+
+
+def _gx0_ez(H, j, k):
+    return 2 * cb1 * H["Hy"][0, j, k]
+
+
+def _gxmax_ez(H, j, k):
+    return -2 * cb1 * H["Hy"][nx - 1, j, k]
+
+
+def _gy0_ez(H, i, k):
+    return -2 * cb2 * H["Hx"][i, 0, k]
+
+
+def _gymax_ez(H, i, k):
+    return 2 * cb2 * H["Hx"][i, ny - 1, k]
+
+
+def _gx0_ey(H, j, k):
+    return -2 * cb1 * H["Hz"][0, j, k]
+
+
+def _gxmax_ey(H, j, k):
+    return 2 * cb1 * H["Hz"][nx - 1, j, k]
+
+
+def _gz0_ey(H, i, j):
+    return 2 * cb3 * H["Hx"][i, j, 0]
+
+
+def _gzmax_ey(H, i, j):
+    return -2 * cb3 * H["Hx"][i, j, nz - 1]
+
+
+def _gy0_ex(H, i, k):
+    return 2 * cb2 * H["Hz"][i, 0, k]
+
+
+def _gymax_ex(H, i, k):
+    return -2 * cb2 * H["Hz"][i, ny - 1, k]
+
+
+def _gz0_ex(H, i, j):
+    return -2 * cb3 * H["Hy"][i, j, 0]
+
+
+def _gzmax_ex(H, i, j):
+    return 2 * cb3 * H["Hy"][i, j, nz - 1]
+
+
+_EDGES = [
+    ("Ez_X0_Y0", sbdc.update_symmetry_boundary_electric_dispersive_Ez_X0_Y0,
+     sbdc.update_symmetry_boundary_electric_dispersive_b_Ez_X0_Y0,
+     lambda k: (0, 0, k), range(nz), "Ez",
+     lambda H, k: _gx0_ez(H, 0, k), lambda H, k: _gy0_ez(H, 0, k)),
+    ("Ez_X0_YMax", sbdc.update_symmetry_boundary_electric_dispersive_Ez_X0_YMax,
+     sbdc.update_symmetry_boundary_electric_dispersive_b_Ez_X0_YMax,
+     lambda k: (0, ny, k), range(nz), "Ez",
+     lambda H, k: _gx0_ez(H, ny, k), lambda H, k: _gymax_ez(H, 0, k)),
+    ("Ez_XMax_Y0", sbdc.update_symmetry_boundary_electric_dispersive_Ez_XMax_Y0,
+     sbdc.update_symmetry_boundary_electric_dispersive_b_Ez_XMax_Y0,
+     lambda k: (nx, 0, k), range(nz), "Ez",
+     lambda H, k: _gxmax_ez(H, 0, k), lambda H, k: _gy0_ez(H, nx, k)),
+    ("Ez_XMax_YMax", sbdc.update_symmetry_boundary_electric_dispersive_Ez_XMax_YMax,
+     sbdc.update_symmetry_boundary_electric_dispersive_b_Ez_XMax_YMax,
+     lambda k: (nx, ny, k), range(nz), "Ez",
+     lambda H, k: _gxmax_ez(H, ny, k), lambda H, k: _gymax_ez(H, nx, k)),
+    ("Ey_X0_Z0", sbdc.update_symmetry_boundary_electric_dispersive_Ey_X0_Z0,
+     sbdc.update_symmetry_boundary_electric_dispersive_b_Ey_X0_Z0,
+     lambda j: (0, j, 0), range(ny), "Ey",
+     lambda H, j: _gx0_ey(H, j, 0), lambda H, j: _gz0_ey(H, 0, j)),
+    ("Ey_X0_ZMax", sbdc.update_symmetry_boundary_electric_dispersive_Ey_X0_ZMax,
+     sbdc.update_symmetry_boundary_electric_dispersive_b_Ey_X0_ZMax,
+     lambda j: (0, j, nz), range(ny), "Ey",
+     lambda H, j: _gx0_ey(H, j, nz), lambda H, j: _gzmax_ey(H, 0, j)),
+    ("Ey_XMax_Z0", sbdc.update_symmetry_boundary_electric_dispersive_Ey_XMax_Z0,
+     sbdc.update_symmetry_boundary_electric_dispersive_b_Ey_XMax_Z0,
+     lambda j: (nx, j, 0), range(ny), "Ey",
+     lambda H, j: _gxmax_ey(H, j, 0), lambda H, j: _gz0_ey(H, nx, j)),
+    ("Ey_XMax_ZMax", sbdc.update_symmetry_boundary_electric_dispersive_Ey_XMax_ZMax,
+     sbdc.update_symmetry_boundary_electric_dispersive_b_Ey_XMax_ZMax,
+     lambda j: (nx, j, nz), range(ny), "Ey",
+     lambda H, j: _gxmax_ey(H, j, nz), lambda H, j: _gzmax_ey(H, nx, j)),
+    ("Ex_Y0_Z0", sbdc.update_symmetry_boundary_electric_dispersive_Ex_Y0_Z0,
+     sbdc.update_symmetry_boundary_electric_dispersive_b_Ex_Y0_Z0,
+     lambda i: (i, 0, 0), range(nx), "Ex",
+     lambda H, i: _gy0_ex(H, i, 0), lambda H, i: _gz0_ex(H, i, 0)),
+    ("Ex_Y0_ZMax", sbdc.update_symmetry_boundary_electric_dispersive_Ex_Y0_ZMax,
+     sbdc.update_symmetry_boundary_electric_dispersive_b_Ex_Y0_ZMax,
+     lambda i: (i, 0, nz), range(nx), "Ex",
+     lambda H, i: _gy0_ex(H, i, nz), lambda H, i: _gzmax_ex(H, i, 0)),
+    ("Ex_YMax_Z0", sbdc.update_symmetry_boundary_electric_dispersive_Ex_YMax_Z0,
+     sbdc.update_symmetry_boundary_electric_dispersive_b_Ex_YMax_Z0,
+     lambda i: (i, ny, 0), range(nx), "Ex",
+     lambda H, i: _gymax_ex(H, i, 0), lambda H, i: _gz0_ex(H, i, ny)),
+    ("Ex_YMax_ZMax", sbdc.update_symmetry_boundary_electric_dispersive_Ex_YMax_ZMax,
+     sbdc.update_symmetry_boundary_electric_dispersive_b_Ex_YMax_ZMax,
+     lambda i: (i, ny, nz), range(nx), "Ex",
+     lambda H, i: _gymax_ex(H, i, nz), lambda H, i: _gzmax_ex(H, i, ny)),
+]
+
+
+@pytest.mark.parametrize("edge", _EDGES, ids=[e[0] for e in _EDGES])
+@pytest.mark.parametrize("a_pmc,b_pmc", [(True, False), (False, True), (True, True)])
+def test_edge_matches_independent_hand_derivation(edge, a_pmc, b_pmc):
+    name, func, func_b, pos_fn, free_range, comp, ghost_a, ghost_b = edge
+    ID, C, D, E, H, T = _make_arrays()
+    comp_arr = E[comp]
+    t_arr = T[_T_FOR_E[comp]]
+    h1_name, h2_name = _CALL_H_ORDER[comp]
+
+    expected_e = comp_arr.copy()
+    expected_t_after_a = t_arr.copy()
+    expected_t_after_b = t_arr.copy()
+    for t in free_range:
+        pos = pos_fn(t)
+        phi, t_new = _phi_and_new_t(t_arr[(slice(None),) + pos], comp_arr[pos])
+        expected_t_after_a[(slice(None),) + pos] = t_new
+        if a_pmc or b_pmc:
+            expected_e[pos] = ca * comp_arr[pos] - ce * phi
+        if a_pmc:
+            expected_e[pos] = expected_e[pos] + ghost_a(H, t)
+        if b_pmc:
+            expected_e[pos] = expected_e[pos] + ghost_b(H, t)
+        expected_t_after_b[(slice(None),) + pos] = [
+            t_new[p] - gamma[p] * expected_e[pos] for p in range(maxpoles)
+        ]
+
+    func(nx, ny, nz, 1, a_pmc, b_pmc, maxpoles, C, D, ID, t_arr, comp_arr, H[h1_name], H[h2_name])
+
+    assert np.allclose(comp_arr, expected_e), f"{name} a_pmc={a_pmc} b_pmc={b_pmc} E mismatch"
+    assert not np.iscomplexobj(comp_arr)
+    assert np.allclose(t_arr, expected_t_after_a), f"{name} a_pmc={a_pmc} b_pmc={b_pmc} T (phase A) mismatch"
+
+    func_b(nx, ny, nz, 1, maxpoles, D, ID, t_arr, comp_arr)
+
+    assert np.allclose(t_arr, expected_t_after_b), f"{name} a_pmc={a_pmc} b_pmc={b_pmc} T (phase B) mismatch"
+
+
+@pytest.mark.parametrize("edge", _EDGES, ids=[e[0] for e in _EDGES])
+def test_edge_neither_pmc_leaves_e_untouched_but_still_updates_t(edge):
+    name, func, func_b, pos_fn, free_range, comp, ghost_a, ghost_b = edge
+    ID, C, D, E, H, T = _make_arrays()
+    comp_arr = E[comp]
+    t_arr = T[_T_FOR_E[comp]]
+    h1_name, h2_name = _CALL_H_ORDER[comp]
+    e_before = comp_arr.copy()
+
+    expected_t_after_a = t_arr.copy()
+    for t in free_range:
+        pos = pos_fn(t)
+        _, t_new = _phi_and_new_t(t_arr[(slice(None),) + pos], comp_arr[pos])
+        expected_t_after_a[(slice(None),) + pos] = t_new
+
+    func(nx, ny, nz, 1, False, False, maxpoles, C, D, ID, t_arr, comp_arr, H[h1_name], H[h2_name])
+
+    assert np.array_equal(comp_arr, e_before), f"{name}: E changed even though neither face is PMC"
+    assert np.allclose(t_arr, expected_t_after_a), f"{name}: T did not update despite unconditional bookkeeping"

--- a/tests/materials/test_symmetry_boundary_pmc_dispersive_complex_updates.py
+++ b/tests/materials/test_symmetry_boundary_pmc_dispersive_complex_updates.py
@@ -1,0 +1,364 @@
+"""Tests for the complex-pole dispersive (Lorentz/Drude) per-iteration PMC
+ghost-node E update (gprMax.cython.symmetry_boundaries_dispersive_complex),
+the face-interior (non-edge) counterpart of
+test_symmetry_boundary_pmc_dispersive_updates.py (Debye/real-pole) for
+materials with complex ADE poles.
+
+The only difference from the real-pole file: Tx/Ty/Tz and
+updatecoeffsdispersive are complex here, so phi (which must stay real - it
+feeds directly into a real E-field update) accumulates
+Real(updatecoeffsdispersive[...]) * Real(T[...]) per pole - the real part of
+each factor individually, matching
+fields_updates_dispersive_template.jinja's own complex branch exactly (not
+"fixed" to Real(a*b), which would be a different, not-implemented, formula -
+see gprMax/cython/symmetry_boundaries_dispersive_complex.pyx's module
+docstring). The T-array recursion itself and Phase B are unchanged in form
+from the real-pole case - ordinary complex arithmetic handles them directly.
+
+maxpoles=2 with genuinely complex (non-zero imaginary part) per-pole
+coefficients is used throughout, specifically to exercise that the .real
+extraction is happening correctly (a bug that silently used the full
+complex value, or zero, or the imaginary part, would not be caught by
+real-valued test coefficients).
+"""
+import numpy as np
+import pytest
+
+from gprMax.cython import symmetry_boundaries_dispersive_complex as sbdc
+from gprMax.grid.fdtd_grid import FDTDGrid
+
+nx, ny, nz = 6, 5, 4
+maxpoles = 2
+ca, cb1, cb2, cb3, ce = 0.7, 0.11, 0.22, 0.33, 0.15
+# Per-pole complex dispersive coefficients: alpha (phi weight), beta (T
+# decay), gamma (E-driving) - all genuinely complex.
+alpha = [0.05 + 0.09j, 0.03 - 0.06j]
+beta = [0.9 - 0.2j, 0.8 + 0.15j]
+gamma = [0.02 + 0.01j, 0.01 - 0.03j]
+
+_FACE_FUNCS = {
+    "x0": sbdc.update_symmetry_boundary_electric_dispersive_x0,
+    "xmax": sbdc.update_symmetry_boundary_electric_dispersive_xmax,
+    "y0": sbdc.update_symmetry_boundary_electric_dispersive_y0,
+    "ymax": sbdc.update_symmetry_boundary_electric_dispersive_ymax,
+    "z0": sbdc.update_symmetry_boundary_electric_dispersive_z0,
+    "zmax": sbdc.update_symmetry_boundary_electric_dispersive_zmax,
+}
+
+_FACE_FUNCS_B = {
+    "x0": sbdc.update_symmetry_boundary_electric_dispersive_b_x0,
+    "xmax": sbdc.update_symmetry_boundary_electric_dispersive_b_xmax,
+    "y0": sbdc.update_symmetry_boundary_electric_dispersive_b_y0,
+    "ymax": sbdc.update_symmetry_boundary_electric_dispersive_b_ymax,
+    "z0": sbdc.update_symmetry_boundary_electric_dispersive_b_z0,
+    "zmax": sbdc.update_symmetry_boundary_electric_dispersive_b_zmax,
+}
+
+
+def _update_face_interior(grid, face):
+    _FACE_FUNCS[face](
+        grid.nx, grid.ny, grid.nz, 1, maxpoles,
+        grid.updatecoeffsE, grid.updatecoeffsdispersive, grid.ID,
+        grid.Tx, grid.Ty, grid.Tz,
+        grid.Ex, grid.Ey, grid.Ez,
+        grid.Hx, grid.Hy, grid.Hz,
+    )
+
+
+def _update_face_interior_b(grid, face):
+    _FACE_FUNCS_B[face](
+        grid.nx, grid.ny, grid.nz, 1, maxpoles,
+        grid.updatecoeffsdispersive, grid.ID,
+        grid.Tx, grid.Ty, grid.Tz,
+        grid.Ex, grid.Ey, grid.Ez,
+    )
+
+
+def _make_grid():
+    grid = FDTDGrid()
+    grid.nx, grid.ny, grid.nz = nx, ny, nz
+    grid.ID = np.ones((6, nx + 1, ny + 1, nz + 1), dtype=np.uint32)
+    grid.updatecoeffsE = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.0, 0.0],
+            [ca, cb1, cb2, cb3, ce],
+        ]
+    )
+    grid.updatecoeffsdispersive = np.array(
+        [
+            [0.0] * (3 * maxpoles),
+            [alpha[0], beta[0], gamma[0], alpha[1], beta[1], gamma[1]],
+        ],
+        dtype=np.complex128,
+    )
+
+    def field(offset, shape=None, dtype=np.float64):
+        shape = shape or (nx + 1, ny + 1, nz + 1)
+        arr = np.zeros(shape, dtype=dtype)
+        it = np.nditer(arr, flags=["multi_index", "refs_ok"])
+        for _ in it:
+            idx = it.multi_index
+            arr[idx] = sum(1000**p * v for p, v in enumerate(idx)) + offset
+        return arr
+
+    grid.Ex, grid.Ey, grid.Ez = field(1), field(2), field(3)
+    grid.Hx, grid.Hy, grid.Hz = field(4), field(5), field(6)
+    # Complex T arrays - give them a genuinely non-zero imaginary part too
+    # (offset*1j on top of the real ramp), not just real numbers cast wide.
+    tshape = (maxpoles, nx + 1, ny + 1, nz + 1)
+    grid.Tx = field(7, tshape, dtype=np.complex128) + 0.5j * field(0.7, tshape, dtype=np.complex128)
+    grid.Ty = field(8, tshape, dtype=np.complex128) + 0.5j * field(0.8, tshape, dtype=np.complex128)
+    grid.Tz = field(9, tshape, dtype=np.complex128) + 0.5j * field(0.9, tshape, dtype=np.complex128)
+    return grid
+
+
+def _phi_and_new_t(t_old_poles, e_old):
+    """Independently re-derives phi (real: Re(alpha)*Re(T) per pole, NOT
+    Re(alpha*T)) and the new per-pole complex T values for a single grid
+    position - matches the Cython pole loop exactly."""
+    phi = 0.0
+    t_new = []
+    for p in range(maxpoles):
+        phi += alpha[p].real * t_old_poles[p].real
+        t_new.append(beta[p] * t_old_poles[p] + gamma[p] * e_old)
+    return phi, t_new
+
+
+def _expected_x0(grid):
+    Ey, Ez = grid.Ey.copy(), grid.Ez.copy()
+    Ty, Tz = grid.Ty.copy(), grid.Tz.copy()
+    Ty_b, Tz_b = grid.Ty.copy(), grid.Tz.copy()
+    for j in range(ny):
+        for k in range(1, nz):
+            phi, t_new = _phi_and_new_t(grid.Ty[:, 0, j, k], grid.Ey[0, j, k])
+            Ty[:, 0, j, k] = t_new
+            Ey[0, j, k] = (
+                ca * grid.Ey[0, j, k]
+                + cb3 * (grid.Hx[0, j, k] - grid.Hx[0, j, k - 1])
+                - cb1 * (2 * grid.Hz[0, j, k])
+                - ce * phi
+            )
+            Ty_b[:, 0, j, k] = [t_new[p] - gamma[p] * Ey[0, j, k] for p in range(maxpoles)]
+    for j in range(1, ny):
+        for k in range(nz):
+            phi, t_new = _phi_and_new_t(grid.Tz[:, 0, j, k], grid.Ez[0, j, k])
+            Tz[:, 0, j, k] = t_new
+            Ez[0, j, k] = (
+                ca * grid.Ez[0, j, k]
+                - cb2 * (grid.Hx[0, j, k] - grid.Hx[0, j - 1, k])
+                + cb1 * (2 * grid.Hy[0, j, k])
+                - ce * phi
+            )
+            Tz_b[:, 0, j, k] = [t_new[p] - gamma[p] * Ez[0, j, k] for p in range(maxpoles)]
+    return Ey, Ez, Ty, Tz, Ty_b, Tz_b
+
+
+def _expected_xmax(grid):
+    Ey, Ez = grid.Ey.copy(), grid.Ez.copy()
+    Ty, Tz = grid.Ty.copy(), grid.Tz.copy()
+    Ty_b, Tz_b = grid.Ty.copy(), grid.Tz.copy()
+    for j in range(ny):
+        for k in range(1, nz):
+            phi, t_new = _phi_and_new_t(grid.Ty[:, nx, j, k], grid.Ey[nx, j, k])
+            Ty[:, nx, j, k] = t_new
+            Ey[nx, j, k] = (
+                ca * grid.Ey[nx, j, k]
+                + cb3 * (grid.Hx[nx, j, k] - grid.Hx[nx, j, k - 1])
+                + cb1 * (2 * grid.Hz[nx - 1, j, k])
+                - ce * phi
+            )
+            Ty_b[:, nx, j, k] = [t_new[p] - gamma[p] * Ey[nx, j, k] for p in range(maxpoles)]
+    for j in range(1, ny):
+        for k in range(nz):
+            phi, t_new = _phi_and_new_t(grid.Tz[:, nx, j, k], grid.Ez[nx, j, k])
+            Tz[:, nx, j, k] = t_new
+            Ez[nx, j, k] = (
+                ca * grid.Ez[nx, j, k]
+                - cb2 * (grid.Hx[nx, j, k] - grid.Hx[nx, j - 1, k])
+                - cb1 * (2 * grid.Hy[nx - 1, j, k])
+                - ce * phi
+            )
+            Tz_b[:, nx, j, k] = [t_new[p] - gamma[p] * Ez[nx, j, k] for p in range(maxpoles)]
+    return Ey, Ez, Ty, Tz, Ty_b, Tz_b
+
+
+def _expected_y0(grid):
+    Ex, Ez = grid.Ex.copy(), grid.Ez.copy()
+    Tx, Tz = grid.Tx.copy(), grid.Tz.copy()
+    Tx_b, Tz_b = grid.Tx.copy(), grid.Tz.copy()
+    for i in range(nx):
+        for k in range(1, nz):
+            phi, t_new = _phi_and_new_t(grid.Tx[:, i, 0, k], grid.Ex[i, 0, k])
+            Tx[:, i, 0, k] = t_new
+            Ex[i, 0, k] = (
+                ca * grid.Ex[i, 0, k]
+                - cb3 * (grid.Hy[i, 0, k] - grid.Hy[i, 0, k - 1])
+                + cb2 * (2 * grid.Hz[i, 0, k])
+                - ce * phi
+            )
+            Tx_b[:, i, 0, k] = [t_new[p] - gamma[p] * Ex[i, 0, k] for p in range(maxpoles)]
+    for i in range(1, nx):
+        for k in range(nz):
+            phi, t_new = _phi_and_new_t(grid.Tz[:, i, 0, k], grid.Ez[i, 0, k])
+            Tz[:, i, 0, k] = t_new
+            Ez[i, 0, k] = (
+                ca * grid.Ez[i, 0, k]
+                + cb1 * (grid.Hy[i, 0, k] - grid.Hy[i - 1, 0, k])
+                - cb2 * (2 * grid.Hx[i, 0, k])
+                - ce * phi
+            )
+            Tz_b[:, i, 0, k] = [t_new[p] - gamma[p] * Ez[i, 0, k] for p in range(maxpoles)]
+    return Ex, Ez, Tx, Tz, Tx_b, Tz_b
+
+
+def _expected_ymax(grid):
+    Ex, Ez = grid.Ex.copy(), grid.Ez.copy()
+    Tx, Tz = grid.Tx.copy(), grid.Tz.copy()
+    Tx_b, Tz_b = grid.Tx.copy(), grid.Tz.copy()
+    for i in range(nx):
+        for k in range(1, nz):
+            phi, t_new = _phi_and_new_t(grid.Tx[:, i, ny, k], grid.Ex[i, ny, k])
+            Tx[:, i, ny, k] = t_new
+            Ex[i, ny, k] = (
+                ca * grid.Ex[i, ny, k]
+                - cb3 * (grid.Hy[i, ny, k] - grid.Hy[i, ny, k - 1])
+                - cb2 * (2 * grid.Hz[i, ny - 1, k])
+                - ce * phi
+            )
+            Tx_b[:, i, ny, k] = [t_new[p] - gamma[p] * Ex[i, ny, k] for p in range(maxpoles)]
+    for i in range(1, nx):
+        for k in range(nz):
+            phi, t_new = _phi_and_new_t(grid.Tz[:, i, ny, k], grid.Ez[i, ny, k])
+            Tz[:, i, ny, k] = t_new
+            Ez[i, ny, k] = (
+                ca * grid.Ez[i, ny, k]
+                + cb1 * (grid.Hy[i, ny, k] - grid.Hy[i - 1, ny, k])
+                + cb2 * (2 * grid.Hx[i, ny - 1, k])
+                - ce * phi
+            )
+            Tz_b[:, i, ny, k] = [t_new[p] - gamma[p] * Ez[i, ny, k] for p in range(maxpoles)]
+    return Ex, Ez, Tx, Tz, Tx_b, Tz_b
+
+
+def _expected_z0(grid):
+    Ex, Ey = grid.Ex.copy(), grid.Ey.copy()
+    Tx, Ty = grid.Tx.copy(), grid.Ty.copy()
+    Tx_b, Ty_b = grid.Tx.copy(), grid.Ty.copy()
+    for i in range(nx):
+        for j in range(1, ny):
+            phi, t_new = _phi_and_new_t(grid.Tx[:, i, j, 0], grid.Ex[i, j, 0])
+            Tx[:, i, j, 0] = t_new
+            Ex[i, j, 0] = (
+                ca * grid.Ex[i, j, 0]
+                + cb2 * (grid.Hz[i, j, 0] - grid.Hz[i, j - 1, 0])
+                - cb3 * (2 * grid.Hy[i, j, 0])
+                - ce * phi
+            )
+            Tx_b[:, i, j, 0] = [t_new[p] - gamma[p] * Ex[i, j, 0] for p in range(maxpoles)]
+    for i in range(1, nx):
+        for j in range(ny):
+            phi, t_new = _phi_and_new_t(grid.Ty[:, i, j, 0], grid.Ey[i, j, 0])
+            Ty[:, i, j, 0] = t_new
+            Ey[i, j, 0] = (
+                ca * grid.Ey[i, j, 0]
+                - cb1 * (grid.Hz[i, j, 0] - grid.Hz[i - 1, j, 0])
+                + cb3 * (2 * grid.Hx[i, j, 0])
+                - ce * phi
+            )
+            Ty_b[:, i, j, 0] = [t_new[p] - gamma[p] * Ey[i, j, 0] for p in range(maxpoles)]
+    return Ex, Ey, Tx, Ty, Tx_b, Ty_b
+
+
+def _expected_zmax(grid):
+    Ex, Ey = grid.Ex.copy(), grid.Ey.copy()
+    Tx, Ty = grid.Tx.copy(), grid.Ty.copy()
+    Tx_b, Ty_b = grid.Tx.copy(), grid.Ty.copy()
+    for i in range(nx):
+        for j in range(1, ny):
+            phi, t_new = _phi_and_new_t(grid.Tx[:, i, j, nz], grid.Ex[i, j, nz])
+            Tx[:, i, j, nz] = t_new
+            Ex[i, j, nz] = (
+                ca * grid.Ex[i, j, nz]
+                + cb2 * (grid.Hz[i, j, nz] - grid.Hz[i, j - 1, nz])
+                + cb3 * (2 * grid.Hy[i, j, nz - 1])
+                - ce * phi
+            )
+            Tx_b[:, i, j, nz] = [t_new[p] - gamma[p] * Ex[i, j, nz] for p in range(maxpoles)]
+    for i in range(1, nx):
+        for j in range(ny):
+            phi, t_new = _phi_and_new_t(grid.Ty[:, i, j, nz], grid.Ey[i, j, nz])
+            Ty[:, i, j, nz] = t_new
+            Ey[i, j, nz] = (
+                ca * grid.Ey[i, j, nz]
+                - cb1 * (grid.Hz[i, j, nz] - grid.Hz[i - 1, j, nz])
+                - cb3 * (2 * grid.Hx[i, j, nz - 1])
+                - ce * phi
+            )
+            Ty_b[:, i, j, nz] = [t_new[p] - gamma[p] * Ey[i, j, nz] for p in range(maxpoles)]
+    return Ex, Ey, Tx, Ty, Tx_b, Ty_b
+
+
+_FACES = {
+    "x0": (_expected_x0, ("Ey", "Ez"), ("Ty", "Tz")),
+    "xmax": (_expected_xmax, ("Ey", "Ez"), ("Ty", "Tz")),
+    "y0": (_expected_y0, ("Ex", "Ez"), ("Tx", "Tz")),
+    "ymax": (_expected_ymax, ("Ex", "Ez"), ("Tx", "Tz")),
+    "z0": (_expected_z0, ("Ex", "Ey"), ("Tx", "Ty")),
+    "zmax": (_expected_zmax, ("Ex", "Ey"), ("Tx", "Ty")),
+}
+
+
+@pytest.mark.parametrize("face", _FACES.keys())
+def test_face_interior_matches_independent_hand_derivation(face):
+    expected_fn, e_components, t_components = _FACES[face]
+    grid = _make_grid()
+    expected_e1, expected_e2, expected_t1, expected_t2, _, _ = expected_fn(grid)
+
+    _update_face_interior(grid, face)
+
+    assert np.allclose(getattr(grid, e_components[0]), expected_e1), f"{face}/{e_components[0]} mismatch"
+    assert np.allclose(getattr(grid, e_components[1]), expected_e2), f"{face}/{e_components[1]} mismatch"
+    assert np.allclose(getattr(grid, t_components[0]), expected_t1), f"{face}/{t_components[0]} mismatch"
+    assert np.allclose(getattr(grid, t_components[1]), expected_t2), f"{face}/{t_components[1]} mismatch"
+    # E must stay strictly real (float64), not accidentally promoted to
+    # complex by having picked up a complex intermediate somewhere.
+    assert not np.iscomplexobj(getattr(grid, e_components[0]))
+    assert not np.iscomplexobj(getattr(grid, e_components[1]))
+
+
+@pytest.mark.parametrize("face", _FACES.keys())
+def test_face_interior_does_not_touch_the_other_components(face):
+    _, e_components, t_components = _FACES[face]
+    all_e = ("Ex", "Ey", "Ez")
+    all_t = ("Tx", "Ty", "Tz")
+    untouched_e = [c for c in all_e if c not in e_components]
+    untouched_t = [c for c in all_t if c not in t_components]
+
+    grid = _make_grid()
+    before = {c: getattr(grid, c).copy() for c in untouched_e + untouched_t + ["Hx", "Hy", "Hz"]}
+
+    _update_face_interior(grid, face)
+
+    for c in before:
+        assert np.array_equal(getattr(grid, c), before[c]), f"{face}: {c} changed unexpectedly"
+
+
+@pytest.mark.parametrize("face", _FACES.keys())
+def test_phase_b_corrects_t_using_the_e_value_current_when_it_runs(face):
+    """Same regression guard as the real-pole file's equivalent test: phase
+    B's correction (T -= gamma*E) must use whatever (real) E value is
+    current at the time phase B runs - here, phase A's own output E."""
+    expected_fn, e_components, t_components = _FACES[face]
+
+    grid = _make_grid()
+    _, _, _, _, expected_t1_after_b, expected_t2_after_b = expected_fn(grid)
+
+    _update_face_interior(grid, face)
+    _update_face_interior_b(grid, face)
+
+    assert np.allclose(getattr(grid, t_components[0]), expected_t1_after_b), (
+        f"{face}: phase B's T ({t_components[0]}) does not match independent hand derivation"
+    )
+    assert np.allclose(getattr(grid, t_components[1]), expected_t2_after_b), (
+        f"{face}: phase B's T ({t_components[1]}) does not match independent hand derivation"
+    )

--- a/tests/materials/test_symmetry_boundary_pmc_dispersive_edges.py
+++ b/tests/materials/test_symmetry_boundary_pmc_dispersive_edges.py
@@ -1,0 +1,230 @@
+"""Tests for the dispersive (Debye) per-iteration PMC ghost-node E update on
+the 12 domain edges (gprMax.cython.symmetry_boundaries_dispersive), the edge
+counterpart of test_symmetry_boundary_pmc_dispersive_updates.py, mirroring
+test_symmetry_boundary_pmc_edges.py's structure for the non-dispersive case.
+
+Design decision under direct test here (see
+gprMax/cython/symmetry_boundaries_dispersive.pyx's module docstring): the
+phi/T-array bookkeeping runs UNCONDITIONALLY at every edge cell, regardless
+of the a_pmc/b_pmc flags - only the E-field self/ghost terms are gated by
+them, exactly as in the non-dispersive edge kernels. This is what lets a
+single-PMC-neighbour edge (where the other side has already been forced to
+"pec" elsewhere, giving Ca=Cb=Ce=0 and a zero updatecoeffsdispersive row for
+that material) degenerate correctly to zero without any explicit
+PEC-transparency branch - not directly exercised here (that's the
+build-time/material-ID concern covered by test_symmetry_boundary.py and the
+end-to-end tests), just confirmed structurally: T still updates even when
+both flags are False (never happens via the real per-iteration dispatch,
+which drops such edges entirely, but is part of the documented per-cell
+contract).
+"""
+import numpy as np
+import pytest
+
+from gprMax.cython import symmetry_boundaries_dispersive as sbd
+
+nx, ny, nz = 6, 5, 4
+maxpoles = 2
+ca, cb1, cb2, cb3, ce = 0.7, 0.11, 0.22, 0.33, 0.15
+alpha = [0.05, 0.03]
+beta = [0.9, 0.8]
+gamma = [0.02, 0.01]
+
+_CALL_H_ORDER = {"Ez": ("Hx", "Hy"), "Ey": ("Hx", "Hz"), "Ex": ("Hy", "Hz")}
+_T_FOR_E = {"Ez": "Tz", "Ey": "Ty", "Ex": "Tx"}
+
+
+def _make_arrays():
+    ID = np.ones((6, nx + 1, ny + 1, nz + 1), dtype=np.uint32)
+    C = np.array([[0.0, 0.0, 0.0, 0.0, 0.0], [ca, cb1, cb2, cb3, ce]])
+    D = np.array([[0.0] * (3 * maxpoles), [alpha[0], beta[0], gamma[0], alpha[1], beta[1], gamma[1]]])
+
+    def field(offset, shape=(nx + 1, ny + 1, nz + 1)):
+        arr = np.zeros(shape)
+        it = np.nditer(arr, flags=["multi_index"])
+        for _ in it:
+            idx = it.multi_index
+            arr[idx] = sum(1000**p * v for p, v in enumerate(idx)) + offset
+        return arr
+
+    Ex, Ey, Ez = field(1), field(2), field(3)
+    Hx, Hy, Hz = field(4), field(5), field(6)
+    tshape = (maxpoles, nx + 1, ny + 1, nz + 1)
+    Tx, Ty, Tz = field(7, tshape), field(8, tshape), field(9, tshape)
+    return ID, C, D, {"Ex": Ex, "Ey": Ey, "Ez": Ez}, {"Hx": Hx, "Hy": Hy, "Hz": Hz}, {"Tx": Tx, "Ty": Ty, "Tz": Tz}
+
+
+def _phi_and_new_t(t_old_poles, e_old):
+    phi = 0.0
+    t_new = []
+    for p in range(maxpoles):
+        phi += alpha[p] * t_old_poles[p]
+        t_new.append(beta[p] * t_old_poles[p] + gamma[p] * e_old)
+    return phi, t_new
+
+
+# Ghost-term helpers - identical formulas to test_symmetry_boundary_pmc_edges.py.
+def _gx0_ez(H, j, k):
+    return 2 * cb1 * H["Hy"][0, j, k]
+
+
+def _gxmax_ez(H, j, k):
+    return -2 * cb1 * H["Hy"][nx - 1, j, k]
+
+
+def _gy0_ez(H, i, k):
+    return -2 * cb2 * H["Hx"][i, 0, k]
+
+
+def _gymax_ez(H, i, k):
+    return 2 * cb2 * H["Hx"][i, ny - 1, k]
+
+
+def _gx0_ey(H, j, k):
+    return -2 * cb1 * H["Hz"][0, j, k]
+
+
+def _gxmax_ey(H, j, k):
+    return 2 * cb1 * H["Hz"][nx - 1, j, k]
+
+
+def _gz0_ey(H, i, j):
+    return 2 * cb3 * H["Hx"][i, j, 0]
+
+
+def _gzmax_ey(H, i, j):
+    return -2 * cb3 * H["Hx"][i, j, nz - 1]
+
+
+def _gy0_ex(H, i, k):
+    return 2 * cb2 * H["Hz"][i, 0, k]
+
+
+def _gymax_ex(H, i, k):
+    return -2 * cb2 * H["Hz"][i, ny - 1, k]
+
+
+def _gz0_ex(H, i, j):
+    return -2 * cb3 * H["Hy"][i, j, 0]
+
+
+def _gzmax_ex(H, i, j):
+    return 2 * cb3 * H["Hy"][i, j, nz - 1]
+
+
+# Each entry: (name, phase_a_func, phase_b_func, position(t)->(i,j,k), free
+# range, E component, ghostA(H,t), ghostB(H,t)).
+_EDGES = [
+    ("Ez_X0_Y0", sbd.update_symmetry_boundary_electric_dispersive_Ez_X0_Y0,
+     sbd.update_symmetry_boundary_electric_dispersive_b_Ez_X0_Y0,
+     lambda k: (0, 0, k), range(nz), "Ez",
+     lambda H, k: _gx0_ez(H, 0, k), lambda H, k: _gy0_ez(H, 0, k)),
+    ("Ez_X0_YMax", sbd.update_symmetry_boundary_electric_dispersive_Ez_X0_YMax,
+     sbd.update_symmetry_boundary_electric_dispersive_b_Ez_X0_YMax,
+     lambda k: (0, ny, k), range(nz), "Ez",
+     lambda H, k: _gx0_ez(H, ny, k), lambda H, k: _gymax_ez(H, 0, k)),
+    ("Ez_XMax_Y0", sbd.update_symmetry_boundary_electric_dispersive_Ez_XMax_Y0,
+     sbd.update_symmetry_boundary_electric_dispersive_b_Ez_XMax_Y0,
+     lambda k: (nx, 0, k), range(nz), "Ez",
+     lambda H, k: _gxmax_ez(H, 0, k), lambda H, k: _gy0_ez(H, nx, k)),
+    ("Ez_XMax_YMax", sbd.update_symmetry_boundary_electric_dispersive_Ez_XMax_YMax,
+     sbd.update_symmetry_boundary_electric_dispersive_b_Ez_XMax_YMax,
+     lambda k: (nx, ny, k), range(nz), "Ez",
+     lambda H, k: _gxmax_ez(H, ny, k), lambda H, k: _gymax_ez(H, nx, k)),
+    ("Ey_X0_Z0", sbd.update_symmetry_boundary_electric_dispersive_Ey_X0_Z0,
+     sbd.update_symmetry_boundary_electric_dispersive_b_Ey_X0_Z0,
+     lambda j: (0, j, 0), range(ny), "Ey",
+     lambda H, j: _gx0_ey(H, j, 0), lambda H, j: _gz0_ey(H, 0, j)),
+    ("Ey_X0_ZMax", sbd.update_symmetry_boundary_electric_dispersive_Ey_X0_ZMax,
+     sbd.update_symmetry_boundary_electric_dispersive_b_Ey_X0_ZMax,
+     lambda j: (0, j, nz), range(ny), "Ey",
+     lambda H, j: _gx0_ey(H, j, nz), lambda H, j: _gzmax_ey(H, 0, j)),
+    ("Ey_XMax_Z0", sbd.update_symmetry_boundary_electric_dispersive_Ey_XMax_Z0,
+     sbd.update_symmetry_boundary_electric_dispersive_b_Ey_XMax_Z0,
+     lambda j: (nx, j, 0), range(ny), "Ey",
+     lambda H, j: _gxmax_ey(H, j, 0), lambda H, j: _gz0_ey(H, nx, j)),
+    ("Ey_XMax_ZMax", sbd.update_symmetry_boundary_electric_dispersive_Ey_XMax_ZMax,
+     sbd.update_symmetry_boundary_electric_dispersive_b_Ey_XMax_ZMax,
+     lambda j: (nx, j, nz), range(ny), "Ey",
+     lambda H, j: _gxmax_ey(H, j, nz), lambda H, j: _gzmax_ey(H, nx, j)),
+    ("Ex_Y0_Z0", sbd.update_symmetry_boundary_electric_dispersive_Ex_Y0_Z0,
+     sbd.update_symmetry_boundary_electric_dispersive_b_Ex_Y0_Z0,
+     lambda i: (i, 0, 0), range(nx), "Ex",
+     lambda H, i: _gy0_ex(H, i, 0), lambda H, i: _gz0_ex(H, i, 0)),
+    ("Ex_Y0_ZMax", sbd.update_symmetry_boundary_electric_dispersive_Ex_Y0_ZMax,
+     sbd.update_symmetry_boundary_electric_dispersive_b_Ex_Y0_ZMax,
+     lambda i: (i, 0, nz), range(nx), "Ex",
+     lambda H, i: _gy0_ex(H, i, nz), lambda H, i: _gzmax_ex(H, i, 0)),
+    ("Ex_YMax_Z0", sbd.update_symmetry_boundary_electric_dispersive_Ex_YMax_Z0,
+     sbd.update_symmetry_boundary_electric_dispersive_b_Ex_YMax_Z0,
+     lambda i: (i, ny, 0), range(nx), "Ex",
+     lambda H, i: _gymax_ex(H, i, 0), lambda H, i: _gz0_ex(H, i, ny)),
+    ("Ex_YMax_ZMax", sbd.update_symmetry_boundary_electric_dispersive_Ex_YMax_ZMax,
+     sbd.update_symmetry_boundary_electric_dispersive_b_Ex_YMax_ZMax,
+     lambda i: (i, ny, nz), range(nx), "Ex",
+     lambda H, i: _gymax_ex(H, i, nz), lambda H, i: _gzmax_ex(H, i, ny)),
+]
+
+
+@pytest.mark.parametrize("edge", _EDGES, ids=[e[0] for e in _EDGES])
+@pytest.mark.parametrize("a_pmc,b_pmc", [(True, False), (False, True), (True, True)])
+def test_edge_matches_independent_hand_derivation(edge, a_pmc, b_pmc):
+    name, func, func_b, pos_fn, free_range, comp, ghost_a, ghost_b = edge
+    ID, C, D, E, H, T = _make_arrays()
+    comp_arr = E[comp]
+    t_arr = T[_T_FOR_E[comp]]
+    h1_name, h2_name = _CALL_H_ORDER[comp]
+
+    expected_e = comp_arr.copy()
+    expected_t_after_a = t_arr.copy()
+    expected_t_after_b = t_arr.copy()
+    for t in free_range:
+        pos = pos_fn(t)
+        phi, t_new = _phi_and_new_t(t_arr[(slice(None),) + pos], comp_arr[pos])
+        expected_t_after_a[(slice(None),) + pos] = t_new
+        if a_pmc or b_pmc:
+            expected_e[pos] = ca * comp_arr[pos] - ce * phi
+        if a_pmc:
+            expected_e[pos] = expected_e[pos] + ghost_a(H, t)
+        if b_pmc:
+            expected_e[pos] = expected_e[pos] + ghost_b(H, t)
+        expected_t_after_b[(slice(None),) + pos] = [
+            t_new[p] - gamma[p] * expected_e[pos] for p in range(maxpoles)
+        ]
+
+    func(nx, ny, nz, 1, a_pmc, b_pmc, maxpoles, C, D, ID, t_arr, comp_arr, H[h1_name], H[h2_name])
+
+    assert np.allclose(comp_arr, expected_e), f"{name} a_pmc={a_pmc} b_pmc={b_pmc} E mismatch"
+    assert np.allclose(t_arr, expected_t_after_a), f"{name} a_pmc={a_pmc} b_pmc={b_pmc} T (phase A) mismatch"
+
+    func_b(nx, ny, nz, 1, maxpoles, D, ID, t_arr, comp_arr)
+
+    assert np.allclose(t_arr, expected_t_after_b), f"{name} a_pmc={a_pmc} b_pmc={b_pmc} T (phase B) mismatch"
+
+
+@pytest.mark.parametrize("edge", _EDGES, ids=[e[0] for e in _EDGES])
+def test_edge_neither_pmc_leaves_e_untouched_but_still_updates_t(edge):
+    """With both flags False (never actually reached via the real
+    per-iteration dispatch, which drops such edges entirely), E must stay
+    untouched - but T still updates, since the phi/T bookkeeping is
+    unconditional. This is the structural property that lets a
+    single-PMC-neighbour edge's T correctly keep tracking a real (non-pec)
+    dispersive material's state even when momentarily viewed with both
+    flags False."""
+    name, func, func_b, pos_fn, free_range, comp, ghost_a, ghost_b = edge
+    ID, C, D, E, H, T = _make_arrays()
+    comp_arr = E[comp]
+    t_arr = T[_T_FOR_E[comp]]
+    h1_name, h2_name = _CALL_H_ORDER[comp]
+    e_before = comp_arr.copy()
+
+    expected_t_after_a = t_arr.copy()
+    for t in free_range:
+        pos = pos_fn(t)
+        _, t_new = _phi_and_new_t(t_arr[(slice(None),) + pos], comp_arr[pos])
+        expected_t_after_a[(slice(None),) + pos] = t_new
+
+    func(nx, ny, nz, 1, False, False, maxpoles, C, D, ID, t_arr, comp_arr, H[h1_name], H[h2_name])
+
+    assert np.array_equal(comp_arr, e_before), f"{name}: E changed even though neither face is PMC"
+    assert np.allclose(t_arr, expected_t_after_a), f"{name}: T did not update despite unconditional bookkeeping"

--- a/tests/materials/test_symmetry_boundary_pmc_dispersive_updates.py
+++ b/tests/materials/test_symmetry_boundary_pmc_dispersive_updates.py
@@ -1,0 +1,361 @@
+"""Tests for the dispersive (Debye) per-iteration PMC ghost-node E update
+(gprMax.cython.symmetry_boundaries_dispersive), the face-interior (non-edge)
+counterpart of test_symmetry_boundary_pmc_updates.py for materials with
+polarization-current (ADE) poles.
+
+Each dispersive face function does two things beyond its non-dispersive
+sibling: accumulates `phi` from the existing T-array (pole-summed,
+weighted by updatecoeffsdispersive[mat, pole*3]), updates the T-array from
+the OLD E value (updatecoeffsdispersive[mat, 1+pole*3] * T_old +
+updatecoeffsdispersive[mat, 2+pole*3] * E_old), and folds
+`-updatecoeffsE[mat, 4] * phi` into the final E assignment - otherwise
+identical to the non-dispersive ghost-node substitution (same curl terms,
+same face sign conventions).
+
+Phase B (update_symmetry_boundary_electric_dispersive_b_*) only does the
+T-array correction using the (now assumed final, post-PML/source) E value -
+no H arrays, no E-field write.
+
+Each expected-value helper is a plain Python loop (not vectorized),
+independently re-deriving the same formula the Cython implementation
+computes - so a transcription bug in one wouldn't be masked by the same bug
+in the other. maxpoles=2 is used throughout (not 1) specifically to exercise
+the general pole loop, not just a degenerate single-iteration case.
+"""
+import numpy as np
+import pytest
+
+from gprMax.cython import symmetry_boundaries_dispersive as sbd
+from gprMax.grid.fdtd_grid import FDTDGrid
+
+nx, ny, nz = 6, 5, 4
+maxpoles = 2
+ca, cb1, cb2, cb3, ce = 0.7, 0.11, 0.22, 0.33, 0.15
+# Per-pole dispersive coefficients: alpha (phi weight), beta (T decay), gamma (E-driving).
+alpha = [0.05, 0.03]
+beta = [0.9, 0.8]
+gamma = [0.02, 0.01]
+
+_FACE_FUNCS = {
+    "x0": sbd.update_symmetry_boundary_electric_dispersive_x0,
+    "xmax": sbd.update_symmetry_boundary_electric_dispersive_xmax,
+    "y0": sbd.update_symmetry_boundary_electric_dispersive_y0,
+    "ymax": sbd.update_symmetry_boundary_electric_dispersive_ymax,
+    "z0": sbd.update_symmetry_boundary_electric_dispersive_z0,
+    "zmax": sbd.update_symmetry_boundary_electric_dispersive_zmax,
+}
+
+_FACE_FUNCS_B = {
+    "x0": sbd.update_symmetry_boundary_electric_dispersive_b_x0,
+    "xmax": sbd.update_symmetry_boundary_electric_dispersive_b_xmax,
+    "y0": sbd.update_symmetry_boundary_electric_dispersive_b_y0,
+    "ymax": sbd.update_symmetry_boundary_electric_dispersive_b_ymax,
+    "z0": sbd.update_symmetry_boundary_electric_dispersive_b_z0,
+    "zmax": sbd.update_symmetry_boundary_electric_dispersive_b_zmax,
+}
+
+
+def _update_face_interior(grid, face):
+    _FACE_FUNCS[face](
+        grid.nx, grid.ny, grid.nz, 1, maxpoles,
+        grid.updatecoeffsE, grid.updatecoeffsdispersive, grid.ID,
+        grid.Tx, grid.Ty, grid.Tz,
+        grid.Ex, grid.Ey, grid.Ez,
+        grid.Hx, grid.Hy, grid.Hz,
+    )
+
+
+def _update_face_interior_b(grid, face):
+    _FACE_FUNCS_B[face](
+        grid.nx, grid.ny, grid.nz, 1, maxpoles,
+        grid.updatecoeffsdispersive, grid.ID,
+        grid.Tx, grid.Ty, grid.Tz,
+        grid.Ex, grid.Ey, grid.Ez,
+    )
+
+
+def _make_grid():
+    grid = FDTDGrid()
+    grid.nx, grid.ny, grid.nz = nx, ny, nz
+    grid.ID = np.ones((6, nx + 1, ny + 1, nz + 1), dtype=np.uint32)
+    grid.updatecoeffsE = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.0, 0.0],
+            [ca, cb1, cb2, cb3, ce],
+        ]
+    )
+    grid.updatecoeffsdispersive = np.array(
+        [
+            [0.0] * (3 * maxpoles),
+            [alpha[0], beta[0], gamma[0], alpha[1], beta[1], gamma[1]],
+        ]
+    )
+
+    def field(offset, shape=None):
+        shape = shape or (nx + 1, ny + 1, nz + 1)
+        arr = np.zeros(shape)
+        it = np.nditer(arr, flags=["multi_index"])
+        for _ in it:
+            idx = it.multi_index
+            arr[idx] = sum(1000**p * v for p, v in enumerate(idx)) + offset
+        return arr
+
+    grid.Ex, grid.Ey, grid.Ez = field(1), field(2), field(3)
+    grid.Hx, grid.Hy, grid.Hz = field(4), field(5), field(6)
+    grid.Tx = field(7, (maxpoles, nx + 1, ny + 1, nz + 1))
+    grid.Ty = field(8, (maxpoles, nx + 1, ny + 1, nz + 1))
+    grid.Tz = field(9, (maxpoles, nx + 1, ny + 1, nz + 1))
+    return grid
+
+
+def _phi_and_new_t(t_old_poles, e_old):
+    """Independently re-derives phi and the new per-pole T values for a
+    single grid position, given the (maxpoles,)-shaped old T values there
+    and the old E value - matches the Cython pole loop exactly."""
+    phi = 0.0
+    t_new = []
+    for p in range(maxpoles):
+        phi += alpha[p] * t_old_poles[p]
+        t_new.append(beta[p] * t_old_poles[p] + gamma[p] * e_old)
+    return phi, t_new
+
+
+def _expected_x0(grid):
+    Ey, Ez = grid.Ey.copy(), grid.Ez.copy()
+    Ty, Tz = grid.Ty.copy(), grid.Tz.copy()
+    Ty_b, Tz_b = grid.Ty.copy(), grid.Tz.copy()
+    for j in range(ny):
+        for k in range(1, nz):
+            phi, t_new = _phi_and_new_t(grid.Ty[:, 0, j, k], grid.Ey[0, j, k])
+            Ty[:, 0, j, k] = t_new
+            Ey[0, j, k] = (
+                ca * grid.Ey[0, j, k]
+                + cb3 * (grid.Hx[0, j, k] - grid.Hx[0, j, k - 1])
+                - cb1 * (2 * grid.Hz[0, j, k])
+                - ce * phi
+            )
+            Ty_b[:, 0, j, k] = [t_new[p] - gamma[p] * Ey[0, j, k] for p in range(maxpoles)]
+    for j in range(1, ny):
+        for k in range(nz):
+            phi, t_new = _phi_and_new_t(grid.Tz[:, 0, j, k], grid.Ez[0, j, k])
+            Tz[:, 0, j, k] = t_new
+            Ez[0, j, k] = (
+                ca * grid.Ez[0, j, k]
+                - cb2 * (grid.Hx[0, j, k] - grid.Hx[0, j - 1, k])
+                + cb1 * (2 * grid.Hy[0, j, k])
+                - ce * phi
+            )
+            Tz_b[:, 0, j, k] = [t_new[p] - gamma[p] * Ez[0, j, k] for p in range(maxpoles)]
+    return Ey, Ez, Ty, Tz, Ty_b, Tz_b
+
+
+def _expected_xmax(grid):
+    Ey, Ez = grid.Ey.copy(), grid.Ez.copy()
+    Ty, Tz = grid.Ty.copy(), grid.Tz.copy()
+    Ty_b, Tz_b = grid.Ty.copy(), grid.Tz.copy()
+    for j in range(ny):
+        for k in range(1, nz):
+            phi, t_new = _phi_and_new_t(grid.Ty[:, nx, j, k], grid.Ey[nx, j, k])
+            Ty[:, nx, j, k] = t_new
+            Ey[nx, j, k] = (
+                ca * grid.Ey[nx, j, k]
+                + cb3 * (grid.Hx[nx, j, k] - grid.Hx[nx, j, k - 1])
+                + cb1 * (2 * grid.Hz[nx - 1, j, k])
+                - ce * phi
+            )
+            Ty_b[:, nx, j, k] = [t_new[p] - gamma[p] * Ey[nx, j, k] for p in range(maxpoles)]
+    for j in range(1, ny):
+        for k in range(nz):
+            phi, t_new = _phi_and_new_t(grid.Tz[:, nx, j, k], grid.Ez[nx, j, k])
+            Tz[:, nx, j, k] = t_new
+            Ez[nx, j, k] = (
+                ca * grid.Ez[nx, j, k]
+                - cb2 * (grid.Hx[nx, j, k] - grid.Hx[nx, j - 1, k])
+                - cb1 * (2 * grid.Hy[nx - 1, j, k])
+                - ce * phi
+            )
+            Tz_b[:, nx, j, k] = [t_new[p] - gamma[p] * Ez[nx, j, k] for p in range(maxpoles)]
+    return Ey, Ez, Ty, Tz, Ty_b, Tz_b
+
+
+def _expected_y0(grid):
+    Ex, Ez = grid.Ex.copy(), grid.Ez.copy()
+    Tx, Tz = grid.Tx.copy(), grid.Tz.copy()
+    Tx_b, Tz_b = grid.Tx.copy(), grid.Tz.copy()
+    for i in range(nx):
+        for k in range(1, nz):
+            phi, t_new = _phi_and_new_t(grid.Tx[:, i, 0, k], grid.Ex[i, 0, k])
+            Tx[:, i, 0, k] = t_new
+            Ex[i, 0, k] = (
+                ca * grid.Ex[i, 0, k]
+                - cb3 * (grid.Hy[i, 0, k] - grid.Hy[i, 0, k - 1])
+                + cb2 * (2 * grid.Hz[i, 0, k])
+                - ce * phi
+            )
+            Tx_b[:, i, 0, k] = [t_new[p] - gamma[p] * Ex[i, 0, k] for p in range(maxpoles)]
+    for i in range(1, nx):
+        for k in range(nz):
+            phi, t_new = _phi_and_new_t(grid.Tz[:, i, 0, k], grid.Ez[i, 0, k])
+            Tz[:, i, 0, k] = t_new
+            Ez[i, 0, k] = (
+                ca * grid.Ez[i, 0, k]
+                + cb1 * (grid.Hy[i, 0, k] - grid.Hy[i - 1, 0, k])
+                - cb2 * (2 * grid.Hx[i, 0, k])
+                - ce * phi
+            )
+            Tz_b[:, i, 0, k] = [t_new[p] - gamma[p] * Ez[i, 0, k] for p in range(maxpoles)]
+    return Ex, Ez, Tx, Tz, Tx_b, Tz_b
+
+
+def _expected_ymax(grid):
+    Ex, Ez = grid.Ex.copy(), grid.Ez.copy()
+    Tx, Tz = grid.Tx.copy(), grid.Tz.copy()
+    Tx_b, Tz_b = grid.Tx.copy(), grid.Tz.copy()
+    for i in range(nx):
+        for k in range(1, nz):
+            phi, t_new = _phi_and_new_t(grid.Tx[:, i, ny, k], grid.Ex[i, ny, k])
+            Tx[:, i, ny, k] = t_new
+            Ex[i, ny, k] = (
+                ca * grid.Ex[i, ny, k]
+                - cb3 * (grid.Hy[i, ny, k] - grid.Hy[i, ny, k - 1])
+                - cb2 * (2 * grid.Hz[i, ny - 1, k])
+                - ce * phi
+            )
+            Tx_b[:, i, ny, k] = [t_new[p] - gamma[p] * Ex[i, ny, k] for p in range(maxpoles)]
+    for i in range(1, nx):
+        for k in range(nz):
+            phi, t_new = _phi_and_new_t(grid.Tz[:, i, ny, k], grid.Ez[i, ny, k])
+            Tz[:, i, ny, k] = t_new
+            Ez[i, ny, k] = (
+                ca * grid.Ez[i, ny, k]
+                + cb1 * (grid.Hy[i, ny, k] - grid.Hy[i - 1, ny, k])
+                + cb2 * (2 * grid.Hx[i, ny - 1, k])
+                - ce * phi
+            )
+            Tz_b[:, i, ny, k] = [t_new[p] - gamma[p] * Ez[i, ny, k] for p in range(maxpoles)]
+    return Ex, Ez, Tx, Tz, Tx_b, Tz_b
+
+
+def _expected_z0(grid):
+    Ex, Ey = grid.Ex.copy(), grid.Ey.copy()
+    Tx, Ty = grid.Tx.copy(), grid.Ty.copy()
+    Tx_b, Ty_b = grid.Tx.copy(), grid.Ty.copy()
+    for i in range(nx):
+        for j in range(1, ny):
+            phi, t_new = _phi_and_new_t(grid.Tx[:, i, j, 0], grid.Ex[i, j, 0])
+            Tx[:, i, j, 0] = t_new
+            Ex[i, j, 0] = (
+                ca * grid.Ex[i, j, 0]
+                + cb2 * (grid.Hz[i, j, 0] - grid.Hz[i, j - 1, 0])
+                - cb3 * (2 * grid.Hy[i, j, 0])
+                - ce * phi
+            )
+            Tx_b[:, i, j, 0] = [t_new[p] - gamma[p] * Ex[i, j, 0] for p in range(maxpoles)]
+    for i in range(1, nx):
+        for j in range(ny):
+            phi, t_new = _phi_and_new_t(grid.Ty[:, i, j, 0], grid.Ey[i, j, 0])
+            Ty[:, i, j, 0] = t_new
+            Ey[i, j, 0] = (
+                ca * grid.Ey[i, j, 0]
+                - cb1 * (grid.Hz[i, j, 0] - grid.Hz[i - 1, j, 0])
+                + cb3 * (2 * grid.Hx[i, j, 0])
+                - ce * phi
+            )
+            Ty_b[:, i, j, 0] = [t_new[p] - gamma[p] * Ey[i, j, 0] for p in range(maxpoles)]
+    return Ex, Ey, Tx, Ty, Tx_b, Ty_b
+
+
+def _expected_zmax(grid):
+    Ex, Ey = grid.Ex.copy(), grid.Ey.copy()
+    Tx, Ty = grid.Tx.copy(), grid.Ty.copy()
+    Tx_b, Ty_b = grid.Tx.copy(), grid.Ty.copy()
+    for i in range(nx):
+        for j in range(1, ny):
+            phi, t_new = _phi_and_new_t(grid.Tx[:, i, j, nz], grid.Ex[i, j, nz])
+            Tx[:, i, j, nz] = t_new
+            Ex[i, j, nz] = (
+                ca * grid.Ex[i, j, nz]
+                + cb2 * (grid.Hz[i, j, nz] - grid.Hz[i, j - 1, nz])
+                + cb3 * (2 * grid.Hy[i, j, nz - 1])
+                - ce * phi
+            )
+            Tx_b[:, i, j, nz] = [t_new[p] - gamma[p] * Ex[i, j, nz] for p in range(maxpoles)]
+    for i in range(1, nx):
+        for j in range(ny):
+            phi, t_new = _phi_and_new_t(grid.Ty[:, i, j, nz], grid.Ey[i, j, nz])
+            Ty[:, i, j, nz] = t_new
+            Ey[i, j, nz] = (
+                ca * grid.Ey[i, j, nz]
+                - cb1 * (grid.Hz[i, j, nz] - grid.Hz[i - 1, j, nz])
+                - cb3 * (2 * grid.Hx[i, j, nz - 1])
+                - ce * phi
+            )
+            Ty_b[:, i, j, nz] = [t_new[p] - gamma[p] * Ey[i, j, nz] for p in range(maxpoles)]
+    return Ex, Ey, Tx, Ty, Tx_b, Ty_b
+
+
+_FACES = {
+    "x0": (_expected_x0, ("Ey", "Ez"), ("Ty", "Tz")),
+    "xmax": (_expected_xmax, ("Ey", "Ez"), ("Ty", "Tz")),
+    "y0": (_expected_y0, ("Ex", "Ez"), ("Tx", "Tz")),
+    "ymax": (_expected_ymax, ("Ex", "Ez"), ("Tx", "Tz")),
+    "z0": (_expected_z0, ("Ex", "Ey"), ("Tx", "Ty")),
+    "zmax": (_expected_zmax, ("Ex", "Ey"), ("Tx", "Ty")),
+}
+
+
+@pytest.mark.parametrize("face", _FACES.keys())
+def test_face_interior_matches_independent_hand_derivation(face):
+    expected_fn, e_components, t_components = _FACES[face]
+    grid = _make_grid()
+    expected_e1, expected_e2, expected_t1, expected_t2, _, _ = expected_fn(grid)
+
+    _update_face_interior(grid, face)
+
+    assert np.allclose(getattr(grid, e_components[0]), expected_e1), f"{face}/{e_components[0]} mismatch"
+    assert np.allclose(getattr(grid, e_components[1]), expected_e2), f"{face}/{e_components[1]} mismatch"
+    assert np.allclose(getattr(grid, t_components[0]), expected_t1), f"{face}/{t_components[0]} mismatch"
+    assert np.allclose(getattr(grid, t_components[1]), expected_t2), f"{face}/{t_components[1]} mismatch"
+
+
+@pytest.mark.parametrize("face", _FACES.keys())
+def test_face_interior_does_not_touch_the_other_components(face):
+    _, e_components, t_components = _FACES[face]
+    all_e = ("Ex", "Ey", "Ez")
+    all_t = ("Tx", "Ty", "Tz")
+    untouched_e = [c for c in all_e if c not in e_components]
+    untouched_t = [c for c in all_t if c not in t_components]
+
+    grid = _make_grid()
+    before = {c: getattr(grid, c).copy() for c in untouched_e + untouched_t + ["Hx", "Hy", "Hz"]}
+
+    _update_face_interior(grid, face)
+
+    for c in before:
+        assert np.array_equal(getattr(grid, c), before[c]), f"{face}: {c} changed unexpectedly"
+
+
+@pytest.mark.parametrize("face", _FACES.keys())
+def test_phase_b_corrects_t_using_the_e_value_current_when_it_runs(face):
+    """Regression guard for the provisional-vs-final-E semantics: phase B's
+    correction (T -= gamma*E) must use whatever E value is current AT THE
+    TIME phase B runs - here, with nothing (no PML, no source) perturbing E
+    between phase A and phase B, that's phase A's own output E (not the
+    pre-phase-A E(n), and not zero) - i.e. T_after_b == T_after_a -
+    gamma*E_after_a exactly, verified against an independent hand
+    computation of both phases in sequence.
+    """
+    expected_fn, e_components, t_components = _FACES[face]
+
+    grid = _make_grid()
+    _, _, _, _, expected_t1_after_b, expected_t2_after_b = expected_fn(grid)
+
+    _update_face_interior(grid, face)
+    _update_face_interior_b(grid, face)
+
+    assert np.allclose(getattr(grid, t_components[0]), expected_t1_after_b), (
+        f"{face}: phase B's T ({t_components[0]}) does not match independent hand derivation"
+    )
+    assert np.allclose(getattr(grid, t_components[1]), expected_t2_after_b), (
+        f"{face}: phase B's T ({t_components[1]}) does not match independent hand derivation"
+    )

--- a/tests/materials/test_symmetry_boundary_pmc_edges.py
+++ b/tests/materials/test_symmetry_boundary_pmc_edges.py
@@ -1,0 +1,180 @@
+"""Tests for the per-iteration PMC ghost-node E update on the 12 domain
+edges (gprMax.cython.symmetry_boundaries.update_symmetry_boundary_electric_Ez_X0_Y0
+and its 11 siblings) - the edge piece of the #symmetry_boundary PMC feature,
+complementing the face-interior tests in test_symmetry_boundary_pmc_updates.py.
+
+The simplified per-edge scheme applies the self term (Ca*E) once if EITHER
+bordering face is PMC; each face then
+separately, additively contributes its own doubled ghost term only if THAT
+SPECIFIC face is PMC. A single-PMC-neighbour edge reduces correctly to zero
+on its own once the edge's ID has been forced to pec elsewhere (Ca=Cb=0) -
+not exercised directly here (that's a build-time concern, see
+test_symmetry_boundary.py), just confirmed structurally: passing only one of
+the two flags produces exactly the single-face contribution, nothing more.
+
+Each expected-value computation below is a plain Python loop (not
+vectorized), independently re-deriving the same formula the Cython
+implementation computes - so a transcription bug in one wouldn't be masked
+by the same bug in the other.
+"""
+import numpy as np
+import pytest
+
+from gprMax.cython import symmetry_boundaries as sb
+
+nx, ny, nz = 6, 5, 4
+ca, cb1, cb2, cb3 = 0.7, 0.11, 0.22, 0.33
+
+# The two H arrays each cython edge function takes, in its actual positional
+# order (matching gprMax/cython/symmetry_boundaries.pyx exactly).
+_CALL_H_ORDER = {"Ez": ("Hx", "Hy"), "Ey": ("Hx", "Hz"), "Ex": ("Hy", "Hz")}
+
+
+def _make_arrays():
+    ID = np.ones((6, nx + 1, ny + 1, nz + 1), dtype=np.uint32)
+    C = np.array([[0.0, 0.0, 0.0, 0.0, 0.0], [ca, cb1, cb2, cb3, 0.0]])
+
+    def field(offset):
+        arr = np.zeros((nx + 1, ny + 1, nz + 1))
+        for i in range(nx + 1):
+            for j in range(ny + 1):
+                for k in range(nz + 1):
+                    arr[i, j, k] = 1000 * i + 100 * j + 10 * k + offset
+        return arr
+
+    Ex, Ey, Ez = field(1), field(2), field(3)
+    Hx, Hy, Hz = field(4), field(5), field(6)
+    return ID, C, {"Ex": Ex, "Ey": Ey, "Ez": Ez}, {"Hx": Hx, "Hy": Hy, "Hz": Hz}
+
+
+# Ghost-term helpers, each taking the full Hx/Hy/Hz dict and the fixed/free
+# indices - independently re-deriving the formulas already verified for the
+# face-interior update, referenced by name (not position) to avoid any
+# argument-order ambiguity.
+def _gx0_ez(H, j, k):
+    return 2 * cb1 * H["Hy"][0, j, k]
+
+
+def _gxmax_ez(H, j, k):
+    return -2 * cb1 * H["Hy"][nx - 1, j, k]
+
+
+def _gy0_ez(H, i, k):
+    return -2 * cb2 * H["Hx"][i, 0, k]
+
+
+def _gymax_ez(H, i, k):
+    return 2 * cb2 * H["Hx"][i, ny - 1, k]
+
+
+def _gx0_ey(H, j, k):
+    return -2 * cb1 * H["Hz"][0, j, k]
+
+
+def _gxmax_ey(H, j, k):
+    return 2 * cb1 * H["Hz"][nx - 1, j, k]
+
+
+def _gz0_ey(H, i, j):
+    return 2 * cb3 * H["Hx"][i, j, 0]
+
+
+def _gzmax_ey(H, i, j):
+    return -2 * cb3 * H["Hx"][i, j, nz - 1]
+
+
+def _gy0_ex(H, i, k):
+    return 2 * cb2 * H["Hz"][i, 0, k]
+
+
+def _gymax_ex(H, i, k):
+    return -2 * cb2 * H["Hz"][i, ny - 1, k]
+
+
+def _gz0_ex(H, i, j):
+    return -2 * cb3 * H["Hy"][i, j, 0]
+
+
+def _gzmax_ex(H, i, j):
+    return 2 * cb3 * H["Hy"][i, j, nz - 1]
+
+
+# Each entry: (name, cython_func, position(t)->(i,j,k), free range, component,
+# ghostA(H,t), ghostB(H,t)).
+_EDGES = [
+    ("Ez_X0_Y0", sb.update_symmetry_boundary_electric_Ez_X0_Y0,
+     lambda k: (0, 0, k), range(nz), "Ez",
+     lambda H, k: _gx0_ez(H, 0, k), lambda H, k: _gy0_ez(H, 0, k)),
+    ("Ez_X0_YMax", sb.update_symmetry_boundary_electric_Ez_X0_YMax,
+     lambda k: (0, ny, k), range(nz), "Ez",
+     lambda H, k: _gx0_ez(H, ny, k), lambda H, k: _gymax_ez(H, 0, k)),
+    ("Ez_XMax_Y0", sb.update_symmetry_boundary_electric_Ez_XMax_Y0,
+     lambda k: (nx, 0, k), range(nz), "Ez",
+     lambda H, k: _gxmax_ez(H, 0, k), lambda H, k: _gy0_ez(H, nx, k)),
+    ("Ez_XMax_YMax", sb.update_symmetry_boundary_electric_Ez_XMax_YMax,
+     lambda k: (nx, ny, k), range(nz), "Ez",
+     lambda H, k: _gxmax_ez(H, ny, k), lambda H, k: _gymax_ez(H, nx, k)),
+    ("Ey_X0_Z0", sb.update_symmetry_boundary_electric_Ey_X0_Z0,
+     lambda j: (0, j, 0), range(ny), "Ey",
+     lambda H, j: _gx0_ey(H, j, 0), lambda H, j: _gz0_ey(H, 0, j)),
+    ("Ey_X0_ZMax", sb.update_symmetry_boundary_electric_Ey_X0_ZMax,
+     lambda j: (0, j, nz), range(ny), "Ey",
+     lambda H, j: _gx0_ey(H, j, nz), lambda H, j: _gzmax_ey(H, 0, j)),
+    ("Ey_XMax_Z0", sb.update_symmetry_boundary_electric_Ey_XMax_Z0,
+     lambda j: (nx, j, 0), range(ny), "Ey",
+     lambda H, j: _gxmax_ey(H, j, 0), lambda H, j: _gz0_ey(H, nx, j)),
+    ("Ey_XMax_ZMax", sb.update_symmetry_boundary_electric_Ey_XMax_ZMax,
+     lambda j: (nx, j, nz), range(ny), "Ey",
+     lambda H, j: _gxmax_ey(H, j, nz), lambda H, j: _gzmax_ey(H, nx, j)),
+    ("Ex_Y0_Z0", sb.update_symmetry_boundary_electric_Ex_Y0_Z0,
+     lambda i: (i, 0, 0), range(nx), "Ex",
+     lambda H, i: _gy0_ex(H, i, 0), lambda H, i: _gz0_ex(H, i, 0)),
+    ("Ex_Y0_ZMax", sb.update_symmetry_boundary_electric_Ex_Y0_ZMax,
+     lambda i: (i, 0, nz), range(nx), "Ex",
+     lambda H, i: _gy0_ex(H, i, nz), lambda H, i: _gzmax_ex(H, i, 0)),
+    ("Ex_YMax_Z0", sb.update_symmetry_boundary_electric_Ex_YMax_Z0,
+     lambda i: (i, ny, 0), range(nx), "Ex",
+     lambda H, i: _gymax_ex(H, i, 0), lambda H, i: _gz0_ex(H, i, ny)),
+    ("Ex_YMax_ZMax", sb.update_symmetry_boundary_electric_Ex_YMax_ZMax,
+     lambda i: (i, ny, nz), range(nx), "Ex",
+     lambda H, i: _gymax_ex(H, i, nz), lambda H, i: _gzmax_ex(H, i, ny)),
+]
+
+
+@pytest.mark.parametrize("edge", _EDGES, ids=[e[0] for e in _EDGES])
+@pytest.mark.parametrize("a_pmc,b_pmc", [(True, False), (False, True), (True, True), (False, False)])
+def test_edge_matches_independent_hand_derivation(edge, a_pmc, b_pmc):
+    name, func, pos_fn, free_range, comp, ghost_a, ghost_b = edge
+    ID, C, E, H = _make_arrays()
+    comp_arr = E[comp]
+    h1_name, h2_name = _CALL_H_ORDER[comp]
+
+    expected = comp_arr.copy()
+    for t in free_range:
+        pos = pos_fn(t)
+        if a_pmc or b_pmc:
+            expected[pos] = ca * comp_arr[pos]
+        if a_pmc:
+            expected[pos] = expected[pos] + ghost_a(H, t)
+        if b_pmc:
+            expected[pos] = expected[pos] + ghost_b(H, t)
+
+    func(nx, ny, nz, 1, a_pmc, b_pmc, C, ID, comp_arr, H[h1_name], H[h2_name])
+
+    assert np.allclose(comp_arr, expected), f"{name} a_pmc={a_pmc} b_pmc={b_pmc} mismatch"
+
+
+@pytest.mark.parametrize("edge", _EDGES, ids=[e[0] for e in _EDGES])
+def test_edge_neither_pmc_leaves_field_untouched(edge):
+    """Sanity check: with both flags False, nothing should change at all -
+    matches the real pipeline, which never calls an edge function unless at
+    least one of its two faces is actually a declared PMC boundary."""
+    name, func, pos_fn, free_range, comp, ghost_a, ghost_b = edge
+    ID, C, E, H = _make_arrays()
+    comp_arr = E[comp]
+    h1_name, h2_name = _CALL_H_ORDER[comp]
+    before = comp_arr.copy()
+
+    func(nx, ny, nz, 1, False, False, C, ID, comp_arr, H[h1_name], H[h2_name])
+
+    assert np.array_equal(comp_arr, before)

--- a/tests/materials/test_symmetry_boundary_pmc_updates.py
+++ b/tests/materials/test_symmetry_boundary_pmc_updates.py
@@ -1,0 +1,240 @@
+"""Tests for the per-iteration PMC ghost-node E update
+(gprMax.symmetry_boundaries.update_symmetry_boundaries_electric_normal), the
+face-interior (non-edge) piece of the #symmetry_boundary PMC feature.
+
+Ghost-node derivation: tangential H is odd under the PMC mirror, so the
+"ghost" H node just outside the domain equals minus the real interior H node
+it mirrors. Substituting into the standard curl term collapses the missing
+outside-neighbour difference into double one real H value. For a "0" face
+(x0/y0/z0) the doubled term uses the wall's own H index with the bulk
+kernel's own sign; for a "max" face (xmax/ymax/zmax) it uses the
+interior-adjacent H index with the opposite sign - both derived and
+cross-checked against apply_TFSF_conditions_electric's existing identical
+asymmetry.
+
+Each expected-value helper below is a plain Python loop (not vectorized),
+independently re-deriving the same formula the implementation computes with
+numpy - so a transcription bug in one wouldn't be masked by the same bug in
+the other.
+"""
+import numpy as np
+
+from gprMax.cython.symmetry_boundaries import (
+    update_symmetry_boundary_electric_x0,
+    update_symmetry_boundary_electric_xmax,
+    update_symmetry_boundary_electric_y0,
+    update_symmetry_boundary_electric_ymax,
+    update_symmetry_boundary_electric_z0,
+    update_symmetry_boundary_electric_zmax,
+)
+from gprMax.grid.fdtd_grid import FDTDGrid
+
+nx, ny, nz = 6, 5, 4
+ca, cb1, cb2, cb3 = 0.7, 0.11, 0.22, 0.33
+
+_FACE_FUNCS = {
+    "x0": update_symmetry_boundary_electric_x0,
+    "xmax": update_symmetry_boundary_electric_xmax,
+    "y0": update_symmetry_boundary_electric_y0,
+    "ymax": update_symmetry_boundary_electric_ymax,
+    "z0": update_symmetry_boundary_electric_z0,
+    "zmax": update_symmetry_boundary_electric_zmax,
+}
+
+
+def _update_face_interior(grid, face):
+    """Thin wrapper matching the old Python-level signature, calling the
+    real Cython implementation directly (nthreads=1 - single-threaded is
+    enough for these small, deterministic correctness checks)."""
+    _FACE_FUNCS[face](
+        grid.nx,
+        grid.ny,
+        grid.nz,
+        1,
+        grid.updatecoeffsE,
+        grid.ID,
+        grid.Ex,
+        grid.Ey,
+        grid.Ez,
+        grid.Hx,
+        grid.Hy,
+        grid.Hz,
+    )
+
+
+def _make_grid():
+    grid = FDTDGrid()
+    grid.nx, grid.ny, grid.nz = nx, ny, nz
+    # A single, distinguishable material (numID 1) everywhere.
+    grid.ID = np.ones((6, nx + 1, ny + 1, nz + 1), dtype=np.uint32)
+    grid.updatecoeffsE = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.0, 0.0],
+            [ca, cb1, cb2, cb3, 0.0],
+        ]
+    )
+
+    def field(offset):
+        arr = np.zeros((nx + 1, ny + 1, nz + 1))
+        for i in range(nx + 1):
+            for j in range(ny + 1):
+                for k in range(nz + 1):
+                    arr[i, j, k] = 1000 * i + 100 * j + 10 * k + offset
+        return arr
+
+    grid.Ex, grid.Ey, grid.Ez = field(1), field(2), field(3)
+    grid.Hx, grid.Hy, grid.Hz = field(4), field(5), field(6)
+    return grid
+
+
+def _expected_x0(grid):
+    Ey, Ez = grid.Ey.copy(), grid.Ez.copy()
+    for j in range(ny):
+        for k in range(1, nz):
+            Ey[0, j, k] = (
+                ca * grid.Ey[0, j, k]
+                + cb3 * (grid.Hx[0, j, k] - grid.Hx[0, j, k - 1])
+                - cb1 * (2 * grid.Hz[0, j, k])
+            )
+    for j in range(1, ny):
+        for k in range(nz):
+            Ez[0, j, k] = (
+                ca * grid.Ez[0, j, k]
+                - cb2 * (grid.Hx[0, j, k] - grid.Hx[0, j - 1, k])
+                + cb1 * (2 * grid.Hy[0, j, k])
+            )
+    return Ey, Ez
+
+
+def _expected_xmax(grid):
+    Ey, Ez = grid.Ey.copy(), grid.Ez.copy()
+    for j in range(ny):
+        for k in range(1, nz):
+            Ey[nx, j, k] = (
+                ca * grid.Ey[nx, j, k]
+                + cb3 * (grid.Hx[nx, j, k] - grid.Hx[nx, j, k - 1])
+                + cb1 * (2 * grid.Hz[nx - 1, j, k])
+            )
+    for j in range(1, ny):
+        for k in range(nz):
+            Ez[nx, j, k] = (
+                ca * grid.Ez[nx, j, k]
+                - cb2 * (grid.Hx[nx, j, k] - grid.Hx[nx, j - 1, k])
+                - cb1 * (2 * grid.Hy[nx - 1, j, k])
+            )
+    return Ey, Ez
+
+
+def _expected_y0(grid):
+    Ex, Ez = grid.Ex.copy(), grid.Ez.copy()
+    for i in range(nx):
+        for k in range(1, nz):
+            Ex[i, 0, k] = (
+                ca * grid.Ex[i, 0, k]
+                - cb3 * (grid.Hy[i, 0, k] - grid.Hy[i, 0, k - 1])
+                + cb2 * (2 * grid.Hz[i, 0, k])
+            )
+    for i in range(1, nx):
+        for k in range(nz):
+            Ez[i, 0, k] = (
+                ca * grid.Ez[i, 0, k]
+                + cb1 * (grid.Hy[i, 0, k] - grid.Hy[i - 1, 0, k])
+                - cb2 * (2 * grid.Hx[i, 0, k])
+            )
+    return Ex, Ez
+
+
+def _expected_ymax(grid):
+    Ex, Ez = grid.Ex.copy(), grid.Ez.copy()
+    for i in range(nx):
+        for k in range(1, nz):
+            Ex[i, ny, k] = (
+                ca * grid.Ex[i, ny, k]
+                - cb3 * (grid.Hy[i, ny, k] - grid.Hy[i, ny, k - 1])
+                - cb2 * (2 * grid.Hz[i, ny - 1, k])
+            )
+    for i in range(1, nx):
+        for k in range(nz):
+            Ez[i, ny, k] = (
+                ca * grid.Ez[i, ny, k]
+                + cb1 * (grid.Hy[i, ny, k] - grid.Hy[i - 1, ny, k])
+                + cb2 * (2 * grid.Hx[i, ny - 1, k])
+            )
+    return Ex, Ez
+
+
+def _expected_z0(grid):
+    Ex, Ey = grid.Ex.copy(), grid.Ey.copy()
+    for i in range(nx):
+        for j in range(1, ny):
+            Ex[i, j, 0] = (
+                ca * grid.Ex[i, j, 0]
+                + cb2 * (grid.Hz[i, j, 0] - grid.Hz[i, j - 1, 0])
+                - cb3 * (2 * grid.Hy[i, j, 0])
+            )
+    for i in range(1, nx):
+        for j in range(ny):
+            Ey[i, j, 0] = (
+                ca * grid.Ey[i, j, 0]
+                - cb1 * (grid.Hz[i, j, 0] - grid.Hz[i - 1, j, 0])
+                + cb3 * (2 * grid.Hx[i, j, 0])
+            )
+    return Ex, Ey
+
+
+def _expected_zmax(grid):
+    Ex, Ey = grid.Ex.copy(), grid.Ey.copy()
+    for i in range(nx):
+        for j in range(1, ny):
+            Ex[i, j, nz] = (
+                ca * grid.Ex[i, j, nz]
+                + cb2 * (grid.Hz[i, j, nz] - grid.Hz[i, j - 1, nz])
+                + cb3 * (2 * grid.Hy[i, j, nz - 1])
+            )
+    for i in range(1, nx):
+        for j in range(ny):
+            Ey[i, j, nz] = (
+                ca * grid.Ey[i, j, nz]
+                - cb1 * (grid.Hz[i, j, nz] - grid.Hz[i - 1, j, nz])
+                - cb3 * (2 * grid.Hx[i, j, nz - 1])
+            )
+    return Ex, Ey
+
+
+_FACES = {
+    "x0": (_expected_x0, ("Ey", "Ez")),
+    "xmax": (_expected_xmax, ("Ey", "Ez")),
+    "y0": (_expected_y0, ("Ex", "Ez")),
+    "ymax": (_expected_ymax, ("Ex", "Ez")),
+    "z0": (_expected_z0, ("Ex", "Ey")),
+    "zmax": (_expected_zmax, ("Ex", "Ey")),
+}
+
+
+def test_face_interior_matches_independent_hand_derivation():
+    for face, (expected_fn, components) in _FACES.items():
+        grid = _make_grid()
+        expected = expected_fn(grid)
+
+        _update_face_interior(grid, face)
+
+        actual = tuple(getattr(grid, c) for c in components)
+        for a, e, name in zip(actual, expected, components):
+            assert np.allclose(a, e), f"{face}/{name} mismatch"
+
+
+def test_face_interior_does_not_touch_the_other_four_components():
+    """Only the two tangential components for the given face should change -
+    the third E component and the H arrays must be left untouched."""
+    for face, (_, components) in _FACES.items():
+        grid = _make_grid()
+        untouched = [c for c in ("Ex", "Ey", "Ez") if c not in components]
+        before = {c: getattr(grid, c).copy() for c in untouched}
+        before_H = {c: getattr(grid, c).copy() for c in ("Hx", "Hy", "Hz")}
+
+        _update_face_interior(grid, face)
+
+        for c in untouched:
+            assert np.array_equal(getattr(grid, c), before[c]), f"{face}: {c} changed unexpectedly"
+        for c in ("Hx", "Hy", "Hz"):
+            assert np.array_equal(getattr(grid, c), before_H[c]), f"{face}: {c} changed unexpectedly"

--- a/tests/test_geometry_fixed.py
+++ b/tests/test_geometry_fixed.py
@@ -64,6 +64,46 @@ def test_geometry_fixed_multiple_runs_completes_without_exception(tmp_path):
             assert not np.any(np.isnan(f["rxs/rx1/Ez"][:]))
 
 
+def test_geometry_fixed_with_symmetry_boundary_and_steps_produces_distinct_finite_output(tmp_path):
+    """Symmetry build state must survive geometry reuse while sources step."""
+    dl = 1e-3
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(0.02, 0.02, 0.02)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=2e-10))
+    scene.add(gprMax.SymmetryBoundary(face="x0", type="pmc"))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=1.5e10, id="w"))
+    scene.add(
+        gprMax.HertzianDipole(
+            polarisation="z", p1=(0.001, 0.01, 0.01), waveform_id="w"
+        )
+    )
+    scene.add(gprMax.SrcSteps(p1=(0.001, 0.0, 0.0)))
+    scene.add(gprMax.Rx(p1=(0.01, 0.01, 0.01)))
+    scene.add(gprMax.RxSteps(p1=(0.0, 0.0, 0.0)))
+
+    outputfile = tmp_path / "run"
+    gprMax.run(
+        scenes=[scene],
+        n=3,
+        geometry_fixed=True,
+        outputfile=outputfile,
+        hide_progress_bars=True,
+    )
+
+    peaks = []
+    for i in (1, 2, 3):
+        with h5py.File(f"{outputfile}{i}.h5", "r") as f:
+            ez = f["rxs/rx1/Ez"][:]
+            assert not np.any(np.isnan(ez))
+            peak = np.max(np.abs(ez))
+            assert peak > 1e-3
+            peaks.append(peak)
+
+    assert len(set(peaks)) == 3
+
+
 def _make_scene():
     dl = 1e-3
     scene = gprMax.Scene()

--- a/tests/test_geometry_fixed_config_preservation.py
+++ b/tests/test_geometry_fixed_config_preservation.py
@@ -67,6 +67,18 @@ def _capture_materials(monkeypatch):
     return captured
 
 
+def _capture_magnetic_averaging_modes(monkeypatch):
+    captured = []
+    orig_init = CPUUpdates.__init__
+
+    def patched_init(self, grid):
+        orig_init(self, grid)
+        captured.append(config.get_model_config().magnetic_averaging_mode)
+
+    monkeypatch.setattr(CPUUpdates, "__init__", patched_init)
+    return captured
+
+
 def _base_2d_tm_scene(dl=1e-3, domain_transverse=0.02):
     scene = gprMax.Scene()
     scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
@@ -119,6 +131,22 @@ def test_explicit_te_mode_preserved_across_geometry_fixed_runs(monkeypatch, tmp_
     )
 
     assert captured == ["2D TEz", "2D TEz", "2D TEz"]
+
+
+def test_magnetic_averaging_mode_preserved_across_geometry_fixed_runs(monkeypatch, tmp_path):
+    captured = _capture_magnetic_averaging_modes(monkeypatch)
+    scene = _base_2d_tm_scene()
+    scene.add(gprMax.MagneticAveraging(mode="arithmetic"))
+
+    gprMax.run(
+        scenes=[scene],
+        n=3,
+        geometry_fixed=True,
+        outputfile=tmp_path / "run",
+        hide_progress_bars=True,
+    )
+
+    assert captured == ["arithmetic", "arithmetic", "arithmetic"]
 
 
 def _dispersive_scene(material_type, dl=1e-3):

--- a/tests/updates/test_cpu_updates.py
+++ b/tests/updates/test_cpu_updates.py
@@ -88,11 +88,12 @@ def test_update_magnetic(config_mock):
     expected_Hx = grid.Hx.copy()
     expected_Hy = grid.Hy.copy()
     expected_Hz = grid.Hz.copy()
-    expected_Hx[1:, :-1, :-1] = np.tile(np.array([[[2]]], dtype=np.float32), (21, 21, 21))
-    expected_Hy[:-1, 1:, :-1] = np.tile(np.array([[[3]]], dtype=np.float32), (21, 21, 21))
-    expected_Hz[:-1, :-1, 1:] = np.tile(np.array([[[4]]], dtype=np.float32), (21, 21, 21))
+    expected_Hx[:, :-1, :-1] = np.tile(np.array([[[2]]], dtype=np.float32), (22, 21, 21))
+    expected_Hy[:-1, :, :-1] = np.tile(np.array([[[3]]], dtype=np.float32), (21, 22, 21))
+    expected_Hz[:-1, :-1, :] = np.tile(np.array([[[4]]], dtype=np.float32), (21, 21, 22))
 
-    # Magnetic components occupy the positive, staggered Yee-grid locations.
+    # The own-axis range includes both domain walls; this is required for
+    # symmetric PMC ghost-node updates at the lower and upper faces.
     cpu_updates = CPUUpdates(grid)
     cpu_updates.update_magnetic()
 

--- a/tests/updates/test_cuda_symmetry_boundary_solve.py
+++ b/tests/updates/test_cuda_symmetry_boundary_solve.py
@@ -1,0 +1,88 @@
+"""End-to-end CUDA/CPU parity for a nondispersive PMC boundary."""
+
+import h5py
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import gprMax
+
+try:
+    import pycuda.driver as _cuda_driver
+
+    _cuda_driver.init()
+    HAS_CUDA = _cuda_driver.Device.count() > 0
+except Exception:
+    HAS_CUDA = False
+
+
+def _scene(faces, source_position, receiver_position):
+    dl = 1e-3
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(0.02, 0.02, 0.02)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=2e-10))
+    for face in faces:
+        scene.add(gprMax.SymmetryBoundary(face=face, type="pmc"))
+    scene.add(
+        gprMax.Waveform(wave_type="ricker", amp=1, freq=1.5e10, id="w")
+    )
+    scene.add(
+        gprMax.HertzianDipole(
+            polarisation="z", p1=source_position, waveform_id="w"
+        )
+    )
+    scene.add(gprMax.Rx(p1=receiver_position, id="rx"))
+    return scene
+
+
+@pytest.mark.skipif(not HAS_CUDA, reason="No CUDA device/pycuda available")
+@pytest.mark.parametrize(
+    "case,faces,source_position,receiver_position",
+    [
+        ("face", ("x0",), (0.0, 0.01, 0.01), (0.006, 0.01, 0.01)),
+        (
+            "max_face",
+            ("xmax",),
+            (0.02, 0.01, 0.01),
+            (0.014, 0.01, 0.01),
+        ),
+        (
+            "edge",
+            ("x0", "y0"),
+            (0.0, 0.0, 0.01),
+            (0.006, 0.006, 0.01),
+        ),
+    ],
+)
+def test_cuda_pmc_waveform_matches_cpu(
+    tmp_path, case, faces, source_position, receiver_position
+):
+    cpu_path = tmp_path / f"cpu_pmc_{case}"
+    cuda_path = tmp_path / f"cuda_pmc_{case}"
+    gprMax.run(
+        scenes=[_scene(faces, source_position, receiver_position)],
+        n=1,
+        outputfile=cpu_path,
+        hide_progress_bars=True,
+        cpu_precision="double",
+    )
+    gprMax.run(
+        scenes=[_scene(faces, source_position, receiver_position)],
+        n=1,
+        outputfile=cuda_path,
+        hide_progress_bars=True,
+        gpu=[0],
+        gpu_precision="double",
+    )
+
+    with h5py.File(str(cpu_path) + ".h5", "r") as output:
+        cpu = output["rxs/rx1/Ez"][:]
+    with h5py.File(str(cuda_path) + ".h5", "r") as output:
+        cuda = output["rxs/rx1/Ez"][:]
+
+    scale = np.max(np.abs(cpu))
+    assert scale > 1e-3
+    assert np.isfinite(cuda).all()
+    assert_allclose(cuda, cpu, rtol=2e-6, atol=2e-8 * scale)

--- a/tests/updates/test_gpu_symmetry_boundaries.py
+++ b/tests/updates/test_gpu_symmetry_boundaries.py
@@ -1,0 +1,270 @@
+"""Hardware-independent coverage of accelerator symmetry boundaries."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from gprMax import config
+from gprMax.cuda_opencl.knl_symmetry_boundaries import update_electric_pmc
+from gprMax.model import Model
+from gprMax.updates.cuda_updates import CUDAUpdates
+from gprMax.updates.metal_updates import MetalUpdates
+from gprMax.updates.opencl_updates import OpenCLUpdates
+from gprMax.user_objects.cmds_multiuse import SymmetryBoundary
+
+
+@pytest.mark.parametrize(
+    "backend,marker",
+    [
+        ("cuda", "__global__ void update_electric_pmc"),
+        ("opencl", "__global float* Ex"),
+        ("metal", "thread_position_in_grid"),
+    ],
+)
+def test_pmc_kernel_templates_cover_faces_and_edges(backend, marker):
+    declaration = update_electric_pmc[f"args_{backend}"].substitute(REAL="float")
+    body = update_electric_pmc["func"].substitute(
+        REAL="float",
+        CUDA_IDX=(
+            "int i = blockIdx.x * blockDim.x + threadIdx.x;"
+            if backend == "cuda"
+            else ""
+        ),
+        NX_FIELDS=5,
+        NY_FIELDS=6,
+        NZ_FIELDS=7,
+        NX_ID=5,
+        NY_ID=6,
+        NZ_ID=7,
+    )
+
+    source = declaration + body
+    assert marker in source
+    assert "ex_on_pmc" in source
+    assert "ey_on_pmc" in source
+    assert "ez_on_pmc" in source
+    assert "PMC_X0" in source and "PMC_XMAX" in source
+    assert "PMC_Y0" in source and "PMC_YMAX" in source
+    assert "PMC_Z0" in source and "PMC_ZMAX" in source
+
+
+def _command_grid():
+    return SimpleNamespace(
+        symmetry_boundaries={},
+        pmls={
+            "thickness": {
+                face: 10
+                for face in ("x0", "xmax", "y0", "ymax", "z0", "zmax")
+            }
+        },
+    )
+
+
+@pytest.mark.parametrize("solver", ["cuda", "opencl", "metal"])
+@pytest.mark.parametrize("boundary_type", ["pec", "pmc"])
+def test_nondispersive_gpu_symmetry_command_is_accepted(
+    monkeypatch, solver, boundary_type
+):
+    monkeypatch.setattr(
+        config,
+        "sim_config",
+        SimpleNamespace(general={"solver": solver}, mpi=False),
+    )
+    monkeypatch.setattr(
+        config,
+        "get_model_config",
+        lambda: SimpleNamespace(materials={"maxpoles": 0}, mode="3D"),
+    )
+    grid = _command_grid()
+
+    SymmetryBoundary(face="x0", type=boundary_type).build(grid)
+
+    assert grid.symmetry_boundaries == {"x0": boundary_type}
+    assert grid.pmls["thickness"]["x0"] == 0
+
+
+@pytest.mark.parametrize("solver", ["cuda", "opencl", "metal"])
+def test_dispersive_gpu_pmc_is_rejected_after_material_resolution(
+    monkeypatch, solver
+):
+    monkeypatch.setattr(
+        config,
+        "sim_config",
+        SimpleNamespace(general={"solver": solver}, mpi=False),
+    )
+    monkeypatch.setattr(
+        config,
+        "get_model_config",
+        lambda: SimpleNamespace(materials={"maxpoles": 1}, mode="3D"),
+    )
+
+    grid = _command_grid()
+    SymmetryBoundary(face="x0", type="pmc").build(grid)
+
+    with pytest.raises(ValueError, match="Dispersive PMC"):
+        Model.__new__(Model)._check_accelerator_symmetry_boundaries([grid])
+
+
+class _FakeCUDAArray:
+    def __init__(self, name):
+        self.gpudata = name
+
+
+def _dispatch_grid():
+    arrays = {
+        name: _FakeCUDAArray(name)
+        for name in ("ID_dev", "Ex_dev", "Ey_dev", "Ez_dev", "Hx_dev", "Hy_dev", "Hz_dev")
+    }
+    return SimpleNamespace(
+        nx=4,
+        ny=5,
+        nz=6,
+        symmetry_boundaries={"x0": "pmc", "ymax": "pmc"},
+        tpb=(64, 1, 1),
+        bpg=(2, 1, 1),
+        **arrays,
+    )
+
+
+def test_cuda_pmc_dispatch_uses_canonical_face_flag_order():
+    updates = CUDAUpdates.__new__(CUDAUpdates)
+    updates.grid = _dispatch_grid()
+    calls = []
+    updates.update_electric_pmc_dev = lambda *args, **kwargs: calls.append(
+        (args, kwargs)
+    )
+
+    updates.update_symmetry_boundaries_electric()
+
+    args, kwargs = calls[0]
+    assert args[:3] == (4, 5, 6)
+    assert args[3:9] == (1, 0, 0, 1, 0, 0)
+    assert args[9:16] == (
+        "ID_dev",
+        "Ex_dev",
+        "Ey_dev",
+        "Ez_dev",
+        "Hx_dev",
+        "Hy_dev",
+        "Hz_dev",
+    )
+    assert kwargs == {"block": (64, 1, 1), "grid": (2, 1, 1)}
+
+
+def test_opencl_pmc_dispatch_uses_device_arrays():
+    updates = OpenCLUpdates.__new__(OpenCLUpdates)
+    updates.grid = _dispatch_grid()
+    calls = []
+    updates.update_electric_pmc_dev = lambda *args: calls.append(args)
+
+    updates.update_symmetry_boundaries_electric()
+
+    args = calls[0]
+    assert args[3:9] == (1, 0, 0, 1, 0, 0)
+    assert args[9].gpudata == "ID_dev"
+    assert args[15].gpudata == "Hz_dev"
+
+
+def test_opencl_pmc_kernel_builder_substitutes_real_type(monkeypatch):
+    updates = OpenCLUpdates.__new__(OpenCLUpdates)
+    updates.grid = SimpleNamespace(
+        nx=4,
+        ny=5,
+        nz=6,
+        ID=np.zeros((6, 5, 6, 7), dtype=np.uint32),
+    )
+    updates.ctx = object()
+    updates.knl_common = "common"
+    captured = {}
+
+    def fake_elementwise_kernel(ctx, arguments, operation, name, **kwargs):
+        captured.update(arguments=arguments, operation=operation, name=name, kwargs=kwargs)
+        return object()
+
+    updates.elwiseknl = fake_elementwise_kernel
+    monkeypatch.setattr(
+        config,
+        "sim_config",
+        SimpleNamespace(
+            dtypes={"C_float_or_double": "float"},
+            devices={"compiler_opts": []},
+        ),
+    )
+
+    updates._set_symmetry_boundary_knl()
+
+    assert "$REAL" not in captured["arguments"]
+    assert "$REAL" not in captured["operation"]
+    assert "float" in captured["arguments"]
+    assert "float" in captured["operation"]
+    assert captured["name"] == "update_electric_pmc"
+
+
+class _FakeMetalEncoder:
+    def __init__(self):
+        self.pipeline = None
+        self.scalars = {}
+        self.buffers = {}
+        self.dispatch = None
+        self.ended = False
+
+    def setComputePipelineState_(self, pipeline):
+        self.pipeline = pipeline
+
+    def setBytes_length_atIndex_(self, value, length, index):
+        self.scalars[index] = (value, length)
+
+    def setBuffer_offset_atIndex_(self, buffer, offset, index):
+        self.buffers[index] = (buffer, offset)
+
+    def dispatchThreads_threadsPerThreadgroup_(self, threads, group):
+        self.dispatch = (threads, group)
+
+    def endEncoding(self):
+        self.ended = True
+
+
+class _FakeMetalCommand:
+    def __init__(self, encoder):
+        self.encoder = encoder
+        self.committed = False
+        self.waited = False
+
+    def computeCommandEncoder(self):
+        return self.encoder
+
+    def commit(self):
+        self.committed = True
+
+    def waitUntilCompleted(self):
+        self.waited = True
+
+
+def test_metal_pmc_dispatch_uses_expected_scalar_and_buffer_slots():
+    updates = MetalUpdates.__new__(MetalUpdates)
+    updates.grid = _dispatch_grid()
+    updates.grid.tptg = "threads"
+    encoder = _FakeMetalEncoder()
+    command = _FakeMetalCommand(encoder)
+    updates.cmdqueue = SimpleNamespace(commandBuffer=lambda: command)
+    updates.pso_electric_pmc = SimpleNamespace(
+        maxTotalThreadsPerThreadgroup=lambda: 128
+    )
+    updates.metal = SimpleNamespace(
+        MTLSizeMake=lambda x, y, z: (x, y, z)
+    )
+
+    updates.update_symmetry_boundaries_electric()
+
+    scalar_values = tuple(
+        np.frombuffer(encoder.scalars[index][0], dtype=np.int32)[0]
+        for index in range(9)
+    )
+    assert scalar_values == (4, 5, 6, 1, 0, 0, 1, 0, 0)
+    assert tuple(encoder.buffers) == tuple(range(9, 16))
+    assert encoder.buffers[9] == (updates.grid.ID_dev, 0)
+    assert encoder.buffers[15] == (updates.grid.Hz_dev, 0)
+    assert encoder.pipeline is updates.pso_electric_pmc
+    assert encoder.dispatch == ("threads", (128, 1, 1))
+    assert encoder.ended and command.committed and command.waited

--- a/tests/updates/test_h_boundary_symmetry.py
+++ b/tests/updates/test_h_boundary_symmetry.py
@@ -1,0 +1,69 @@
+"""Regression test for the CPU update_magnetic() 3D-branch boundary-symmetry
+fix.
+
+Previously the 3D magnetic update loop only ever reached each H component's
+*upper* own-axis wall (Hx at i=nx, Hy at j=ny, Hz at k=nz) - the lower wall
+(i=0/j=0/k=0) was never visited at all, staying permanently at its initial
+value. Both walls are mathematically inert for standard usage (the
+tangential-E curl terms they depend on are themselves never updated at the
+domain edge, by update_electric's own loop-bound construction), but the
+asymmetry was still a real structural gap - GPU's kernel, by contrast, was
+already symmetric (excluding *both* walls uniformly). CPU now matches GPU:
+both walls are genuinely visited by the update loop (still computing to
+zero for ordinary non-magnetic materials), not just the upper one.
+
+Unit-level coverage of the exact new values written at the boundary lives
+in test_cpu_updates.py::test_update_magnetic. This file covers the
+end-to-end, real-solve claim: a physically propagating field still leaves
+every domain-wall H position at exactly zero, on both a small and a
+larger domain, matching the pre-fix result bit-for-bit for the interior.
+"""
+import numpy as np
+
+import gprMax
+import gprMax.model as model_mod
+
+
+def _capture_grid(monkeypatch):
+    captured = {}
+    orig_build = model_mod.Model.build
+
+    def patched_build(self):
+        orig_build(self)
+        captured["grid"] = self.G
+
+    monkeypatch.setattr(model_mod.Model, "build", patched_build)
+    return captured
+
+
+def test_h_boundary_walls_remain_zero_with_real_propagating_field(monkeypatch, tmp_path):
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(1e-3, 1e-3, 1e-3)))
+    scene.add(gprMax.Domain(p1=(20e-3, 20e-3, 20e-3)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=5e-10))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=10e9, id="w"))
+    scene.add(gprMax.HertzianDipole(polarisation="z", p1=(0.01, 0.01, 0.01), waveform_id="w"))
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(scenes=[scene], n=1, outputfile=tmp_path / "run", hide_progress_bars=True)
+    grid = captured["grid"]
+    nx, ny, nz = grid.nx, grid.ny, grid.nz
+
+    # A genuinely propagating field, not a degenerate all-zero run - proves
+    # the boundary-wall zeros below are a real physical result, not just
+    # "nothing happened yet" (the failure mode of an earlier, too-short
+    # TimeWindow attempt at verifying this by hand).
+    assert np.max(np.abs(grid.Ez)) > 1.0
+    assert np.max(np.abs(grid.Hx)) > 1e-6
+    assert np.max(np.abs(grid.Hy)) > 1e-6
+
+    for arr, idx in (
+        (grid.Hx, (0, slice(None), slice(None))),
+        (grid.Hx, (nx, slice(None), slice(None))),
+        (grid.Hy, (slice(None), 0, slice(None))),
+        (grid.Hy, (slice(None), ny, slice(None))),
+        (grid.Hz, (slice(None), slice(None), 0)),
+        (grid.Hz, (slice(None), slice(None), nz)),
+    ):
+        assert np.max(np.abs(arr[idx])) == 0.0

--- a/tests/updates/test_symmetry_boundary_solve_loop.py
+++ b/tests/updates/test_symmetry_boundary_solve_loop.py
@@ -1,0 +1,119 @@
+"""End-to-end test that the PMC symmetry-boundary ghost-node update is
+actually wired into the CPU solve loop (gprMax/solvers.py calling
+CPUUpdates.update_symmetry_boundaries_electric, right after
+update_electric_a()) - not just implemented and unit-tested in isolation.
+
+A real time-stepped run (not geometry_only) with an x0 PMC boundary must
+complete without exception and produce finite, genuinely propagating
+fields at a nearby receiver - not NaN, and not a degenerate all-zero result
+(which would mask a wave that never actually reached the receiver in time,
+a trap this project has hit before with too-short time windows).
+"""
+import numpy as np
+
+import gprMax
+
+
+def test_pmc_symmetry_boundary_solve_produces_finite_propagating_field(tmp_path):
+    dl = 1e-3
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(0.02, 0.02, 0.02)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=2e-10))
+    scene.add(gprMax.SymmetryBoundary(face="x0", type="pmc"))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=1.5e10, id="w"))
+    scene.add(gprMax.HertzianDipole(polarisation="z", p1=(0.001, 0.01, 0.01), waveform_id="w"))
+    scene.add(gprMax.Rx(p1=(0.01, 0.01, 0.01)))
+
+    outputfile = tmp_path / "pmc_solve"
+    gprMax.run(scenes=[scene], n=1, outputfile=outputfile, hide_progress_bars=True)
+
+    import h5py
+
+    with h5py.File(str(outputfile) + ".h5", "r") as f:
+        ez = f["rxs/rx1/Ez"][:]
+        for comp in ("Ex", "Ey", "Ez", "Hx", "Hy", "Hz"):
+            data = f["rxs/rx1/" + comp][:]
+            assert not np.any(np.isnan(data)), f"{comp} contains NaN"
+
+    assert np.max(np.abs(ez)) > 1e-3, "Ez is degenerate (all-zero) - wave never reached the receiver"
+
+
+def test_pmc_symmetry_boundary_solve_with_lorentz_material_produces_finite_propagating_field(tmp_path):
+    """Complex-pole (Lorentz) counterpart of the Debye test below - exercises
+    CPUUpdates.update_symmetry_boundaries_electric()/_b()'s complex-pole
+    branch (gprMax.cython.symmetry_boundaries_dispersive_complex), selected
+    via materials["drudelorentz"].
+    """
+    dl = 1e-3
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(0.02, 0.02, 0.02)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=2e-10))
+    scene.add(gprMax.SymmetryBoundary(face="x0", type="pmc"))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=1.5e10, id="w"))
+    scene.add(gprMax.Material(er=3, se=0.001, mr=1, sm=0, id="metal"))
+    scene.add(
+        gprMax.AddLorentzDispersion(
+            poles=1, er_delta=[2.0], omega=[2e10], delta=[5e9], material_ids=["metal"]
+        )
+    )
+    scene.add(gprMax.Box(p1=(0.0, 0.0, 0.0), p2=(0.02, 0.02, 0.02), material_id="metal"))
+    # Fed directly on the PMC wall - as with the Debye test, the scenario
+    # most likely to catch a missing/broken Phase B.
+    scene.add(gprMax.HertzianDipole(polarisation="z", p1=(0.0, 0.01, 0.01), waveform_id="w"))
+    scene.add(gprMax.Rx(p1=(0.01, 0.01, 0.01)))
+
+    outputfile = tmp_path / "pmc_solve_lorentz"
+    gprMax.run(scenes=[scene], n=1, outputfile=outputfile, hide_progress_bars=True)
+
+    import h5py
+
+    with h5py.File(str(outputfile) + ".h5", "r") as f:
+        ez = f["rxs/rx1/Ez"][:]
+        for comp in ("Ex", "Ey", "Ez", "Hx", "Hy", "Hz"):
+            data = f["rxs/rx1/" + comp][:]
+            assert not np.any(np.isnan(data)), f"{comp} contains NaN"
+
+    assert np.max(np.abs(ez)) > 1e-3, "Ez is degenerate (all-zero) - wave never reached the receiver"
+
+
+def test_pmc_symmetry_boundary_solve_with_debye_material_produces_finite_propagating_field(tmp_path):
+    """Same wiring check as above, but with a Debye-dispersive material
+    filling the domain (including the PMC wall itself) - exercises
+    CPUUpdates.update_symmetry_boundaries_electric()'s dispersive branch and
+    the new update_symmetry_boundaries_electric_b() call in gprMax/solvers.py
+    (right before update_electric_b()), not just the non-dispersive path the
+    test above covers.
+    """
+    dl = 1e-3
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(0.02, 0.02, 0.02)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=2e-10))
+    scene.add(gprMax.SymmetryBoundary(face="x0", type="pmc"))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=1.5e10, id="w"))
+    scene.add(gprMax.Material(er=3, se=0.001, mr=1, sm=0, id="soil"))
+    scene.add(gprMax.AddDebyeDispersion(poles=1, er_delta=[2.0], tau=[1e-11], material_ids=["soil"]))
+    scene.add(gprMax.Box(p1=(0.0, 0.0, 0.0), p2=(0.02, 0.02, 0.02), material_id="soil"))
+    # Fed directly on the PMC wall - the scenario most likely to catch a
+    # missing/broken Phase B (a source here is exactly the case where PML/
+    # source corrections modify E after the ghost-node Phase A has run).
+    scene.add(gprMax.HertzianDipole(polarisation="z", p1=(0.0, 0.01, 0.01), waveform_id="w"))
+    scene.add(gprMax.Rx(p1=(0.01, 0.01, 0.01)))
+
+    outputfile = tmp_path / "pmc_solve_debye"
+    gprMax.run(scenes=[scene], n=1, outputfile=outputfile, hide_progress_bars=True)
+
+    import h5py
+
+    with h5py.File(str(outputfile) + ".h5", "r") as f:
+        ez = f["rxs/rx1/Ez"][:]
+        for comp in ("Ex", "Ey", "Ez", "Hx", "Hy", "Hz"):
+            data = f["rxs/rx1/" + comp][:]
+            assert not np.any(np.isnan(data)), f"{comp} contains NaN"
+
+    assert np.max(np.abs(ez)) > 1e-3, "Ez is degenerate (all-zero) - wave never reached the receiver"


### PR DESCRIPTION
## PR Description

PR #700 was merged after its stacked base PR #699 had already been merged. Because #700 still targeted `feature/2d-te-mode`, its magnetic-material and symmetry-boundary changes were merged into that feature branch rather than `devel`.

This recovery PR applies the same three reviewed commits directly to the current `devel` branch. The resulting source tree is byte-for-byte identical to the merged #700 tree; there are no additional code or documentation changes.

Closes the branch sequencing gap left by #700.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] This change requires a documentation update.

## Validation

- [x] Resulting Git tree exactly matches merged PR #700 (`0bc134b0e17712c80b50f8b7eefe0f87c64f7299`).
- [x] Full validation previously completed on this exact tree: 688 passed, 6 skipped.
- [x] Cython extensions and Sphinx documentation previously built successfully on this exact tree.
- [x] No KSIR/NTFF or `docs/design` files are included.
- [ ] Pre-commit was not available locally; GitHub checks should run it.
