### PR TITLE
Add solver-independent KSIR mathematical core

### DIFF
--- a/gprMax/ntff/__init__.py
+++ b/gprMax/ntff/__init__.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+
+"""Solver-independent near-to-far-field transformation utilities."""
+
+from .conventions import (
+    FORWARD_TRANSFORM_KERNEL,
+    OUTGOING_GREEN_RADIAL_FACTOR,
+    PHASOR_TIME_DEPENDENCE,
+    engineering_dft,
+)
+from .evaluator import (
+    evaluate_exact_points_patches,
+    evaluate_far_zone,
+    evaluate_far_zone_patches,
+    project_cartesian_to_spherical,
+    spherical_basis,
+    spherical_directions,
+    spherical_observation_points,
+)
+from .surfaces import (
+    COMPONENTS,
+    COMPONENT_OFFSETS,
+    FACES,
+    KSIRComponentSurface,
+    KSIRSurfaceFace,
+    build_all_component_surfaces,
+    build_component_surface,
+)
+
+__all__ = [
+    "COMPONENTS",
+    "COMPONENT_OFFSETS",
+    "FACES",
+    "FORWARD_TRANSFORM_KERNEL",
+    "KSIRComponentSurface",
+    "KSIRSurfaceFace",
+    "OUTGOING_GREEN_RADIAL_FACTOR",
+    "PHASOR_TIME_DEPENDENCE",
+    "build_all_component_surfaces",
+    "build_component_surface",
+    "engineering_dft",
+    "evaluate_exact_points_patches",
+    "evaluate_far_zone",
+    "evaluate_far_zone_patches",
+    "project_cartesian_to_spherical",
+    "spherical_basis",
+    "spherical_directions",
+    "spherical_observation_points",
+]

--- a/gprMax/ntff/conventions.py
+++ b/gprMax/ntff/conventions.py
@@ -1,0 +1,122 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+
+"""Fourier and phasor conventions used by gprMax NTFF calculations.
+
+The convention is the standard electrical-engineering convention:
+
+* physical time dependence: ``Re{X(omega) exp(+j omega t)}``;
+* forward transform: ``X(omega) = integral x(t) exp(-j omega t) dt``;
+* outgoing Green function: ``exp(-j k R) / (4 pi R)``.
+
+These signs are part of the public data contract, not configurable options.
+"""
+
+import operator
+from typing import Optional
+
+import numpy as np
+import numpy.typing as npt
+
+
+PHASOR_TIME_DEPENDENCE = "exp(+j*omega*t)"
+FORWARD_TRANSFORM_KERNEL = "exp(-j*omega*t)"
+OUTGOING_GREEN_RADIAL_FACTOR = "exp(-j*k*R)"
+
+
+def engineering_dft(
+    samples: npt.ArrayLike,
+    frequencies: npt.ArrayLike,
+    dt: float,
+    *,
+    time_offset: float = 0.0,
+    window: Optional[npt.ArrayLike] = None,
+    axis: int = 0,
+) -> npt.NDArray[np.complexfloating]:
+    """Evaluate the engineering-convention DFT at arbitrary frequencies.
+
+    This is a small NumPy reference implementation for tests and prototypes;
+    the production collector will use a recursive phasor. The transformed time
+    axis is replaced by a leading frequency axis.
+
+    Args:
+        samples: Real or complex time samples.
+        frequencies: Non-negative frequencies in Hz.
+        dt: Sample interval in seconds.
+        time_offset: Physical time of sample zero in seconds.
+        window: Optional one-dimensional window with one value per sample.
+        axis: Axis of ``samples`` containing time.
+
+    Returns:
+        Complex transform values with shape ``(nf, *samples_without_time)``.
+    """
+
+    values = np.asarray(samples)
+    if values.ndim == 0:
+        raise ValueError("samples must have at least one dimension")
+    if not np.isfinite(dt) or dt <= 0:
+        raise ValueError("dt must be finite and greater than zero")
+    if not np.isfinite(time_offset):
+        raise ValueError("time_offset must be finite")
+
+    if values.dtype.kind == "c":
+        real_dtype = values.real.dtype
+        complex_dtype = values.dtype
+    elif values.dtype.kind == "f" and values.dtype.itemsize in (4, 8):
+        real_dtype = values.dtype
+        complex_dtype = np.dtype(f"c{2 * real_dtype.itemsize}")
+    else:
+        real_dtype = np.dtype(float)
+        complex_dtype = np.dtype(complex)
+    freqs = np.asarray(frequencies, dtype=real_dtype)
+    if freqs.ndim != 1 or freqs.size == 0:
+        raise ValueError("frequencies must be a non-empty one-dimensional array")
+    if not np.all(np.isfinite(freqs)) or np.any(freqs < 0):
+        raise ValueError("frequencies must contain finite, non-negative values")
+
+    try:
+        axis = operator.index(axis)
+    except TypeError as exc:
+        raise ValueError("axis is not valid for samples") from exc
+    if axis < -values.ndim or axis >= values.ndim:
+        raise ValueError("axis is not valid for samples")
+    values = np.moveaxis(values, axis, 0)
+
+    nsamples = values.shape[0]
+    if window is None:
+        weights = np.ones(nsamples, dtype=real_dtype)
+    else:
+        weights = np.asarray(window, dtype=real_dtype)
+        if weights.ndim != 1 or weights.size != nsamples:
+            raise ValueError("window must have one value per time sample")
+        if not np.all(np.isfinite(weights)):
+            raise ValueError("window must contain only finite values")
+
+    times = time_offset + dt * np.arange(nsamples, dtype=real_dtype)
+    phase = np.exp(
+        -2j * np.pi * freqs[:, np.newaxis] * times[np.newaxis, :]
+    ).astype(complex_dtype)
+    values = values.astype(
+        complex_dtype if values.dtype.kind == "c" else real_dtype, copy=False
+    )
+    weighted_values = values * weights.reshape((nsamples,) + (1,) * (values.ndim - 1))
+    return np.asarray(
+        dt * np.tensordot(phase, weighted_values, axes=((1,), (0,))),
+        dtype=complex_dtype,
+    )

--- a/gprMax/ntff/evaluator.py
+++ b/gprMax/ntff/evaluator.py
@@ -1,0 +1,548 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+
+"""Pure NumPy reference evaluator for frequency-domain KSIR data."""
+
+import numpy as np
+import numpy.typing as npt
+from scipy.constants import c
+
+from .surfaces import KSIRComponentSurface
+
+
+def _floating_input_dtype(*values) -> np.dtype:
+    dtype = np.result_type(*(np.asarray(value).dtype for value in values))
+    return dtype if dtype.kind == "f" else np.dtype(float)
+
+
+def spherical_directions(
+    theta: npt.ArrayLike, phi: npt.ArrayLike, *, degrees: bool = False
+) -> npt.NDArray[np.floating]:
+    """Convert paired spherical angles to Cartesian unit vectors.
+
+    ``theta`` is the polar angle from +z and ``phi`` is the azimuth from +x
+    toward +y. Inputs are broadcast together and the result has shape
+    ``broadcast(theta, phi).shape + (3,)``.
+    """
+
+    dtype = _floating_input_dtype(theta, phi)
+    theta_values, phi_values = np.broadcast_arrays(
+        np.asarray(theta, dtype=dtype), np.asarray(phi, dtype=dtype)
+    )
+    if not np.all(np.isfinite(theta_values)) or not np.all(np.isfinite(phi_values)):
+        raise ValueError("theta and phi must contain only finite values")
+    if degrees:
+        theta_values = np.deg2rad(theta_values)
+        phi_values = np.deg2rad(phi_values)
+
+    sin_theta = np.sin(theta_values)
+    return np.stack(
+        (
+            sin_theta * np.cos(phi_values),
+            sin_theta * np.sin(phi_values),
+            np.cos(theta_values),
+        ),
+        axis=-1,
+    )
+
+
+def spherical_observation_points(
+    origin: npt.ArrayLike,
+    radius: npt.ArrayLike,
+    theta: npt.ArrayLike,
+    phi: npt.ArrayLike,
+    *,
+    degrees: bool = False,
+) -> npt.NDArray[np.floating]:
+    """Create Cartesian KSIR observation points from spherical coordinates.
+
+    ``theta`` is measured from +z and ``phi`` from +x toward +y. Radius and
+    angles use NumPy broadcasting; the broadcast result is flattened to the
+    ``(npoints, 3)`` array accepted by the exact-point KSIR evaluator. For an
+    angular product grid, pass (for example) ``theta[:, None]`` and
+    ``phi[None, :]``.
+    """
+
+    dtype = _floating_input_dtype(origin, radius, theta, phi)
+    centre = np.asarray(origin, dtype=dtype)
+    if centre.shape != (3,) or not np.all(np.isfinite(centre)):
+        raise ValueError("origin must contain exactly three finite values")
+
+    radii, theta_values, phi_values = np.broadcast_arrays(
+        np.asarray(radius, dtype=dtype),
+        np.asarray(theta, dtype=dtype),
+        np.asarray(phi, dtype=dtype),
+    )
+    if radii.size == 0:
+        raise ValueError("spherical observation coordinates must not be empty")
+    if not np.all(np.isfinite(radii)) or np.any(radii <= 0):
+        raise ValueError("radius must contain only finite, positive values")
+
+    directions = spherical_directions(
+        theta_values, phi_values, degrees=degrees
+    )
+    points = centre + radii[..., np.newaxis] * directions
+    return np.ascontiguousarray(points.reshape(-1, 3), dtype=dtype)
+
+
+def _phasors(
+    name: str, values: npt.ArrayLike, nfrequencies: int, npatches: int
+) -> npt.NDArray[np.complexfloating]:
+    array = np.asarray(values)
+    expected_shape = (nfrequencies, npatches)
+    if array.shape != expected_shape:
+        raise ValueError(f"{name} must have shape {expected_shape}, got {array.shape}")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain only finite values")
+    if array.dtype.kind != "c":
+        raise ValueError(f"{name} must use a complex dtype")
+    return array
+
+
+def evaluate_far_zone_patches(
+    patch_positions: npt.ArrayLike,
+    patch_normals: npt.ArrayLike,
+    area_weights: npt.ArrayLike,
+    frequencies: npt.ArrayLike,
+    directions: npt.ArrayLike,
+    surface_field: npt.ArrayLike,
+    normal_derivative: npt.ArrayLike,
+    *,
+    wave_speed: float = c,
+    origin: npt.ArrayLike = (0.0, 0.0, 0.0),
+    direction_block_size: int = 256,
+    patch_block_size: int = 8192,
+) -> npt.NDArray[np.complexfloating]:
+    """Evaluate KSIR from explicit patch geometry and phasors."""
+
+    raw_field = np.asarray(surface_field)
+    raw_derivative = np.asarray(normal_derivative)
+    complex_dtype = np.result_type(raw_field.dtype, raw_derivative.dtype)
+    if complex_dtype.kind != "c":
+        raise ValueError("surface phasors must use a complex dtype")
+    real_dtype = np.empty((), dtype=complex_dtype).real.dtype
+    freqs = np.asarray(frequencies, dtype=real_dtype)
+    if freqs.ndim != 1 or freqs.size == 0:
+        raise ValueError("frequencies must be a non-empty one-dimensional array")
+    if not np.all(np.isfinite(freqs)) or np.any(freqs < 0):
+        raise ValueError("frequencies must contain finite, non-negative values")
+    if not np.isfinite(wave_speed) or wave_speed <= 0:
+        raise ValueError("wave_speed must be finite and greater than zero")
+    reference_origin = np.asarray(origin, dtype=real_dtype)
+    if reference_origin.shape != (3,) or not np.all(np.isfinite(reference_origin)):
+        raise ValueError("origin must contain exactly three finite values")
+    if (
+        not isinstance(direction_block_size, (int, np.integer))
+        or direction_block_size <= 0
+    ):
+        raise ValueError("direction_block_size must be a positive integer")
+    if (
+        not isinstance(patch_block_size, (int, np.integer))
+        or patch_block_size <= 0
+    ):
+        raise ValueError("patch_block_size must be a positive integer")
+
+    direction_vectors = np.asarray(directions, dtype=real_dtype)
+    if direction_vectors.ndim != 2 or direction_vectors.shape[1] != 3:
+        raise ValueError("directions must have shape (ndirections, 3)")
+    if direction_vectors.shape[0] == 0 or not np.all(np.isfinite(direction_vectors)):
+        raise ValueError("directions must contain finite unit vectors")
+    direction_norms = np.linalg.norm(direction_vectors, axis=1)
+    unit_tolerance = max(1e-12, 64 * np.finfo(real_dtype).eps)
+    if not np.allclose(
+        direction_norms, 1.0, rtol=unit_tolerance, atol=unit_tolerance
+    ):
+        raise ValueError("directions must be unit vectors")
+
+    positions = np.asarray(patch_positions, dtype=real_dtype)
+    normals = np.asarray(patch_normals, dtype=real_dtype)
+    areas = np.asarray(area_weights, dtype=real_dtype)
+    if positions.ndim != 2 or positions.shape[1] != 3 or positions.shape[0] == 0:
+        raise ValueError("patch_positions must have shape (npatches, 3)")
+    if normals.shape != positions.shape:
+        raise ValueError("patch_normals must match patch_positions")
+    if areas.shape != (positions.shape[0],):
+        raise ValueError("area_weights must have one value per patch")
+    if (
+        not np.all(np.isfinite(positions))
+        or not np.all(np.isfinite(normals))
+        or not np.all(np.isfinite(areas))
+        or np.any(areas <= 0)
+    ):
+        raise ValueError("patch geometry must be finite with positive areas")
+    if not np.allclose(np.linalg.norm(normals, axis=1), 1.0):
+        raise ValueError("patch_normals must be unit vectors")
+
+    npatches = positions.shape[0]
+    field = _phasors("surface_field", raw_field, freqs.size, npatches).astype(
+        complex_dtype, copy=False
+    )
+    derivative = _phasors(
+        "normal_derivative", raw_derivative, freqs.size, npatches
+    ).astype(complex_dtype, copy=False)
+    positions = positions - reference_origin
+    wavenumbers = 2 * np.pi * freqs / wave_speed
+    result = np.zeros(
+        (freqs.size, direction_vectors.shape[0]), dtype=complex_dtype
+    )
+
+    for direction_start in range(0, direction_vectors.shape[0], direction_block_size):
+        direction_stop = min(
+            direction_start + direction_block_size, direction_vectors.shape[0]
+        )
+        direction_block = direction_vectors[direction_start:direction_stop]
+        block_result = result[:, direction_start:direction_stop]
+        for patch_start in range(0, npatches, patch_block_size):
+            patch_stop = min(patch_start + patch_block_size, npatches)
+            direction_dot_position = (
+                direction_block @ positions[patch_start:patch_stop].T
+            )
+            normal_dot_direction = (
+                direction_block @ normals[patch_start:patch_stop].T
+            )
+            phase = np.exp(
+                1j
+                * wavenumbers[:, np.newaxis, np.newaxis]
+                * direction_dot_position[np.newaxis, :, :]
+            ).astype(complex_dtype, copy=False)
+            integrand = -derivative[:, np.newaxis, patch_start:patch_stop] + (
+                1j
+                * wavenumbers[:, np.newaxis, np.newaxis]
+                * normal_dot_direction[np.newaxis, :, :]
+                * field[:, np.newaxis, patch_start:patch_stop]
+            )
+            block_result += np.sum(
+                integrand
+                * phase
+                * areas[np.newaxis, np.newaxis, patch_start:patch_stop],
+                axis=2,
+            )
+    return result / np.asarray(4 * np.pi, dtype=real_dtype)
+
+
+def evaluate_exact_points_patches(
+    patch_positions: npt.ArrayLike,
+    patch_normals: npt.ArrayLike,
+    area_weights: npt.ArrayLike,
+    frequencies: npt.ArrayLike,
+    points: npt.ArrayLike,
+    surface_field: npt.ArrayLike,
+    normal_derivative: npt.ArrayLike,
+    *,
+    wave_speed: float = c,
+    point_block_size: int = 64,
+    patch_block_size: int = 4096,
+) -> npt.NDArray[np.complexfloating]:
+    """Evaluate the exact finite-distance scalar KSIR surface integral.
+
+    The engineering phasor convention ``exp(+j omega t)`` is used, so the
+    outgoing Green function is ``exp(-j k R) / (4 pi R)``. Unlike
+    :func:`evaluate_far_zone_patches`, this function retains every ``1/R``
+    and ``1/R**2`` term and therefore returns the physical field at each
+    requested point rather than a range-normalized far-field amplitude.
+    """
+
+    raw_field = np.asarray(surface_field)
+    raw_derivative = np.asarray(normal_derivative)
+    complex_dtype = np.result_type(raw_field.dtype, raw_derivative.dtype)
+    if complex_dtype.kind != "c":
+        raise ValueError("surface phasors must use a complex dtype")
+    real_dtype = np.empty((), dtype=complex_dtype).real.dtype
+
+    freqs = np.asarray(frequencies, dtype=real_dtype)
+    if freqs.ndim != 1 or freqs.size == 0:
+        raise ValueError("frequencies must be a non-empty one-dimensional array")
+    if not np.all(np.isfinite(freqs)) or np.any(freqs < 0):
+        raise ValueError("frequencies must contain finite, non-negative values")
+    if not np.isfinite(wave_speed) or wave_speed <= 0:
+        raise ValueError("wave_speed must be finite and greater than zero")
+    if not isinstance(point_block_size, (int, np.integer)) or point_block_size <= 0:
+        raise ValueError("point_block_size must be a positive integer")
+    if not isinstance(patch_block_size, (int, np.integer)) or patch_block_size <= 0:
+        raise ValueError("patch_block_size must be a positive integer")
+
+    observation_points = np.asarray(points, dtype=real_dtype)
+    if observation_points.ndim == 1:
+        observation_points = observation_points[np.newaxis, :]
+    if (
+        observation_points.ndim != 2
+        or observation_points.shape[0] == 0
+        or observation_points.shape[1] != 3
+        or not np.all(np.isfinite(observation_points))
+    ):
+        raise ValueError("points must have shape (npoints, 3) and be finite")
+
+    positions = np.asarray(patch_positions, dtype=real_dtype)
+    normals = np.asarray(patch_normals, dtype=real_dtype)
+    areas = np.asarray(area_weights, dtype=real_dtype)
+    if positions.ndim != 2 or positions.shape[1] != 3 or positions.shape[0] == 0:
+        raise ValueError("patch_positions must have shape (npatches, 3)")
+    if normals.shape != positions.shape:
+        raise ValueError("patch_normals must match patch_positions")
+    if areas.shape != (positions.shape[0],):
+        raise ValueError("area_weights must have one value per patch")
+    if (
+        not np.all(np.isfinite(positions))
+        or not np.all(np.isfinite(normals))
+        or not np.all(np.isfinite(areas))
+        or np.any(areas <= 0)
+    ):
+        raise ValueError("patch geometry must be finite with positive areas")
+    if not np.allclose(np.linalg.norm(normals, axis=1), 1.0):
+        raise ValueError("patch_normals must be unit vectors")
+
+    npatches = positions.shape[0]
+    field = _phasors("surface_field", raw_field, freqs.size, npatches).astype(
+        complex_dtype, copy=False
+    )
+    derivative = _phasors(
+        "normal_derivative", raw_derivative, freqs.size, npatches
+    ).astype(complex_dtype, copy=False)
+    wavenumbers = np.asarray(2 * np.pi * freqs / wave_speed, dtype=real_dtype)
+    result = np.zeros(
+        (freqs.size, observation_points.shape[0]), dtype=complex_dtype
+    )
+    four_pi = np.asarray(4 * np.pi, dtype=real_dtype)
+
+    for point_start in range(0, observation_points.shape[0], point_block_size):
+        point_stop = min(
+            point_start + point_block_size, observation_points.shape[0]
+        )
+        point_block = observation_points[point_start:point_stop]
+        block_result = result[:, point_start:point_stop]
+        for patch_start in range(0, npatches, patch_block_size):
+            patch_stop = min(patch_start + patch_block_size, npatches)
+            patch_positions_block = positions[patch_start:patch_stop]
+            displacement = (
+                point_block[:, np.newaxis, :] - patch_positions_block[np.newaxis, :, :]
+            )
+            radius = np.linalg.norm(displacement, axis=2)
+            if np.any(radius == 0):
+                raise ValueError("observation points must not coincide with surface patches")
+            radial_direction = displacement / radius[:, :, np.newaxis]
+            normal_dot_radial = np.sum(
+                normals[np.newaxis, patch_start:patch_stop, :] * radial_direction,
+                axis=2,
+            )
+            phase = np.exp(
+                -1j
+                * wavenumbers[:, np.newaxis, np.newaxis]
+                * radius[np.newaxis, :, :]
+            ).astype(complex_dtype, copy=False)
+            inverse_radius = 1 / radius
+            field_factor = normal_dot_radial[np.newaxis, :, :] * (
+                inverse_radius[np.newaxis, :, :] ** 2
+                + 1j
+                * wavenumbers[:, np.newaxis, np.newaxis]
+                * inverse_radius[np.newaxis, :, :]
+            )
+            integrand = (
+                -derivative[:, np.newaxis, patch_start:patch_stop]
+                * inverse_radius[np.newaxis, :, :]
+                + field_factor * field[:, np.newaxis, patch_start:patch_stop]
+            )
+            block_result += np.sum(
+                phase
+                * integrand
+                * areas[np.newaxis, np.newaxis, patch_start:patch_stop],
+                axis=2,
+            ) / four_pi
+    return result
+
+
+def evaluate_far_zone(
+    surface: KSIRComponentSurface,
+    frequencies: npt.ArrayLike,
+    directions: npt.ArrayLike,
+    surface_field: npt.ArrayLike,
+    normal_derivative: npt.ArrayLike,
+    *,
+    wave_speed: float = c,
+    origin: npt.ArrayLike = (0.0, 0.0, 0.0),
+    direction_block_size: int = 256,
+    patch_block_size: int = 8192,
+) -> npt.NDArray[np.complexfloating]:
+    """Evaluate the range-normalized scalar far-zone KSIR integral.
+
+    The implementation follows the engineering convention
+    ``exp(+j omega t)`` with outgoing radial dependence ``exp(-j k r)``.
+    Therefore the returned value is ``r exp(+j k r) psi_far``.
+
+    Args:
+        surface: Closed Yee-aligned surface for one field component.
+        frequencies: Non-negative frequencies in Hz.
+        directions: Cartesian unit observation vectors with shape ``(nd, 3)``.
+        surface_field: Collocated component phasors, shape ``(nf, npatches)``.
+        normal_derivative: Outward-normal derivative phasors with the same shape.
+        wave_speed: Homogeneous-background propagation speed in m/s.
+        origin: Phase-reference origin in metres.
+        direction_block_size: Maximum directions in one temporary block.
+        patch_block_size: Maximum patches in one temporary block.
+
+    Returns:
+        Range-normalized component phasors with shape ``(nf, nd)``.
+    """
+
+    raw_field = np.asarray(surface_field)
+    raw_derivative = np.asarray(normal_derivative)
+    complex_dtype = np.result_type(raw_field.dtype, raw_derivative.dtype)
+    if complex_dtype.kind != "c":
+        raise ValueError("surface phasors must use a complex dtype")
+    real_dtype = np.empty((), dtype=complex_dtype).real.dtype
+    freqs = np.asarray(frequencies, dtype=real_dtype)
+    if freqs.ndim != 1 or freqs.size == 0:
+        raise ValueError("frequencies must be a non-empty one-dimensional array")
+    if not np.all(np.isfinite(freqs)) or np.any(freqs < 0):
+        raise ValueError("frequencies must contain finite, non-negative values")
+    if not np.isfinite(wave_speed) or wave_speed <= 0:
+        raise ValueError("wave_speed must be finite and greater than zero")
+    reference_origin = np.asarray(origin, dtype=real_dtype)
+    if reference_origin.shape != (3,) or not np.all(np.isfinite(reference_origin)):
+        raise ValueError("origin must contain exactly three finite values")
+    if not isinstance(direction_block_size, (int, np.integer)) or direction_block_size <= 0:
+        raise ValueError("direction_block_size must be a positive integer")
+    if not isinstance(patch_block_size, (int, np.integer)) or patch_block_size <= 0:
+        raise ValueError("patch_block_size must be a positive integer")
+
+    direction_vectors = np.asarray(directions, dtype=real_dtype)
+    if direction_vectors.ndim != 2 or direction_vectors.shape[1] != 3:
+        raise ValueError("directions must have shape (ndirections, 3)")
+    if direction_vectors.shape[0] == 0 or not np.all(np.isfinite(direction_vectors)):
+        raise ValueError("directions must contain finite unit vectors")
+    direction_norms = np.linalg.norm(direction_vectors, axis=1)
+    unit_tolerance = max(1e-12, 64 * np.finfo(real_dtype).eps)
+    if not np.allclose(
+        direction_norms, 1.0, rtol=unit_tolerance, atol=unit_tolerance
+    ):
+        raise ValueError("directions must be unit vectors")
+
+    npatches = surface.npatches
+    field = _phasors("surface_field", raw_field, freqs.size, npatches).astype(
+        complex_dtype, copy=False
+    )
+    derivative = _phasors(
+        "normal_derivative", raw_derivative, freqs.size, npatches
+    ).astype(complex_dtype, copy=False)
+
+    positions = np.asarray(surface.patch_positions, dtype=real_dtype) - reference_origin
+    normals = np.asarray(surface.normals, dtype=real_dtype)
+    areas = np.asarray(surface.area_weights, dtype=real_dtype)
+    wavenumbers = 2 * np.pi * freqs / wave_speed
+    result = np.zeros(
+        (freqs.size, direction_vectors.shape[0]), dtype=complex_dtype
+    )
+
+    for direction_start in range(0, direction_vectors.shape[0], direction_block_size):
+        direction_stop = min(
+            direction_start + direction_block_size, direction_vectors.shape[0]
+        )
+        direction_block = direction_vectors[direction_start:direction_stop]
+        block_result = result[:, direction_start:direction_stop]
+
+        for patch_start in range(0, npatches, patch_block_size):
+            patch_stop = min(patch_start + patch_block_size, npatches)
+            direction_dot_position = direction_block @ positions[patch_start:patch_stop].T
+            normal_dot_direction = direction_block @ normals[patch_start:patch_stop].T
+            phase = np.exp(
+                1j
+                * wavenumbers[:, np.newaxis, np.newaxis]
+                * direction_dot_position[np.newaxis, :, :]
+            ).astype(complex_dtype, copy=False)
+            integrand = -derivative[:, np.newaxis, patch_start:patch_stop] + (
+                1j
+                * wavenumbers[:, np.newaxis, np.newaxis]
+                * normal_dot_direction[np.newaxis, :, :]
+                * field[:, np.newaxis, patch_start:patch_stop]
+            )
+            block_result += np.sum(
+                integrand
+                * phase
+                * areas[np.newaxis, np.newaxis, patch_start:patch_stop],
+                axis=2,
+            )
+
+    return result / np.asarray(4 * np.pi, dtype=real_dtype)
+
+
+def spherical_basis(
+    theta: npt.ArrayLike, phi: npt.ArrayLike, *, degrees: bool = False
+) -> tuple[
+    npt.NDArray[np.floating],
+    npt.NDArray[np.floating],
+    npt.NDArray[np.floating],
+]:
+    """Return radial, polar, and azimuthal unit vectors for paired angles."""
+
+    dtype = _floating_input_dtype(theta, phi)
+    theta_values, phi_values = np.broadcast_arrays(
+        np.asarray(theta, dtype=dtype), np.asarray(phi, dtype=dtype)
+    )
+    if not np.all(np.isfinite(theta_values)) or not np.all(np.isfinite(phi_values)):
+        raise ValueError("theta and phi must contain only finite values")
+    if degrees:
+        theta_values = np.deg2rad(theta_values)
+        phi_values = np.deg2rad(phi_values)
+
+    sin_theta = np.sin(theta_values)
+    cos_theta = np.cos(theta_values)
+    sin_phi = np.sin(phi_values)
+    cos_phi = np.cos(phi_values)
+    radial = np.stack(
+        (sin_theta * cos_phi, sin_theta * sin_phi, cos_theta), axis=-1
+    )
+    polar = np.stack(
+        (cos_theta * cos_phi, cos_theta * sin_phi, -sin_theta), axis=-1
+    )
+    azimuthal = np.stack((-sin_phi, cos_phi, np.zeros_like(phi_values)), axis=-1)
+    return radial, polar, azimuthal
+
+
+def project_cartesian_to_spherical(
+    cartesian: npt.ArrayLike,
+    theta: npt.ArrayLike,
+    phi: npt.ArrayLike,
+    *,
+    degrees: bool = False,
+) -> npt.NDArray[np.complexfloating]:
+    """Project Cartesian vector phasors onto the spherical basis.
+
+    The final two dimensions of the input must be direction and Cartesian
+    component. The returned component order is radial, polar, azimuthal.
+    """
+
+    values = np.asarray(cartesian)
+    if values.dtype.kind != "c":
+        raise ValueError("cartesian must use a complex dtype")
+    real_dtype = values.real.dtype
+    if values.ndim < 2 or values.shape[-1] != 3:
+        raise ValueError("cartesian must have a final dimension of length three")
+    radial, polar, azimuthal = spherical_basis(theta, phi, degrees=degrees)
+    radial = radial.astype(real_dtype, copy=False)
+    polar = polar.astype(real_dtype, copy=False)
+    azimuthal = azimuthal.astype(real_dtype, copy=False)
+    if radial.ndim != 2 or radial.shape != (values.shape[-2], 3):
+        raise ValueError("theta and phi must identify one pair per direction")
+    return np.stack(
+        (
+            np.sum(values * radial, axis=-1),
+            np.sum(values * polar, axis=-1),
+            np.sum(values * azimuthal, axis=-1),
+        ),
+        axis=-1,
+    )

--- a/gprMax/ntff/surfaces.py
+++ b/gprMax/ntff/surfaces.py
@@ -1,0 +1,349 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+
+"""Yee-aligned closed surfaces for the KSIR NTFF formulation."""
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, Sequence, Tuple
+
+import numpy as np
+import numpy.typing as npt
+
+
+COMPONENTS = ("Ex", "Ey", "Ez", "Hx", "Hy", "Hz")
+"""Field components supported by the Cartesian KSIR formulation."""
+
+COMPONENT_OFFSETS = {
+    "Ex": (0.5, 0.0, 0.0),
+    "Ey": (0.0, 0.5, 0.0),
+    "Ez": (0.0, 0.0, 0.5),
+    "Hx": (0.0, 0.5, 0.5),
+    "Hy": (0.5, 0.0, 0.5),
+    "Hz": (0.5, 0.5, 0.0),
+}
+"""Yee sample offsets in units of the grid spacing."""
+
+FACES = ("x0", "xmax", "y0", "ymax", "z0", "zmax")
+_FACE_SPECS = {
+    "x0": (0, -1),
+    "xmax": (0, 1),
+    "y0": (1, -1),
+    "ymax": (1, 1),
+    "z0": (2, -1),
+    "zmax": (2, 1),
+}
+
+
+def _readonly(array: npt.NDArray) -> npt.NDArray:
+    """Mark geometry arrays read-only before exposing them to callers."""
+
+    array.setflags(write=False)
+    return array
+
+
+@dataclass(frozen=True)
+class KSIRSurfaceFace:
+    """One non-overlapping midpoint-patch face of a component surface."""
+
+    component: str
+    face_id: str
+    normal_axis: int
+    normal_sign: int
+    normal: npt.NDArray[np.floating]
+    inside_indices: npt.NDArray[np.int32]
+    outside_indices: npt.NDArray[np.int32]
+    inside_flat_indices: npt.NDArray[np.int64]
+    outside_flat_indices: npt.NDArray[np.int64]
+    patch_positions: npt.NDArray[np.floating]
+    area_weights: npt.NDArray[np.floating]
+    normal_spacing: float
+    field_shape: Tuple[int, int, int]
+
+    @property
+    def npatches(self) -> int:
+        return self.patch_positions.shape[0]
+
+    def sample(self, field: npt.ArrayLike) -> Tuple[npt.NDArray, npt.NDArray]:
+        """Gather the inside and outside samples from a gprMax field array."""
+
+        values = np.asarray(field)
+        if values.shape != self.field_shape:
+            raise ValueError(
+                f"field shape {values.shape} does not match surface field shape {self.field_shape}"
+            )
+        inside = values[tuple(self.inside_indices.T)]
+        outside = values[tuple(self.outside_indices.T)]
+        return inside, outside
+
+    def collocate(
+        self, inside: npt.ArrayLike, outside: npt.ArrayLike
+    ) -> Tuple[npt.NDArray, npt.NDArray]:
+        """Collocate same-component samples and calculate the outward derivative.
+
+        The sample arrays may have any leading dimensions, but their final
+        dimension must enumerate this face's patches.
+        """
+
+        inside_values = np.asarray(inside)
+        outside_values = np.asarray(outside)
+        if inside_values.shape != outside_values.shape:
+            raise ValueError("inside and outside samples must have the same shape")
+        if inside_values.ndim == 0 or inside_values.shape[-1] != self.npatches:
+            raise ValueError("the final sample dimension must match the number of face patches")
+        surface_value = 0.5 * (outside_values + inside_values)
+        normal_derivative = (outside_values - inside_values) / self.normal_spacing
+        return surface_value, normal_derivative
+
+
+@dataclass(frozen=True)
+class KSIRComponentSurface:
+    """Closed cuboid used to transform one Cartesian field component."""
+
+    component: str
+    lower: Tuple[int, int, int]
+    upper: Tuple[int, int, int]
+    grid_spacing: Tuple[float, float, float]
+    field_shape: Tuple[int, int, int]
+    physical_lower: npt.NDArray[np.floating]
+    physical_upper: npt.NDArray[np.floating]
+    faces: Tuple[KSIRSurfaceFace, ...]
+
+    @property
+    def centre(self) -> npt.NDArray[np.floating]:
+        return 0.5 * (self.physical_lower + self.physical_upper)
+
+    @property
+    def npatches(self) -> int:
+        return sum(face.npatches for face in self.faces)
+
+    @property
+    def patch_positions(self) -> npt.NDArray[np.floating]:
+        return np.concatenate([face.patch_positions for face in self.faces], axis=0)
+
+    @property
+    def normals(self) -> npt.NDArray[np.floating]:
+        return np.concatenate(
+            [np.broadcast_to(face.normal, (face.npatches, 3)) for face in self.faces], axis=0
+        )
+
+    @property
+    def area_weights(self) -> npt.NDArray[np.floating]:
+        return np.concatenate([face.area_weights for face in self.faces], axis=0)
+
+    def face(self, face_id: str) -> KSIRSurfaceFace:
+        """Return a face by its stable gprMax boundary identifier."""
+
+        try:
+            return next(face for face in self.faces if face.face_id == face_id)
+        except StopIteration as exc:
+            raise KeyError(face_id) from exc
+
+
+def _triplet(name: str, values: Sequence, dtype) -> npt.NDArray:
+    try:
+        array = np.asarray(values, dtype=dtype)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must contain exactly three numeric values") from exc
+    if array.shape != (3,):
+        raise ValueError(f"{name} must contain exactly three values")
+    return array
+
+
+def _index_triplet(name: str, values: Sequence) -> npt.NDArray[np.int64]:
+    numeric = _triplet(name, values, np.dtype(float))
+    if not np.all(np.isfinite(numeric)) or np.any(numeric != np.floor(numeric)):
+        raise ValueError(f"{name} must contain exactly three integer values")
+    return numeric.astype(np.int64)
+
+
+def _component_index_range(lower: int, upper: int, offset: float) -> npt.NDArray[np.int32]:
+    stop = upper if offset == 0.5 else upper + 1
+    return np.arange(lower, stop, dtype=np.int32)
+
+
+def _build_face(
+    component: str,
+    face_id: str,
+    lower: npt.NDArray[np.int64],
+    upper: npt.NDArray[np.int64],
+    spacing: npt.NDArray[np.floating],
+    field_shape: Tuple[int, int, int],
+) -> KSIRSurfaceFace:
+    real_dtype = spacing.dtype
+    offsets = np.asarray(COMPONENT_OFFSETS[component], dtype=real_dtype)
+    normal_axis, normal_sign = _FACE_SPECS[face_id]
+    tangential_axes = tuple(axis for axis in range(3) if axis != normal_axis)
+    tangential_ranges = [
+        _component_index_range(lower[axis], upper[axis], offsets[axis])
+        for axis in tangential_axes
+    ]
+    tangential_mesh = np.meshgrid(*tangential_ranges, indexing="ij")
+    npatches = tangential_mesh[0].size
+
+    inside_indices = np.empty((npatches, 3), dtype=np.int32)
+    for axis, mesh in zip(tangential_axes, tangential_mesh):
+        inside_indices[:, axis] = mesh.ravel()
+
+    if normal_sign < 0:
+        inside_normal_index = lower[normal_axis]
+    elif offsets[normal_axis] == 0.5:
+        inside_normal_index = upper[normal_axis] - 1
+    else:
+        inside_normal_index = upper[normal_axis]
+    inside_indices[:, normal_axis] = inside_normal_index
+
+    outside_indices = inside_indices.copy()
+    outside_indices[:, normal_axis] += normal_sign
+
+    shape_array = np.asarray(field_shape, dtype=np.int64)
+    if np.any(inside_indices < 0) or np.any(inside_indices >= shape_array):
+        raise ValueError(f"{component} {face_id} inside samples lie outside field_shape")
+    if np.any(outside_indices < 0) or np.any(outside_indices >= shape_array):
+        raise ValueError(f"{component} {face_id} outside samples lie outside field_shape")
+
+    patch_positions = (inside_indices.astype(real_dtype) + offsets) * spacing
+    outside_positions = (outside_indices.astype(real_dtype) + offsets) * spacing
+    patch_positions[:, normal_axis] = 0.5 * (
+        patch_positions[:, normal_axis] + outside_positions[:, normal_axis]
+    )
+
+    normal = np.zeros(3, dtype=real_dtype)
+    normal[normal_axis] = normal_sign
+    patch_area = spacing[tangential_axes[0]] * spacing[tangential_axes[1]]
+    area_weights = np.full(npatches, patch_area, dtype=real_dtype)
+
+    inside_flat = np.ravel_multi_index(inside_indices.T, field_shape).astype(np.int64)
+    outside_flat = np.ravel_multi_index(outside_indices.T, field_shape).astype(np.int64)
+
+    return KSIRSurfaceFace(
+        component=component,
+        face_id=face_id,
+        normal_axis=normal_axis,
+        normal_sign=normal_sign,
+        normal=_readonly(normal),
+        inside_indices=_readonly(inside_indices),
+        outside_indices=_readonly(outside_indices),
+        inside_flat_indices=_readonly(inside_flat),
+        outside_flat_indices=_readonly(outside_flat),
+        patch_positions=_readonly(patch_positions),
+        area_weights=_readonly(area_weights),
+        normal_spacing=float(spacing[normal_axis]),
+        field_shape=field_shape,
+    )
+
+
+def build_component_surface(
+    component: str,
+    lower: Sequence[int],
+    upper: Sequence[int],
+    grid_spacing: Sequence[float],
+    field_shape: Sequence[int],
+    *,
+    excluded_faces: Sequence[str] = (),
+    real_dtype=None,
+) -> KSIRComponentSurface:
+    """Build a KSIR surface for one Yee field component.
+
+    ``lower`` and ``upper`` identify a common logical cuboid in grid-line
+    indices. The component's Yee offsets expand axes whose component samples
+    lie on grid lines by half a cell on each side. Consequently all six
+    component surfaces have the same centre while every face remains exactly
+    halfway between two samples of that same component.
+
+    Faces may be excluded only as part of an explicit closure policy. This
+    low-level builder does not decide whether the resulting surface is exact.
+    """
+
+    if component not in COMPONENT_OFFSETS:
+        raise ValueError(f"unknown field component {component!r}; expected one of {COMPONENTS}")
+    excluded = tuple(excluded_faces)
+    unknown_faces = set(excluded) - set(FACES)
+    if unknown_faces:
+        raise ValueError(f"unknown excluded faces: {sorted(unknown_faces)}")
+    if len(set(excluded)) != len(excluded):
+        raise ValueError("excluded_faces must not contain duplicates")
+    if len(excluded) == len(FACES):
+        raise ValueError("at least one surface face must remain active")
+
+    lower_array = _index_triplet("lower", lower)
+    upper_array = _index_triplet("upper", upper)
+    if real_dtype is None:
+        candidate = np.asarray(grid_spacing).dtype
+        real_dtype = candidate if candidate.kind == "f" else np.dtype(float)
+    real_dtype = np.dtype(real_dtype)
+    if real_dtype.kind != "f":
+        raise ValueError("real_dtype must be a floating-point dtype")
+    spacing = _triplet("grid_spacing", grid_spacing, real_dtype)
+    shape_array = _index_triplet("field_shape", field_shape)
+    if np.any(upper_array <= lower_array):
+        raise ValueError("upper bounds must be greater than lower bounds on every axis")
+    if np.any(lower_array < 0):
+        raise ValueError("lower bounds must be non-negative")
+    if not np.all(np.isfinite(spacing)) or np.any(spacing <= 0):
+        raise ValueError("grid_spacing must contain finite values greater than zero")
+    if np.any(shape_array <= 0):
+        raise ValueError("field_shape values must be greater than zero")
+
+    shape_tuple = tuple(int(value) for value in shape_array)
+    faces = tuple(
+        _build_face(component, face_id, lower_array, upper_array, spacing, shape_tuple)
+        for face_id in FACES
+        if face_id not in excluded
+    )
+
+    offsets = np.asarray(COMPONENT_OFFSETS[component], dtype=real_dtype)
+    half_extension = np.where(offsets == 0.0, 0.5, 0.0).astype(real_dtype)
+    physical_lower = (lower_array.astype(real_dtype) - half_extension) * spacing
+    physical_upper = (upper_array.astype(real_dtype) + half_extension) * spacing
+
+    return KSIRComponentSurface(
+        component=component,
+        lower=tuple(int(value) for value in lower_array),
+        upper=tuple(int(value) for value in upper_array),
+        grid_spacing=tuple(float(value) for value in spacing),
+        field_shape=shape_tuple,
+        physical_lower=_readonly(physical_lower),
+        physical_upper=_readonly(physical_upper),
+        faces=faces,
+    )
+
+
+def build_all_component_surfaces(
+    lower: Sequence[int],
+    upper: Sequence[int],
+    grid_spacing: Sequence[float],
+    field_shape: Sequence[int],
+    *,
+    excluded_faces: Sequence[str] = (),
+    real_dtype=None,
+) -> Mapping[str, KSIRComponentSurface]:
+    """Build surfaces for all six Cartesian field components."""
+
+    surfaces: Dict[str, KSIRComponentSurface] = {}
+    for component in COMPONENTS:
+        surfaces[component] = build_component_surface(
+            component,
+            lower,
+            upper,
+            grid_spacing,
+            field_shape,
+            excluded_faces=excluded_faces,
+            real_dtype=real_dtype,
+        )
+    return surfaces

--- a/tests/ntff/test_conventions.py
+++ b/tests/ntff/test_conventions.py
@@ -1,0 +1,90 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from gprMax.ntff.conventions import (
+    FORWARD_TRANSFORM_KERNEL,
+    OUTGOING_GREEN_RADIAL_FACTOR,
+    PHASOR_TIME_DEPENDENCE,
+    engineering_dft,
+)
+
+
+def test_engineering_convention_signs_are_explicit_and_fixed():
+    assert PHASOR_TIME_DEPENDENCE == "exp(+j*omega*t)"
+    assert FORWARD_TRANSFORM_KERNEL == "exp(-j*omega*t)"
+    assert OUTGOING_GREEN_RADIAL_FACTOR == "exp(-j*k*R)"
+
+
+def test_engineering_dft_matches_numpy_fft_positive_frequency_bin():
+    nsamples = 128
+    dt = 2.5e-12
+    bin_index = 9
+    frequency = bin_index / (nsamples * dt)
+    amplitude = 2.4
+    phase = 0.37
+    times = dt * np.arange(nsamples)
+    samples = amplitude * np.cos(2 * np.pi * frequency * times + phase)
+
+    actual = engineering_dft(samples, [frequency], dt)[0]
+    expected = dt * np.fft.fft(samples)[bin_index]
+
+    assert_allclose(actual, expected, rtol=2e-14, atol=2e-24)
+    assert_allclose(actual, 0.5 * nsamples * dt * amplitude * np.exp(1j * phase))
+
+
+def test_engineering_dft_uses_physical_time_offset_and_arbitrary_axis():
+    nsamples = 96
+    dt = 1e-11
+    frequency = 7 / (nsamples * dt)
+    time_offset = 0.35 * dt
+    phase = -0.61
+    times = time_offset + dt * np.arange(nsamples)
+    signal = np.cos(2 * np.pi * frequency * times + phase)
+    samples = np.stack((signal, 3 * signal), axis=0)
+
+    actual = engineering_dft(
+        samples, [frequency], dt, time_offset=time_offset, axis=1
+    )
+    expected = 0.5 * nsamples * dt * np.exp(1j * phase) * np.array([1, 3])
+
+    assert actual.shape == (1, 2)
+    assert_allclose(actual[0], expected, rtol=2e-14, atol=2e-24)
+
+
+def test_engineering_dft_time_derivative_has_positive_jomega_factor():
+    nsamples = 64
+    dt = 1e-10
+    frequency = 5 / (nsamples * dt)
+    omega = 2 * np.pi * frequency
+    times = dt * np.arange(nsamples)
+    samples = np.exp(1j * omega * times)
+    time_derivative = 1j * omega * samples
+
+    field_dft = engineering_dft(samples, [frequency], dt)[0]
+    derivative_dft = engineering_dft(time_derivative, [frequency], dt)[0]
+
+    assert_allclose(derivative_dft, 1j * omega * field_dft, rtol=2e-14)
+
+
+def test_engineering_dft_preserves_configured_single_precision():
+    samples = np.linspace(-1, 1, 32, dtype=np.float32)
+
+    result = engineering_dft(samples, np.asarray([2e8], dtype=np.float32), 1e-10)
+
+    assert result.dtype == np.complex64
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"frequencies": [], "dt": 1.0}, "frequencies"),
+        ({"frequencies": [-1.0], "dt": 1.0}, "non-negative"),
+        ({"frequencies": [1.0], "dt": 0.0}, "dt"),
+        ({"frequencies": [1.0], "dt": 1.0, "window": [1.0]}, "window"),
+        ({"frequencies": [1.0], "dt": 1.0, "axis": 2}, "axis"),
+    ],
+)
+def test_engineering_dft_rejects_invalid_inputs(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        engineering_dft(np.ones(4), **kwargs)

--- a/tests/ntff/test_evaluator.py
+++ b/tests/ntff/test_evaluator.py
@@ -1,0 +1,273 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+from scipy.constants import c
+
+from gprMax.ntff.evaluator import (
+    evaluate_exact_points_patches,
+    evaluate_far_zone,
+    evaluate_far_zone_patches,
+    project_cartesian_to_spherical,
+    spherical_directions,
+    spherical_observation_points,
+)
+from gprMax.ntff.surfaces import build_component_surface
+
+
+def _outgoing_point_source_phasors(surface, frequency, source_position):
+    positions = surface.patch_positions
+    normals = surface.normals
+    displacement = positions - source_position
+    radius = np.linalg.norm(displacement, axis=1)
+    radial_direction = displacement / radius[:, np.newaxis]
+    wavenumber = 2 * np.pi * frequency / c
+    field = np.exp(-1j * wavenumber * radius) / (4 * np.pi * radius)
+    radial_derivative = (-1j * wavenumber - 1 / radius) * field
+    normal_derivative = radial_derivative * np.sum(normals * radial_direction, axis=1)
+    return field[np.newaxis, :], normal_derivative[np.newaxis, :]
+
+
+def _point_source_error(spacing, lower, upper, directions, frequency):
+    shape = tuple(value + 6 for value in upper)
+    surface = build_component_surface("Ex", lower, upper, (spacing,) * 3, shape)
+    source_position = 0.5 * (np.asarray(lower) + np.asarray(upper)) * spacing
+    field, derivative = _outgoing_point_source_phasors(
+        surface, frequency, source_position
+    )
+    actual = evaluate_far_zone(surface, [frequency], directions, field, derivative)[0]
+    wavenumber = 2 * np.pi * frequency / c
+    expected = np.exp(1j * wavenumber * (directions @ source_position)) / (4 * np.pi)
+    return np.max(np.abs(actual - expected)), actual, expected
+
+
+def test_spherical_directions_uses_theta_from_z_and_phi_from_x():
+    directions = spherical_directions(
+        [0, 90, 90, 90, 180], [0, 0, 90, 180, 0], degrees=True
+    )
+
+    assert_allclose(
+        directions,
+        np.array(
+            [
+                [0, 0, 1],
+                [1, 0, 0],
+                [0, 1, 0],
+                [-1, 0, 0],
+                [0, 0, -1],
+            ]
+        ),
+        atol=1e-15,
+    )
+
+
+def test_spherical_observation_points_broadcasts_to_cartesian_point_array():
+    points = spherical_observation_points(
+        (1.0, 2.0, 3.0),
+        2.0,
+        np.asarray([0.0, 90.0])[:, np.newaxis],
+        np.asarray([0.0, 90.0])[np.newaxis, :],
+        degrees=True,
+    )
+
+    assert points.shape == (4, 3)
+    assert_allclose(
+        points,
+        [
+            [1.0, 2.0, 5.0],
+            [1.0, 2.0, 5.0],
+            [3.0, 2.0, 3.0],
+            [1.0, 4.0, 3.0],
+        ],
+        atol=1e-15,
+    )
+
+
+@pytest.mark.parametrize(
+    "origin,radius",
+    [((0, 0), 1), ((0, 0, 0), 0), ((0, 0, 0), np.inf)],
+)
+def test_spherical_observation_points_rejects_invalid_geometry(origin, radius):
+    with pytest.raises(ValueError):
+        spherical_observation_points(origin, radius, 0, 0)
+
+
+def test_outgoing_point_source_far_zone_converges_under_surface_refinement():
+    directions = spherical_directions(
+        [0, 30, 60, 90, 120, 150, 180],
+        [0, 17, 83, 141, 211, 289, 0],
+        degrees=True,
+    )
+    frequency = 300e6
+
+    coarse_error, _, _ = _point_source_error(
+        0.05, (4, 4, 4), (16, 16, 16), directions, frequency
+    )
+    fine_error, actual, expected = _point_source_error(
+        0.025, (8, 8, 8), (32, 32, 32), directions, frequency
+    )
+
+    assert fine_error < 0.35 * coarse_error
+    assert_allclose(actual, expected, rtol=3e-3, atol=3e-4)
+
+
+def test_exact_point_evaluator_reproduces_outgoing_green_function():
+    spacing = 0.025
+    lower = (8, 8, 8)
+    upper = (32, 32, 32)
+    surface = build_component_surface(
+        "Ex", lower, upper, (spacing,) * 3, (38, 38, 38)
+    )
+    source_position = 0.5 * (np.asarray(lower) + np.asarray(upper)) * spacing
+    frequency = 300e6
+    field, derivative = _outgoing_point_source_phasors(
+        surface, frequency, source_position
+    )
+    points = np.asarray(((1.1, 0.5, 0.5), (0.5, 1.2, 0.65)))
+
+    actual = evaluate_exact_points_patches(
+        surface.patch_positions,
+        surface.normals,
+        surface.area_weights,
+        [frequency],
+        points,
+        field,
+        derivative,
+        point_block_size=1,
+        patch_block_size=79,
+    )[0]
+    radius = np.linalg.norm(points - source_position, axis=1)
+    wavenumber = 2 * np.pi * frequency / c
+    expected = np.exp(-1j * wavenumber * radius) / (4 * np.pi * radius)
+
+    assert_allclose(actual, expected, rtol=5e-3, atol=5e-4)
+
+
+def test_evaluator_supports_multiple_frequencies_and_directions():
+    surface = build_component_surface(
+        "Ez", (2, 2, 2), (5, 5, 5), (0.1, 0.1, 0.1), (9, 9, 9)
+    )
+    frequencies = np.array((0.0, 1e8))
+    directions = spherical_directions([0, 90], [0, 0], degrees=True)
+    field = np.zeros((2, surface.npatches), dtype=np.complex128)
+    derivative = np.zeros_like(field)
+
+    result = evaluate_far_zone(surface, frequencies, directions, field, derivative)
+
+    assert result.shape == (2, 2)
+    assert_allclose(result, 0.0)
+
+
+def test_explicit_patch_evaluator_matches_surface_wrapper_and_precision():
+    surface = build_component_surface(
+        "Ey",
+        (2, 2, 2),
+        (5, 5, 5),
+        (0.1, 0.1, 0.1),
+        (9, 9, 9),
+        real_dtype=np.float32,
+    )
+    frequencies = np.asarray([1e8, 2e8], dtype=np.float32)
+    directions = spherical_directions(
+        np.asarray([25, 90], dtype=np.float32),
+        np.asarray([15, 120], dtype=np.float32),
+        degrees=True,
+    )
+    patch_index = np.arange(surface.npatches, dtype=np.float32)
+    field = np.asarray(
+        (1 + 0.01 * patch_index)[np.newaxis, :] * np.asarray([[1], [2j]]),
+        dtype=np.complex64,
+    )
+    derivative = np.asarray((0.2 - 0.3j) * field, dtype=np.complex64)
+
+    wrapped = evaluate_far_zone(
+        surface, frequencies, directions, field, derivative, patch_block_size=17
+    )
+    explicit = evaluate_far_zone_patches(
+        surface.patch_positions,
+        surface.normals,
+        surface.area_weights,
+        frequencies,
+        directions,
+        field,
+        derivative,
+        patch_block_size=17,
+    )
+
+    assert wrapped.dtype == np.complex64
+    assert explicit.dtype == np.complex64
+    assert_allclose(explicit, wrapped, rtol=2e-6, atol=2e-6)
+
+
+def test_blocked_evaluator_and_reference_origin_preserve_expected_phase():
+    spacing = 0.025
+    lower = (8, 8, 8)
+    upper = (32, 32, 32)
+    frequency = 300e6
+    directions = spherical_directions(
+        [25, 70, 115, 160], [10, 95, 205, 315], degrees=True
+    )
+    surface = build_component_surface(
+        "Ex", lower, upper, (spacing,) * 3, (38, 38, 38)
+    )
+    source_position = 0.5 * (np.asarray(lower) + np.asarray(upper)) * spacing
+    field, derivative = _outgoing_point_source_phasors(
+        surface, frequency, source_position
+    )
+
+    actual = evaluate_far_zone(
+        surface,
+        [frequency],
+        directions,
+        field,
+        derivative,
+        origin=source_position,
+        direction_block_size=2,
+        patch_block_size=37,
+    )[0]
+
+    assert_allclose(actual, 1 / (4 * np.pi), rtol=4e-3, atol=4e-4)
+
+
+def test_cartesian_projection_uses_radial_polar_azimuthal_order():
+    theta = np.array([0.0, 90.0, 90.0])
+    phi = np.array([0.0, 0.0, 90.0])
+    cartesian = np.array(
+        [[[0, 0, 2], [0, 0, -3], [-4, 0, 0]]], dtype=np.complex128
+    )
+
+    spherical = project_cartesian_to_spherical(
+        cartesian, theta, phi, degrees=True
+    )
+
+    assert_allclose(spherical[0, 0], [2, 0, 0], atol=1e-15)
+    assert_allclose(spherical[0, 1], [0, 3, 0], atol=1e-15)
+    assert_allclose(spherical[0, 2], [0, 0, 4], atol=1e-15)
+
+
+@pytest.mark.parametrize(
+    "frequencies,directions,field_shape,derivative_shape,match",
+    [
+        ([-1.0], [[1, 0, 0]], (1, None), (1, None), "non-negative"),
+        ([1.0], [[2, 0, 0]], (1, None), (1, None), "unit vectors"),
+        ([1.0], [[1, 0]], (1, None), (1, None), "shape"),
+        ([1.0], [[1, 0, 0]], (2, None), (1, None), "surface_field"),
+        ([1.0], [[1, 0, 0]], (1, None), (2, None), "normal_derivative"),
+    ],
+)
+def test_evaluator_rejects_invalid_inputs(
+    frequencies, directions, field_shape, derivative_shape, match
+):
+    surface = build_component_surface(
+        "Ex", (2, 2, 2), (4, 4, 4), (0.1, 0.1, 0.1), (8, 8, 8)
+    )
+    field = np.zeros(
+        tuple(surface.npatches if value is None else value for value in field_shape),
+        dtype=np.complex128,
+    )
+    derivative = np.zeros(
+        tuple(surface.npatches if value is None else value for value in derivative_shape),
+        dtype=np.complex128,
+    )
+
+    with pytest.raises(ValueError, match=match):
+        evaluate_far_zone(surface, frequencies, directions, field, derivative)

--- a/tests/ntff/test_surfaces.py
+++ b/tests/ntff/test_surfaces.py
@@ -1,0 +1,149 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+
+from gprMax.ntff.surfaces import (
+    COMPONENTS,
+    COMPONENT_OFFSETS,
+    FACES,
+    build_all_component_surfaces,
+    build_component_surface,
+)
+
+
+LOWER = np.array((2, 3, 4))
+UPPER = np.array((6, 8, 10))
+SPACING = np.array((0.1, 0.2, 0.3))
+FIELD_SHAPE = (12, 13, 14)
+FACE_SPECS = {
+    "x0": (0, -1),
+    "xmax": (0, 1),
+    "y0": (1, -1),
+    "ymax": (1, 1),
+    "z0": (2, -1),
+    "zmax": (2, 1),
+}
+
+
+@pytest.mark.parametrize("component", COMPONENTS)
+@pytest.mark.parametrize("face_id", FACES)
+def test_all_36_component_faces_have_correct_geometry_and_outward_derivative(
+    component, face_id
+):
+    surface = build_component_surface(component, LOWER, UPPER, SPACING, FIELD_SHAPE)
+    face = surface.face(face_id)
+    offsets = np.asarray(COMPONENT_OFFSETS[component])
+    normal_axis, normal_sign = FACE_SPECS[face_id]
+    tangential_axes = [axis for axis in range(3) if axis != normal_axis]
+
+    assert face.component == component
+    assert face.normal_axis == normal_axis
+    assert face.normal_sign == normal_sign
+    expected_normal = np.zeros(3)
+    expected_normal[normal_axis] = normal_sign
+    assert_array_equal(face.normal, expected_normal)
+
+    index_step = face.outside_indices - face.inside_indices
+    assert_array_equal(index_step, np.broadcast_to(expected_normal, index_step.shape))
+    assert np.all(face.inside_indices >= 0)
+    assert np.all(face.outside_indices >= 0)
+    assert np.all(face.inside_indices < np.asarray(FIELD_SHAPE))
+    assert np.all(face.outside_indices < np.asarray(FIELD_SHAPE))
+
+    expected_normal_position = (
+        surface.physical_lower[normal_axis]
+        if normal_sign < 0
+        else surface.physical_upper[normal_axis]
+    )
+    assert_allclose(face.patch_positions[:, normal_axis], expected_normal_position)
+    for axis in tangential_axes:
+        expected_positions = (face.inside_indices[:, axis] + offsets[axis]) * SPACING[axis]
+        assert_allclose(face.patch_positions[:, axis], expected_positions)
+
+    tangential_counts = [
+        UPPER[axis] - LOWER[axis] + (1 if offsets[axis] == 0.0 else 0)
+        for axis in tangential_axes
+    ]
+    assert face.npatches == np.prod(tangential_counts)
+    expected_face_area = np.prod(
+        surface.physical_upper[tangential_axes]
+        - surface.physical_lower[tangential_axes]
+    )
+    assert_allclose(np.sum(face.area_weights), expected_face_area)
+
+    indices = np.indices(FIELD_SHAPE).reshape(3, -1).T
+    positions = (indices + offsets) * SPACING
+    gradient = np.array((1.7, -0.8, 0.45))
+    intercept = -0.23
+    linear_field = (positions @ gradient + intercept).reshape(FIELD_SHAPE)
+    inside, outside = face.sample(linear_field)
+    collocated, normal_derivative = face.collocate(inside, outside)
+
+    assert_allclose(collocated, face.patch_positions @ gradient + intercept)
+    assert_allclose(normal_derivative, expected_normal @ gradient)
+    assert_array_equal(inside, linear_field.ravel()[face.inside_flat_indices])
+    assert_array_equal(outside, linear_field.ravel()[face.outside_flat_indices])
+
+
+def test_all_component_surfaces_share_centre_and_stable_face_order():
+    surfaces = build_all_component_surfaces(LOWER, UPPER, SPACING, FIELD_SHAPE)
+    expected_centre = 0.5 * (LOWER + UPPER) * SPACING
+
+    assert tuple(surfaces) == COMPONENTS
+    for surface in surfaces.values():
+        assert_allclose(surface.centre, expected_centre)
+        assert tuple(face.face_id for face in surface.faces) == FACES
+        assert surface.patch_positions.shape == (surface.npatches, 3)
+        assert surface.normals.shape == (surface.npatches, 3)
+        assert surface.area_weights.shape == (surface.npatches,)
+
+
+def test_face_collocation_accepts_frequency_by_patch_arrays():
+    face = build_component_surface("Hz", LOWER, UPPER, SPACING, FIELD_SHAPE).face("zmax")
+    inside = np.arange(2 * face.npatches).reshape(2, face.npatches)
+    outside = inside + 3.0
+
+    field, derivative = face.collocate(inside, outside)
+
+    assert field.shape == (2, face.npatches)
+    assert_allclose(field, inside + 1.5)
+    assert_allclose(derivative, 3.0 / SPACING[2])
+
+
+@pytest.mark.parametrize(
+    "component,lower,upper,spacing,shape,match",
+    [
+        ("Qx", LOWER, UPPER, SPACING, FIELD_SHAPE, "unknown field component"),
+        ("Ex", (0, 3, 4), UPPER, SPACING, FIELD_SHAPE, "outside samples"),
+        ("Ex", LOWER, (12, 8, 10), SPACING, FIELD_SHAPE, "outside samples"),
+        ("Ex", LOWER, LOWER, SPACING, FIELD_SHAPE, "greater than"),
+        ("Ex", (2.5, 3, 4), UPPER, SPACING, FIELD_SHAPE, "integer values"),
+        ("Ex", LOWER, UPPER, (0.1, 0.0, 0.3), FIELD_SHAPE, "grid_spacing"),
+        ("Ex", LOWER[:2], UPPER, SPACING, FIELD_SHAPE, "exactly three"),
+    ],
+)
+def test_surface_builder_rejects_invalid_geometry(
+    component, lower, upper, spacing, shape, match
+):
+    with pytest.raises(ValueError, match=match):
+        build_component_surface(component, lower, upper, spacing, shape)
+
+
+def test_surface_geometry_arrays_are_read_only():
+    face = build_component_surface("Ey", LOWER, UPPER, SPACING, FIELD_SHAPE).face("x0")
+
+    with pytest.raises(ValueError, match="read-only"):
+        face.patch_positions[0, 0] = 1.0
+
+
+def test_surface_geometry_uses_requested_real_precision():
+    surface = build_component_surface(
+        "Hy", LOWER, UPPER, SPACING, FIELD_SHAPE, real_dtype=np.float32
+    )
+
+    assert surface.physical_lower.dtype == np.float32
+    assert surface.physical_upper.dtype == np.float32
+    for face in surface.faces:
+        assert face.normal.dtype == np.float32
+        assert face.patch_positions.dtype == np.float32
+        assert face.area_weights.dtype == np.float32


### PR DESCRIPTION
## PR Description

This PR introduces the solver-independent mathematical foundation for the staged gprMax Kirchhoff surface-integral representation (KSIR) near-to-far-field implementation. It intentionally adds no user commands or solver hooks yet.

### Transform conventions

- Fixes the standard electrical-engineering phasor convention: physical fields use `Re{X exp(+j omega t)}`.
- Defines the forward transform as `exp(-j omega t)` and the outgoing Green function as `exp(-j k R)/(4 pi R)`.
- Adds a small reference DFT supporting arbitrary frequencies, sample-time offsets, windows, time axes, and single/double precision.

### Yee-aligned integration surfaces

- Defines the exact electric and magnetic Yee offsets for all six Cartesian field components.
- Builds all 36 component/face combinations with paired inside/outside samples, outward normals, midpoint collocation positions, quadrature weights, and flattened indices.
- Validates geometry, field bounds, spacing, excluded faces, and immutable exported geometry.

### Reference KSIR evaluators

- Adds blocked NumPy evaluators for the range-normalised far zone and exact finite-distance fields.
- Supports explicit patch data or a component-surface wrapper.
- Adds spherical direction/point generation and Cartesian-to-spherical field projection.
- Preserves float32/complex64 or float64/complex128 according to the supplied data.

### Tests

- Verifies the convention against NumPy FFT bins and the `+j omega` derivative rule.
- Verifies geometry and outward derivatives for every component on every face.
- Demonstrates convergence to the outgoing point-source Green function in the far zone and at finite distance.
- Tests blocked evaluation, phase-reference origins, spherical projections, validation errors, explicit-patch parity, and configured precision.

## Deliberate scope

This foundation PR does not include closure policies, FDTD collection, hash/Python commands, Cython or accelerator kernels, HDF5 output, documentation, or validation datasets. Those remain separate staged PRs. 
## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update.

## Validation

- [x] Focused KSIR core tests: 73 passed.
- [x] Full test suite: 761 passed, 6 skipped.
- [x] Standard gprMax Cython extensions build successfully; this PR changes no Cython source.
- [x] Diff and scope checks pass.
- [x] Self-review completed.
- [ ] Pre-commit was not available locally; GitHub checks should run it.
