### PR TITLE
Add KSIR surface closure policies

### DIFF
--- a/gprMax/ntff/__init__.py
+++ b/gprMax/ntff/__init__.py
@@ -19,6 +19,16 @@
 
 """Solver-independent near-to-far-field transformation utilities."""
 
+from .closures import (
+    ExperimentalMask,
+    ResolvedKSIRClosure,
+    SymmetryCompletion,
+    SymmetryImage,
+    SymmetryPlane,
+    closure_from_metadata,
+    component_parity,
+    resolve_closure,
+)
 from .conventions import (
     FORWARD_TRANSFORM_KERNEL,
     OUTGOING_GREEN_RADIAL_FACTOR,
@@ -49,17 +59,25 @@ __all__ = [
     "COMPONENT_OFFSETS",
     "FACES",
     "FORWARD_TRANSFORM_KERNEL",
+    "ExperimentalMask",
     "KSIRComponentSurface",
     "KSIRSurfaceFace",
     "OUTGOING_GREEN_RADIAL_FACTOR",
     "PHASOR_TIME_DEPENDENCE",
+    "ResolvedKSIRClosure",
+    "SymmetryCompletion",
+    "SymmetryImage",
+    "SymmetryPlane",
     "build_all_component_surfaces",
     "build_component_surface",
     "engineering_dft",
+    "closure_from_metadata",
+    "component_parity",
     "evaluate_exact_points_patches",
     "evaluate_far_zone",
     "evaluate_far_zone_patches",
     "project_cartesian_to_spherical",
+    "resolve_closure",
     "spherical_basis",
     "spherical_directions",
     "spherical_observation_points",

--- a/gprMax/ntff/closures.py
+++ b/gprMax/ntff/closures.py
@@ -1,0 +1,407 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+
+"""Closed, symmetry-completed, and experimental KSIR surface policies."""
+
+from dataclasses import dataclass, replace
+from itertools import combinations
+from typing import Iterator, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+import numpy.typing as npt
+
+from .surfaces import COMPONENT_OFFSETS, FACES, KSIRComponentSurface
+
+
+_FACE_AXIS_SIGN = {
+    "x0": (0, -1),
+    "xmax": (0, 1),
+    "y0": (1, -1),
+    "ymax": (1, 1),
+    "z0": (2, -1),
+    "zmax": (2, 1),
+}
+_COMPONENT_AXIS = {"x": 0, "y": 1, "z": 2}
+
+
+def _face_tuple(name: str, faces: Sequence[str]) -> Tuple[str, ...]:
+    values = tuple(faces)
+    unknown = set(values) - set(FACES)
+    if unknown:
+        raise ValueError(f"{name} contains unknown faces: {sorted(unknown)}")
+    if len(set(values)) != len(values):
+        raise ValueError(f"{name} must not contain duplicates")
+    return tuple(face for face in FACES if face in values)
+
+
+@dataclass(frozen=True)
+class SymmetryCompletion:
+    """Request exact completion from resolved gprMax PEC/PMC boundaries.
+
+    If faces is omitted, every declared symmetry boundary touched by the
+    logical KSIR box is used.
+    """
+
+    faces: Optional[Tuple[str, ...]] = None
+
+    def __post_init__(self):
+        if self.faces is not None:
+            object.__setattr__(self, "faces", _face_tuple("faces", self.faces))
+
+
+@dataclass(frozen=True)
+class ExperimentalMask:
+    """Deliberately omit complete physical faces from the KSIR integral."""
+
+    omit_faces: Tuple[str, ...]
+
+    def __post_init__(self):
+        omitted = _face_tuple("omit_faces", self.omit_faces)
+        if not omitted:
+            raise ValueError("ExperimentalMask must omit at least one face")
+        if len(omitted) == len(FACES):
+            raise ValueError("ExperimentalMask must leave at least one active face")
+        object.__setattr__(self, "omit_faces", omitted)
+
+
+@dataclass(frozen=True)
+class SymmetryPlane:
+    """One resolved physical reflection plane."""
+
+    face: str
+    axis: int
+    coordinate: float
+    boundary_type: str
+
+    def __post_init__(self):
+        if self.face not in _FACE_AXIS_SIGN:
+            raise ValueError(f"unknown symmetry face {self.face!r}")
+        expected_axis, _ = _FACE_AXIS_SIGN[self.face]
+        if self.axis != expected_axis:
+            raise ValueError(
+                f"symmetry face {self.face!r} must use axis {expected_axis}"
+            )
+        if not np.isfinite(self.coordinate):
+            raise ValueError("symmetry-plane coordinate must be finite")
+        if self.boundary_type not in ("pec", "pmc"):
+            raise ValueError("symmetry boundary_type must be 'pec' or 'pmc'")
+
+
+@dataclass(frozen=True)
+class SymmetryImage:
+    """One member of the finite reflection group."""
+
+    planes: Tuple[SymmetryPlane, ...]
+    parity: int
+
+    def transform(
+        self,
+        positions: npt.NDArray[np.floating],
+        normals: npt.NDArray[np.floating],
+    ) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]:
+        image_positions = positions.copy()
+        image_normals = normals.copy()
+        for plane in self.planes:
+            image_positions[:, plane.axis] = (
+                2 * plane.coordinate - image_positions[:, plane.axis]
+            )
+            image_normals[:, plane.axis] *= -1
+        return image_positions, image_normals
+
+
+@dataclass(frozen=True)
+class ResolvedKSIRClosure:
+    """Closure policy resolved against one built gprMax grid."""
+
+    name: str
+    omitted_faces: Tuple[str, ...]
+    symmetry_planes: Tuple[SymmetryPlane, ...]
+    mathematically_closed: bool
+    exact: bool
+
+    @property
+    def active_faces(self) -> Tuple[str, ...]:
+        return tuple(face for face in FACES if face not in self.omitted_faces)
+
+    @property
+    def signature(self) -> str:
+        planes = ",".join(
+            f"{plane.face}:{plane.boundary_type}:{plane.coordinate:.17g}"
+            for plane in self.symmetry_planes
+        )
+        omitted = ",".join(self.omitted_faces)
+        return f"{self.name}|{omitted}|{planes}"
+
+    @property
+    def image_count(self) -> int:
+        return 2 ** len(self.symmetry_planes)
+
+    def component_images(self, component: str) -> Tuple[SymmetryImage, ...]:
+        images = []
+        for count in range(len(self.symmetry_planes) + 1):
+            for selected in combinations(self.symmetry_planes, count):
+                parity = 1
+                for plane in selected:
+                    parity *= component_parity(
+                        component, plane.axis, plane.boundary_type
+                    )
+                images.append(SymmetryImage(tuple(selected), parity))
+        return tuple(images)
+
+    def apply_quadrature(
+        self, surface: KSIRComponentSurface
+    ) -> KSIRComponentSurface:
+        """Half-weight patches centred on reflected tangential boundaries."""
+
+        if not self.symmetry_planes:
+            return surface
+        adjusted_faces = []
+        offsets = COMPONENT_OFFSETS[surface.component]
+        for face in surface.faces:
+            weights = face.area_weights.copy()
+            for plane in self.symmetry_planes:
+                if plane.axis == face.normal_axis or offsets[plane.axis] != 0:
+                    continue
+                tolerance = (
+                    16
+                    * np.finfo(face.area_weights.dtype).eps
+                    * max(
+                        abs(plane.coordinate),
+                        surface.grid_spacing[plane.axis],
+                    )
+                )
+                on_plane = np.isclose(
+                    face.patch_positions[:, plane.axis],
+                    plane.coordinate,
+                    rtol=0,
+                    atol=tolerance,
+                )
+                weights[on_plane] *= 0.5
+            weights.setflags(write=False)
+            adjusted_faces.append(replace(face, area_weights=weights))
+        return replace(surface, faces=tuple(adjusted_faces))
+
+    def transformed_faces(
+        self,
+        surface: KSIRComponentSurface,
+        field: npt.NDArray,
+        normal_derivative: npt.NDArray,
+    ) -> Iterator[
+        tuple[
+            str,
+            npt.NDArray[np.floating],
+            npt.NDArray[np.floating],
+            npt.NDArray[np.floating],
+            npt.NDArray,
+            npt.NDArray,
+        ]
+    ]:
+        """Yield physical and virtual face patches ready for evaluation."""
+
+        start = 0
+        images = self.component_images(surface.component)
+        for face in surface.faces:
+            stop = start + face.npatches
+            positions = face.patch_positions
+            normals = np.broadcast_to(face.normal, positions.shape)
+            face_field = field[:, start:stop]
+            face_derivative = normal_derivative[:, start:stop]
+            for image in images:
+                image_positions, image_normals = image.transform(
+                    positions, normals
+                )
+                yield (
+                    face.face_id,
+                    image_positions,
+                    image_normals,
+                    face.area_weights,
+                    image.parity * face_field,
+                    image.parity * face_derivative,
+                )
+            start = stop
+
+
+def component_parity(component: str, axis: int, boundary_type: str) -> int:
+    """Return scalar component parity under a PEC or PMC reflection."""
+
+    if len(component) != 2 or component[0] not in ("E", "H"):
+        raise ValueError(f"unknown field component {component!r}")
+    if component[1].lower() not in _COMPONENT_AXIS:
+        raise ValueError(f"unknown field component {component!r}")
+    if axis not in (0, 1, 2):
+        raise ValueError("axis must be 0, 1, or 2")
+    if boundary_type not in ("pec", "pmc"):
+        raise ValueError("boundary_type must be 'pec' or 'pmc'")
+
+    normal_component = _COMPONENT_AXIS[component[1].lower()] == axis
+    if boundary_type == "pec":
+        even = normal_component if component[0] == "E" else not normal_component
+    else:
+        even = not normal_component if component[0] == "E" else normal_component
+    return 1 if even else -1
+
+
+def resolve_closure(
+    policy,
+    symmetry_boundaries: Mapping[str, str],
+    lower: Sequence[int],
+    upper: Sequence[int],
+    grid_size: Sequence[int],
+    grid_spacing: Sequence[float],
+    real_dtype=None,
+) -> ResolvedKSIRClosure:
+    """Resolve a public closure policy against actual grid boundaries."""
+
+    if policy == "closed":
+        return ResolvedKSIRClosure("closed", (), (), True, True)
+    if isinstance(policy, ExperimentalMask):
+        return ResolvedKSIRClosure(
+            "experimental_mask",
+            policy.omit_faces,
+            (),
+            False,
+            False,
+        )
+    if not isinstance(policy, SymmetryCompletion):
+        raise ValueError(
+            "closure must be 'closed', SymmetryCompletion, or ExperimentalMask"
+        )
+
+    unknown_boundaries = set(symmetry_boundaries) - set(FACES)
+    if unknown_boundaries:
+        raise ValueError(
+            f"symmetry_boundaries contains unknown faces: {sorted(unknown_boundaries)}"
+        )
+    invalid_types = {
+        face: boundary_type
+        for face, boundary_type in symmetry_boundaries.items()
+        if boundary_type not in ("pec", "pmc")
+    }
+    if invalid_types:
+        raise ValueError(
+            "symmetry_boundaries types must be 'pec' or 'pmc': "
+            f"{invalid_types}"
+        )
+
+    lower_values = np.asarray(lower, dtype=np.int64)
+    upper_values = np.asarray(upper, dtype=np.int64)
+    size_values = np.asarray(grid_size, dtype=np.int64)
+    if real_dtype is None:
+        candidate = np.asarray(grid_spacing).dtype
+        real_dtype = candidate if candidate.kind == "f" else np.dtype(float)
+    spacing = np.asarray(grid_spacing, dtype=real_dtype)
+    touched = []
+    for face, boundary_type in symmetry_boundaries.items():
+        axis, sign = _FACE_AXIS_SIGN[face]
+        if (sign < 0 and lower_values[axis] == 0) or (
+            sign > 0 and upper_values[axis] == size_values[axis]
+        ):
+            touched.append(face)
+    requested = tuple(touched) if policy.faces is None else policy.faces
+    if not requested:
+        raise ValueError(
+            "SymmetryCompletion requires the KSIR box to touch a declared "
+            "symmetry boundary"
+        )
+    for face in requested:
+        if face not in symmetry_boundaries:
+            raise ValueError(
+                f"KSIR symmetry face {face!r} is not a declared boundary"
+            )
+        axis, sign = _FACE_AXIS_SIGN[face]
+        touches = (
+            lower_values[axis] == 0
+            if sign < 0
+            else upper_values[axis] == size_values[axis]
+        )
+        if not touches:
+            raise ValueError(
+                f"KSIR box does not touch declared symmetry face {face!r}"
+            )
+    axes = [_FACE_AXIS_SIGN[face][0] for face in requested]
+    if len(set(axes)) != len(axes):
+        raise ValueError(
+            "SymmetryCompletion supports at most one reflection plane per axis"
+        )
+
+    planes = []
+    for face in FACES:
+        if face not in requested:
+            continue
+        axis, sign = _FACE_AXIS_SIGN[face]
+        coordinate = 0.0 if sign < 0 else size_values[axis] * spacing[axis]
+        planes.append(
+            SymmetryPlane(
+                face,
+                axis,
+                float(coordinate),
+                symmetry_boundaries[face],
+            )
+        )
+    return ResolvedKSIRClosure(
+        "symmetry",
+        tuple(plane.face for plane in planes),
+        tuple(planes),
+        True,
+        True,
+    )
+
+
+def closure_from_metadata(
+    name: str,
+    omitted_faces: Sequence[str],
+    plane_faces: Sequence[str],
+    plane_types: Sequence[str],
+    plane_coordinates: Sequence[float],
+) -> ResolvedKSIRClosure:
+    """Rebuild a resolved closure from persisted HDF5 metadata."""
+
+    if name not in ("closed", "symmetry", "experimental_mask"):
+        raise ValueError(f"unknown saved closure policy {name!r}")
+    if not (
+        len(plane_faces) == len(plane_types) == len(plane_coordinates)
+    ):
+        raise ValueError("saved symmetry-plane metadata has inconsistent lengths")
+    omitted = _face_tuple("omitted_faces", omitted_faces)
+    if name == "closed" and (omitted or plane_faces):
+        raise ValueError("saved closed policy must not omit faces or contain planes")
+    if name == "symmetry" and (not omitted or not plane_faces):
+        raise ValueError("saved symmetry policy requires omitted faces and planes")
+    if name == "experimental_mask" and (not omitted or plane_faces):
+        raise ValueError(
+            "saved experimental mask requires omitted faces and no symmetry planes"
+        )
+    if name == "symmetry" and _face_tuple("plane_faces", plane_faces) != omitted:
+        raise ValueError("saved symmetry plane faces must match omitted faces")
+    planes = []
+    for face, boundary_type, coordinate in zip(
+        plane_faces, plane_types, plane_coordinates
+    ):
+        axis, _ = _FACE_AXIS_SIGN[face]
+        planes.append(
+            SymmetryPlane(face, axis, float(coordinate), boundary_type)
+        )
+    mathematically_closed = name != "experimental_mask"
+    return ResolvedKSIRClosure(
+        name,
+        omitted,
+        tuple(planes),
+        mathematically_closed,
+        mathematically_closed,
+    )

--- a/tests/ntff/test_closures.py
+++ b/tests/ntff/test_closures.py
@@ -1,0 +1,401 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+from scipy.constants import c
+
+from gprMax.ntff.closures import (
+    ExperimentalMask,
+    ResolvedKSIRClosure,
+    SymmetryCompletion,
+    SymmetryPlane,
+    closure_from_metadata,
+    component_parity,
+    resolve_closure,
+)
+from gprMax.ntff.evaluator import (
+    evaluate_far_zone_patches,
+    spherical_directions,
+)
+from gprMax.ntff.surfaces import FACES, build_component_surface
+
+
+@pytest.mark.parametrize("axis", range(3))
+@pytest.mark.parametrize("boundary_type", ("pec", "pmc"))
+def test_component_parity_matches_electric_edge_image_theory(axis, boundary_type):
+    for family in ("E", "H"):
+        for component_axis, letter in enumerate("xyz"):
+            component = family + letter
+            normal = component_axis == axis
+            if boundary_type == "pec":
+                expected_even = normal if family == "E" else not normal
+            else:
+                expected_even = not normal if family == "E" else normal
+            assert component_parity(component, axis, boundary_type) == (
+                1 if expected_even else -1
+            )
+
+
+def test_resolver_uses_only_declared_electric_grid_line_planes():
+    closure = resolve_closure(
+        SymmetryCompletion(),
+        {"x0": "pmc", "ymax": "pec"},
+        (0, 3, 2),
+        (8, 10, 9),
+        (12, 10, 11),
+        (0.1, 0.2, 0.3),
+    )
+
+    assert closure.omitted_faces == ("x0", "ymax")
+    assert [plane.axis for plane in closure.symmetry_planes] == [0, 1]
+    assert [plane.coordinate for plane in closure.symmetry_planes] == [0.0, 2.0]
+    assert [plane.boundary_type for plane in closure.symmetry_planes] == [
+        "pmc",
+        "pec",
+    ]
+    assert closure.image_count == 4
+
+
+def test_resolver_rejects_unresolved_or_untouched_symmetry_assertions():
+    kwargs = dict(
+        symmetry_boundaries={"x0": "pmc"},
+        lower=(0, 2, 2),
+        upper=(8, 8, 8),
+        grid_size=(12, 12, 12),
+        grid_spacing=(0.1, 0.1, 0.1),
+    )
+    with pytest.raises(ValueError, match="not a declared"):
+        resolve_closure(SymmetryCompletion(("y0",)), **kwargs)
+    with pytest.raises(ValueError, match="does not touch"):
+        resolve_closure(
+            SymmetryCompletion(("x0",)),
+            symmetry_boundaries={"x0": "pmc"},
+            lower=(1, 2, 2),
+            upper=(8, 8, 8),
+            grid_size=(12, 12, 12),
+            grid_spacing=(0.1, 0.1, 0.1),
+        )
+
+
+@pytest.mark.parametrize(
+    "boundaries,match",
+    [
+        ({"left": "pec"}, "unknown faces"),
+        ({"x0": "open"}, "types"),
+    ],
+)
+def test_resolver_rejects_invalid_boundary_maps(boundaries, match):
+    with pytest.raises(ValueError, match=match):
+        resolve_closure(
+            SymmetryCompletion(),
+            boundaries,
+            (0, 2, 2),
+            (8, 8, 8),
+            (12, 12, 12),
+            (0.1, 0.1, 0.1),
+        )
+
+
+@pytest.mark.parametrize(
+    "face,lower,upper,plane_coordinate,boundary_index",
+    [
+        ("x0", (0, 2, 2), (6, 7, 7), 0.0, 0),
+        ("xmax", (2, 2, 2), (8, 7, 7), 0.8, 8),
+    ],
+)
+@pytest.mark.parametrize("real_dtype", [np.dtype("f4"), np.dtype("f8")])
+def test_on_plane_electric_edge_patches_receive_half_area(
+    face, lower, upper, plane_coordinate, boundary_index, real_dtype
+):
+    plane = SymmetryPlane(face, 0, plane_coordinate, "pmc")
+    closure = ResolvedKSIRClosure(
+        "symmetry", (face,), (plane,), True, True
+    )
+    surface = build_component_surface(
+        "Ey",
+        lower,
+        upper,
+        (0.1, 0.1, 0.1),
+        (10, 10, 10),
+        excluded_faces=(face,),
+        real_dtype=real_dtype,
+    )
+    adjusted = closure.apply_quadrature(surface)
+    tangential_face = adjusted.face("y0")
+    on_plane = tangential_face.inside_indices[:, 0] == boundary_index
+
+    assert on_plane.any()
+    assert tangential_face.area_weights.dtype == real_dtype
+    assert_allclose(tangential_face.area_weights[on_plane], 0.005)
+    assert_allclose(tangential_face.area_weights[~on_plane], 0.01)
+
+
+def _point_source_phasors(surface, frequency, sources):
+    positions = surface.patch_positions
+    normals = surface.normals
+    wavenumber = 2 * np.pi * frequency / c
+    field = np.zeros(surface.npatches, dtype=np.complex128)
+    derivative = np.zeros_like(field)
+    for source_position, amplitude in sources:
+        displacement = positions - source_position
+        radius = np.linalg.norm(displacement, axis=1)
+        radial_direction = displacement / radius[:, np.newaxis]
+        source_field = (
+            amplitude * np.exp(-1j * wavenumber * radius) / (4 * np.pi * radius)
+        )
+        radial_derivative = (-1j * wavenumber - 1 / radius) * source_field
+        field += source_field
+        derivative += radial_derivative * np.sum(
+            normals * radial_direction, axis=1
+        )
+    return field[np.newaxis, :], derivative[np.newaxis, :]
+
+
+def _evaluate_with_closure(
+    surface, field, derivative, closure, frequency, directions, origin
+):
+    """Evaluate all physical and virtual patches using only the core API."""
+
+    result = np.zeros((1, directions.shape[0]), dtype=field.dtype)
+    for _, positions, normals, areas, image_field, image_derivative in (
+        closure.transformed_faces(surface, field, derivative)
+    ):
+        result += evaluate_far_zone_patches(
+            positions,
+            normals,
+            areas,
+            [frequency],
+            directions,
+            image_field,
+            image_derivative,
+            origin=origin,
+        )
+    return result
+
+
+@pytest.mark.parametrize(
+    "component,boundary_type,sources",
+    [
+        ("Ey", "pmc", (((1.1, 1.0, 1.0), 1.0),)),
+        (
+            "Ex",
+            "pmc",
+            (
+                ((1.3, 1.0, 1.0), 1.0),
+                ((0.9, 1.0, 1.0), -1.0),
+            ),
+        ),
+    ],
+)
+def test_half_surface_image_completion_matches_full_surface(
+    component, boundary_type, sources
+):
+    frequency = 250e6
+    spacing = (0.1, 0.1, 0.1)
+    shape = (25, 22, 22)
+    full = build_component_surface(
+        component, (2, 4, 4), (20, 16, 16), spacing, shape
+    )
+    plane = SymmetryPlane("x0", 0, 1.1, boundary_type)
+    symmetry = ResolvedKSIRClosure(
+        "symmetry", ("x0",), (plane,), True, True
+    )
+    half = symmetry.apply_quadrature(
+        build_component_surface(
+            component,
+            (11, 4, 4),
+            (20, 16, 16),
+            spacing,
+            shape,
+            excluded_faces=("x0",),
+        )
+    )
+    closed = ResolvedKSIRClosure("closed", (), (), True, True)
+    directions = spherical_directions(
+        [20, 55, 90, 125, 160], [10, 80, 155, 240, 320], degrees=True
+    )
+    full_field, full_derivative = _point_source_phasors(
+        full, frequency, sources
+    )
+    half_field, half_derivative = _point_source_phasors(
+        half, frequency, sources
+    )
+
+    expected = _evaluate_with_closure(
+        full,
+        full_field,
+        full_derivative,
+        closed,
+        frequency,
+        directions,
+        (1.1, 1.0, 1.0),
+    )
+    actual = _evaluate_with_closure(
+        half,
+        half_field,
+        half_derivative,
+        symmetry,
+        frequency,
+        directions,
+        (1.1, 1.0, 1.0),
+    )
+
+    assert_allclose(actual, expected, rtol=2e-14, atol=2e-14)
+
+
+def test_triple_reflection_matches_full_surface_and_uses_eight_images():
+    frequency = 300e6
+    spacing = (0.1, 0.1, 0.1)
+    shape = (24, 24, 24)
+    component = "Ex"
+    full = build_component_surface(
+        component, (2, 2, 2), (20, 20, 20), spacing, shape
+    )
+    planes = (
+        SymmetryPlane("x0", 0, 1.1, "pec"),
+        SymmetryPlane("y0", 1, 1.1, "pmc"),
+        SymmetryPlane("z0", 2, 1.1, "pmc"),
+    )
+    symmetry = ResolvedKSIRClosure(
+        "symmetry", ("x0", "y0", "z0"), planes, True, True
+    )
+    octant = symmetry.apply_quadrature(
+        build_component_surface(
+            component,
+            (11, 11, 11),
+            (20, 20, 20),
+            spacing,
+            shape,
+            excluded_faces=("x0", "y0", "z0"),
+        )
+    )
+    source = (((1.1, 1.1, 1.1), 1.0),)
+    directions = spherical_directions(
+        [30, 65, 100, 145], [15, 110, 220, 310], degrees=True
+    )
+    full_field, full_derivative = _point_source_phasors(
+        full, frequency, source
+    )
+    octant_field, octant_derivative = _point_source_phasors(
+        octant, frequency, source
+    )
+    closed = ResolvedKSIRClosure("closed", (), (), True, True)
+
+    expected = _evaluate_with_closure(
+        full,
+        full_field,
+        full_derivative,
+        closed,
+        frequency,
+        directions,
+        (1.1, 1.1, 1.1),
+    )
+    actual = _evaluate_with_closure(
+        octant,
+        octant_field,
+        octant_derivative,
+        symmetry,
+        frequency,
+        directions,
+        (1.1, 1.1, 1.1),
+    )
+
+    assert symmetry.image_count == 8
+    assert_allclose(actual, expected, rtol=3e-14, atol=3e-14)
+
+
+def test_experimental_mask_is_explicitly_open_and_removes_only_requested_faces():
+    mask = ExperimentalMask(("zmax",))
+    closure = resolve_closure(
+        mask,
+        {},
+        (2, 2, 2),
+        (5, 5, 5),
+        (8, 8, 8),
+        (0.02, 0.02, 0.02),
+    )
+    surface = build_component_surface(
+        "Ex",
+        (2, 2, 2),
+        (5, 5, 5),
+        (0.02, 0.02, 0.02),
+        (9, 9, 9),
+        excluded_faces=closure.omitted_faces,
+    )
+
+    assert closure.name == "experimental_mask"
+    assert closure.omitted_faces == ("zmax",)
+    assert closure.active_faces == tuple(face for face in FACES if face != "zmax")
+    assert not closure.mathematically_closed
+    assert not closure.exact
+    assert tuple(face.face_id for face in surface.faces) == closure.active_faces
+
+
+def test_saved_symmetry_metadata_reconstructs_the_same_closure():
+    closure = resolve_closure(
+        SymmetryCompletion(("x0", "zmax")),
+        {"x0": "pmc", "zmax": "pec"},
+        (0, 2, 2),
+        (8, 8, 10),
+        (12, 12, 10),
+        (0.1, 0.2, 0.3),
+    )
+
+    restored = closure_from_metadata(
+        closure.name,
+        closure.omitted_faces,
+        [plane.face for plane in closure.symmetry_planes],
+        [plane.boundary_type for plane in closure.symmetry_planes],
+        [plane.coordinate for plane in closure.symmetry_planes],
+    )
+
+    assert restored == closure
+    assert restored.signature == closure.signature
+
+
+@pytest.mark.parametrize(
+    "args,match",
+    [
+        (("unknown", (), (), (), ()), "unknown saved"),
+        (("closed", ("x0",), (), (), ()), "must not omit"),
+        (("symmetry", ("x0",), (), (), ()), "requires"),
+        (("symmetry", ("x0",), ("y0",), ("pmc",), (0.0,)), "must match"),
+        (("experimental_mask", ("zmax",), ("x0",), ("pmc",), (0.0,)), "no symmetry"),
+        (("symmetry", ("x0",), ("x0",), ("open",), (0.0,)), "boundary_type"),
+    ],
+)
+def test_saved_closure_metadata_rejects_inconsistent_state(args, match):
+    with pytest.raises(ValueError, match=match):
+        closure_from_metadata(*args)
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ("Qx", 0, "pec"),
+        ("Ex", 3, "pec"),
+        ("Ex", 0, "open"),
+    ],
+)
+def test_component_parity_rejects_invalid_inputs(args):
+    with pytest.raises(ValueError):
+        component_parity(*args)
+
+
+@pytest.mark.parametrize(
+    "args,match",
+    [
+        (("left", 0, 0.0, "pec"), "unknown symmetry face"),
+        (("x0", 1, 0.0, "pec"), "must use axis"),
+        (("x0", 0, np.inf, "pec"), "finite"),
+        (("x0", 0, 0.0, "open"), "boundary_type"),
+    ],
+)
+def test_symmetry_plane_rejects_invalid_geometry(args, match):
+    with pytest.raises(ValueError, match=match):
+        SymmetryPlane(*args)
+
+
+@pytest.mark.parametrize("faces", [(), ("x0", "x0"), FACES])
+def test_experimental_mask_requires_a_nonempty_proper_face_subset(faces):
+    with pytest.raises(ValueError):
+        ExperimentalMask(faces)


### PR DESCRIPTION
## PR Description

This is PR 5 of the staged implementation. It adds the closure policies used by KSIR integration surfaces while remaining independent of FDTD field collection and user commands.

### Closed and symmetry-completed surfaces

- Represents ordinary closed surfaces explicitly.
- Resolves omitted KSIR faces only from PEC/PMC symmetry boundaries declared on the corresponding gprMax electric-grid-line planes.
- Implements the exact finite reflection group for one, two, or three orthogonal planes.
- Applies electric/magnetic component parity for PEC and PMC image theory.
- Reflects both patch positions and outward normals.
- Half-weights patches centred on tangential reflection planes; repeated weighting correctly handles plane intersections.

### Experimental face omission

- Adds an explicit `ExperimentalMask` policy for deliberately open integrations.
- Marks masked surfaces as mathematically open and non-exact so later stages can disable integrated power and directivity rather than presenting them as valid closed-surface results.
- Requires at least one active face and rejects duplicate or unknown faces.

### Persistence and validation

- Provides stable closure signatures and reconstruction from saved metadata.
- Rejects unknown or inconsistent persisted closure states, plane geometry, faces, and boundary types.
- Validates boundary maps and supports configured float32 or float64 quadrature geometry.

### Tests

- Verifies PEC/PMC image parity for every electric and magnetic component on every axis.
- Compares half-domain and eight-image octant completion directly against independently modelled full closed surfaces.
- Verifies half-area quadrature on both lower and upper symmetry planes in single and double precision.
- Covers automatic/manual plane resolution, invalid maps, experimental masks, and metadata round trips.

## Deliberate scope

This PR does not include FDTD collection, frequency/time monitors, Cython or accelerator kernels, user commands, HDF5 field data, documentation, validation datasets.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update.

## Validation

- [x] Focused closure tests: 35 passed.
- [x] Full test suite: 796 passed, 6 skipped.
- [x] Standard gprMax Cython extensions build successfully; this PR changes no Cython source.
- [x] Diff and scope checks pass.
- [x] Self-review completed.
- [ ] Pre-commit was not available locally; GitHub checks should run it.
