### PR TITLE
Add CPU advanced-time KSIR field extension

### DIFF
--- a/gprMax/cython/ntff.pyx
+++ b/gprMax/cython/ntff.pyx
@@ -65,3 +65,83 @@ cpdef void accumulate_surface_dft(
             phase = multiplier[frequency]
             inside_dft[frequency, patch] += phase * inside_value
             outside_dft[frequency, patch] += phase * outside_value
+
+
+cpdef void gather_time_domain_surface(
+    int nthreads,
+    const np.int64_t[::1] inside_indices,
+    const np.int64_t[::1] outside_indices,
+    const float_or_double[::1] normal_spacing,
+    const float_or_double[::1] field,
+    float_or_double[::1] surface_value,
+    float_or_double[::1] normal_derivative,
+):
+    """Gather and collocate a two-sided surface for advanced-time KSIR."""
+
+    cdef Py_ssize_t patch
+    cdef Py_ssize_t npatches = inside_indices.shape[0]
+    cdef float_or_double inside_value, outside_value
+
+    for patch in prange(
+        npatches,
+        nogil=True,
+        schedule="static",
+        num_threads=nthreads,
+    ):
+        inside_value = field[inside_indices[patch]]
+        outside_value = field[outside_indices[patch]]
+        surface_value[patch] = 0.5 * (inside_value + outside_value)
+        normal_derivative[patch] = (
+            outside_value - inside_value
+        ) / normal_spacing[patch]
+
+
+cpdef void deposit_time_domain_surface(
+    int nthreads,
+    Py_ssize_t sample_index,
+    const float_or_double[::1] surface_value,
+    const float_or_double[::1] normal_derivative,
+    const float_or_double[::1] time_derivative,
+    const np.int64_t[::1] source_patch_index,
+    const float_or_double[:, ::1] normal_derivative_weight,
+    const float_or_double[:, ::1] field_weight,
+    const float_or_double[:, ::1] time_derivative_weight,
+    const np.int64_t[:, ::1] integer_delay,
+    const float_or_double[:, ::1] fractional_delay,
+    const np.int64_t[::1] time_origin_steps,
+    float_or_double[:, ::1] output,
+):
+    """Deposit one collocated surface time level into per-point traces.
+
+    Each OpenMP worker owns complete output rows, so accumulation requires no
+    atomics even when many patches share the same destination time bin.
+    """
+
+    cdef Py_ssize_t point, patch, source_patch, destination
+    cdef Py_ssize_t npoints = output.shape[0]
+    cdef Py_ssize_t npatches = source_patch_index.shape[0]
+    cdef float_or_double contribution, fraction
+
+    for point in prange(
+        npoints,
+        nogil=True,
+        schedule="static",
+        num_threads=nthreads,
+    ):
+        for patch in range(npatches):
+            source_patch = source_patch_index[patch]
+            contribution = (
+                normal_derivative_weight[point, patch]
+                * normal_derivative[source_patch]
+                + field_weight[point, patch] * surface_value[source_patch]
+                + time_derivative_weight[point, patch]
+                * time_derivative[source_patch]
+            )
+            fraction = fractional_delay[point, patch]
+            destination = (
+                sample_index
+                + integer_delay[point, patch]
+                - time_origin_steps[point]
+            )
+            output[point, destination] += (1 - fraction) * contribution
+            output[point, destination + 1] += fraction * contribution

--- a/gprMax/ntff/__init__.py
+++ b/gprMax/ntff/__init__.py
@@ -62,6 +62,7 @@ from .surfaces import (
     build_all_component_surfaces,
     build_component_surface,
 )
+from .time_domain import KSIRTimeDomainMonitor, KSIRTimeDomainResult
 
 __all__ = [
     "COMPONENTS",
@@ -75,6 +76,8 @@ __all__ = [
     "KSIRFrequencyResult",
     "KSIRSavedFarField",
     "KSIRSurfaceFace",
+    "KSIRTimeDomainMonitor",
+    "KSIRTimeDomainResult",
     "OUTGOING_GREEN_RADIAL_FACTOR",
     "PHASOR_TIME_DEPENDENCE",
     "ResolvedKSIRClosure",

--- a/gprMax/ntff/time_domain.py
+++ b/gprMax/ntff/time_domain.py
@@ -1,0 +1,734 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+
+"""Advanced-time KSIR field extension for the CPU solver."""
+
+from collections import deque
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Deque, Dict, Mapping, Tuple
+
+import numpy as np
+import numpy.typing as npt
+from scipy.constants import c
+
+from .closures import ResolvedKSIRClosure
+from .surfaces import KSIRComponentSurface
+
+try:
+    from gprMax.cython.ntff import (
+        deposit_time_domain_surface as _deposit_time_domain_surface,
+        gather_time_domain_surface as _gather_time_domain_surface,
+    )
+except ImportError:  # Source-tree use before extensions are rebuilt.
+    _deposit_time_domain_surface = None
+    _gather_time_domain_surface = None
+
+
+ELECTRIC_COMPONENTS = ("Ex", "Ey", "Ez")
+MAGNETIC_COMPONENTS = ("Hx", "Hy", "Hz")
+
+
+@dataclass(frozen=True)
+class KSIRTimeDomainResult:
+    """In-memory time histories reconstructed at exterior points."""
+
+    name: str
+    times: npt.NDArray[np.floating]
+    points: npt.NDArray[np.floating]
+    fields: Mapping[str, npt.NDArray[np.floating]]
+    sample_time_offsets: Mapping[str, float]
+    time_origin: str
+    time_origins: npt.NDArray[np.floating]
+    valid_lengths: npt.NDArray[np.int64]
+    collection_backend: str
+    closure: str
+    mathematically_closed: bool
+
+    def point_times(self, point_index: int) -> npt.NDArray[np.floating]:
+        """Return physical times for one point's valid output samples."""
+
+        length = int(self.valid_lengths[point_index])
+        return self.time_origins[point_index] + self.times[:length]
+
+    def point_field(
+        self, component: str, point_index: int
+    ) -> npt.NDArray[np.floating]:
+        """Return one point's valid field trace without padded trailing bins."""
+
+        length = int(self.valid_lengths[point_index])
+        return self.fields[component][point_index, :length]
+
+
+class _ComponentAccumulator:
+    """Streaming time derivative and advanced-time deposition for one component."""
+
+    def __init__(
+        self,
+        surface: KSIRComponentSurface,
+        points: npt.NDArray[np.floating],
+        dt: float,
+        iterations: int,
+        wave_speed: float,
+        sample_time_offset_steps: float,
+        real_dtype,
+        nthreads: int,
+        closure: ResolvedKSIRClosure,
+    ):
+        self.surface = surface
+        self.points = points
+        self.dt = dt
+        self.iterations = iterations
+        self.wave_speed = wave_speed
+        self.sample_time_offset_steps = sample_time_offset_steps
+        self.real_dtype = np.dtype(real_dtype)
+        self.nthreads = nthreads
+        self._recent: Deque[Tuple[int, npt.NDArray, npt.NDArray]] = deque(maxlen=3)
+        self._next_iteration = 0
+        self._last_deposited = -1
+        self._finalised = False
+
+        base_positions = surface.patch_positions
+        base_normals = surface.normals
+        base_areas = surface.area_weights
+        base_indices = np.arange(surface.npatches, dtype=np.int64)
+        positions = []
+        normals = []
+        areas = []
+        source_patch_indices = []
+        parities = []
+        for image in closure.component_images(surface.component):
+            image_positions, image_normals = image.transform(
+                base_positions, base_normals
+            )
+            positions.append(image_positions)
+            normals.append(image_normals)
+            areas.append(base_areas)
+            source_patch_indices.append(base_indices)
+            parities.append(
+                np.full(surface.npatches, image.parity, dtype=self.real_dtype)
+            )
+        positions = np.concatenate(positions)
+        normals = np.concatenate(normals)
+        areas = np.concatenate(areas)
+        parity = np.concatenate(parities)
+        self._source_patch_index = np.ascontiguousarray(
+            np.concatenate(source_patch_indices), dtype=np.int64
+        )
+        # Point validation must use the rectangular support of the surface
+        # patches, not only their centre coordinates.  On a symmetry axis the
+        # physical half-surface ends at the reflection plane; reflecting that
+        # clipped cuboid gives the support of the completed surface.
+        support_lower = surface.physical_lower.copy()
+        support_upper = surface.physical_upper.copy()
+        for plane in closure.symmetry_planes:
+            if plane.face.endswith("0"):
+                support_lower[plane.axis] = plane.coordinate
+            else:
+                support_upper[plane.axis] = plane.coordinate
+        support_axes = [
+            np.asarray((lower, upper), dtype=self.real_dtype)
+            for lower, upper in zip(support_lower, support_upper)
+        ]
+        support_corners = np.stack(
+            np.meshgrid(*support_axes, indexing="ij"), axis=-1
+        ).reshape(-1, 3)
+        completed_corners = []
+        corner_normals = np.zeros_like(support_corners)
+        for image in closure.component_images(surface.component):
+            image_corners, _ = image.transform(support_corners, corner_normals)
+            completed_corners.append(image_corners)
+        completed_corners = np.concatenate(completed_corners)
+        self.completed_physical_lower = np.min(completed_corners, axis=0)
+        self.completed_physical_upper = np.max(completed_corners, axis=0)
+        displacement = points[:, np.newaxis, :] - positions[np.newaxis, :, :]
+        distance = np.linalg.norm(displacement, axis=2)
+        if np.any(distance == 0):
+            raise ValueError(
+                "observation points must not coincide with surface patches"
+            )
+        direction = displacement / distance[:, :, np.newaxis]
+        normal_projection = np.sum(normals[np.newaxis, :, :] * direction, axis=2)
+
+        self._normal_derivative_weight = np.ascontiguousarray(
+            -areas[np.newaxis, :] * parity[np.newaxis, :]
+            / (4 * np.pi * distance),
+            dtype=self.real_dtype,
+        )
+        self._field_weight = np.ascontiguousarray(
+            areas[np.newaxis, :]
+            * parity[np.newaxis, :]
+            * normal_projection
+            / (4 * np.pi * distance**2),
+            dtype=self.real_dtype,
+        )
+        self._time_derivative_weight = np.ascontiguousarray(
+            areas[np.newaxis, :]
+            * parity[np.newaxis, :]
+            * normal_projection
+            / (4 * np.pi * wave_speed * distance),
+            dtype=self.real_dtype,
+        )
+
+        delay = sample_time_offset_steps + distance / (wave_speed * dt)
+        self._integer_delay = np.ascontiguousarray(
+            np.floor(delay), dtype=np.int64
+        )
+        self._fractional_delay = np.ascontiguousarray(
+            delay - self._integer_delay, dtype=self.real_dtype
+        )
+        self.minimum_delay_steps = np.min(delay, axis=1)
+        self.maximum_integer_delay_steps = np.max(self._integer_delay, axis=1)
+        self._inside_indices = np.ascontiguousarray(
+            np.concatenate(
+                [face.inside_flat_indices for face in self.surface.faces]
+            ),
+            dtype=np.int64,
+        )
+        self._outside_indices = np.ascontiguousarray(
+            np.concatenate(
+                [face.outside_flat_indices for face in self.surface.faces]
+            ),
+            dtype=np.int64,
+        )
+        self._normal_spacing = np.ascontiguousarray(
+            np.concatenate(
+                [
+                    np.full(face.npatches, face.normal_spacing)
+                    for face in self.surface.faces
+                ]
+            ),
+            dtype=self.real_dtype,
+        )
+        self._surface_buffer = np.empty(
+            self.surface.npatches, dtype=self.real_dtype
+        )
+        self._derivative_buffer = np.empty_like(self._surface_buffer)
+        self._time_origin_steps: npt.NDArray[np.int64]
+        self.output: npt.NDArray[np.floating]
+
+    def allocate(
+        self,
+        output_length: int,
+        time_origin_steps: npt.NDArray[np.int64],
+    ) -> None:
+        self._time_origin_steps = np.ascontiguousarray(
+            time_origin_steps, dtype=np.int64
+        )
+        self.output = np.zeros(
+            (self.points.shape[0], output_length), dtype=self.real_dtype
+        )
+
+    def _surface_values(
+        self, field: npt.ArrayLike
+    ) -> Tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]:
+        values_array = np.asarray(field)
+        if values_array.shape != self.surface.field_shape:
+            raise ValueError(
+                f"field shape {values_array.shape} does not match surface field shape "
+                f"{self.surface.field_shape}"
+            )
+        if _gather_time_domain_surface is not None:
+            flat = np.ascontiguousarray(
+                values_array, dtype=self.real_dtype
+            ).ravel()
+            _gather_time_domain_surface(
+                self.nthreads,
+                self._inside_indices,
+                self._outside_indices,
+                self._normal_spacing,
+                flat,
+                self._surface_buffer,
+                self._derivative_buffer,
+            )
+            return self._surface_buffer.copy(), self._derivative_buffer.copy()
+
+        values = []
+        derivatives = []
+        for face in self.surface.faces:
+            inside, outside = face.sample(field)
+            surface_value, normal_derivative = face.collocate(inside, outside)
+            values.append(np.asarray(surface_value, dtype=self.real_dtype))
+            derivatives.append(np.asarray(normal_derivative, dtype=self.real_dtype))
+        return np.concatenate(values), np.concatenate(derivatives)
+
+    def _deposit(
+        self,
+        sample_index: int,
+        surface_value: npt.NDArray,
+        normal_derivative: npt.NDArray,
+        time_derivative: npt.NDArray,
+    ) -> None:
+        if sample_index != self._last_deposited + 1:
+            raise RuntimeError(
+                "KSIR samples must be deposited exactly once in time order"
+            )
+
+        if _deposit_time_domain_surface is not None:
+            _deposit_time_domain_surface(
+                self.nthreads,
+                sample_index,
+                np.ascontiguousarray(surface_value, dtype=self.real_dtype),
+                np.ascontiguousarray(normal_derivative, dtype=self.real_dtype),
+                np.ascontiguousarray(time_derivative, dtype=self.real_dtype),
+                self._source_patch_index,
+                self._normal_derivative_weight,
+                self._field_weight,
+                self._time_derivative_weight,
+                self._integer_delay,
+                self._fractional_delay,
+                self._time_origin_steps,
+                self.output,
+            )
+            self._last_deposited = sample_index
+            return
+
+        source = self._source_patch_index
+        integrand = (
+            self._normal_derivative_weight
+            * normal_derivative[source][np.newaxis, :]
+            + self._field_weight * surface_value[source][np.newaxis, :]
+            + self._time_derivative_weight
+            * time_derivative[source][np.newaxis, :]
+        )
+        destination = (
+            sample_index
+            + self._integer_delay
+            - self._time_origin_steps[:, np.newaxis]
+        )
+        for point_index in range(self.points.shape[0]):
+            np.add.at(
+                self.output[point_index],
+                destination[point_index],
+                (1 - self._fractional_delay[point_index]) * integrand[point_index],
+            )
+            np.add.at(
+                self.output[point_index],
+                destination[point_index] + 1,
+                self._fractional_delay[point_index] * integrand[point_index],
+            )
+        self._last_deposited = sample_index
+
+    def observe(self, iteration: int, field: npt.ArrayLike) -> None:
+        """Observe one completed component time level."""
+
+        if self._finalised:
+            raise RuntimeError("cannot observe a finalised KSIR accumulator")
+        if iteration != self._next_iteration:
+            raise ValueError(
+                f"expected KSIR iteration {self._next_iteration}, received {iteration}"
+            )
+
+        surface_value, normal_derivative = self._surface_values(field)
+        self._recent.append((iteration, surface_value, normal_derivative))
+        self._next_iteration += 1
+
+        if len(self._recent) < 3:
+            return
+
+        previous, centre, following = self._recent
+        if iteration == 2:
+            forward_derivative = (
+                -3 * previous[1] + 4 * centre[1] - following[1]
+            ) / (2 * self.dt)
+            self._deposit(previous[0], previous[1], previous[2], forward_derivative)
+
+        centred_derivative = (following[1] - previous[1]) / (2 * self.dt)
+        self._deposit(centre[0], centre[1], centre[2], centred_derivative)
+
+    def finalise(self) -> None:
+        """Deposit the final endpoint using a second-order backward derivative."""
+
+        if self._finalised:
+            return
+        if self._next_iteration != self.iterations:
+            raise RuntimeError(
+                f"KSIR component {self.surface.component} received "
+                f"{self._next_iteration} "
+                f"of {self.iterations} expected samples"
+            )
+
+        if len(self._recent) == 1:
+            only = self._recent[0]
+            self._deposit(only[0], only[1], only[2], np.zeros_like(only[1]))
+        elif len(self._recent) == 2:
+            first, last = self._recent
+            derivative = (last[1] - first[1]) / self.dt
+            self._deposit(first[0], first[1], first[2], derivative)
+            self._deposit(last[0], last[1], last[2], derivative)
+        elif len(self._recent) == 3:
+            before_previous, previous, last = self._recent
+            backward_derivative = (
+                3 * last[1] - 4 * previous[1] + before_previous[1]
+            ) / (2 * self.dt)
+            self._deposit(last[0], last[1], last[2], backward_derivative)
+
+        self.output.setflags(write=False)
+        self._finalised = True
+
+
+class KSIRTimeDomainMonitor:
+    """Advanced-time field reconstruction at explicit exterior points.
+
+    Collection uses configured-dtype Cython/OpenMP kernels, with a NumPy
+    fallback for source-tree use before the extensions are compiled.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        surfaces: Mapping[str, KSIRComponentSurface],
+        points: npt.ArrayLike,
+        dt: float,
+        iterations: int,
+        *,
+        real_dtype,
+        wave_speed: float = c,
+        nthreads: int = 1,
+        time_origin: str = "simulation",
+        closure: ResolvedKSIRClosure | None = None,
+    ):
+        if not name:
+            raise ValueError("KSIR monitor name must not be empty")
+        if not surfaces:
+            raise ValueError("at least one component surface is required")
+        if not np.isfinite(dt) or dt <= 0:
+            raise ValueError("dt must be finite and greater than zero")
+        if not isinstance(iterations, (int, np.integer)) or iterations <= 0:
+            raise ValueError("iterations must be an integer greater than zero")
+        if not np.isfinite(wave_speed) or wave_speed <= 0:
+            raise ValueError("wave_speed must be finite and greater than zero")
+        if not isinstance(nthreads, (int, np.integer)) or nthreads < 1:
+            raise ValueError("nthreads must be an integer greater than zero")
+        if not isinstance(time_origin, str) or time_origin not in (
+            "simulation",
+            "first_arrival",
+        ):
+            raise ValueError(
+                "time_origin must be 'simulation' or 'first_arrival'"
+            )
+        self.real_dtype = np.dtype(real_dtype)
+        if self.real_dtype.kind != "f":
+            raise ValueError("real_dtype must be a floating-point dtype")
+        point_array = np.asarray(points, dtype=self.real_dtype)
+        if point_array.ndim == 1:
+            point_array = point_array[np.newaxis, :]
+        if (
+            point_array.ndim != 2
+            or point_array.shape[0] == 0
+            or point_array.shape[1] != 3
+        ):
+            raise ValueError("points must have shape (npoints, 3)")
+        if not np.all(np.isfinite(point_array)):
+            raise ValueError("points must contain only finite values")
+
+        components = tuple(surfaces)
+        unknown = set(components) - set(ELECTRIC_COMPONENTS + MAGNETIC_COMPONENTS)
+        if unknown:
+            raise ValueError(f"unknown field components: {sorted(unknown)}")
+
+        self.name = name
+        self.points = point_array.copy()
+        self.points.setflags(write=False)
+        self.dt = float(dt)
+        self.iterations = int(iterations)
+        self.wave_speed = float(wave_speed)
+        self.nthreads = int(nthreads)
+        self.time_origin = time_origin
+        self.collection_backend = (
+            "cython_openmp"
+            if _gather_time_domain_surface is not None
+            and _deposit_time_domain_surface is not None
+            else "numpy_fallback"
+        )
+        self.components = components
+        self.surfaces = MappingProxyType(dict(surfaces))
+        self.closure = closure or ResolvedKSIRClosure(
+            "closed", (), (), True, True
+        )
+        if not self.closure.mathematically_closed:
+            raise ValueError(
+                "advanced-time KSIR requires a closed or symmetry-completed surface"
+            )
+        for surface in surfaces.values():
+            face_ids = tuple(face.face_id for face in surface.faces)
+            if face_ids != self.closure.active_faces:
+                raise ValueError(
+                    f"{surface.component} surface faces {face_ids} do not match "
+                    f"closure faces {self.closure.active_faces}"
+                )
+        self._accumulators: Dict[str, _ComponentAccumulator] = {}
+        self._finalised = False
+        self._result = None
+        self.surface_material_id = None
+
+        for component, surface in surfaces.items():
+            offset_steps = 0.0 if component in ELECTRIC_COMPONENTS else 0.5
+            self._accumulators[component] = _ComponentAccumulator(
+                surface,
+                self.points,
+                self.dt,
+                self.iterations,
+                self.wave_speed,
+                offset_steps,
+                self.real_dtype,
+                self.nthreads,
+                self.closure,
+            )
+
+        for component, accumulator in self._accumulators.items():
+            completed_scale = max(
+                1.0,
+                np.max(np.abs(accumulator.completed_physical_lower)),
+                np.max(np.abs(accumulator.completed_physical_upper)),
+            )
+            tolerance = 10 * np.finfo(self.real_dtype).eps * completed_scale
+            on_or_inside = np.all(
+                (
+                    point_array
+                    >= accumulator.completed_physical_lower - tolerance
+                )
+                & (
+                    point_array
+                    <= accumulator.completed_physical_upper + tolerance
+                ),
+                axis=1,
+            )
+            if np.any(on_or_inside):
+                raise ValueError(
+                    "observation points must be strictly outside the completed "
+                    f"{component} surface"
+                )
+
+        minimum_delay = np.min(
+            np.stack(
+                [
+                    accumulator.minimum_delay_steps
+                    for accumulator in self._accumulators.values()
+                ]
+            ),
+            axis=0,
+        )
+        maximum_integer_delay = np.max(
+            np.stack(
+                [
+                    accumulator.maximum_integer_delay_steps
+                    for accumulator in self._accumulators.values()
+                ]
+            ),
+            axis=0,
+        )
+        if self.time_origin == "first_arrival":
+            time_origin_steps = np.floor(minimum_delay).astype(np.int64)
+        else:
+            time_origin_steps = np.zeros(self.points.shape[0], dtype=np.int64)
+        valid_lengths = (
+            self.iterations
+            + maximum_integer_delay
+            - time_origin_steps
+            + 1
+        )
+        self.time_origin_steps = np.ascontiguousarray(
+            time_origin_steps, dtype=np.int64
+        )
+        self.time_origin_steps.setflags(write=False)
+        self.time_origins = np.asarray(
+            self.time_origin_steps * self.dt, dtype=self.real_dtype
+        )
+        self.time_origins.setflags(write=False)
+        self.valid_lengths = np.ascontiguousarray(valid_lengths, dtype=np.int64)
+        self.valid_lengths.setflags(write=False)
+        self.output_length = int(np.max(self.valid_lengths))
+        for accumulator in self._accumulators.values():
+            accumulator.allocate(self.output_length, self.time_origin_steps)
+
+    @property
+    def result(self) -> KSIRTimeDomainResult:
+        if self._result is None:
+            raise RuntimeError(
+                "KSIR result is not available until the solver has finalised"
+            )
+        return self._result
+
+    def validate_materials(
+        self, material_ids: npt.ArrayLike, id_lookup: Mapping[str, int]
+    ) -> int:
+        """Verify that all straddling samples use one homogeneous material ID."""
+
+        ids = np.asarray(material_ids)
+        sampled_ids = []
+        for component, surface in self.surfaces.items():
+            component_ids = ids[id_lookup[component]]
+            for face in surface.faces:
+                keep = np.ones(face.npatches, dtype=bool)
+                for plane in self.closure.symmetry_planes:
+                    tolerance = (
+                        16
+                        * np.finfo(self.real_dtype).eps
+                        * max(
+                            abs(plane.coordinate),
+                            surface.grid_spacing[plane.axis],
+                        )
+                    )
+                    keep &= ~np.isclose(
+                        face.patch_positions[:, plane.axis],
+                        plane.coordinate,
+                        rtol=0,
+                        atol=tolerance,
+                    )
+                if np.any(keep):
+                    sampled_ids.append(
+                        component_ids[tuple(face.inside_indices[keep].T)]
+                    )
+                    sampled_ids.append(
+                        component_ids[tuple(face.outside_indices[keep].T)]
+                    )
+        if not sampled_ids:
+            raise ValueError(
+                f"KSIR monitor {self.name!r} has no off-symmetry samples "
+                "for material validation"
+            )
+        unique_ids = np.unique(np.concatenate(sampled_ids))
+        if unique_ids.size != 1:
+            raise ValueError(
+                f"KSIR monitor {self.name!r} surface straddles multiple material IDs: "
+                f"{unique_ids.tolist()}"
+            )
+        self.surface_material_id = int(unique_ids[0])
+        return self.surface_material_id
+
+    def observe_electric(
+        self,
+        iteration: int,
+        Ex: npt.ArrayLike,
+        Ey: npt.ArrayLike,
+        Ez: npt.ArrayLike,
+    ) -> None:
+        fields = {"Ex": Ex, "Ey": Ey, "Ez": Ez}
+        for component in ELECTRIC_COMPONENTS:
+            if component in self._accumulators:
+                self._accumulators[component].observe(iteration, fields[component])
+
+    def observe_magnetic(
+        self,
+        iteration: int,
+        Hx: npt.ArrayLike,
+        Hy: npt.ArrayLike,
+        Hz: npt.ArrayLike,
+    ) -> None:
+        fields = {"Hx": Hx, "Hy": Hy, "Hz": Hz}
+        for component in MAGNETIC_COMPONENTS:
+            if component in self._accumulators:
+                self._accumulators[component].observe(iteration, fields[component])
+
+    def finalise(self) -> None:
+        if self._finalised:
+            return
+        for accumulator in self._accumulators.values():
+            accumulator.finalise()
+
+        times = self.dt * np.arange(self.output_length, dtype=self.real_dtype)
+        times.setflags(write=False)
+        fields = MappingProxyType(
+            {
+                component: self._accumulators[component].output
+                for component in self.components
+            }
+        )
+        offsets = MappingProxyType(
+            {
+                component: (0.0 if component in ELECTRIC_COMPONENTS else 0.5 * self.dt)
+                for component in self.components
+            }
+        )
+        self._result = KSIRTimeDomainResult(
+            name=self.name,
+            times=times,
+            points=self.points,
+            fields=fields,
+            sample_time_offsets=offsets,
+            time_origin=self.time_origin,
+            time_origins=self.time_origins,
+            valid_lengths=self.valid_lengths,
+            collection_backend=self.collection_backend,
+            closure=self.closure.name,
+            mathematically_closed=self.closure.mathematically_closed,
+        )
+        self._finalised = True
+
+    def write_hdf5(self, base_group) -> None:
+        """Write compact time-domain histories to the normal model output."""
+
+        result = self.result
+        ntff_group = base_group.require_group("ntff")
+        if self.name in ntff_group:
+            raise ValueError(f"duplicate NTFF output group {self.name!r}")
+        group = ntff_group.create_group(self.name)
+        first_surface = next(iter(self.surfaces.values()))
+        group.attrs["formulation"] = "KSIR"
+        group.attrs["output_type"] = "time_domain_field_extension"
+        group.attrs["domain"] = "time"
+        group.attrs["mathematically_closed"] = self.closure.mathematically_closed
+        group.attrs["closure"] = self.closure.name
+        group.attrs["closure_exact"] = self.closure.exact
+        group.attrs["omitted_faces"] = np.asarray(
+            self.closure.omitted_faces, dtype="S5"
+        )
+        group.attrs["symmetry_plane_faces"] = np.asarray(
+            [plane.face for plane in self.closure.symmetry_planes], dtype="S5"
+        )
+        group.attrs["symmetry_plane_types"] = np.asarray(
+            [plane.boundary_type for plane in self.closure.symmetry_planes],
+            dtype="S3",
+        )
+        group.attrs["symmetry_plane_coordinates"] = np.asarray(
+            [plane.coordinate for plane in self.closure.symmetry_planes],
+            dtype=self.real_dtype,
+        )
+        group.attrs["symmetry_image_count"] = self.closure.image_count
+        group.attrs["logical_bounds"] = (
+            *first_surface.lower,
+            *first_surface.upper,
+        )
+        group.attrs["wave_speed"] = self.wave_speed
+        group.attrs["precision"] = (
+            "single" if self.real_dtype.itemsize == 4 else "double"
+        )
+        group.attrs["real_dtype"] = self.real_dtype.name
+        group.attrs["solver"] = "cpu"
+        group.attrs["collection_backend"] = self.collection_backend
+        group.attrs["openmp_threads"] = self.nthreads
+        group.attrs["dt"] = self.dt
+        group.attrs["iterations"] = self.iterations
+        group.attrs["components"] = np.asarray(self.components, dtype="S2")
+        group.attrs["sample_time_offsets"] = np.asarray(
+            [result.sample_time_offsets[item] for item in self.components],
+            dtype=self.real_dtype,
+        )
+        group.attrs["time_origin"] = self.time_origin
+        if self.surface_material_id is not None:
+            group.attrs["background_material_id"] = self.surface_material_id
+
+        group["points"] = result.points
+        group["times"] = result.times
+        group["time_origins"] = result.time_origins
+        group["valid_lengths"] = result.valid_lengths
+        fields_group = group.create_group("fields")
+        for component, values in result.fields.items():
+            fields_group[component] = values

--- a/tests/ntff/test_cython_time_domain.py
+++ b/tests/ntff/test_cython_time_domain.py
@@ -1,0 +1,183 @@
+"""Tests for Cython/OpenMP advanced-time KSIR kernels."""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import gprMax.ntff.time_domain as time_domain
+from gprMax.cython.ntff import (
+    deposit_time_domain_surface,
+    gather_time_domain_surface,
+)
+from gprMax.ntff.closures import SymmetryCompletion, resolve_closure
+from gprMax.ntff.surfaces import build_component_surface
+from gprMax.ntff.time_domain import KSIRTimeDomainMonitor
+
+
+@pytest.mark.parametrize("dtype,rtol", [(np.float32, 1e-5), (np.float64, 5e-14)])
+@pytest.mark.parametrize("nthreads", [1, 2])
+def test_cython_gather_and_deposit_match_numpy(dtype, rtol, nthreads):
+    rng = np.random.default_rng(7351)
+    nfield = 512
+    npatches = 83
+    neffective = 2 * npatches
+    npoints = 5
+    field = rng.standard_normal(nfield).astype(dtype)
+    inside = rng.integers(0, nfield, npatches, dtype=np.int64)
+    outside = rng.integers(0, nfield, npatches, dtype=np.int64)
+    spacing = rng.uniform(0.01, 0.04, npatches).astype(dtype)
+    surface = np.empty(npatches, dtype=dtype)
+    derivative = np.empty(npatches, dtype=dtype)
+
+    gather_time_domain_surface(
+        nthreads, inside, outside, spacing, field, surface, derivative
+    )
+
+    expected_surface = 0.5 * (field[inside] + field[outside])
+    expected_derivative = (field[outside] - field[inside]) / spacing
+    assert_allclose(surface, expected_surface, rtol=rtol)
+    assert_allclose(derivative, expected_derivative, rtol=rtol)
+
+    time_derivative = rng.standard_normal(npatches).astype(dtype)
+    weights = [
+        rng.standard_normal((npoints, neffective)).astype(dtype)
+        for _ in range(3)
+    ]
+    integer_delay = rng.integers(
+        20, 35, (npoints, neffective), dtype=np.int64
+    )
+    fractional_delay = rng.random((npoints, neffective)).astype(dtype)
+    origins = np.asarray((15, 17, 19, 21, 23), dtype=np.int64)
+    sample_index = 4
+    output = np.zeros((npoints, 30), dtype=dtype)
+    source_patch_index = np.tile(
+        np.arange(npatches, dtype=np.int64), 2
+    )
+
+    deposit_time_domain_surface(
+        nthreads,
+        sample_index,
+        surface,
+        derivative,
+        time_derivative,
+        source_patch_index,
+        weights[0],
+        weights[1],
+        weights[2],
+        integer_delay,
+        fractional_delay,
+        origins,
+        output,
+    )
+
+    contribution = (
+        weights[0] * derivative[source_patch_index][np.newaxis, :]
+        + weights[1] * surface[source_patch_index][np.newaxis, :]
+        + weights[2] * time_derivative[source_patch_index][np.newaxis, :]
+    )
+    expected = np.zeros_like(output)
+    destination = sample_index + integer_delay - origins[:, np.newaxis]
+    for point in range(npoints):
+        np.add.at(
+            expected[point],
+            destination[point],
+            (1 - fractional_delay[point]) * contribution[point],
+        )
+        np.add.at(
+            expected[point],
+            destination[point] + 1,
+            fractional_delay[point] * contribution[point],
+        )
+    assert_allclose(output, expected, rtol=rtol, atol=rtol)
+
+
+def _monitor(name, surface, nthreads, closure=None):
+    return KSIRTimeDomainMonitor(
+        name,
+        {"Ex": surface},
+        ((0.8, 0.4, 0.4), (0.4, 0.9, 0.5)),
+        0.01,
+        6,
+        real_dtype=np.dtype("f8"),
+        wave_speed=1.0,
+        nthreads=nthreads,
+        closure=closure,
+    )
+
+
+def test_monitor_cython_path_matches_numpy_fallback(monkeypatch):
+    shape = (10, 10, 10)
+    surface = build_component_surface(
+        "Ex", (2, 2, 2), (6, 6, 6), (0.08, 0.08, 0.08), shape
+    )
+    indices = np.indices(shape)
+    fields = [
+        np.asarray((iteration + 1) * (indices[0] - 0.3 * indices[2]))
+        for iteration in range(6)
+    ]
+    zeros = np.zeros(shape)
+    cython_monitor = _monitor("cython", surface, 2)
+    for iteration, field in enumerate(fields):
+        cython_monitor.observe_electric(iteration, field, zeros, zeros)
+    cython_monitor.finalise()
+
+    monkeypatch.setattr(time_domain, "_gather_time_domain_surface", None)
+    monkeypatch.setattr(time_domain, "_deposit_time_domain_surface", None)
+    fallback_monitor = _monitor("fallback", surface, 1)
+    for iteration, field in enumerate(fields):
+        fallback_monitor.observe_electric(iteration, field, zeros, zeros)
+    fallback_monitor.finalise()
+
+    assert cython_monitor.collection_backend == "cython_openmp"
+    assert fallback_monitor.collection_backend == "numpy_fallback"
+    assert_allclose(
+        cython_monitor.result.fields["Ex"],
+        fallback_monitor.result.fields["Ex"],
+        rtol=2e-14,
+        atol=2e-14,
+    )
+
+def test_symmetry_image_mapping_matches_numpy_fallback(monkeypatch):
+    shape = (10, 10, 10)
+    closure = resolve_closure(
+        SymmetryCompletion(),
+        {"x0": "pmc"},
+        (0, 2, 2),
+        (6, 6, 6),
+        (9, 9, 9),
+        (0.08, 0.08, 0.08),
+    )
+    surface = closure.apply_quadrature(
+        build_component_surface(
+            "Ex",
+            (0, 2, 2),
+            (6, 6, 6),
+            (0.08, 0.08, 0.08),
+            shape,
+            excluded_faces=closure.omitted_faces,
+        )
+    )
+    indices = np.indices(shape)
+    fields = [
+        np.asarray((iteration + 1) * (indices[0] - 0.3 * indices[2]))
+        for iteration in range(6)
+    ]
+    zeros = np.zeros(shape)
+    cython_monitor = _monitor("cython_symmetry", surface, 2, closure)
+    for iteration, field in enumerate(fields):
+        cython_monitor.observe_electric(iteration, field, zeros, zeros)
+    cython_monitor.finalise()
+
+    monkeypatch.setattr(time_domain, "_gather_time_domain_surface", None)
+    monkeypatch.setattr(time_domain, "_deposit_time_domain_surface", None)
+    fallback_monitor = _monitor("fallback_symmetry", surface, 1, closure)
+    for iteration, field in enumerate(fields):
+        fallback_monitor.observe_electric(iteration, field, zeros, zeros)
+    fallback_monitor.finalise()
+
+    assert_allclose(
+        cython_monitor.result.fields["Ex"],
+        fallback_monitor.result.fields["Ex"],
+        rtol=2e-14,
+        atol=2e-14,
+    )

--- a/tests/ntff/test_time_domain.py
+++ b/tests/ntff/test_time_domain.py
@@ -1,0 +1,456 @@
+import h5py
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from gprMax.ntff.closures import SymmetryCompletion, resolve_closure
+from gprMax.ntff.surfaces import COMPONENT_OFFSETS, build_component_surface
+from gprMax.ntff.time_domain import KSIRTimeDomainMonitor
+
+
+def _component_field(component, shape, spacing, gradient, intercept):
+    indices = np.indices(shape).reshape(3, -1).T
+    positions = (indices + np.asarray(COMPONENT_OFFSETS[component])) * spacing
+    return (positions @ gradient + intercept).reshape(shape)
+
+
+def _reference_polynomial_deposition(
+    surface,
+    points,
+    dt,
+    iterations,
+    wave_speed,
+    sample_offset_steps,
+    gradient,
+    intercept,
+):
+    positions = surface.patch_positions
+    normals = surface.normals
+    areas = surface.area_weights
+    spatial_field = positions @ gradient + intercept
+    spatial_derivative = normals @ gradient
+    displacement = points[:, np.newaxis, :] - positions[np.newaxis, :, :]
+    distance = np.linalg.norm(displacement, axis=2)
+    direction = displacement / distance[:, :, np.newaxis]
+    normal_projection = np.sum(normals[np.newaxis, :, :] * direction, axis=2)
+    weight_a = -areas[np.newaxis, :] / (4 * np.pi * distance)
+    weight_b = areas[np.newaxis, :] * normal_projection / (4 * np.pi * distance**2)
+    weight_c = (
+        areas[np.newaxis, :]
+        * normal_projection
+        / (4 * np.pi * wave_speed * distance)
+    )
+    delay = sample_offset_steps + distance / (wave_speed * dt)
+    integer_delay = np.floor(delay).astype(np.int64)
+    fractional_delay = delay - integer_delay
+    output_length = iterations + int(np.max(integer_delay)) + 1
+    expected = np.zeros((points.shape[0], output_length))
+
+    for iteration in range(iterations):
+        time = (iteration + sample_offset_steps) * dt
+        time_factor = 1 + 0.7 * time + 0.3 * time**2
+        derivative_factor = 0.7 + 0.6 * time
+        field = time_factor * spatial_field
+        derivative = time_factor * spatial_derivative
+        time_derivative = derivative_factor * spatial_field
+        integrand = (
+            weight_a * derivative[np.newaxis, :]
+            + weight_b * field[np.newaxis, :]
+            + weight_c * time_derivative[np.newaxis, :]
+        )
+        destination = iteration + integer_delay
+        for point_index in range(points.shape[0]):
+            np.add.at(
+                expected[point_index],
+                destination[point_index],
+                (1 - fractional_delay[point_index]) * integrand[point_index],
+            )
+            np.add.at(
+                expected[point_index],
+                destination[point_index] + 1,
+                fractional_delay[point_index] * integrand[point_index],
+            )
+    return expected
+
+
+@pytest.mark.parametrize("component,sample_offset_steps", [("Ex", 0.0), ("Hx", 0.5)])
+def test_advanced_time_monitor_matches_independent_polynomial_deposition(
+    component, sample_offset_steps
+):
+    spacing = np.array((0.1, 0.12, 0.08))
+    shape = (10, 11, 12)
+    surface = build_component_surface(component, (2, 2, 2), (6, 7, 8), spacing, shape)
+    points = np.array(((0.9, 0.5, 0.4), (0.4, 1.1, 0.5)))
+    dt = 0.05
+    iterations = 7
+    wave_speed = 2.3
+    gradient = np.array((0.8, -0.35, 0.6))
+    intercept = 0.2
+    spatial_grid = _component_field(component, shape, spacing, gradient, intercept)
+    monitor = KSIRTimeDomainMonitor(
+        "polynomial",
+        {component: surface},
+        points,
+        dt,
+        iterations,
+        real_dtype=np.dtype(float),
+        wave_speed=wave_speed,
+    )
+
+    for iteration in range(iterations):
+        time = (iteration + sample_offset_steps) * dt
+        time_factor = 1 + 0.7 * time + 0.3 * time**2
+        field = time_factor * spatial_grid
+        zeros = np.zeros_like(field)
+        if component == "Ex":
+            monitor.observe_electric(iteration, field, zeros, zeros)
+        else:
+            monitor.observe_magnetic(iteration, field, zeros, zeros)
+    monitor.finalise()
+
+    expected = _reference_polynomial_deposition(
+        surface,
+        points,
+        dt,
+        iterations,
+        wave_speed,
+        sample_offset_steps,
+        gradient,
+        intercept,
+    )
+    result = monitor.result
+
+    assert_allclose(result.fields[component], expected, rtol=2e-13, atol=2e-13)
+    assert_allclose(result.times, dt * np.arange(monitor.output_length))
+    assert result.sample_time_offsets[component] == sample_offset_steps * dt
+    assert not result.fields[component].flags.writeable
+
+
+def test_advanced_time_monitor_reconstructs_direct_outgoing_scalar_pulse():
+    spacing = 0.04
+    shape = (25, 25, 25)
+    surface = build_component_surface(
+        "Ex", (5, 5, 5), (20, 20, 20), (spacing,) * 3, shape
+    )
+    source_position = np.array((0.5, 0.5, 0.5))
+    point = np.array((1.05, 0.5, 0.5))
+    dt = 0.01
+    iterations = 160
+    wave_speed = 1.0
+    monitor = KSIRTimeDomainMonitor(
+        "pulse",
+        {"Ex": surface},
+        point,
+        dt,
+        iterations,
+        real_dtype=np.dtype(float),
+        wave_speed=wave_speed,
+    )
+
+    indices = np.indices(shape).reshape(3, -1).T
+    positions = (indices + np.asarray(COMPONENT_OFFSETS["Ex"])) * spacing
+    radius = np.linalg.norm(positions - source_position, axis=1)
+    pulse_centre = 0.28
+    pulse_width = 0.07
+
+    for iteration in range(iterations):
+        retarded_time = iteration * dt - radius / wave_speed
+        pulse = np.exp(-((retarded_time - pulse_centre) / pulse_width) ** 2)
+        field = np.divide(
+            pulse,
+            4 * np.pi * radius,
+            out=np.zeros_like(radius),
+            where=radius != 0,
+        ).reshape(shape)
+        zeros = np.zeros_like(field)
+        monitor.observe_electric(iteration, field, zeros, zeros)
+    monitor.finalise()
+
+    result = monitor.result.fields["Ex"][0]
+    direct_radius = np.linalg.norm(point - source_position)
+    direct = np.exp(
+        -(
+            (monitor.result.times - direct_radius / wave_speed - pulse_centre)
+            / pulse_width
+        )
+        ** 2
+    ) / (4 * np.pi * direct_radius)
+    significant = direct > 0.02 * np.max(direct)
+    relative_error = np.linalg.norm(
+        result[significant] - direct[significant]
+    ) / np.linalg.norm(direct[significant])
+
+    # Fifteen cells per side is intentionally a modest reference mesh; the
+    # combined midpoint-surface and fractional-delay error should remain well
+    # below ten percent without tuning the test to a very large surface.
+    assert relative_error < 0.06
+
+
+def test_monitor_rejects_points_on_or_inside_any_component_surface():
+    surface = build_component_surface(
+        "Ez", (2, 2, 2), (6, 6, 6), (0.1, 0.1, 0.1), (10, 10, 10)
+    )
+
+    with pytest.raises(ValueError, match="strictly outside"):
+        KSIRTimeDomainMonitor(
+            "inside",
+            {"Ez": surface},
+            surface.centre,
+            0.01,
+            5,
+            real_dtype=np.dtype(float),
+            wave_speed=1.0,
+        )
+
+
+def test_monitor_uses_patch_support_not_only_patch_centres_for_point_validation():
+    surface = build_component_surface(
+        "Ez", (2, 2, 2), (6, 6, 6), (0.1, 0.1, 0.1), (10, 10, 10)
+    )
+    # Ez patches on a y-normal face are centred from y=0.2, but their
+    # quadrature support starts at y=0.15.  This point is therefore inside the
+    # closed component surface even though it lies below every patch centre.
+    with pytest.raises(ValueError, match="strictly outside"):
+        KSIRTimeDomainMonitor(
+            "inside_patch_support",
+            {"Ez": surface},
+            (0.4, 0.175, 0.4),
+            0.01,
+            5,
+            real_dtype=np.dtype(float),
+            wave_speed=1.0,
+        )
+
+
+def test_monitor_requires_every_expected_sample_before_finalising():
+    surface = build_component_surface(
+        "Ex", (2, 2, 2), (5, 5, 5), (0.1, 0.1, 0.1), (9, 9, 9)
+    )
+    monitor = KSIRTimeDomainMonitor(
+        "incomplete",
+        {"Ex": surface},
+        (0.8, 0.4, 0.4),
+        0.01,
+        2,
+        real_dtype=np.dtype(float),
+        wave_speed=1.0,
+    )
+    field = np.zeros((9, 9, 9))
+    monitor.observe_electric(0, field, field, field)
+
+    with pytest.raises(RuntimeError, match="1 of 2 expected samples"):
+        monitor.finalise()
+
+
+def test_monitor_requires_one_material_id_across_all_straddling_samples():
+    shape = (9, 9, 9)
+    surface = build_component_surface(
+        "Ex", (2, 2, 2), (5, 5, 5), (0.1, 0.1, 0.1), shape
+    )
+    monitor = KSIRTimeDomainMonitor(
+        "materials",
+        {"Ex": surface},
+        (0.8, 0.4, 0.4),
+        0.01,
+        1,
+        real_dtype=np.dtype(float),
+        wave_speed=1.0,
+    )
+    material_ids = np.full((6,) + shape, 2, dtype=np.uint32)
+
+    monitor.validate_materials(material_ids, {"Ex": 0})
+    assert monitor.surface_material_id == 2
+
+    first_outside = tuple(surface.faces[0].outside_indices[0])
+    material_ids[(0,) + first_outside] = 3
+    with pytest.raises(ValueError, match="multiple material IDs"):
+        monitor.validate_materials(material_ids, {"Ex": 0})
+
+
+def test_first_arrival_time_origin_removes_range_dependent_zero_prefix():
+    shape = (9, 9, 9)
+    surface = build_component_surface(
+        "Ex", (2, 2, 2), (6, 6, 6), (0.1, 0.1, 0.1), shape
+    )
+    points = ((20.0, 0.4, 0.4), (35.0, 0.5, 0.4))
+    kwargs = dict(
+        surfaces={"Ex": surface},
+        points=points,
+        dt=0.01,
+        iterations=6,
+        real_dtype=np.dtype("f8"),
+        wave_speed=1.0,
+        nthreads=2,
+    )
+    absolute = KSIRTimeDomainMonitor("absolute", **kwargs)
+    shifted = KSIRTimeDomainMonitor(
+        "shifted", **kwargs, time_origin="first_arrival"
+    )
+    indices = np.indices(shape)
+    zeros = np.zeros(shape)
+    for iteration in range(6):
+        field = (iteration + 1) * (indices[0] + 0.2 * indices[1])
+        absolute.observe_electric(iteration, field, zeros, zeros)
+        shifted.observe_electric(iteration, field, zeros, zeros)
+    absolute.finalise()
+    shifted.finalise()
+
+    assert shifted.output_length < absolute.output_length / 50
+    assert shifted.output_length < 2 * absolute.iterations + 50
+    assert shifted.result.time_origin == "first_arrival"
+    assert np.all(shifted.result.time_origins > 0)
+    assert shifted.result.times[0] == 0
+    for point_index, origin in enumerate(shifted.time_origin_steps):
+        length = int(shifted.result.valid_lengths[point_index])
+        assert_allclose(
+            shifted.result.point_field("Ex", point_index),
+            absolute.result.fields["Ex"][
+                point_index, origin : origin + length
+            ],
+        )
+        assert_allclose(
+            shifted.result.point_times(point_index),
+            absolute.result.times[origin : origin + length],
+        )
+
+
+@pytest.mark.parametrize("time_origin", [None, "arrival", 3])
+def test_monitor_rejects_unknown_time_origin(time_origin):
+    surface = build_component_surface(
+        "Ex", (2, 2, 2), (5, 5, 5), (0.1, 0.1, 0.1), (9, 9, 9)
+    )
+    with pytest.raises(ValueError, match="time_origin"):
+        KSIRTimeDomainMonitor(
+            "invalid",
+            {"Ex": surface},
+            (0.8, 0.4, 0.4),
+            0.01,
+            5,
+            real_dtype=np.dtype(float),
+            time_origin=time_origin,
+        )
+
+
+def test_monitor_rejects_surface_faces_inconsistent_with_closure():
+    closure = resolve_closure(
+        SymmetryCompletion(),
+        {"x0": "pec"},
+        (0, 2, 2),
+        (5, 5, 5),
+        (9, 9, 9),
+        (0.1, 0.1, 0.1),
+    )
+    surface = build_component_surface(
+        "Ex",
+        (0, 2, 2),
+        (5, 5, 5),
+        (0.1, 0.1, 0.1),
+        (10, 10, 10),
+        excluded_faces=("x0", "zmax"),
+    )
+
+    with pytest.raises(ValueError, match="do not match closure faces"):
+        KSIRTimeDomainMonitor(
+            "inconsistent",
+            {"Ex": surface},
+            (0.8, 0.4, 0.4),
+            0.01,
+            5,
+            real_dtype=np.dtype(float),
+            wave_speed=1.0,
+            closure=closure,
+        )
+
+def test_compact_time_histories_and_metadata_are_written_to_hdf5(tmp_path):
+    shape = (9, 9, 9)
+    surface = build_component_surface(
+        "Ex", (2, 2, 2), (6, 6, 6), (0.1, 0.1, 0.1), shape
+    )
+    monitor = KSIRTimeDomainMonitor(
+        "compact",
+        {"Ex": surface},
+        ((20.0, 0.4, 0.4), (25.0, 0.5, 0.4)),
+        0.01,
+        3,
+        real_dtype=np.dtype("f8"),
+        wave_speed=1.0,
+        time_origin="first_arrival",
+        nthreads=2,
+    )
+    material_ids = np.ones((6,) + shape, dtype=np.uint32)
+    monitor.validate_materials(material_ids, {"Ex": 0})
+    indices = np.indices(shape)
+    zeros = np.zeros(shape)
+    for iteration in range(3):
+        field = (iteration + 1) * (indices[0] + 0.2 * indices[1])
+        monitor.observe_electric(iteration, field, zeros, zeros)
+    monitor.finalise()
+
+    filename = tmp_path / "compact.h5"
+    with h5py.File(filename, "w") as output:
+        monitor.write_hdf5(output)
+    with h5py.File(filename, "r") as output:
+        group = output["ntff/compact"]
+        assert group.attrs["formulation"] == "KSIR"
+        assert group.attrs["output_type"] == "time_domain_field_extension"
+        assert group.attrs["solver"] == "cpu"
+        assert group.attrs["time_origin"] == "first_arrival"
+        assert group.attrs["background_material_id"] == 1
+        assert group.attrs["openmp_threads"] == 2
+        assert_allclose(group["points"][:], monitor.result.points)
+        assert_allclose(group["times"][:], monitor.result.times)
+        assert_allclose(group["time_origins"][:], monitor.result.time_origins)
+        assert_allclose(group["valid_lengths"][:], monitor.result.valid_lengths)
+        assert_allclose(group["fields/Ex"][:], monitor.result.fields["Ex"])
+
+
+def test_symmetry_images_define_completed_surface_and_effective_patches():
+    lower = (0, 0, 2)
+    upper = (4, 4, 6)
+    spacing = (0.1, 0.1, 0.1)
+    closure = resolve_closure(
+        SymmetryCompletion(),
+        {"x0": "pmc", "y0": "pec"},
+        lower,
+        upper,
+        (10, 10, 10),
+        spacing,
+    )
+    surface = closure.apply_quadrature(
+        build_component_surface(
+            "Ez",
+            lower,
+            upper,
+            spacing,
+            (11, 11, 11),
+            excluded_faces=closure.omitted_faces,
+        )
+    )
+    monitor = KSIRTimeDomainMonitor(
+        "quarter",
+        {"Ez": surface},
+        (0.8, 0.8, 0.4),
+        0.01,
+        5,
+        real_dtype=np.dtype(float),
+        wave_speed=1.0,
+        closure=closure,
+    )
+    accumulator = monitor._accumulators["Ez"]
+
+    assert closure.image_count == 4
+    assert accumulator._source_patch_index.size == 4 * surface.npatches
+    assert_allclose(accumulator.completed_physical_lower, (-0.45, -0.45, 0.2))
+    assert_allclose(accumulator.completed_physical_upper, (0.45, 0.45, 0.6))
+
+    with pytest.raises(ValueError, match="completed Ez surface"):
+        KSIRTimeDomainMonitor(
+            "inside_virtual_box",
+            {"Ez": surface},
+            (-0.2, 0.2, 0.4),
+            0.01,
+            5,
+            real_dtype=np.dtype(float),
+            wave_speed=1.0,
+            closure=closure,
+        )


### PR DESCRIPTION
## Summary

- add CPU advanced-time KSIR field reconstruction at explicit exterior observation points
- evaluate the scalar Green-identity surface terms with field, normal-derivative, and time-derivative contributions
- retain electric integer-step and magnetic half-step Yee timing
- use second-order endpoint/centred time differentiation and fractional-delay interpolation
- support simulation-referenced histories for near-field use and compact first-arrival histories that remove range-dependent leading zeros
- store per-point time origins and valid lengths so multiple ranges share one bounded output array without losing physical time
- add Cython/OpenMP gather and deposition kernels using gprMax fused configured real types
- apply PEC/PMC symmetry images and reject surfaces inconsistent with the selected closure
- validate observation points and homogeneous surface materials
- write compact histories, timing metadata, closure metadata, precision, and collection details to the normal HDF5 output hierarchy

## Scope

This PR contains the CPU advanced-time monitor and its Cython acceleration only. Public hash/Python commands, solver-loop integration, accelerator implementations, user documentation, and end-to-end model validation remain deliberately separated into later PRs.

## Validation

- Cython extension built successfully with python setup.py build_ext --inplace
- focused advanced-time and closure suite: 102 passed
- complete NTFF suite: 152 passed
- complete automated suite: 840 passed, 6 skipped with python -m pytest -q tests
- staged diff passed git diff --check

## Related issue

N/A

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] This change requires a documentation update (planned as a separate documentation PR)

## Checklist

- [ ] Pre-commit passed all checks (pre-commit is not installed in this environment)
- [x] I have performed a self-review of my code
- [x] I have added comments for hard-to-understand numerical sections
- [ ] I have made corresponding changes to the documentation (planned separately)
- [x] My changes generate no new warnings
- [x] The title of my pull request is a short description of my changes
