### PR TITLE
Add GPU-resident KSIR collection for CUDA, OpenCL, and Metal

### DIFF
--- a/gprMax/cuda_opencl/knl_ntff.py
+++ b/gprMax/cuda_opencl/knl_ntff.py
@@ -1,0 +1,352 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+
+"""Runtime kernels for device-resident frequency- and time-domain KSIR."""
+
+from string import Template
+
+accumulate_ntff = {
+    "args_cuda": Template(
+        """
+extern "C" __global__ void accumulate_ntff(
+    int total, int npatches,
+    const int* __restrict__ inside_index,
+    const int* __restrict__ outside_index,
+    const $REAL* __restrict__ multiplier_real,
+    const $REAL* __restrict__ multiplier_imag,
+    const $REAL* __restrict__ field,
+    $REAL* inside_real, $REAL* inside_imag,
+    $REAL* outside_real, $REAL* outside_imag)
+"""
+    ),
+    "args_opencl": Template(
+        """
+__kernel void accumulate_ntff(
+    int total, int npatches,
+    __global const int* restrict inside_index,
+    __global const int* restrict outside_index,
+    __global const $REAL* restrict multiplier_real,
+    __global const $REAL* restrict multiplier_imag,
+    __global const $REAL* restrict field,
+    __global $REAL* inside_real, __global $REAL* inside_imag,
+    __global $REAL* outside_real, __global $REAL* outside_imag)
+"""
+    ),
+    "args_metal": Template(
+        """
+kernel void accumulate_ntff(
+    device const int& total, device const int& npatches,
+    device const int* inside_index,
+    device const int* outside_index,
+    device const $REAL* multiplier_real,
+    device const $REAL* multiplier_imag,
+    device const $REAL* field,
+    device $REAL* inside_real, device $REAL* inside_imag,
+    device $REAL* outside_real, device $REAL* outside_imag,
+    uint i [[thread_position_in_grid]])
+"""
+    ),
+    "func": Template(
+        """
+    if (i < total) {
+        int frequency = i / npatches;
+        int patch = i - frequency * npatches;
+        $REAL inside_value = field[inside_index[patch]];
+        $REAL outside_value = field[outside_index[patch]];
+        $REAL real_weight = multiplier_real[frequency];
+        $REAL imag_weight = multiplier_imag[frequency];
+        inside_real[i] += real_weight * inside_value;
+        inside_imag[i] += imag_weight * inside_value;
+        outside_real[i] += real_weight * outside_value;
+        outside_imag[i] += imag_weight * outside_value;
+    }
+"""
+    ),
+}
+
+
+def build_ntff_kernel_source(backend: str, c_real: str) -> str:
+    """Render a standalone NTFF kernel for CUDA, OpenCL, or Metal."""
+
+    try:
+        declaration = accumulate_ntff[f"args_{backend}"].substitute(REAL=c_real)
+    except KeyError as exc:
+        raise ValueError("backend must be 'cuda', 'opencl', or 'metal'") from exc
+
+    if backend == "cuda":
+        index = "int i = blockIdx.x * blockDim.x + threadIdx.x;\n"
+        preamble = ""
+    elif backend == "opencl":
+        index = "int i = get_global_id(0);\n"
+        preamble = "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n" if c_real == "double" else ""
+    else:
+        index = ""
+        preamble = "#include <metal_stdlib>\nusing namespace metal;\n"
+
+    body = accumulate_ntff["func"].substitute(REAL=c_real)
+    return f"{preamble}{declaration}{{\n{index}{body}}}\n"
+
+
+gather_time_domain_ntff = {
+    "args_cuda": Template(
+        """
+extern "C" __global__ void gather_time_domain_ntff(
+    int npatches,
+    const int* __restrict__ inside_index,
+    const int* __restrict__ outside_index,
+    const $REAL* __restrict__ normal_spacing,
+    const $REAL* __restrict__ field,
+    $REAL* surface_value,
+    $REAL* normal_derivative)
+"""
+    ),
+    "args_opencl": Template(
+        """
+__kernel void gather_time_domain_ntff(
+    int npatches,
+    __global const int* restrict inside_index,
+    __global const int* restrict outside_index,
+    __global const $REAL* restrict normal_spacing,
+    __global const $REAL* restrict field,
+    __global $REAL* surface_value,
+    __global $REAL* normal_derivative)
+"""
+    ),
+    "args_metal": Template(
+        """
+kernel void gather_time_domain_ntff(
+    device const int& npatches,
+    device const int* inside_index,
+    device const int* outside_index,
+    device const $REAL* normal_spacing,
+    device const $REAL* field,
+    device $REAL* surface_value,
+    device $REAL* normal_derivative,
+    uint patch [[thread_position_in_grid]])
+"""
+    ),
+    "func": Template(
+        """
+    $INDEX
+    if (patch < npatches) {
+        $REAL inside_value = field[inside_index[patch]];
+        $REAL outside_value = field[outside_index[patch]];
+        surface_value[patch] = ($REAL)0.5 * (inside_value + outside_value);
+        normal_derivative[patch] =
+            (outside_value - inside_value) / normal_spacing[patch];
+    }
+"""
+    ),
+}
+
+
+deposit_time_domain_ntff = {
+    "args_cuda": Template(
+        """
+extern "C" __global__ void deposit_time_domain_ntff(
+    int total,
+    int neffective_patches,
+    int output_length,
+    int sample_index,
+    const $REAL* __restrict__ surface_value,
+    const $REAL* __restrict__ normal_derivative,
+    const $REAL* __restrict__ time_surface_a,
+    const $REAL* __restrict__ time_surface_b,
+    const $REAL* __restrict__ time_surface_c,
+    $REAL coefficient_a,
+    $REAL coefficient_b,
+    $REAL coefficient_c,
+    const $REAL* __restrict__ normal_derivative_weight,
+    const $REAL* __restrict__ field_weight,
+    const $REAL* __restrict__ time_derivative_weight,
+    const int* __restrict__ source_patch_index,
+    const int* __restrict__ integer_delay,
+    const $REAL* __restrict__ fractional_delay,
+    const int* __restrict__ time_origin_steps,
+    $REAL* output)
+"""
+    ),
+    "args_opencl": Template(
+        """
+__kernel void deposit_time_domain_ntff(
+    int npoints,
+    int neffective_patches,
+    int output_length,
+    int sample_index,
+    __global const $REAL* restrict surface_value,
+    __global const $REAL* restrict normal_derivative,
+    __global const $REAL* restrict time_surface_a,
+    __global const $REAL* restrict time_surface_b,
+    __global const $REAL* restrict time_surface_c,
+    $REAL coefficient_a,
+    $REAL coefficient_b,
+    $REAL coefficient_c,
+    __global const $REAL* restrict normal_derivative_weight,
+    __global const $REAL* restrict field_weight,
+    __global const $REAL* restrict time_derivative_weight,
+    __global const int* restrict source_patch_index,
+    __global const int* restrict integer_delay,
+    __global const $REAL* restrict fractional_delay,
+    __global const int* restrict time_origin_steps,
+    __global $REAL* output)
+"""
+    ),
+    "args_metal": Template(
+        """
+kernel void deposit_time_domain_ntff(
+    device const int& npoints,
+    device const int& neffective_patches,
+    device const int& output_length,
+    device const int& sample_index,
+    device const $REAL* surface_value,
+    device const $REAL* normal_derivative,
+    device const $REAL* time_surface_a,
+    device const $REAL* time_surface_b,
+    device const $REAL* time_surface_c,
+    device const $REAL& coefficient_a,
+    device const $REAL& coefficient_b,
+    device const $REAL& coefficient_c,
+    device const $REAL* normal_derivative_weight,
+    device const $REAL* field_weight,
+    device const $REAL* time_derivative_weight,
+    device const int* source_patch_index,
+    device const int* integer_delay,
+    device const $REAL* fractional_delay,
+    device const int* time_origin_steps,
+    device $REAL* output,
+    uint point [[thread_position_in_grid]])
+"""
+    ),
+    "func_cuda": Template(
+        """
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < total) {
+        int point = i / neffective_patches;
+        int patch = i - point * neffective_patches;
+        int source_patch = source_patch_index[patch];
+        int destination = sample_index - time_origin_steps[point]
+            + integer_delay[i];
+        $REAL time_derivative = coefficient_a * time_surface_a[source_patch]
+            + coefficient_b * time_surface_b[source_patch]
+            + coefficient_c * time_surface_c[source_patch];
+        $REAL contribution = normal_derivative_weight[i]
+                * normal_derivative[source_patch]
+            + field_weight[i] * surface_value[source_patch]
+            + time_derivative_weight[i] * time_derivative;
+        $REAL fraction = fractional_delay[i];
+        ksir_atomic_add(
+            &output[point * output_length + destination],
+            (($REAL)1 - fraction) * contribution);
+        ksir_atomic_add(
+            &output[point * output_length + destination + 1],
+            fraction * contribution);
+    }
+"""
+    ),
+    "func_portable": Template(
+        """
+    $INDEX
+    if (point < npoints) {
+        int point_offset = point * neffective_patches;
+        int output_offset = point * output_length;
+        for (int patch = 0; patch < neffective_patches; patch++) {
+            int i = point_offset + patch;
+            int source_patch = source_patch_index[patch];
+            int destination = sample_index - time_origin_steps[point]
+                + integer_delay[i];
+            $REAL time_derivative = coefficient_a * time_surface_a[source_patch]
+                + coefficient_b * time_surface_b[source_patch]
+                + coefficient_c * time_surface_c[source_patch];
+            $REAL contribution = normal_derivative_weight[i]
+                    * normal_derivative[source_patch]
+                + field_weight[i] * surface_value[source_patch]
+                + time_derivative_weight[i] * time_derivative;
+            $REAL fraction = fractional_delay[i];
+            output[output_offset + destination] +=
+                (($REAL)1 - fraction) * contribution;
+            output[output_offset + destination + 1] += fraction * contribution;
+        }
+    }
+"""
+    ),
+}
+
+
+_CUDA_FLOAT_ATOMIC_PREAMBLE = r"""
+__device__ inline void ksir_atomic_add(float* address, float value)
+{
+    atomicAdd(address, value);
+}
+"""
+
+
+_CUDA_DOUBLE_ATOMIC_PREAMBLE = r"""
+__device__ inline void ksir_atomic_add(double* address, double value)
+{
+#if __CUDA_ARCH__ >= 600
+    atomicAdd(address, value);
+#else
+    unsigned long long int* integer_address =
+        reinterpret_cast<unsigned long long int*>(address);
+    unsigned long long int old = *integer_address;
+    unsigned long long int assumed;
+    do {
+        assumed = old;
+        old = atomicCAS(
+            integer_address,
+            assumed,
+            __double_as_longlong(value + __longlong_as_double(assumed)));
+    } while (assumed != old);
+#endif
+}
+"""
+
+
+def build_time_domain_ntff_kernel_source(c_real: str, backend: str = "cuda") -> str:
+    """Render advanced-time gather and delayed-deposition kernels."""
+
+    if c_real not in ("float", "double"):
+        raise ValueError("c_real must be 'float' or 'double'")
+    if backend not in ("cuda", "opencl", "metal"):
+        raise ValueError("backend must be 'cuda', 'opencl', or 'metal'")
+
+    if backend == "cuda":
+        preamble = (
+            _CUDA_FLOAT_ATOMIC_PREAMBLE if c_real == "float" else _CUDA_DOUBLE_ATOMIC_PREAMBLE
+        )
+        gather_index = "int patch = blockIdx.x * blockDim.x + threadIdx.x;"
+        deposit_body = deposit_time_domain_ntff["func_cuda"].substitute(REAL=c_real)
+    elif backend == "opencl":
+        preamble = "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n" if c_real == "double" else ""
+        gather_index = "int patch = get_global_id(0);"
+        deposit_body = deposit_time_domain_ntff["func_portable"].substitute(
+            REAL=c_real, INDEX="int point = get_global_id(0);"
+        )
+    else:
+        preamble = "#include <metal_stdlib>\nusing namespace metal;\n"
+        gather_index = ""
+        deposit_body = deposit_time_domain_ntff["func_portable"].substitute(REAL=c_real, INDEX="")
+
+    gather_declaration = gather_time_domain_ntff[f"args_{backend}"].substitute(REAL=c_real)
+    gather_body = gather_time_domain_ntff["func"].substitute(REAL=c_real, INDEX=gather_index)
+    deposit_declaration = deposit_time_domain_ntff[f"args_{backend}"].substitute(REAL=c_real)
+    return (
+        f"{preamble}\n{gather_declaration}{{\n{gather_body}}}\n"
+        f"{deposit_declaration}{{\n{deposit_body}}}\n"
+    )

--- a/gprMax/ntff/device.py
+++ b/gprMax/ntff/device.py
@@ -1,0 +1,976 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+
+"""Device-resident KSIR DFT collection for CUDA, OpenCL, and Metal."""
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+import numpy as np
+import numpy.typing as npt
+
+from gprMax.cuda_opencl.knl_ntff import (
+    build_ntff_kernel_source,
+    build_time_domain_ntff_kernel_source,
+)
+
+ELECTRIC_COMPONENTS = ("Ex", "Ey", "Ez")
+MAGNETIC_COMPONENTS = ("Hx", "Hy", "Hz")
+
+
+def _is_frequency_monitor(monitor) -> bool:
+    return hasattr(monitor, "device_sampling_multiplier")
+
+
+def _is_time_domain_monitor(monitor) -> bool:
+    return hasattr(monitor, "load_device_component_output")
+
+
+def configure_ntff_monitors(grid, *, allow_time_domain: bool = False) -> None:
+    """Perform backend-independent material validation before time stepping."""
+
+    for monitor in grid.ntff_monitors:
+        if _is_time_domain_monitor(monitor) and not allow_time_domain:
+            raise ValueError("advanced-time KSIR requires a time-domain-capable device collector")
+        if not (_is_frequency_monitor(monitor) or _is_time_domain_monitor(monitor)):
+            raise TypeError("unrecognised NTFF monitor type")
+        monitor.validate_materials(grid.ID, grid.IDlookup)
+        configure_background = getattr(monitor, "configure_background", None)
+        if configure_background is not None:
+            configure_background(grid.materials)
+
+
+@dataclass
+class _ComponentRecord:
+    monitor: object
+    component: str
+    npatches: int
+    nfrequencies: int
+    inside_index: npt.NDArray[np.int32]
+    outside_index: npt.NDArray[np.int32]
+    device: Dict[str, object]
+
+    @property
+    def total(self) -> int:
+        return self.npatches * self.nfrequencies
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        return self.nfrequencies, self.npatches
+
+
+class _DeviceKSIRCollector:
+    """Backend-neutral sequencing and configured-dtype reconstruction."""
+
+    def __init__(self, updates, monitors=None, *, configure: bool = True):
+        self.updates = updates
+        self.grid = updates.grid
+        if configure:
+            configure_ntff_monitors(self.grid)
+        self.monitors = list(self.grid.ntff_monitors if monitors is None else monitors)
+        self.records: List[_ComponentRecord] = []
+        limits = np.iinfo(np.int32)
+        for monitor in self.monitors:
+            if not _is_frequency_monitor(monitor):
+                raise TypeError("frequency collector received a time-domain monitor")
+            collector_dtype = getattr(self, "real_dtype", None)
+            if collector_dtype is not None and monitor.real_dtype != collector_dtype:
+                raise ValueError("KSIR monitor dtype does not match field dtype")
+            for component, surface in monitor.surfaces.items():
+                npatches = int(surface.npatches)
+                nfrequencies = int(monitor.frequencies.size)
+                total = npatches * nfrequencies
+                if npatches > limits.max or nfrequencies > limits.max or total > limits.max:
+                    raise ValueError(
+                        "KSIR frequency-domain work-item count "
+                        f"{total} ({npatches} surface patches * "
+                        f"{nfrequencies} frequencies) exceeds device int32 "
+                        "indexing"
+                    )
+                inside = np.concatenate([face.inside_flat_indices for face in surface.faces])
+                outside = np.concatenate([face.outside_flat_indices for face in surface.faces])
+                if (
+                    np.any(inside < limits.min)
+                    or np.any(inside > limits.max)
+                    or np.any(outside < limits.min)
+                    or np.any(outside > limits.max)
+                ):
+                    raise ValueError("KSIR device surface indices exceed int32 range")
+                record = _ComponentRecord(
+                    monitor=monitor,
+                    component=component,
+                    npatches=npatches,
+                    nfrequencies=nfrequencies,
+                    inside_index=inside.astype(np.int32),
+                    outside_index=outside.astype(np.int32),
+                    device={},
+                )
+                self._allocate(record)
+                self.records.append(record)
+
+    def _allocate(self, record: _ComponentRecord) -> None:
+        raise NotImplementedError
+
+    def _accumulate(
+        self,
+        record: _ComponentRecord,
+        field,
+        multiplier: npt.NDArray[np.complexfloating],
+    ) -> None:
+        raise NotImplementedError
+
+    def _download(
+        self, record: _ComponentRecord
+    ) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
+        raise NotImplementedError
+
+    def _observe(self, iteration: int, components: Iterable[str]) -> None:
+        selected = set(components)
+        for record in self.records:
+            if record.component not in selected:
+                continue
+            multiplier = record.monitor.device_sampling_multiplier(record.component, iteration)
+            field = getattr(self.grid, f"{record.component}_dev")
+            self._accumulate(record, field, multiplier)
+
+    def observe_electric(self, iteration: int) -> None:
+        self._observe(iteration, ELECTRIC_COMPONENTS)
+
+    def observe_magnetic(self, iteration: int) -> None:
+        self._observe(iteration, MAGNETIC_COMPONENTS)
+
+    def finalise(self) -> None:
+        for record in self.records:
+            inside_real, inside_imag, outside_real, outside_imag = self._download(record)
+            dtype = record.monitor.complex_dtype
+            inside = np.empty(record.shape, dtype=dtype)
+            outside = np.empty(record.shape, dtype=dtype)
+            inside.real = np.asarray(inside_real).reshape(record.shape)
+            inside.imag = np.asarray(inside_imag).reshape(record.shape)
+            outside.real = np.asarray(outside_real).reshape(record.shape)
+            outside.imag = np.asarray(outside_imag).reshape(record.shape)
+            record.monitor.load_device_component_dfts(record.component, inside, outside)
+        for monitor in self.monitors:
+            monitor.finalise()
+
+
+class CUDAKSIRCollector(_DeviceKSIRCollector):
+    """CUDA raw-surface DFT collector."""
+
+    def __init__(self, updates, monitors=None, *, configure: bool = True):
+        c_real = updates.ntff_c_real
+        source = build_ntff_kernel_source("cuda", c_real)
+        module = updates.source_module(
+            source, options=getattr(updates, "ntff_compiler_options", None)
+        )
+        self.kernel = module.get_function("accumulate_ntff")
+        self.gpuarray = updates.grid.gpuarray
+        self.real_dtype = np.dtype(updates.grid.Ex.dtype)
+        super().__init__(updates, monitors, configure=configure)
+
+    def _allocate(self, record: _ComponentRecord) -> None:
+        record.device["inside_index"] = self.gpuarray.to_gpu(record.inside_index)
+        record.device["outside_index"] = self.gpuarray.to_gpu(record.outside_index)
+        record.device["multiplier_real"] = self.gpuarray.empty(record.nfrequencies, self.real_dtype)
+        record.device["multiplier_imag"] = self.gpuarray.empty(record.nfrequencies, self.real_dtype)
+        for name in ("inside_real", "inside_imag", "outside_real", "outside_imag"):
+            record.device[name] = self.gpuarray.zeros(record.total, self.real_dtype)
+
+    def _accumulate(self, record, field, multiplier) -> None:
+        real = np.asarray(multiplier.real, dtype=self.real_dtype)
+        imag = np.asarray(multiplier.imag, dtype=self.real_dtype)
+        record.device["multiplier_real"].set(real)
+        record.device["multiplier_imag"].set(imag)
+        self.kernel(
+            np.int32(record.total),
+            np.int32(record.npatches),
+            record.device["inside_index"].gpudata,
+            record.device["outside_index"].gpudata,
+            record.device["multiplier_real"].gpudata,
+            record.device["multiplier_imag"].gpudata,
+            field.gpudata,
+            record.device["inside_real"].gpudata,
+            record.device["inside_imag"].gpudata,
+            record.device["outside_real"].gpudata,
+            record.device["outside_imag"].gpudata,
+            block=(128, 1, 1),
+            grid=((record.total + 127) // 128, 1, 1),
+        )
+
+    def _download(self, record):
+        return tuple(
+            record.device[name].get()
+            for name in ("inside_real", "inside_imag", "outside_real", "outside_imag")
+        )
+
+
+@dataclass
+class _TimeComponentRecord:
+    monitor: object
+    component: str
+    nbase_patches: int
+    neffective_patches: int
+    npoints: int
+    output_length: int
+    device: Dict[str, object]
+    observed: int = 0
+
+    @property
+    def total(self) -> int:
+        return self.neffective_patches * self.npoints
+
+
+class CUDATimeDomainKSIRCollector:
+    """Device-resident advanced-time KSIR collection and deposition."""
+
+    _threads = 128
+
+    def __init__(self, updates, monitors):
+        self.updates = updates
+        self.grid = updates.grid
+        self.monitors = list(monitors)
+        self.real_dtype = np.dtype(self.grid.Ex.dtype)
+        self.real_scalar = self.real_dtype.type
+        self.inverse_dt = 1 / self.grid.dt
+        self.inverse_two_dt = 1 / (2 * self.grid.dt)
+        self.gpuarray = self.grid.gpuarray
+        source = build_time_domain_ntff_kernel_source(updates.ntff_c_real)
+        module = updates.source_module(
+            source, options=getattr(updates, "ntff_compiler_options", None)
+        )
+        self.gather_kernel = module.get_function("gather_time_domain_ntff")
+        self.deposit_kernel = module.get_function("deposit_time_domain_ntff")
+        self._initialise_records("cuda")
+
+    def _initialise_records(self, backend: str) -> None:
+        """Build backend-independent record metadata and device allocations."""
+
+        self.records: List[_TimeComponentRecord] = []
+
+        int_limit = np.iinfo(np.int32)
+        for monitor in self.monitors:
+            if monitor.device_backend != backend:
+                raise ValueError(f"{backend} time-domain monitor is not configured for {backend}")
+            if monitor.real_dtype != self.real_dtype:
+                raise ValueError("KSIR monitor dtype does not match field dtype")
+            if monitor.iterations > int_limit.max or monitor.output_length > int_limit.max:
+                raise ValueError("KSIR time-domain extent exceeds device int32 indexing")
+            for component, surface in monitor.surfaces.items():
+                accumulator = monitor._accumulators[component]
+                record = _TimeComponentRecord(
+                    monitor=monitor,
+                    component=component,
+                    nbase_patches=surface.npatches,
+                    neffective_patches=accumulator._source_patch_index.size,
+                    npoints=monitor.points.shape[0],
+                    output_length=monitor.output_length,
+                    device={},
+                )
+                if (
+                    record.total > int_limit.max
+                    or record.npoints * record.output_length > int_limit.max
+                ):
+                    raise ValueError("KSIR time-domain arrays exceed device int32 indexing")
+                self._allocate(record, accumulator)
+                self.records.append(record)
+
+    def _to_int32(self, name: str, values: npt.ArrayLike) -> npt.NDArray[np.int32]:
+        array = np.asarray(values)
+        limits = np.iinfo(np.int32)
+        if np.any(array < limits.min) or np.any(array > limits.max):
+            raise ValueError(f"{name} exceeds device int32 indexing")
+        return np.ascontiguousarray(array, dtype=np.int32)
+
+    def _allocate(self, record: _TimeComponentRecord, accumulator) -> None:
+        integer_arrays = {
+            "inside_index": accumulator._inside_indices,
+            "outside_index": accumulator._outside_indices,
+            "source_patch_index": accumulator._source_patch_index,
+            "integer_delay": accumulator._integer_delay.ravel(),
+            "time_origin_steps": accumulator._time_origin_steps,
+        }
+        for name, values in integer_arrays.items():
+            record.device[name] = self.gpuarray.to_gpu(self._to_int32(name, values))
+
+        real_arrays = {
+            "normal_spacing": accumulator._normal_spacing,
+            "normal_derivative_weight": accumulator._normal_derivative_weight.ravel(),
+            "field_weight": accumulator._field_weight.ravel(),
+            "time_derivative_weight": accumulator._time_derivative_weight.ravel(),
+            "fractional_delay": accumulator._fractional_delay.ravel(),
+        }
+        for name, values in real_arrays.items():
+            record.device[name] = self.gpuarray.to_gpu(
+                np.ascontiguousarray(values, dtype=self.real_dtype)
+            )
+
+        record.device["surface"] = [
+            self.gpuarray.empty(record.nbase_patches, self.real_dtype) for _ in range(3)
+        ]
+        record.device["normal_derivative"] = [
+            self.gpuarray.empty(record.nbase_patches, self.real_dtype) for _ in range(3)
+        ]
+        record.device["output"] = self.gpuarray.zeros(
+            record.npoints * record.output_length, self.real_dtype
+        )
+
+    def _gather(self, record: _TimeComponentRecord, iteration: int) -> None:
+        slot = iteration % 3
+        field = getattr(self.grid, f"{record.component}_dev")
+        self.gather_kernel(
+            np.int32(record.nbase_patches),
+            record.device["inside_index"].gpudata,
+            record.device["outside_index"].gpudata,
+            record.device["normal_spacing"].gpudata,
+            field.gpudata,
+            record.device["surface"][slot].gpudata,
+            record.device["normal_derivative"][slot].gpudata,
+            block=(self._threads, 1, 1),
+            grid=(
+                ((record.nbase_patches + self._threads - 1) // self._threads),
+                1,
+                1,
+            ),
+        )
+
+    def _deposit(
+        self,
+        record: _TimeComponentRecord,
+        sample_index: int,
+        derivative_samples: tuple[int, int, int],
+        derivative_coefficients: tuple[float, float, float],
+    ) -> None:
+        surface_slot = sample_index % 3
+        time_surfaces = [record.device["surface"][sample % 3] for sample in derivative_samples]
+        coefficients = [self.real_scalar(value) for value in derivative_coefficients]
+        self.deposit_kernel(
+            np.int32(record.total),
+            np.int32(record.neffective_patches),
+            np.int32(record.output_length),
+            np.int32(sample_index),
+            record.device["surface"][surface_slot].gpudata,
+            record.device["normal_derivative"][surface_slot].gpudata,
+            time_surfaces[0].gpudata,
+            time_surfaces[1].gpudata,
+            time_surfaces[2].gpudata,
+            coefficients[0],
+            coefficients[1],
+            coefficients[2],
+            record.device["normal_derivative_weight"].gpudata,
+            record.device["field_weight"].gpudata,
+            record.device["time_derivative_weight"].gpudata,
+            record.device["source_patch_index"].gpudata,
+            record.device["integer_delay"].gpudata,
+            record.device["fractional_delay"].gpudata,
+            record.device["time_origin_steps"].gpudata,
+            record.device["output"].gpudata,
+            block=(self._threads, 1, 1),
+            grid=((record.total + self._threads - 1) // self._threads, 1, 1),
+        )
+
+    def _observe(self, iteration: int, components: Iterable[str]) -> None:
+        selected = set(components)
+        for record in self.records:
+            if record.component not in selected:
+                continue
+            if iteration != record.observed:
+                raise ValueError(
+                    f"expected device KSIR iteration {record.observed}, received {iteration}"
+                )
+            self._gather(record, iteration)
+            record.observed += 1
+            if iteration < 2:
+                continue
+            if iteration == 2:
+                self._deposit(
+                    record,
+                    0,
+                    (0, 1, 2),
+                    (
+                        -3 * self.inverse_two_dt,
+                        4 * self.inverse_two_dt,
+                        -self.inverse_two_dt,
+                    ),
+                )
+            self._deposit(
+                record,
+                iteration - 1,
+                (iteration - 2, iteration, iteration),
+                (-self.inverse_two_dt, self.inverse_two_dt, 0),
+            )
+
+    def observe_electric(self, iteration: int) -> None:
+        self._observe(iteration, ELECTRIC_COMPONENTS)
+
+    def observe_magnetic(self, iteration: int) -> None:
+        self._observe(iteration, MAGNETIC_COMPONENTS)
+
+    def _deposit_endpoint(self, record: _TimeComponentRecord) -> None:
+        iterations = record.monitor.iterations
+        if record.observed != iterations:
+            raise RuntimeError(
+                f"device KSIR component {record.component} received "
+                f"{record.observed} of {iterations} samples"
+            )
+        if iterations == 1:
+            self._deposit(record, 0, (0, 0, 0), (0, 0, 0))
+        elif iterations == 2:
+            coefficients = (-self.inverse_dt, self.inverse_dt, 0)
+            self._deposit(record, 0, (0, 1, 1), coefficients)
+            self._deposit(record, 1, (0, 1, 1), coefficients)
+        else:
+            last = iterations - 1
+            self._deposit(
+                record,
+                last,
+                (last - 2, last - 1, last),
+                (
+                    self.inverse_two_dt,
+                    -4 * self.inverse_two_dt,
+                    3 * self.inverse_two_dt,
+                ),
+            )
+
+    def finalise(self) -> None:
+        for record in self.records:
+            self._deposit_endpoint(record)
+            output = self._download_output(record).reshape(record.npoints, record.output_length)
+            record.monitor.load_device_component_output(record.component, output)
+        for monitor in self.monitors:
+            monitor.finalise()
+
+    def _download_output(self, record: _TimeComponentRecord) -> npt.NDArray:
+        return record.device["output"].get()
+
+
+class CUDACombinedKSIRCollector:
+    """Dispatch frequency-domain and advanced-time monitors on CUDA."""
+
+    def __init__(self, updates):
+        configure_ntff_monitors(updates.grid, allow_time_domain=True)
+        frequency_monitors = [
+            monitor for monitor in updates.grid.ntff_monitors if _is_frequency_monitor(monitor)
+        ]
+        time_monitors = [
+            monitor for monitor in updates.grid.ntff_monitors if _is_time_domain_monitor(monitor)
+        ]
+        self.frequency = (
+            CUDAKSIRCollector(updates, frequency_monitors, configure=False)
+            if frequency_monitors
+            else None
+        )
+        self.time_domain = (
+            CUDATimeDomainKSIRCollector(updates, time_monitors) if time_monitors else None
+        )
+
+    def observe_electric(self, iteration: int) -> None:
+        if self.frequency is not None:
+            self.frequency.observe_electric(iteration)
+        if self.time_domain is not None:
+            self.time_domain.observe_electric(iteration)
+
+    def observe_magnetic(self, iteration: int) -> None:
+        if self.frequency is not None:
+            self.frequency.observe_magnetic(iteration)
+        if self.time_domain is not None:
+            self.time_domain.observe_magnetic(iteration)
+
+    def finalise(self) -> None:
+        if self.frequency is not None:
+            self.frequency.finalise()
+        if self.time_domain is not None:
+            self.time_domain.finalise()
+
+
+class OpenCLKSIRCollector(_DeviceKSIRCollector):
+    """OpenCL raw-surface DFT collector."""
+
+    def __init__(self, updates, monitors=None, *, configure: bool = True):
+        c_real = updates.ntff_c_real
+        source = build_ntff_kernel_source("opencl", c_real)
+        options = getattr(updates, "ntff_compiler_options", None)
+        self.kernel = updates.cl.Program(updates.ctx, source).build(options=options).accumulate_ntff
+        self.clarray = updates.grid.clarray
+        self.queue = updates.queue
+        self.real_dtype = np.dtype(updates.grid.Ex.dtype)
+        super().__init__(updates, monitors, configure=configure)
+
+    def _allocate(self, record: _ComponentRecord) -> None:
+        record.device["inside_index"] = self.clarray.to_device(self.queue, record.inside_index)
+        record.device["outside_index"] = self.clarray.to_device(self.queue, record.outside_index)
+        record.device["multiplier_real"] = self.clarray.empty(
+            self.queue, record.nfrequencies, self.real_dtype
+        )
+        record.device["multiplier_imag"] = self.clarray.empty(
+            self.queue, record.nfrequencies, self.real_dtype
+        )
+        for name in ("inside_real", "inside_imag", "outside_real", "outside_imag"):
+            record.device[name] = self.clarray.zeros(self.queue, record.total, self.real_dtype)
+
+    def _accumulate(self, record, field, multiplier) -> None:
+        record.device["multiplier_real"].set(
+            np.asarray(multiplier.real, dtype=self.real_dtype), queue=self.queue
+        )
+        record.device["multiplier_imag"].set(
+            np.asarray(multiplier.imag, dtype=self.real_dtype), queue=self.queue
+        )
+        self.kernel(
+            self.queue,
+            (record.total,),
+            None,
+            np.int32(record.total),
+            np.int32(record.npatches),
+            record.device["inside_index"].data,
+            record.device["outside_index"].data,
+            record.device["multiplier_real"].data,
+            record.device["multiplier_imag"].data,
+            field.data,
+            record.device["inside_real"].data,
+            record.device["inside_imag"].data,
+            record.device["outside_real"].data,
+            record.device["outside_imag"].data,
+        )
+
+    def _download(self, record):
+        return tuple(
+            record.device[name].get(queue=self.queue)
+            for name in ("inside_real", "inside_imag", "outside_real", "outside_imag")
+        )
+
+
+class OpenCLTimeDomainKSIRCollector(CUDATimeDomainKSIRCollector):
+    """Device-resident advanced-time KSIR collection on OpenCL."""
+
+    def __init__(self, updates, monitors):
+        self.updates = updates
+        self.grid = updates.grid
+        self.monitors = list(monitors)
+        self.real_dtype = np.dtype(self.grid.Ex.dtype)
+        self.real_scalar = self.real_dtype.type
+        self.inverse_dt = 1 / self.grid.dt
+        self.inverse_two_dt = 1 / (2 * self.grid.dt)
+        self.clarray = self.grid.clarray
+        self.queue = updates.queue
+        source = build_time_domain_ntff_kernel_source(updates.ntff_c_real, backend="opencl")
+        options = getattr(updates, "ntff_compiler_options", None)
+        program = updates.cl.Program(updates.ctx, source).build(options=options)
+        self.gather_kernel = program.gather_time_domain_ntff
+        self.deposit_kernel = program.deposit_time_domain_ntff
+        self._initialise_records("opencl")
+
+    def _allocate(self, record: _TimeComponentRecord, accumulator) -> None:
+        integer_arrays = {
+            "inside_index": accumulator._inside_indices,
+            "outside_index": accumulator._outside_indices,
+            "source_patch_index": accumulator._source_patch_index,
+            "integer_delay": accumulator._integer_delay.ravel(),
+            "time_origin_steps": accumulator._time_origin_steps,
+        }
+        for name, values in integer_arrays.items():
+            record.device[name] = self.clarray.to_device(self.queue, self._to_int32(name, values))
+
+        real_arrays = {
+            "normal_spacing": accumulator._normal_spacing,
+            "normal_derivative_weight": accumulator._normal_derivative_weight.ravel(),
+            "field_weight": accumulator._field_weight.ravel(),
+            "time_derivative_weight": accumulator._time_derivative_weight.ravel(),
+            "fractional_delay": accumulator._fractional_delay.ravel(),
+        }
+        for name, values in real_arrays.items():
+            record.device[name] = self.clarray.to_device(
+                self.queue, np.ascontiguousarray(values, dtype=self.real_dtype)
+            )
+
+        record.device["surface"] = [
+            self.clarray.empty(self.queue, record.nbase_patches, self.real_dtype) for _ in range(3)
+        ]
+        record.device["normal_derivative"] = [
+            self.clarray.empty(self.queue, record.nbase_patches, self.real_dtype) for _ in range(3)
+        ]
+        record.device["output"] = self.clarray.zeros(
+            self.queue,
+            record.npoints * record.output_length,
+            self.real_dtype,
+        )
+
+    def _gather(self, record: _TimeComponentRecord, iteration: int) -> None:
+        slot = iteration % 3
+        field = getattr(self.grid, f"{record.component}_dev")
+        self.gather_kernel(
+            self.queue,
+            (record.nbase_patches,),
+            None,
+            np.int32(record.nbase_patches),
+            record.device["inside_index"].data,
+            record.device["outside_index"].data,
+            record.device["normal_spacing"].data,
+            field.data,
+            record.device["surface"][slot].data,
+            record.device["normal_derivative"][slot].data,
+        )
+
+    def _deposit(
+        self,
+        record: _TimeComponentRecord,
+        sample_index: int,
+        derivative_samples: tuple[int, int, int],
+        derivative_coefficients: tuple[float, float, float],
+    ) -> None:
+        surface_slot = sample_index % 3
+        time_surfaces = [record.device["surface"][sample % 3] for sample in derivative_samples]
+        coefficients = [self.real_scalar(value) for value in derivative_coefficients]
+        self.deposit_kernel(
+            self.queue,
+            (record.npoints,),
+            None,
+            np.int32(record.npoints),
+            np.int32(record.neffective_patches),
+            np.int32(record.output_length),
+            np.int32(sample_index),
+            record.device["surface"][surface_slot].data,
+            record.device["normal_derivative"][surface_slot].data,
+            time_surfaces[0].data,
+            time_surfaces[1].data,
+            time_surfaces[2].data,
+            coefficients[0],
+            coefficients[1],
+            coefficients[2],
+            record.device["normal_derivative_weight"].data,
+            record.device["field_weight"].data,
+            record.device["time_derivative_weight"].data,
+            record.device["source_patch_index"].data,
+            record.device["integer_delay"].data,
+            record.device["fractional_delay"].data,
+            record.device["time_origin_steps"].data,
+            record.device["output"].data,
+        )
+
+    def _download_output(self, record: _TimeComponentRecord) -> npt.NDArray:
+        return record.device["output"].get(queue=self.queue)
+
+
+class OpenCLCombinedKSIRCollector:
+    """Dispatch frequency-domain and advanced-time monitors on OpenCL."""
+
+    def __init__(self, updates):
+        configure_ntff_monitors(updates.grid, allow_time_domain=True)
+        frequency_monitors = [
+            monitor for monitor in updates.grid.ntff_monitors if _is_frequency_monitor(monitor)
+        ]
+        time_monitors = [
+            monitor for monitor in updates.grid.ntff_monitors if _is_time_domain_monitor(monitor)
+        ]
+        self.frequency = (
+            OpenCLKSIRCollector(updates, frequency_monitors, configure=False)
+            if frequency_monitors
+            else None
+        )
+        self.time_domain = (
+            OpenCLTimeDomainKSIRCollector(updates, time_monitors) if time_monitors else None
+        )
+
+    def observe_electric(self, iteration: int) -> None:
+        if self.frequency is not None:
+            self.frequency.observe_electric(iteration)
+        if self.time_domain is not None:
+            self.time_domain.observe_electric(iteration)
+
+    def observe_magnetic(self, iteration: int) -> None:
+        if self.frequency is not None:
+            self.frequency.observe_magnetic(iteration)
+        if self.time_domain is not None:
+            self.time_domain.observe_magnetic(iteration)
+
+    def finalise(self) -> None:
+        if self.frequency is not None:
+            self.frequency.finalise()
+        if self.time_domain is not None:
+            self.time_domain.finalise()
+
+
+class MetalKSIRCollector(_DeviceKSIRCollector):
+    """Metal raw-surface DFT collector using shared MTLBuffers."""
+
+    def __init__(self, updates, monitors=None, *, configure: bool = True):
+        c_real = updates.ntff_c_real
+        source = build_ntff_kernel_source("metal", c_real)
+        library, error = updates.dev.newLibraryWithSource_options_error_(source, updates.opts, None)
+        if library is None:
+            raise RuntimeError(f"Failed to compile Metal NTFF kernel: {error}")
+        function = library.newFunctionWithName_("accumulate_ntff")
+        self.pipeline = updates.dev.newComputePipelineStateWithFunction_error_(function, None)[0]
+        self.dev = updates.dev
+        self.queue = updates.cmdqueue
+        self.metal = updates.metal
+        self.storage = getattr(updates.grid, "storage", 0)
+        self.real_dtype = np.dtype(updates.grid.Ex.dtype)
+        super().__init__(updates, monitors, configure=configure)
+
+    def _buffer(self, values: npt.NDArray):
+        contiguous = np.ascontiguousarray(values)
+        return self.dev.newBufferWithBytes_length_options_(
+            contiguous, contiguous.nbytes, self.storage
+        )
+
+    def _allocate(self, record: _ComponentRecord) -> None:
+        record.device["inside_index"] = self._buffer(record.inside_index)
+        record.device["outside_index"] = self._buffer(record.outside_index)
+        zeros = np.zeros(record.total, dtype=self.real_dtype)
+        for name in ("inside_real", "inside_imag", "outside_real", "outside_imag"):
+            record.device[name] = self._buffer(zeros)
+
+    def _accumulate(self, record, field, multiplier) -> None:
+        total = self._buffer(np.asarray((record.total,), dtype=np.int32))
+        npatches = self._buffer(np.asarray((record.npatches,), dtype=np.int32))
+        multiplier_real = self._buffer(np.asarray(multiplier.real, dtype=self.real_dtype))
+        multiplier_imag = self._buffer(np.asarray(multiplier.imag, dtype=self.real_dtype))
+        command = self.queue.commandBuffer()
+        encoder = command.computeCommandEncoder()
+        encoder.setComputePipelineState_(self.pipeline)
+        buffers = (
+            total,
+            npatches,
+            record.device["inside_index"],
+            record.device["outside_index"],
+            multiplier_real,
+            multiplier_imag,
+            field,
+            record.device["inside_real"],
+            record.device["inside_imag"],
+            record.device["outside_real"],
+            record.device["outside_imag"],
+        )
+        for index, buffer in enumerate(buffers):
+            encoder.setBuffer_offset_atIndex_(buffer, 0, index)
+        encoder.dispatchThreads_threadsPerThreadgroup_(
+            self.metal.MTLSizeMake(record.total, 1, 1),
+            self.metal.MTLSizeMake(
+                min(record.total, self.pipeline.maxTotalThreadsPerThreadgroup()),
+                1,
+                1,
+            ),
+        )
+        encoder.endEncoding()
+        command.commit()
+        command.waitUntilCompleted()
+
+    def _download(self, record):
+        nbytes = record.total * self.real_dtype.itemsize
+        return tuple(
+            np.frombuffer(
+                record.device[name].contents().as_buffer(nbytes),
+                dtype=self.real_dtype,
+            ).copy()
+            for name in ("inside_real", "inside_imag", "outside_real", "outside_imag")
+        )
+
+
+class MetalTimeDomainKSIRCollector(CUDATimeDomainKSIRCollector):
+    """Device-resident advanced-time KSIR collection on Apple Metal."""
+
+    def __init__(self, updates, monitors):
+        self.updates = updates
+        self.grid = updates.grid
+        self.monitors = list(monitors)
+        self.real_dtype = np.dtype(self.grid.Ex.dtype)
+        self.real_scalar = self.real_dtype.type
+        self.inverse_dt = 1 / self.grid.dt
+        self.inverse_two_dt = 1 / (2 * self.grid.dt)
+        self.dev = updates.dev
+        self.queue = updates.cmdqueue
+        self.metal = updates.metal
+        self.storage = getattr(self.grid, "storage", 0)
+        source = build_time_domain_ntff_kernel_source(updates.ntff_c_real, backend="metal")
+        library, error = self.dev.newLibraryWithSource_options_error_(source, updates.opts, None)
+        if library is None:
+            raise RuntimeError(f"Failed to compile Metal time-domain NTFF: {error}")
+        gather = library.newFunctionWithName_("gather_time_domain_ntff")
+        deposit = library.newFunctionWithName_("deposit_time_domain_ntff")
+        self.gather_pipeline = self.dev.newComputePipelineStateWithFunction_error_(gather, None)[0]
+        self.deposit_pipeline = self.dev.newComputePipelineStateWithFunction_error_(deposit, None)[
+            0
+        ]
+        self._initialise_records("metal")
+
+    def _buffer(self, values: npt.NDArray):
+        contiguous = np.ascontiguousarray(values)
+        return self.dev.newBufferWithBytes_length_options_(
+            contiguous, contiguous.nbytes, self.storage
+        )
+
+    @staticmethod
+    def _set_scalar(encoder, index: int, value) -> None:
+        scalar = np.asarray(value)
+        encoder.setBytes_length_atIndex_(scalar.tobytes(), scalar.dtype.itemsize, index)
+
+    def _dispatch(self, command, encoder, pipeline, work_items: int) -> None:
+        encoder.dispatchThreads_threadsPerThreadgroup_(
+            self.metal.MTLSizeMake(work_items, 1, 1),
+            self.metal.MTLSizeMake(
+                min(work_items, pipeline.maxTotalThreadsPerThreadgroup()),
+                1,
+                1,
+            ),
+        )
+        encoder.endEncoding()
+        command.commit()
+        command.waitUntilCompleted()
+
+    def _allocate(self, record: _TimeComponentRecord, accumulator) -> None:
+        integer_arrays = {
+            "inside_index": accumulator._inside_indices,
+            "outside_index": accumulator._outside_indices,
+            "source_patch_index": accumulator._source_patch_index,
+            "integer_delay": accumulator._integer_delay.ravel(),
+            "time_origin_steps": accumulator._time_origin_steps,
+        }
+        for name, values in integer_arrays.items():
+            record.device[name] = self._buffer(self._to_int32(name, values))
+
+        real_arrays = {
+            "normal_spacing": accumulator._normal_spacing,
+            "normal_derivative_weight": accumulator._normal_derivative_weight.ravel(),
+            "field_weight": accumulator._field_weight.ravel(),
+            "time_derivative_weight": accumulator._time_derivative_weight.ravel(),
+            "fractional_delay": accumulator._fractional_delay.ravel(),
+        }
+        for name, values in real_arrays.items():
+            record.device[name] = self._buffer(np.ascontiguousarray(values, dtype=self.real_dtype))
+
+        empty = np.empty(record.nbase_patches, dtype=self.real_dtype)
+        record.device["surface"] = [self._buffer(empty) for _ in range(3)]
+        record.device["normal_derivative"] = [self._buffer(empty) for _ in range(3)]
+        record.device["output"] = self._buffer(
+            np.zeros(
+                record.npoints * record.output_length,
+                dtype=self.real_dtype,
+            )
+        )
+
+    def _gather(self, record: _TimeComponentRecord, iteration: int) -> None:
+        slot = iteration % 3
+        field = getattr(self.grid, f"{record.component}_dev")
+        command = self.queue.commandBuffer()
+        encoder = command.computeCommandEncoder()
+        encoder.setComputePipelineState_(self.gather_pipeline)
+        self._set_scalar(encoder, 0, np.int32(record.nbase_patches))
+        buffers = (
+            record.device["inside_index"],
+            record.device["outside_index"],
+            record.device["normal_spacing"],
+            field,
+            record.device["surface"][slot],
+            record.device["normal_derivative"][slot],
+        )
+        for index, buffer in enumerate(buffers, start=1):
+            encoder.setBuffer_offset_atIndex_(buffer, 0, index)
+        self._dispatch(command, encoder, self.gather_pipeline, record.nbase_patches)
+
+    def _deposit(
+        self,
+        record: _TimeComponentRecord,
+        sample_index: int,
+        derivative_samples: tuple[int, int, int],
+        derivative_coefficients: tuple[float, float, float],
+    ) -> None:
+        surface_slot = sample_index % 3
+        time_surfaces = [record.device["surface"][sample % 3] for sample in derivative_samples]
+        command = self.queue.commandBuffer()
+        encoder = command.computeCommandEncoder()
+        encoder.setComputePipelineState_(self.deposit_pipeline)
+        for index, value in enumerate(
+            (
+                np.int32(record.npoints),
+                np.int32(record.neffective_patches),
+                np.int32(record.output_length),
+                np.int32(sample_index),
+            )
+        ):
+            self._set_scalar(encoder, index, value)
+        initial_buffers = (
+            record.device["surface"][surface_slot],
+            record.device["normal_derivative"][surface_slot],
+            time_surfaces[0],
+            time_surfaces[1],
+            time_surfaces[2],
+        )
+        for index, buffer in enumerate(initial_buffers, start=4):
+            encoder.setBuffer_offset_atIndex_(buffer, 0, index)
+        for index, value in enumerate(derivative_coefficients, start=9):
+            self._set_scalar(encoder, index, self.real_scalar(value))
+        final_buffers = (
+            record.device["normal_derivative_weight"],
+            record.device["field_weight"],
+            record.device["time_derivative_weight"],
+            record.device["source_patch_index"],
+            record.device["integer_delay"],
+            record.device["fractional_delay"],
+            record.device["time_origin_steps"],
+            record.device["output"],
+        )
+        for index, buffer in enumerate(final_buffers, start=12):
+            encoder.setBuffer_offset_atIndex_(buffer, 0, index)
+        self._dispatch(command, encoder, self.deposit_pipeline, record.npoints)
+
+    def _download_output(self, record: _TimeComponentRecord) -> npt.NDArray:
+        count = record.npoints * record.output_length
+        nbytes = count * self.real_dtype.itemsize
+        return np.frombuffer(
+            record.device["output"].contents().as_buffer(nbytes),
+            dtype=self.real_dtype,
+        ).copy()
+
+
+class MetalCombinedKSIRCollector:
+    """Dispatch frequency-domain and advanced-time monitors on Metal."""
+
+    def __init__(self, updates):
+        configure_ntff_monitors(updates.grid, allow_time_domain=True)
+        frequency_monitors = [
+            monitor for monitor in updates.grid.ntff_monitors if _is_frequency_monitor(monitor)
+        ]
+        time_monitors = [
+            monitor for monitor in updates.grid.ntff_monitors if _is_time_domain_monitor(monitor)
+        ]
+        self.frequency = (
+            MetalKSIRCollector(updates, frequency_monitors, configure=False)
+            if frequency_monitors
+            else None
+        )
+        self.time_domain = (
+            MetalTimeDomainKSIRCollector(updates, time_monitors) if time_monitors else None
+        )
+
+    def observe_electric(self, iteration: int) -> None:
+        if self.frequency is not None:
+            self.frequency.observe_electric(iteration)
+        if self.time_domain is not None:
+            self.time_domain.observe_electric(iteration)
+
+    def observe_magnetic(self, iteration: int) -> None:
+        if self.frequency is not None:
+            self.frequency.observe_magnetic(iteration)
+        if self.time_domain is not None:
+            self.time_domain.observe_magnetic(iteration)
+
+    def finalise(self) -> None:
+        if self.frequency is not None:
+            self.frequency.finalise()
+        if self.time_domain is not None:
+            self.time_domain.finalise()

--- a/gprMax/ntff/frequency_domain.py
+++ b/gprMax/ntff/frequency_domain.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax. If not, see <http://www.gnu.org/licenses/>.
 
-"""Streaming frequency-domain KSIR monitor for the CPU solver."""
+"""Streaming frequency-domain KSIR monitor shared by all local solvers."""
 
 from dataclasses import dataclass
 from hashlib import sha256
@@ -401,6 +401,28 @@ class _ComponentDFTAccumulator:
             self.inside_dft += contribution * inside[np.newaxis, :]
             self.outside_dft += contribution * outside[np.newaxis, :]
 
+    def load_device_dfts(
+        self, inside: npt.ArrayLike, outside: npt.ArrayLike
+    ) -> None:
+        """Load completed raw DFTs accumulated by a device backend."""
+
+        if self._finalised:
+            raise RuntimeError("cannot load a finalised KSIR DFT accumulator")
+        if self._next_iteration != self.iterations:
+            raise RuntimeError(
+                f"KSIR component {self.surface.component} received "
+                f"{self._next_iteration} of {self.iterations} expected samples"
+            )
+        expected = self.inside_dft.shape
+        inside_values = np.asarray(inside)
+        outside_values = np.asarray(outside)
+        if inside_values.shape != expected or outside_values.shape != expected:
+            raise ValueError(f"device DFT arrays must have shape {expected}")
+        if inside_values.dtype != self.dtype or outside_values.dtype != self.dtype:
+            raise ValueError(f"device DFT arrays must use dtype {self.dtype}")
+        self.inside_dft[...] = inside_values
+        self.outside_dft[...] = outside_values
+
     def finalise(
         self, background_er: float, background_mr: float
     ) -> KSIRComponentPhasors:
@@ -460,6 +482,7 @@ class KSIRFrequencyDomainMonitor:
         real_dtype,
         complex_dtype,
         nthreads: int = 1,
+        solver_backend: str = "cpu",
         origin: Optional[npt.ArrayLike] = None,
         window: str = "rectangular",
         wave_speed: Optional[float] = None,
@@ -537,12 +560,18 @@ class KSIRFrequencyDomainMonitor:
         elif self.window_name == "hanning":
             self.window_name = "hann"
         self.precision = "single" if self.real_dtype.itemsize == 4 else "double"
+        if solver_backend not in ("cpu", "cuda", "opencl", "metal"):
+            raise ValueError("solver_backend is not a supported gprMax solver")
+        self.solver_backend = solver_backend
         self.nthreads = int(nthreads)
-        self.collection_backend = (
-            "cython_openmp"
-            if _accumulate_surface_dft is not None
-            else "numpy_fallback"
-        )
+        if solver_backend == "cpu":
+            self.collection_backend = (
+                "cython_openmp"
+                if _accumulate_surface_dft is not None
+                else "numpy_fallback"
+            )
+        else:
+            self.collection_backend = f"{solver_backend}_device"
         self.save_surface_dft = bool(save_surface_dft)
         self.incident_surface_file = (
             None if incident_surface_file is None else Path(incident_surface_file)
@@ -861,6 +890,35 @@ class KSIRFrequencyDomainMonitor:
         for component in MAGNETIC_COMPONENTS:
             if component in self._accumulators:
                 self._accumulators[component].observe(iteration, fields[component])
+
+    def device_sampling_multiplier(
+        self, component: str, iteration: int
+    ) -> npt.NDArray[np.complexfloating]:
+        """Advance and return a component multiplier for device accumulation."""
+
+        try:
+            accumulator = self._accumulators[component]
+        except KeyError as exc:
+            raise ValueError(
+                f"component {component!r} is not active in monitor {self.name!r}"
+            ) from exc
+        return accumulator.sampling_multiplier(iteration)
+
+    def load_device_component_dfts(
+        self,
+        component: str,
+        inside: npt.ArrayLike,
+        outside: npt.ArrayLike,
+    ) -> None:
+        """Load raw DFTs downloaded from an accelerator backend."""
+
+        try:
+            accumulator = self._accumulators[component]
+        except KeyError as exc:
+            raise ValueError(
+                f"component {component!r} is not active in monitor {self.name!r}"
+            ) from exc
+        accumulator.load_device_dfts(inside, outside)
 
     def _subtract_incident_surface(
         self, data: Mapping[str, KSIRComponentPhasors]
@@ -1193,10 +1251,11 @@ class KSIRFrequencyDomainMonitor:
         group.attrs["real_dtype"] = self.real_dtype.name
         group.attrs["complex_dtype"] = self.complex_dtype.name
         group.attrs["window"] = self.window_name
-        group.attrs["solver"] = "cpu"
+        group.attrs["solver"] = self.solver_backend
         group.attrs["collection_backend"] = self.collection_backend
         group.attrs["phase_reanchor_interval"] = DFT_PHASE_REANCHOR_INTERVAL
-        group.attrs["openmp_threads"] = self.nthreads
+        if self.solver_backend == "cpu":
+            group.attrs["openmp_threads"] = self.nthreads
         group.attrs["dt"] = self.dt
         group.attrs["iterations"] = self.iterations
         group.attrs["components"] = np.asarray(self.components, dtype="S2")

--- a/gprMax/ntff/interface.py
+++ b/gprMax/ntff/interface.py
@@ -689,6 +689,7 @@ class KSIRCompiledOutputs:
 
         for key, spec in self.time_requests.items():
             result = self.result_for(key)
+            monitor, _ = self.time_bindings[key]
             group = (
                 base_group[f"ntff/{spec.surface_id}"]
                 .require_group("time")
@@ -697,6 +698,8 @@ class KSIRCompiledOutputs:
             group.attrs["coordinate_system"] = spec.coordinate_system
             group.attrs["time_origin"] = spec.time_origin
             group.attrs["outputs"] = np.asarray(spec.outputs, dtype="S20")
+            group.attrs["solver"] = monitor.device_backend or "cpu"
+            group.attrs["collection_backend"] = monitor.collection_backend
             group["points"] = result.points
             group["times"] = result.times
             group["time_origins"] = result.time_origins
@@ -719,6 +722,7 @@ class KSIRCompiledOutputs:
             group.attrs["wave_speed"] = monitor.wave_speed
             group.attrs["impedance"] = monitor.impedance
             group.attrs["precision"] = monitor.precision
+            group.attrs["solver"] = monitor.solver_backend
             group.attrs["collection_backend"] = monitor.collection_backend
             group["frequencies"] = monitor.frequencies
             if transform.save_surface_dft:
@@ -827,8 +831,10 @@ def compile_ksir_outputs(model, grid) -> Optional[KSIRCompiledOutputs]:
         return None
     if config.sim_config.mpi:
         raise ValueError("the reusable KSIR interface does not yet support MPI")
-    if config.sim_config.general["solver"] != "cpu":
-        raise ValueError("the reusable KSIR interface currently supports only the CPU solver")
+    if config.sim_config.general["solver"] not in ("cpu", "cuda", "opencl", "metal"):
+        raise ValueError(
+            "the reusable KSIR interface supports CPU, CUDA, OpenCL, and Metal solvers"
+        )
     if config.get_model_config().mode != "3D":
         raise ValueError("the reusable KSIR interface currently supports only 3-D models")
 
@@ -924,6 +930,11 @@ def compile_ksir_outputs(model, grid) -> Optional[KSIRCompiledOutputs]:
             wave_speed=wave_speed,
             nthreads=config.get_model_config().ompthreads,
             time_origin=time_origin,
+            device_backend=(
+                config.sim_config.general["solver"]
+                if config.sim_config.general["solver"] in ("cuda", "opencl", "metal")
+                else None
+            ),
             closure=compiled.closure,
         )
         monitor.managed_output = True
@@ -957,6 +968,7 @@ def compile_ksir_outputs(model, grid) -> Optional[KSIRCompiledOutputs]:
             real_dtype=real_dtype,
             complex_dtype=config.sim_config.dtypes["complex"],
             nthreads=config.get_model_config().ompthreads,
+            solver_backend=config.sim_config.general["solver"],
             origin=compiled.origin,
             window=transform.window,
             save_surface_dft=transform.save_surface_dft,

--- a/gprMax/ntff/time_domain.py
+++ b/gprMax/ntff/time_domain.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax. If not, see <http://www.gnu.org/licenses/>.
 
-"""Advanced-time KSIR field extension for the CPU solver."""
+"""Advanced-time KSIR field extension for CPU and device collectors."""
 
 from collections import deque
 from dataclasses import dataclass
@@ -221,19 +221,24 @@ class _ComponentAccumulator:
         )
         self._derivative_buffer = np.empty_like(self._surface_buffer)
         self._time_origin_steps: npt.NDArray[np.int64]
-        self.output: npt.NDArray[np.floating]
+        self.output: npt.NDArray[np.floating] | None
 
     def allocate(
         self,
         output_length: int,
         time_origin_steps: npt.NDArray[np.int64],
+        *,
+        allocate_output: bool = True,
     ) -> None:
         self._time_origin_steps = np.ascontiguousarray(
             time_origin_steps, dtype=np.int64
         )
-        self.output = np.zeros(
-            (self.points.shape[0], output_length), dtype=self.real_dtype
-        )
+        if allocate_output:
+            self.output = np.zeros(
+                (self.points.shape[0], output_length), dtype=self.real_dtype
+            )
+        else:
+            self.output = None
 
     def _surface_values(
         self, field: npt.ArrayLike
@@ -386,8 +391,9 @@ class _ComponentAccumulator:
 class KSIRTimeDomainMonitor:
     """Advanced-time field reconstruction at explicit exterior points.
 
-    Collection uses configured-dtype Cython/OpenMP kernels, with a NumPy
-    fallback for source-tree use before the extensions are compiled.
+    CPU collection uses configured-dtype Cython/OpenMP kernels, with a NumPy
+    fallback before the extensions are compiled. Accelerator collection and
+    compact output storage remain device-resident until finalisation.
     """
 
     def __init__(
@@ -402,6 +408,7 @@ class KSIRTimeDomainMonitor:
         wave_speed: float = c,
         nthreads: int = 1,
         time_origin: str = "simulation",
+        device_backend: str | None = None,
         closure: ResolvedKSIRClosure | None = None,
     ):
         if not name:
@@ -422,6 +429,10 @@ class KSIRTimeDomainMonitor:
         ):
             raise ValueError(
                 "time_origin must be 'simulation' or 'first_arrival'"
+            )
+        if device_backend not in (None, "cuda", "opencl", "metal"):
+            raise ValueError(
+                "device_backend must be None, 'cuda', 'opencl', or 'metal'"
             )
         self.real_dtype = np.dtype(real_dtype)
         if self.real_dtype.kind != "f":
@@ -451,12 +462,16 @@ class KSIRTimeDomainMonitor:
         self.wave_speed = float(wave_speed)
         self.nthreads = int(nthreads)
         self.time_origin = time_origin
-        self.collection_backend = (
-            "cython_openmp"
-            if _gather_time_domain_surface is not None
-            and _deposit_time_domain_surface is not None
-            else "numpy_fallback"
-        )
+        self.device_backend = device_backend
+        if device_backend is None:
+            self.collection_backend = (
+                "cython_openmp"
+                if _gather_time_domain_surface is not None
+                and _deposit_time_domain_surface is not None
+                else "numpy_fallback"
+            )
+        else:
+            self.collection_backend = f"{device_backend}_device"
         self.components = components
         self.surfaces = MappingProxyType(dict(surfaces))
         self.closure = closure or ResolvedKSIRClosure(
@@ -556,7 +571,11 @@ class KSIRTimeDomainMonitor:
         self.valid_lengths.setflags(write=False)
         self.output_length = int(np.max(self.valid_lengths))
         for accumulator in self._accumulators.values():
-            accumulator.allocate(self.output_length, self.time_origin_steps)
+            accumulator.allocate(
+                self.output_length,
+                self.time_origin_steps,
+                allocate_output=self.device_backend is None,
+            )
 
     @property
     def result(self) -> KSIRTimeDomainResult:
@@ -620,6 +639,8 @@ class KSIRTimeDomainMonitor:
         Ey: npt.ArrayLike,
         Ez: npt.ArrayLike,
     ) -> None:
+        if self.device_backend is not None:
+            raise RuntimeError("device KSIR monitors must be observed on the device")
         fields = {"Ex": Ex, "Ey": Ey, "Ez": Ez}
         for component in ELECTRIC_COMPONENTS:
             if component in self._accumulators:
@@ -632,6 +653,8 @@ class KSIRTimeDomainMonitor:
         Hy: npt.ArrayLike,
         Hz: npt.ArrayLike,
     ) -> None:
+        if self.device_backend is not None:
+            raise RuntimeError("device KSIR monitors must be observed on the device")
         fields = {"Hx": Hx, "Hy": Hy, "Hz": Hz}
         for component in MAGNETIC_COMPONENTS:
             if component in self._accumulators:
@@ -640,8 +663,14 @@ class KSIRTimeDomainMonitor:
     def finalise(self) -> None:
         if self._finalised:
             return
-        for accumulator in self._accumulators.values():
-            accumulator.finalise()
+        if self.device_backend is None:
+            for accumulator in self._accumulators.values():
+                accumulator.finalise()
+        elif any(
+            accumulator.output is None
+            for accumulator in self._accumulators.values()
+        ):
+            raise RuntimeError("not all device KSIR component outputs were loaded")
 
         times = self.dt * np.arange(self.output_length, dtype=self.real_dtype)
         times.setflags(write=False)
@@ -671,6 +700,31 @@ class KSIRTimeDomainMonitor:
             mathematically_closed=self.closure.mathematically_closed,
         )
         self._finalised = True
+
+    def load_device_component_output(
+        self, component: str, output: npt.ArrayLike
+    ) -> None:
+        """Attach one configured-dtype history downloaded at finalisation."""
+
+        if self.device_backend is None:
+            raise RuntimeError("CPU KSIR monitors do not accept device output")
+        if self._finalised:
+            raise RuntimeError("cannot load output into a finalised KSIR monitor")
+        if component not in self._accumulators:
+            raise ValueError(f"component {component!r} is not monitored")
+        values = np.asarray(output)
+        expected_shape = (self.points.shape[0], self.output_length)
+        if values.shape != expected_shape:
+            raise ValueError(
+                f"device output for {component} must have shape {expected_shape}"
+            )
+        if values.dtype != self.real_dtype:
+            raise ValueError(
+                f"device output for {component} must use dtype {self.real_dtype}"
+            )
+        values = np.ascontiguousarray(values)
+        values.setflags(write=False)
+        self._accumulators[component].output = values
 
     def write_hdf5(self, base_group) -> None:
         """Write compact time-domain histories to the normal model output."""
@@ -711,9 +765,10 @@ class KSIRTimeDomainMonitor:
             "single" if self.real_dtype.itemsize == 4 else "double"
         )
         group.attrs["real_dtype"] = self.real_dtype.name
-        group.attrs["solver"] = "cpu"
+        group.attrs["solver"] = self.device_backend or "cpu"
         group.attrs["collection_backend"] = self.collection_backend
-        group.attrs["openmp_threads"] = self.nthreads
+        if self.device_backend is None:
+            group.attrs["openmp_threads"] = self.nthreads
         group.attrs["dt"] = self.dt
         group.attrs["iterations"] = self.iterations
         group.attrs["components"] = np.asarray(self.components, dtype="S2")

--- a/gprMax/updates/cuda_updates.py
+++ b/gprMax/updates/cuda_updates.py
@@ -33,6 +33,7 @@ from gprMax.cuda_opencl import (
     knl_symmetry_boundaries,
 )
 from gprMax.grid.cuda_grid import CUDAGrid
+from gprMax.ntff.device import CUDACombinedKSIRCollector
 from gprMax.receivers import dtoh_rx_array, htod_rx_arrays
 from gprMax.snapshots import (
     Snapshot,
@@ -107,6 +108,11 @@ class CUDAUpdates(Updates[CUDAGrid]):
             self._set_src_knls()
         if self.grid.snapshots:
             self._set_snapshot_knl()
+        self.ntff_collector = None
+        if self.grid.ntff_monitors:
+            self.ntff_c_real = config.sim_config.dtypes["C_float_or_double"]
+            self.ntff_compiler_options = config.sim_config.devices["nvcc_opts"]
+            self.ntff_collector = CUDACombinedKSIRCollector(self)
 
     def _build_knl(self, knl_func, subs_name_args, subs_func):
         """Builds a CUDA kernel from templates: 1) function name and args;
@@ -481,6 +487,20 @@ class CUDAUpdates(Updates[CUDAGrid]):
             grid=self.grid.bpg,
         )
 
+    def observe_ntff_electric(self, iteration):
+        """Collect electric frequency- and time-domain KSIR data on CUDA."""
+
+        collector = getattr(self, "ntff_collector", None)
+        if collector is not None:
+            collector.observe_electric(iteration)
+
+    def observe_ntff_magnetic(self, iteration):
+        """Collect magnetic frequency- and time-domain KSIR data on CUDA."""
+
+        collector = getattr(self, "ntff_collector", None)
+        if collector is not None:
+            collector.observe_magnetic(iteration)
+
     def update_magnetic_pml(self):
         """Updates magnetic field components with the PML correction."""
         for pml in self.grid.pmls["slabs"]:
@@ -668,6 +688,10 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
     def finalise(self):
         """Copies data from GPU back to CPU to save to file(s)."""
+        collector = getattr(self, "ntff_collector", None)
+        if collector is not None:
+            collector.finalise()
+
         # Copy output from receivers array back to correct receiver objects
         if self.grid.rxs:
             dtoh_rx_array(self.rxs_dev.get(), self.rxcoords_dev.get(), self.grid)

--- a/gprMax/updates/metal_updates.py
+++ b/gprMax/updates/metal_updates.py
@@ -31,6 +31,7 @@ from gprMax.cuda_opencl import (
     knl_store_outputs,
     knl_symmetry_boundaries,
 )
+from gprMax.ntff.device import MetalCombinedKSIRCollector
 from gprMax.receivers import dtoh_rx_array, htod_rx_arrays
 from gprMax.snapshots import (
     Snapshot,
@@ -107,6 +108,10 @@ class MetalUpdates:
             self._set_src_knls()
         if self.grid.snapshots:
             self._set_snapshot_knl()
+        self.ntff_collector = None
+        if self.grid.ntff_monitors:
+            self.ntff_c_real = config.sim_config.dtypes["C_float_or_double"]
+            self.ntff_collector = MetalCombinedKSIRCollector(self)
 
     def _build_knl(self, knl_func, subs_name_args, subs_func):
         """Builds an Apple Metal kernel from templates: 1) function name and args;
@@ -652,6 +657,20 @@ class MetalUpdates:
                         *self._metal_snapshot_buffers_to_numpy(), 0, snap
                     )
 
+    def observe_ntff_electric(self, iteration):
+        """Collect electric frequency- and time-domain KSIR data on Metal."""
+
+        collector = getattr(self, "ntff_collector", None)
+        if collector is not None:
+            collector.observe_electric(iteration)
+
+    def observe_ntff_magnetic(self, iteration):
+        """Collect magnetic frequency- and time-domain KSIR data on Metal."""
+
+        collector = getattr(self, "ntff_collector", None)
+        if collector is not None:
+            collector.observe_magnetic(iteration)
+
     def update_magnetic(self):
         """Updates magnetic field components."""
         self.cmdbufferH = self.cmdqueue.commandBuffer()
@@ -1137,6 +1156,10 @@ class MetalUpdates:
 
     def finalise(self):
         """Copies data from compute device back to CPU to save to file(s)."""
+        collector = getattr(self, "ntff_collector", None)
+        if collector is not None:
+            collector.finalise()
+
         # Copy output from receivers array back to correct receiver objects
         if self.grid.rxs:
             dtoh_rx_array(self.rxs_dev, self.rxcoords_dev, self.grid)

--- a/gprMax/updates/opencl_updates.py
+++ b/gprMax/updates/opencl_updates.py
@@ -32,6 +32,7 @@ from gprMax.cuda_opencl import (
     knl_symmetry_boundaries,
 )
 from gprMax.grid.opencl_grid import OpenCLGrid
+from gprMax.ntff.device import OpenCLCombinedKSIRCollector
 from gprMax.receivers import dtoh_rx_array, htod_rx_arrays
 from gprMax.snapshots import (
     Snapshot,
@@ -89,6 +90,11 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
             self._set_src_knls()
         if self.grid.snapshots:
             self._set_snapshot_knl()
+        self.ntff_collector = None
+        if self.grid.ntff_monitors:
+            self.ntff_c_real = config.sim_config.dtypes["C_float_or_double"]
+            self.ntff_compiler_options = config.sim_config.devices["compiler_opts"]
+            self.ntff_collector = OpenCLCombinedKSIRCollector(self)
 
     def _set_macros(self):
         """Common macros to be used in kernels."""
@@ -493,6 +499,20 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
             self.grid.Ez_dev,
         )
 
+    def observe_ntff_electric(self, iteration):
+        """Collect electric frequency- and time-domain KSIR data on OpenCL."""
+
+        collector = getattr(self, "ntff_collector", None)
+        if collector is not None:
+            collector.observe_electric(iteration)
+
+    def observe_ntff_magnetic(self, iteration):
+        """Collect magnetic frequency- and time-domain KSIR data on OpenCL."""
+
+        collector = getattr(self, "ntff_collector", None)
+        if collector is not None:
+            collector.observe_magnetic(iteration)
+
     def update_magnetic_pml(self):
         """Updates magnetic field components with the PML correction."""
         for pml in self.grid.pmls["slabs"]:
@@ -663,6 +683,10 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
 
     def finalise(self):
         """Copies data from compute device back to CPU to save to file(s)."""
+        collector = getattr(self, "ntff_collector", None)
+        if collector is not None:
+            collector.finalise()
+
         # Copy output from receivers array back to correct receiver objects
         if self.grid.rxs:
             dtoh_rx_array(self.rxs_dev.get(), self.rxcoords_dev.get(), self.grid)

--- a/gprMax/updates/updates.py
+++ b/gprMax/updates/updates.py
@@ -54,8 +54,8 @@ class Updates(Generic[GridType], ABC):
     def observe_ntff_electric(self, iteration: int) -> None:
         """Observe electric fields for any KSIR monitors.
 
-        CPU updates override this hook. Other backends retain the no-op until
-        their device integration is added.
+        Local solver implementations override this hook; unsupported backends
+        retain the no-op.
         """
 
         pass

--- a/gprMax/user_objects/cmds_output.py
+++ b/gprMax/user_objects/cmds_output.py
@@ -278,8 +278,10 @@ def _check_ksir_interface_context(user_object, grid):
         raise ValueError(f"{user_object.params_str()} does not support subgrids.")
     if config.sim_config.mpi:
         raise ValueError(f"{user_object.params_str()} does not yet support MPI.")
-    if config.sim_config.general["solver"] != "cpu":
-        raise ValueError(f"{user_object.params_str()} currently supports only the CPU solver.")
+    if config.sim_config.general["solver"] not in ("cpu", "cuda", "opencl", "metal"):
+        raise ValueError(
+            f"{user_object.params_str()} supports CPU, CUDA, OpenCL, and Metal solvers."
+        )
     if config.sim_config.args.geometry_fixed:
         raise ValueError(f"{user_object.params_str()} does not support geometry-fixed runs.")
     if config.get_model_config().mode != "3D":

--- a/tests/ntff/test_cuda_reusable_interface.py
+++ b/tests/ntff/test_cuda_reusable_interface.py
@@ -1,0 +1,135 @@
+"""CUDA/CPU parity for the reusable grouped KSIR interface."""
+
+import h5py
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+
+import gprMax
+
+try:
+    import pycuda.driver as _cuda_driver
+
+    _cuda_driver.init()
+    HAS_CUDA = _cuda_driver.Device.count() > 0
+except Exception:
+    HAS_CUDA = False
+
+
+def _scene():
+    dl = 0.004
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(0.08, 0.08, 0.08)))
+    scene.add(gprMax.TimeWindow(time=2e-10))
+    scene.add(gprMax.PMLThickness(thickness=3))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
+    scene.add(gprMax.HertzianDipole(polarisation="z", p1=(0.04, 0.04, 0.04), waveform_id="pulse"))
+    scene.add(
+        gprMax.KSIRSurface(
+            p1=(0.028, 0.028, 0.028),
+            p2=(0.052, 0.052, 0.052),
+            id="surface",
+        )
+    )
+    transform = gprMax.KSIRFrequencyTransform("surface", "spectrum", (5e9,))
+    time_receiver = gprMax.KSIRTimeRx(
+        ((0.064, 0.04, 0.042), (0.068, 0.04, 0.042)),
+        "surface",
+        id="time",
+        outputs=("Ez", "Hy"),
+        time_origin="first_arrival",
+    )
+    frequency_receiver = gprMax.KSIRFrequencyRx(
+        (0.064, 0.04, 0.042),
+        "spectrum",
+        id="frequency",
+        outputs=("Ez",),
+    )
+    far_field = gprMax.KSIRFarField(
+        (30, 90, 150),
+        (0, 0, 0),
+        "spectrum",
+        id="far",
+        outputs=("Etheta", "Ephi"),
+    )
+    for item in (transform, time_receiver, frequency_receiver, far_field):
+        scene.add(item)
+    return scene, transform, time_receiver, frequency_receiver, far_field
+
+
+@pytest.mark.skipif(not HAS_CUDA, reason="No CUDA device/pycuda available")
+@pytest.mark.parametrize(
+    "precision,real_dtype,complex_dtype,rtol",
+    [
+        ("single", np.dtype("float32"), np.dtype("complex64"), 1e-3),
+        ("double", np.dtype("float64"), np.dtype("complex128"), 2e-10),
+    ],
+)
+def test_cuda_reusable_outputs_match_cpu(tmp_path, precision, real_dtype, complex_dtype, rtol):
+    cpu_scene, cpu_transform, cpu_time, cpu_frequency, cpu_far = _scene()
+    cuda_scene, cuda_transform, cuda_time, cuda_frequency, cuda_far = _scene()
+    gprMax.run(
+        scenes=[cpu_scene],
+        n=1,
+        outputfile=tmp_path / f"cpu_{precision}",
+        hide_progress_bars=True,
+        cpu_precision=precision,
+    )
+    gprMax.run(
+        scenes=[cuda_scene],
+        n=1,
+        outputfile=tmp_path / f"cuda_{precision}",
+        hide_progress_bars=True,
+        gpu=[0],
+        gpu_precision=precision,
+    )
+
+    assert cuda_time.result.fields["Ez"].dtype == real_dtype
+    assert cuda_frequency.result.fields["Ez"].dtype == complex_dtype
+    assert cuda_far.result.fields["Etheta"].dtype == complex_dtype
+    assert_array_equal(cuda_time.result.valid_lengths, cpu_time.result.valid_lengths)
+    assert_allclose(cuda_time.result.time_origins, cpu_time.result.time_origins, rtol=0, atol=0)
+
+    for component in ("Ez", "Hy"):
+        expected = cpu_time.result.fields[component]
+        scale = np.max(np.abs(expected))
+        assert_allclose(
+            cuda_time.result.fields[component],
+            expected,
+            rtol=rtol,
+            atol=rtol * scale,
+        )
+    for component in cuda_transform.surface_data:
+        expected = cpu_transform.surface_data[component]
+        actual = cuda_transform.surface_data[component]
+        assert_allclose(
+            actual.field, expected.field, rtol=rtol, atol=rtol * np.max(np.abs(expected.field))
+        )
+        assert_allclose(
+            actual.normal_derivative,
+            expected.normal_derivative,
+            rtol=2 * rtol,
+            atol=2 * rtol * np.max(np.abs(expected.normal_derivative)),
+        )
+    assert_allclose(
+        cuda_frequency.result.fields["Ez"],
+        cpu_frequency.result.fields["Ez"],
+        rtol=2 * rtol,
+        atol=2 * rtol * np.max(np.abs(cpu_frequency.result.fields["Ez"])),
+    )
+    assert_allclose(
+        cuda_far.result.fields["Etheta"],
+        cpu_far.result.fields["Etheta"],
+        rtol=2 * rtol,
+        atol=2 * rtol * np.max(np.abs(cpu_far.result.fields["Etheta"])),
+    )
+
+    with h5py.File(tmp_path / f"cuda_{precision}.h5", "r") as output:
+        time_group = output["ntff/surface/time/time"]
+        frequency_group = output["ntff/surface/frequency/spectrum"]
+        assert time_group.attrs["solver"] == "cuda"
+        assert time_group.attrs["collection_backend"] == "cuda_device"
+        assert frequency_group.attrs["solver"] == "cuda"
+        assert frequency_group.attrs["collection_backend"] == "cuda_device"
+        assert frequency_group["surface_dft/Ez/field"].dtype == complex_dtype

--- a/tests/ntff/test_device_collection.py
+++ b/tests/ntff/test_device_collection.py
@@ -1,0 +1,402 @@
+"""Backend-neutral tests for device-resident NTFF DFT collection."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from gprMax.cuda_opencl.knl_ntff import (
+    build_ntff_kernel_source,
+    build_time_domain_ntff_kernel_source,
+)
+from gprMax.ntff.device import (
+    CUDAKSIRCollector,
+    MetalKSIRCollector,
+    MetalTimeDomainKSIRCollector,
+    OpenCLKSIRCollector,
+    OpenCLTimeDomainKSIRCollector,
+    _DeviceKSIRCollector,
+)
+from gprMax.ntff.frequency_domain import KSIRFrequencyDomainMonitor
+from gprMax.ntff.surfaces import build_component_surface
+
+
+class _HostEmulatedDeviceCollector(_DeviceKSIRCollector):
+    """Execute the device kernel contract with NumPy for deterministic tests."""
+
+    def _allocate(self, record):
+        for name in ("inside_real", "inside_imag", "outside_real", "outside_imag"):
+            record.device[name] = np.zeros(record.total, dtype=record.monitor.real_dtype)
+
+    def _accumulate(self, record, field, multiplier):
+        values = np.asarray(field).ravel()
+        inside = values[record.inside_index]
+        outside = values[record.outside_index]
+        shape = record.shape
+        record.device["inside_real"] += (
+            (multiplier.real[:, np.newaxis] * inside[np.newaxis, :]).reshape(shape).ravel()
+        )
+        record.device["inside_imag"] += (
+            (multiplier.imag[:, np.newaxis] * inside[np.newaxis, :]).reshape(shape).ravel()
+        )
+        record.device["outside_real"] += (
+            (multiplier.real[:, np.newaxis] * outside[np.newaxis, :]).reshape(shape).ravel()
+        )
+        record.device["outside_imag"] += (
+            (multiplier.imag[:, np.newaxis] * outside[np.newaxis, :]).reshape(shape).ravel()
+        )
+
+    def _download(self, record):
+        return tuple(
+            record.device[name]
+            for name in ("inside_real", "inside_imag", "outside_real", "outside_imag")
+        )
+
+
+def test_frequency_collector_rejects_int32_work_item_overflow():
+    int32_max = int(np.iinfo(np.int32).max)
+    surface = SimpleNamespace(
+        npatches=int32_max // 2 + 1,
+        faces=[
+            SimpleNamespace(
+                inside_flat_indices=np.asarray([0]),
+                outside_flat_indices=np.asarray([1]),
+            )
+        ],
+    )
+    monitor = SimpleNamespace(
+        device_sampling_multiplier=None,
+        frequencies=SimpleNamespace(size=2),
+        surfaces={"Ex": surface},
+    )
+    updates = SimpleNamespace(grid=SimpleNamespace())
+
+    with pytest.raises(ValueError, match="exceeds device int32 indexing"):
+        _HostEmulatedDeviceCollector(updates, monitors=[monitor], configure=False)
+
+
+def _material():
+    return SimpleNamespace(
+        numID=1,
+        ID="free_space",
+        er=1.0,
+        mr=1.0,
+        se=0.0,
+        sm=0.0,
+        poles=0,
+    )
+
+
+def _monitor(name, surfaces, real_dtype, complex_dtype, iterations, dt):
+    return KSIRFrequencyDomainMonitor(
+        name,
+        surfaces,
+        [2 / (iterations * dt), 5 / (iterations * dt)],
+        [40.0, 90.0],
+        [20.0, 120.0],
+        dt,
+        iterations,
+        real_dtype=real_dtype,
+        complex_dtype=complex_dtype,
+    )
+
+
+@pytest.mark.parametrize(
+    "real_dtype,complex_dtype,rtol",
+    [(np.dtype("f4"), np.dtype("c8"), 2e-6), (np.dtype("f8"), np.dtype("c16"), 2e-13)],
+)
+def test_device_contract_matches_cpu_flat_index_collection(real_dtype, complex_dtype, rtol):
+    shape = (9, 10, 8)
+    surfaces = {
+        component: build_component_surface(
+            component, (2, 2, 2), (5, 6, 5), (0.03, 0.04, 0.05), shape
+        )
+        for component in ("Ex", "Hx")
+    }
+    iterations = 12
+    dt = 1e-11
+    cpu = _monitor("cpu", surfaces, real_dtype, complex_dtype, iterations, dt)
+    device = _monitor("device", surfaces, real_dtype, complex_dtype, iterations, dt)
+
+    ids = np.ones((6,) + shape, dtype=np.uint32)
+    lookup = {"Ex": 0, "Hx": 3}
+    cpu.validate_materials(ids, lookup)
+    cpu.configure_background([_material()])
+
+    grid = SimpleNamespace(
+        ntff_monitors=[device],
+        ID=ids,
+        IDlookup=lookup,
+        materials=[_material()],
+    )
+    for component in ("Ex", "Ey", "Ez", "Hx", "Hy", "Hz"):
+        setattr(grid, f"{component}_dev", np.zeros(shape, dtype=real_dtype))
+    collector = _HostEmulatedDeviceCollector(SimpleNamespace(grid=grid))
+
+    indices = np.indices(shape)
+    zeros = np.zeros(shape, dtype=real_dtype)
+    for iteration in range(iterations):
+        ex = np.asarray(
+            (iteration + 1) * (indices[0] - 0.3 * indices[1]),
+            dtype=real_dtype,
+        )
+        hx = np.asarray(
+            (iteration + 0.5) * (indices[2] + 0.2 * indices[1]),
+            dtype=real_dtype,
+        )
+        grid.Ex_dev[...] = ex
+        grid.Hx_dev[...] = hx
+        cpu.observe_electric(iteration, ex, zeros, zeros)
+        collector.observe_electric(iteration)
+        cpu.observe_magnetic(iteration, hx, zeros, zeros)
+        collector.observe_magnetic(iteration)
+
+    cpu.finalise()
+    collector.finalise()
+    for component in ("Ex", "Hx"):
+        assert device.surface_data[component].field.dtype == complex_dtype
+        assert device.result.range_normalized_fields[component].dtype == complex_dtype
+        assert_allclose(
+            device.surface_data[component].field,
+            cpu.surface_data[component].field,
+            rtol=rtol,
+        )
+        assert_allclose(
+            device.surface_data[component].normal_derivative,
+            cpu.surface_data[component].normal_derivative,
+            rtol=rtol,
+        )
+
+
+@pytest.mark.parametrize(
+    "backend,c_real,marker",
+    [
+        ("cuda", "float", "blockIdx.x"),
+        ("opencl", "double", "cl_khr_fp64"),
+        ("metal", "float", "thread_position_in_grid"),
+    ],
+)
+def test_backend_kernel_sources_use_configured_real_type(backend, c_real, marker):
+    source = build_ntff_kernel_source(backend, c_real)
+    assert marker in source
+    assert f"const {c_real}*" in source
+    assert "inside_real[i] +=" in source
+    assert "complex" not in source.lower()
+
+
+@pytest.mark.parametrize(
+    "backend,c_real,marker",
+    [
+        ("cuda", "float", "ksir_atomic_add"),
+        ("opencl", "double", "get_global_id(0)"),
+        ("metal", "float", "thread_position_in_grid"),
+    ],
+)
+def test_time_domain_kernel_uses_configured_real_type(backend, c_real, marker):
+    source = build_time_domain_ntff_kernel_source(c_real, backend=backend)
+
+    assert "gather_time_domain_ntff" in source
+    assert "deposit_time_domain_ntff" in source
+    assert c_real in source
+    assert marker in source
+    assert "time_origin_steps[point]" in source
+    if backend != "cuda":
+        assert "ksir_atomic_add" not in source
+        assert "for (int patch = 0; patch < neffective_patches; patch++)" in source
+
+
+class _FakeArray:
+    def __init__(self, name):
+        self.gpudata = f"ptr:{name}"
+        self.data = f"buffer:{name}"
+        self.set_value = None
+
+    def set(self, value, **kwargs):
+        self.set_value = np.asarray(value).copy()
+
+
+def _dispatch_record():
+    arrays = {
+        name: _FakeArray(name)
+        for name in (
+            "inside_index",
+            "outside_index",
+            "multiplier_real",
+            "multiplier_imag",
+            "inside_real",
+            "inside_imag",
+            "outside_real",
+            "outside_imag",
+        )
+    }
+    return SimpleNamespace(total=6, npatches=3, device=arrays)
+
+
+def test_cuda_dispatch_uses_split_configured_real_buffers():
+    collector = CUDAKSIRCollector.__new__(CUDAKSIRCollector)
+    collector.real_dtype = np.dtype("f4")
+    calls = []
+    collector.kernel = lambda *args, **kwargs: calls.append((args, kwargs))
+    record = _dispatch_record()
+    field = _FakeArray("field")
+    multiplier = np.asarray([1 + 2j, 3 + 4j], dtype="c8")
+
+    collector._accumulate(record, field, multiplier)
+
+    args, kwargs = calls[0]
+    assert args[6] == "ptr:field"
+    assert args[7:11] == (
+        "ptr:inside_real",
+        "ptr:inside_imag",
+        "ptr:outside_real",
+        "ptr:outside_imag",
+    )
+    assert kwargs["block"] == (128, 1, 1)
+    assert record.device["multiplier_real"].set_value.dtype == np.dtype("f4")
+    assert_allclose(record.device["multiplier_imag"].set_value, [2, 4])
+
+
+def test_opencl_dispatch_uses_split_configured_real_buffers():
+    collector = OpenCLKSIRCollector.__new__(OpenCLKSIRCollector)
+    collector.real_dtype = np.dtype("f8")
+    collector.queue = object()
+    calls = []
+    collector.kernel = lambda *args: calls.append(args)
+    record = _dispatch_record()
+    field = _FakeArray("field")
+    multiplier = np.asarray([1 + 2j, 3 + 4j], dtype="c16")
+
+    collector._accumulate(record, field, multiplier)
+
+    args = calls[0]
+    assert args[0] is collector.queue
+    assert args[5] == "buffer:inside_index"
+    assert args[9] == "buffer:field"
+    assert args[10:14] == (
+        "buffer:inside_real",
+        "buffer:inside_imag",
+        "buffer:outside_real",
+        "buffer:outside_imag",
+    )
+    assert record.device["multiplier_real"].set_value.dtype == np.dtype("f8")
+
+
+class _FakeMetalEncoder:
+    def __init__(self):
+        self.buffers = {}
+        self.scalar_bytes = {}
+        self.dispatched = None
+
+    def setComputePipelineState_(self, pipeline):
+        self.pipeline = pipeline
+
+    def setBuffer_offset_atIndex_(self, buffer, offset, index):
+        self.buffers[index] = buffer
+
+    def setBytes_length_atIndex_(self, value, length, index):
+        self.scalar_bytes[index] = (bytes(value), length)
+
+    def dispatchThreads_threadsPerThreadgroup_(self, threads, group):
+        self.dispatched = (threads, group)
+
+    def endEncoding(self):
+        pass
+
+
+class _FakeMetalCommand:
+    def __init__(self):
+        self.encoder = _FakeMetalEncoder()
+
+    def computeCommandEncoder(self):
+        return self.encoder
+
+    def commit(self):
+        pass
+
+    def waitUntilCompleted(self):
+        pass
+
+
+def test_metal_dispatch_preserves_kernel_buffer_order():
+    collector = MetalKSIRCollector.__new__(MetalKSIRCollector)
+    collector.real_dtype = np.dtype("f4")
+    collector.pipeline = SimpleNamespace(maxTotalThreadsPerThreadgroup=lambda: 64)
+    command = _FakeMetalCommand()
+    collector.queue = SimpleNamespace(commandBuffer=lambda: command)
+    collector.metal = SimpleNamespace(MTLSizeMake=lambda x, y, z: (x, y, z))
+    collector._buffer = lambda values: ("temporary", np.asarray(values).copy())
+    record = _dispatch_record()
+    field = object()
+
+    collector._accumulate(record, field, np.asarray([1 + 2j, 3 + 4j], dtype="c8"))
+
+    buffers = command.encoder.buffers
+    assert set(buffers) == set(range(11))
+    assert buffers[2] is record.device["inside_index"]
+    assert buffers[3] is record.device["outside_index"]
+    assert buffers[6] is field
+    assert buffers[7] is record.device["inside_real"]
+    assert buffers[10] is record.device["outside_imag"]
+    assert command.encoder.dispatched == ((6, 1, 1), (6, 1, 1))
+
+
+def _time_dispatch_record():
+    arrays = {
+        name: _FakeArray(name)
+        for name in (
+            "normal_derivative_weight",
+            "field_weight",
+            "time_derivative_weight",
+            "source_patch_index",
+            "integer_delay",
+            "fractional_delay",
+            "time_origin_steps",
+            "output",
+        )
+    }
+    arrays["surface"] = [_FakeArray(f"surface{item}") for item in range(3)]
+    arrays["normal_derivative"] = [_FakeArray(f"normal{item}") for item in range(3)]
+    return SimpleNamespace(
+        npoints=2,
+        neffective_patches=3,
+        output_length=11,
+        device=arrays,
+    )
+
+
+def test_opencl_time_deposit_dispatch_is_point_owned():
+    collector = OpenCLTimeDomainKSIRCollector.__new__(OpenCLTimeDomainKSIRCollector)
+    collector.queue = object()
+    collector.real_scalar = np.float32
+    calls = []
+    collector.deposit_kernel = lambda *args: calls.append(args)
+    record = _time_dispatch_record()
+
+    collector._deposit(record, 4, (2, 3, 4), (-1.0, 1.0, 0.0))
+
+    args = calls[0]
+    assert args[1] == (record.npoints,)
+    assert args[3] == record.npoints
+    assert args[4] == record.neffective_patches
+    assert args[7] == "buffer:surface1"
+    assert args[-1] == "buffer:output"
+
+
+def test_metal_time_deposit_dispatch_preserves_argument_contract():
+    collector = MetalTimeDomainKSIRCollector.__new__(MetalTimeDomainKSIRCollector)
+    collector.real_scalar = np.float32
+    collector.deposit_pipeline = SimpleNamespace(maxTotalThreadsPerThreadgroup=lambda: 64)
+    command = _FakeMetalCommand()
+    collector.queue = SimpleNamespace(commandBuffer=lambda: command)
+    collector.metal = SimpleNamespace(MTLSizeMake=lambda x, y, z: (x, y, z))
+    record = _time_dispatch_record()
+
+    collector._deposit(record, 4, (2, 3, 4), (-1.0, 1.0, 0.0))
+
+    encoder = command.encoder
+    assert set(encoder.scalar_bytes) == set(range(4)) | set(range(9, 12))
+    assert encoder.buffers[4] is record.device["surface"][1]
+    assert encoder.buffers[12] is record.device["normal_derivative_weight"]
+    assert encoder.buffers[19] is record.device["output"]
+    assert encoder.dispatched == ((record.npoints, 1, 1), (2, 1, 1))

--- a/tests/ntff/test_reusable_interface.py
+++ b/tests/ntff/test_reusable_interface.py
@@ -10,7 +10,7 @@ from gprMax import config
 
 
 @pytest.mark.parametrize("solver", ["cuda", "opencl", "metal"])
-def test_time_receiver_registration_rejects_accelerator_backends(monkeypatch, solver):
+def test_time_receiver_registration_accepts_accelerator_backends(monkeypatch, solver):
     monkeypatch.setattr(
         config,
         "sim_config",
@@ -34,8 +34,10 @@ def test_time_receiver_registration_rejects_accelerator_backends(monkeypatch, so
         outputs=("Ez",),
     )
 
-    with pytest.raises(ValueError, match="only the CPU solver"):
-        receiver.build(None, grid)
+    receiver.build(None, grid)
+
+    assert grid.ksir_time_requests[0].output_id == "point"
+    assert grid.ksir_request_owners["time:surface:point"] is receiver
 
 
 def test_python_api_groups_requests_and_exposes_results(tmp_path):


### PR DESCRIPTION
# PR Description

## Summary

- Add device-resident KSIR frequency-domain accumulation for CUDA, OpenCL, and Metal.
- Add device-resident advanced-time KSIR collection and compact output storage.
- Keep field sampling, DFT accumulation, delayed deposition, and output histories on the GPU until finalisation.
- Use gprMax-configured single/double precision types.
- Add int32 indexing and work-size overflow guards.
- Integrate the reusable KSIR commands with accelerator solvers.
- Store solver and collection-backend metadata in grouped HDF5 output.
- Add backend-neutral kernel tests and real CUDA/CPU parity tests.

MPI and GPU plane-wave support remain outside this PR.

## Testing

- Full automated suite: 892 passed, 6 skipped.
- CUDA/CPU parity verified in single and double precision.
- Frequency-domain, advanced-time, exact-frequency, far-field, and HDF5 outputs tested.
- OpenCL and Metal kernel generation and dispatch contracts tested without hardware.

## Notes

- Uses the engineering FFT convention already adopted by KSIR.
- No field or output data are transferred from GPU to CPU during time stepping; results are downloaded only at finalisation.
- MPI and GPU plane-wave support remain deferred.
- Design documents are intentionally excluded from this PR.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update.

## Checklist

- [ ] Did pre-commit passed all checks?
- [x] I have performed a self-review of my code.
- [x] I have added comments for my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.
