### PR TITLE
 Validate KSIR PEC-sphere scattering against Mie theory

### DIFF
--- a/testing/validation/__init__.py
+++ b/testing/validation/__init__.py
@@ -1,0 +1,1 @@
+"""Independent analytical references and end-to-end validation helpers."""

--- a/testing/validation/mie_pec.py
+++ b/testing/validation/mie_pec.py
@@ -1,0 +1,111 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+
+"""Analytical far-field scattering by a perfectly conducting sphere."""
+
+import numpy as np
+import numpy.typing as npt
+from scipy.constants import c
+from scipy.special import spherical_jn, spherical_yn
+
+
+def _maximum_order(size_parameter: float) -> int:
+    """Return the usual converged Mie-series truncation order."""
+
+    return max(1, int(np.ceil(size_parameter + 4 * np.cbrt(size_parameter) + 2)))
+
+
+def pec_mie_coefficients(
+    size_parameter: float,
+) -> tuple[npt.NDArray[np.complex128], npt.NDArray[np.complex128]]:
+    """Return electric and magnetic PEC Mie coefficients for orders 1..N."""
+
+    if not np.isfinite(size_parameter) or size_parameter <= 0:
+        raise ValueError("size_parameter must be finite and greater than zero")
+    orders = np.arange(1, _maximum_order(size_parameter) + 1)
+    jn = spherical_jn(orders, size_parameter)
+    yn = spherical_yn(orders, size_parameter)
+    jn_derivative = spherical_jn(orders, size_parameter, derivative=True)
+    yn_derivative = spherical_yn(orders, size_parameter, derivative=True)
+    psi = size_parameter * jn
+    psi_derivative = jn + size_parameter * jn_derivative
+    xi = size_parameter * (jn + 1j * yn)
+    xi_derivative = (
+        jn + 1j * yn + size_parameter * (jn_derivative + 1j * yn_derivative)
+    )
+    electric = -psi_derivative / xi_derivative
+    magnetic = -psi / xi
+    return electric.astype(np.complex128), magnetic.astype(np.complex128)
+
+
+def pec_mie_amplitudes(
+    size_parameter: float, scattering_angles: npt.ArrayLike
+) -> tuple[npt.NDArray[np.complex128], npt.NDArray[np.complex128]]:
+    """Return perpendicular and parallel dimensionless amplitudes ``S1,S2``."""
+
+    angles = np.atleast_1d(np.asarray(scattering_angles, dtype=np.float64))
+    if angles.ndim != 1 or not np.all(np.isfinite(angles)):
+        raise ValueError("scattering_angles must be a finite one-dimensional array")
+    electric, magnetic = pec_mie_coefficients(size_parameter)
+    cosine = np.cos(angles)
+    perpendicular = np.zeros(angles.shape, dtype=np.complex128)
+    parallel = np.zeros_like(perpendicular)
+    pi_previous = np.zeros_like(cosine)
+    pi_current = np.ones_like(cosine)
+
+    for order, (electric_n, magnetic_n) in enumerate(zip(electric, magnetic), start=1):
+        if order == 1:
+            pi_n = pi_current
+        else:
+            pi_n = (
+                (2 * order - 1) * cosine * pi_current - order * pi_previous
+            ) / (order - 1)
+            pi_previous, pi_current = pi_current, pi_n
+        tau_n = order * cosine * pi_n - (order + 1) * pi_previous
+        factor = (2 * order + 1) / (order * (order + 1))
+        perpendicular += factor * (electric_n * pi_n + magnetic_n * tau_n)
+        parallel += factor * (electric_n * tau_n + magnetic_n * pi_n)
+
+    return perpendicular, parallel
+
+
+def pec_sphere_bistatic_rcs(
+    frequency: float,
+    radius: float,
+    scattering_angles: npt.ArrayLike,
+    *,
+    polarisation: str = "perpendicular",
+) -> npt.NDArray[np.float64]:
+    """Return PEC-sphere bistatic RCS in square metres."""
+
+    if not np.isfinite(frequency) or frequency <= 0:
+        raise ValueError("frequency must be finite and greater than zero")
+    if not np.isfinite(radius) or radius <= 0:
+        raise ValueError("radius must be finite and greater than zero")
+    wavenumber = 2 * np.pi * frequency / c
+    perpendicular, parallel = pec_mie_amplitudes(
+        wavenumber * radius, scattering_angles
+    )
+    if polarisation == "perpendicular":
+        amplitude = perpendicular
+    elif polarisation == "parallel":
+        amplitude = parallel
+    else:
+        raise ValueError("polarisation must be 'perpendicular' or 'parallel'")
+    return np.asarray(4 * np.pi * np.abs(amplitude) ** 2 / wavenumber**2)

--- a/tests/ntff/test_mie_fdtd_validation.py
+++ b/tests/ntff/test_mie_fdtd_validation.py
@@ -1,0 +1,126 @@
+"""End-to-end CPU TFSF/KSIR validation against PEC-sphere Mie scattering."""
+
+import h5py
+import numpy as np
+from numpy.testing import assert_allclose
+from scipy.constants import c
+
+import gprMax
+from testing.validation.mie_pec import pec_mie_amplitudes, pec_sphere_bistatic_rcs
+
+FREQUENCY = 5e9
+SPHERE_RADIUS = 0.0096
+SPHERE_CENTRE = (0.048, 0.048, 0.048)
+SCATTERING_ANGLES = np.arange(0.0, 181.0, 10.0)
+
+
+def _mie_scene():
+    dl = 0.0016
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl,) * 3))
+    scene.add(gprMax.Domain(p1=(0.096,) * 3))
+    scene.add(gprMax.TimeWindow(iterations=900))
+    scene.add(gprMax.OMPThreads(n=4))
+    scene.add(gprMax.PMLThickness(thickness=10))
+    scene.add(
+        gprMax.Waveform(
+            wave_type="ricker", amp=1, freq=FREQUENCY, id="plane_pulse"
+        )
+    )
+    scene.add(
+        gprMax.DiscretePlaneWaveAxial(
+            p1=(0.032,) * 3,
+            p2=(0.064,) * 3,
+            axis="x",
+            psi=90,
+            waveform_id="plane_pulse",
+        )
+    )
+    scene.add(
+        gprMax.Sphere(
+            p1=SPHERE_CENTRE,
+            r=SPHERE_RADIUS,
+            material_id="pec",
+        )
+    )
+    scene.add(
+        gprMax.KSIRSurface(
+            p1=(0.024,) * 3,
+            p2=(0.072,) * 3,
+            id="mie_surface",
+            origin=SPHERE_CENTRE,
+        )
+    )
+    transform = gprMax.KSIRFrequencyTransform(
+        surface_id="mie_surface",
+        id="mie_spectrum",
+        frequencies=(FREQUENCY,),
+        save_surface_dft=False,
+    )
+    far_field = gprMax.KSIRFarField(
+        theta=np.full(SCATTERING_ANGLES.shape, 90.0),
+        phi=SCATTERING_ANGLES,
+        transform_id="mie_spectrum",
+        id="mie_pattern",
+        outputs=("Etheta", "Ephi", "rcs"),
+    )
+    scene.add(transform)
+    scene.add(far_field)
+    return scene, transform, far_field
+
+
+def test_cpu_tfsf_ksir_pec_sphere_matches_mie(tmp_path):
+    """Exercise the production FDTD scattering and HDF5 paths."""
+
+    scene, transform, far_field = _mie_scene()
+    outputfile = tmp_path / "mie_sphere"
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        outputfile=outputfile,
+        hide_progress_bars=True,
+        cpu_precision="double",
+    )
+
+    simulated = np.asarray(far_field.result.fields["rcs"][0])
+    analytic = pec_sphere_bistatic_rcs(
+        FREQUENCY,
+        SPHERE_RADIUS,
+        np.deg2rad(SCATTERING_ANGLES),
+        polarisation="perpendicular",
+    )
+    simulated_pattern = simulated / np.max(simulated)
+    analytic_pattern = analytic / np.max(analytic)
+    pattern_rms_error = np.sqrt(np.mean((simulated_pattern - analytic_pattern) ** 2))
+    relative_l2_error = np.linalg.norm(simulated - analytic) / np.linalg.norm(analytic)
+    backscatter_error = abs(simulated[-1] - analytic[-1]) / analytic[-1]
+
+    monitor = transform._compiled_outputs.transform_monitor(transform.ID)
+    incident_electric = monitor.result.incident_electric[0, 2]
+    wavenumber = 2 * np.pi * FREQUENCY / c
+    perpendicular, _ = pec_mie_amplitudes(
+        wavenumber * SPHERE_RADIUS,
+        np.deg2rad(SCATTERING_ANGLES),
+    )
+    analytic_amplitude = -1j * np.conj(perpendicular) / wavenumber
+    numerical_amplitude = far_field.result.fields["Etheta"][0] / incident_electric
+    complex_relative_l2_error = np.linalg.norm(
+        numerical_amplitude - analytic_amplitude
+    ) / np.linalg.norm(analytic_amplitude)
+    phase_rms_error = np.sqrt(
+        np.mean(np.angle(numerical_amplitude / analytic_amplitude) ** 2)
+    )
+
+    assert np.all(np.isfinite(simulated))
+    assert np.all(simulated > 0)
+    assert pattern_rms_error < 0.12
+    assert relative_l2_error < 0.35
+    assert backscatter_error < 0.25
+    assert complex_relative_l2_error < 0.25
+    assert phase_rms_error < 0.20
+
+    with h5py.File(str(outputfile) + ".h5", "r") as output:
+        group = output["ntff/mie_surface/frequency/mie_spectrum"]
+        assert group.attrs["collection_backend"] == "cython_openmp"
+        assert "surface_dft" not in group
+        assert_allclose(group["far_field/mie_pattern/fields/rcs"][:], simulated[None, :])

--- a/tests/ntff/test_mie_reference.py
+++ b/tests/ntff/test_mie_reference.py
@@ -1,0 +1,80 @@
+"""Checks for the independent analytical PEC-sphere Mie reference."""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+from scipy.constants import c
+
+from testing.validation.mie_pec import (
+    pec_mie_amplitudes,
+    pec_mie_coefficients,
+    pec_sphere_bistatic_rcs,
+)
+
+
+def test_forward_mie_amplitudes_are_polarisation_independent():
+    perpendicular, parallel = pec_mie_amplitudes(1.3, [0.0])
+
+    assert_allclose(perpendicular, parallel, rtol=1e-14)
+
+
+def test_backscatter_rcs_matches_coefficient_identity():
+    frequency = 5e9
+    radius = 0.0075
+    wavenumber = 2 * np.pi * frequency / c
+    size_parameter = wavenumber * radius
+    electric, magnetic = pec_mie_coefficients(size_parameter)
+    orders = np.arange(1, electric.size + 1)
+    backscatter_efficiency = np.abs(
+        np.sum((2 * orders + 1) * (-1) ** orders * (electric - magnetic))
+    ) ** 2 / size_parameter**2
+
+    actual = pec_sphere_bistatic_rcs(
+        frequency, radius, [np.pi], polarisation="perpendicular"
+    )[0]
+
+    assert_allclose(
+        actual / (np.pi * radius**2), backscatter_efficiency, rtol=2e-14
+    )
+
+
+def test_mie_rcs_is_finite_nonnegative_and_has_requested_shape():
+    angles = np.linspace(0, np.pi, 181)
+    result = pec_sphere_bistatic_rcs(5e9, 0.0075, angles)
+
+    assert result.shape == angles.shape
+    assert np.all(np.isfinite(result))
+    assert np.all(result >= 0)
+    assert np.max(result) > 0
+
+
+def test_small_pec_sphere_backscatter_approaches_rayleigh_limit():
+    radius = 1e-3
+    size_parameter = 0.01
+    frequency = size_parameter * c / (2 * np.pi * radius)
+    actual = pec_sphere_bistatic_rcs(frequency, radius, [np.pi])[0]
+    wavenumber = size_parameter / radius
+    expected = 9 * np.pi * wavenumber**4 * radius**6
+
+    assert_allclose(actual, expected, rtol=2e-4)
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"frequency": 0, "radius": 1, "scattering_angles": [0]}, "frequency"),
+        ({"frequency": 1, "radius": 0, "scattering_angles": [0]}, "radius"),
+        (
+            {
+                "frequency": 1,
+                "radius": 1,
+                "scattering_angles": [0],
+                "polarisation": "unknown",
+            },
+            "polarisation",
+        ),
+    ],
+)
+def test_mie_reference_rejects_invalid_inputs(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        pec_sphere_bistatic_rcs(**kwargs)


### PR DESCRIPTION
# PR Description

## Summary

Adds automated validation of the production CPU TFSF/KSIR scattering path against an independent analytical PEC-sphere Mie-series solution.

- Adds reusable PEC-sphere Mie coefficients, amplitudes, and bistatic RCS.
- Tests analytical identities and the Rayleigh limit.
- Runs a real 3-D FDTD plane-wave/PEC-sphere model.
- Compares angular RCS, backscatter, magnitude, and phase.
- Verifies the generated HDF5 NTFF output.

## 🛠️ Related Issue (Number)

N/A

## Type of change

- [x] Test and validation coverage
- [ ] This change requires a documentation update.

## Checklist

- [x] Clean Cython build completed.
- [x] Full NTFF suite: 212 passed.
- [x] Self-review completed.
- [x] No generated results or files included.
- [x] PR title is a short description of the changes.
- [ ] Pre-commit/CI checks completed.
