### PR TITLE
test(ntff): add benchmark and validation utilities

### DIFF
--- a/docs/source/benchmarking.rst
+++ b/docs/source/benchmarking.rst
@@ -23,6 +23,42 @@ The performance metric used to measure the throughput of the solver is:
 
 where P is the throughput in millions of cells per second; NX, NY, and NZ are the number of cells in domain in the x, y, and z directions; NT is the number of time-steps in the simulation; and T is the runtime of the simulation in seconds.
 
+NTFF benchmarking and validation
+================================
+
+The incremental cost of KSIR near-to-far-field collection can be measured with
+the reusable-surface benchmark. It brackets the monitored cases with
+unmonitored baseline runs and writes the complete configuration, individual
+run times, collection backend, slowdown, and overhead to JSON. CPU, CUDA,
+OpenCL, and Metal use the same benchmark model and configured gprMax precision.
+
+.. code-block:: none
+
+    (gprMax)$ python -m testing.benchmarking.benchmark_ntff --backend cpu --threads 8 --precision double
+    (gprMax)$ python -m testing.benchmarking.benchmark_ntff --backend cuda --device 0 --precision single
+
+The surface sizes, frequency counts, number of repeats, and output filename
+can be changed using command-line options; run the module with ``--help`` for
+the complete list.
+
+End-to-end KSIR validation cases are provided separately. They include the
+closed-form Hertzian-dipole pattern in both principal planes, PEC-sphere RCS
+against Mie theory, a broadband PEC-sphere backscatter sweep through the Mie
+resonances, finite-distance time-domain fields against direct Yee-grid
+receivers, and CPU/accelerator time-domain parity.
+
+.. code-block:: none
+
+    (gprMax)$ python -m testing.validation.validate_ntff --case all --backend cpu
+    (gprMax)$ python -m testing.validation.validate_ntff --case mie-sweep --backend cpu --plot mie-sweep.png
+    (gprMax)$ python -m testing.validation.validate_ntff --case dipole --backend cuda --device 0
+    (gprMax)$ python -m testing.validation.validate_ntff --case parity --backend opencl --device 0
+
+Results are written to ``ntff_validation_results.json`` by default. A summary
+figure can be requested with ``--plot filename.png``. The TFSF PEC-sphere Mie
+case is CPU-only because discrete plane-wave excitation is not currently
+available for accelerator solvers.
+
 Apple Metal GPU Benchmarking
 =============================
 

--- a/testing/benchmarking/benchmark_ntff.py
+++ b/testing/benchmarking/benchmark_ntff.py
@@ -1,0 +1,317 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+
+"""Benchmark the incremental wall-clock cost of KSIR frequency collection.
+
+The benchmark brackets monitored cases with unmonitored baseline runs. Each
+case requests one far-field direction and does not save surface phasors, so
+the measured increase is dominated by timestep collection rather than angular
+post-processing or extra HDF5 datasets.
+
+Run from the repository root, for example::
+
+    python -m testing.benchmarking.benchmark_ntff --backend cpu --threads 8
+    python -m testing.benchmarking.benchmark_ntff --backend cuda --device 0
+"""
+
+import argparse
+import json
+import logging
+import os
+import platform
+import statistics
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from time import perf_counter
+
+import h5py
+import numpy as np
+
+import gprMax
+import gprMax.config as config
+
+ACCELERATOR_ARGUMENTS = {"cuda": "gpu", "opencl": "opencl", "metal": "metal"}
+
+
+def _positive_int(value):
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be a positive integer")
+    return parsed
+
+
+def _monitor_bounds(cells, surface_cells, pml_cells, dl):
+    """Return centred bounds with at least two free cells before the PML."""
+
+    if surface_cells % 2:
+        raise ValueError("surface cell counts must be even")
+    lower = (cells - surface_cells) // 2
+    upper = lower + surface_cells
+    if lower < pml_cells + 2 or upper > cells - pml_cells - 2:
+        raise ValueError(
+            f"surface size {surface_cells} does not leave two cells beyond "
+            f"a {pml_cells}-cell PML in a {cells}-cell domain"
+        )
+    return (lower * dl,) * 3, (upper * dl,) * 3
+
+
+def _frequencies(count, centre_frequency):
+    if count == 1:
+        return [centre_frequency]
+    return np.linspace(
+        0.6 * centre_frequency,
+        1.4 * centre_frequency,
+        count,
+    ).tolist()
+
+
+def _solver_options(backend, device, precision):
+    if backend == "cpu":
+        return {"cpu_precision": precision}
+    return {
+        ACCELERATOR_ARGUMENTS[backend]: [device],
+        "gpu_precision": precision,
+    }
+
+
+def _scene(args, surface_cells=None, frequency_count=0):
+    extent = args.cells * args.dl
+    centre = (0.5 * extent,) * 3
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(args.dl,) * 3))
+    scene.add(gprMax.Domain(p1=(extent,) * 3))
+    scene.add(gprMax.TimeWindow(iterations=args.iterations))
+    scene.add(gprMax.PMLThickness(thickness=args.pml_cells))
+    scene.add(gprMax.OMPThreads(n=args.threads))
+    scene.add(
+        gprMax.Waveform(
+            wave_type="ricker",
+            amp=1,
+            freq=args.centre_frequency,
+            id="pulse",
+        )
+    )
+    scene.add(
+        gprMax.HertzianDipole(
+            polarisation="z",
+            p1=centre,
+            waveform_id="pulse",
+        )
+    )
+
+    transform = None
+    if surface_cells is not None:
+        lower, upper = _monitor_bounds(args.cells, surface_cells, args.pml_cells, args.dl)
+        scene.add(
+            gprMax.KSIRSurface(
+                p1=lower,
+                p2=upper,
+                id="benchmark_surface",
+                origin=centre,
+            )
+        )
+        transform = gprMax.KSIRFrequencyTransform(
+            surface_id="benchmark_surface",
+            id="benchmark_spectrum",
+            frequencies=_frequencies(frequency_count, args.centre_frequency),
+            save_surface_dft=False,
+        )
+        far_field = gprMax.KSIRFarField(
+            theta=(90.0,),
+            phi=(0.0,),
+            transform_id="benchmark_spectrum",
+            id="benchmark_direction",
+            outputs=("Etheta",),
+        )
+        scene.add(transform)
+        scene.add(far_field)
+    return scene, transform
+
+
+def _run_once(args, output_directory, label, surface_cells=None, frequency_count=0):
+    scene, transform = _scene(args, surface_cells, frequency_count)
+    outputfile = output_directory / label
+    start = perf_counter()
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        outputfile=outputfile,
+        hide_progress_bars=True,
+        log_level=logging.WARNING,
+        **_solver_options(args.backend, args.device, args.precision),
+    )
+    elapsed = perf_counter() - start
+
+    component_patches = 0
+    collection_backend = None
+    if transform is not None:
+        component_patches = sum(
+            component.surface.npatches for component in transform.surface_data.values()
+        )
+        with h5py.File(outputfile.with_suffix(".h5"), "r") as output:
+            group = output["ntff/benchmark_surface/frequency/benchmark_spectrum"]
+            collection_backend = group.attrs["collection_backend"]
+            if isinstance(collection_backend, bytes):
+                collection_backend = collection_backend.decode()
+    return elapsed, component_patches, collection_backend
+
+
+def _median_runs(
+    args,
+    output_directory,
+    label,
+    surface_cells=None,
+    frequency_count=0,
+):
+    times = []
+    patches = 0
+    collection_backend = None
+    for repeat in range(args.repeats):
+        elapsed, patches, collection_backend = _run_once(
+            args,
+            output_directory,
+            f"{label}_{repeat}",
+            surface_cells,
+            frequency_count,
+        )
+        times.append(elapsed)
+    return statistics.median(times), times, patches, collection_backend
+
+
+def run_benchmark(args):
+    """Run the requested matrix and return JSON-serialisable measurements."""
+
+    for surface_cells in args.surface_cells:
+        _monitor_bounds(args.cells, surface_cells, args.pml_cells, args.dl)
+
+    with tempfile.TemporaryDirectory(prefix="gprmax_ntff_benchmark_") as temporary:
+        output_directory = Path(temporary)
+        for warmup in range(args.warmups):
+            _run_once(args, output_directory, f"warmup_{warmup}")
+            _run_once(
+                args,
+                output_directory,
+                f"warmup_ntff_{warmup}",
+                max(args.surface_cells),
+                max(args.frequency_counts),
+            )
+
+        _, baseline_before, _, _ = _median_runs(args, output_directory, "baseline")
+        cases = []
+        for surface_cells in args.surface_cells:
+            for frequency_count in args.frequency_counts:
+                label = f"surface_{surface_cells}_frequencies_{frequency_count}"
+                elapsed, times, patches, collection_backend = _median_runs(
+                    args,
+                    output_directory,
+                    label,
+                    surface_cells,
+                    frequency_count,
+                )
+                cases.append(
+                    {
+                        "surface_cells": surface_cells,
+                        "frequency_count": frequency_count,
+                        "component_patches": patches,
+                        "collection_backend": collection_backend,
+                        "median_seconds": elapsed,
+                        "run_seconds": times,
+                    }
+                )
+        _, baseline_after, _, _ = _median_runs(args, output_directory, "baseline_after")
+        baseline_times = baseline_before + baseline_after
+        baseline = statistics.median(baseline_times)
+        for case in cases:
+            case["slowdown"] = case["median_seconds"] / baseline
+            case["overhead_percent"] = 100 * (case["slowdown"] - 1)
+
+    hostinfo = config.sim_config.hostinfo or {}
+    return {
+        "created_utc": datetime.now(timezone.utc).isoformat(),
+        "host": {
+            "platform": platform.platform(),
+            "processor": platform.processor(),
+            "logical_cpus": os.cpu_count(),
+            "cpu_id": hostinfo.get("cpuID"),
+            "physical_cores": hostinfo.get("physicalcores"),
+        },
+        "software": {
+            "gprmax": gprMax.__version__,
+            "numpy": np.__version__,
+            "python": platform.python_version(),
+        },
+        "configuration": {
+            "backend": args.backend,
+            "device": None if args.backend == "cpu" else args.device,
+            "cells": args.cells,
+            "iterations": args.iterations,
+            "dl": args.dl,
+            "pml_cells": args.pml_cells,
+            "threads": args.threads,
+            "precision": args.precision,
+            "centre_frequency": args.centre_frequency,
+            "components": ["Ex", "Ey", "Ez"],
+            "surface_cells": args.surface_cells,
+            "frequency_counts": args.frequency_counts,
+            "repeats": args.repeats,
+            "warmups": args.warmups,
+        },
+        "baseline": {
+            "median_seconds": baseline,
+            "run_seconds": baseline_times,
+            "before_seconds": baseline_before,
+            "after_seconds": baseline_after,
+        },
+        "cases": cases,
+    }
+
+
+def _parser():
+    parser = argparse.ArgumentParser(
+        description="Benchmark incremental reusable-KSIR collection overhead."
+    )
+    parser.add_argument("--backend", choices=("cpu", "cuda", "opencl", "metal"), default="cpu")
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--cells", type=_positive_int, default=80)
+    parser.add_argument("--iterations", type=_positive_int, default=300)
+    parser.add_argument("--dl", type=float, default=0.002)
+    parser.add_argument("--pml-cells", type=_positive_int, default=10)
+    parser.add_argument("--threads", type=_positive_int, default=8)
+    parser.add_argument("--precision", choices=("single", "double"), default="double")
+    parser.add_argument("--centre-frequency", type=float, default=4e9)
+    parser.add_argument("--surface-cells", nargs="+", type=_positive_int, default=[24, 40, 56])
+    parser.add_argument("--frequency-counts", nargs="+", type=_positive_int, default=[1, 5, 10])
+    parser.add_argument("--repeats", type=_positive_int, default=3)
+    parser.add_argument("--warmups", type=int, choices=range(0, 10), default=1)
+    parser.add_argument("--output", type=Path, default=Path("ntff_benchmark_results.json"))
+    return parser
+
+
+def main():
+    args = _parser().parse_args()
+    results = run_benchmark(args)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(results, indent=2))
+    print(f"Results written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/validation/validate_ntff.py
+++ b/testing/validation/validate_ntff.py
@@ -1,0 +1,760 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+
+"""Run reproducible end-to-end validations of the reusable KSIR interface.
+
+Available cases are a Hertzian-dipole far-field pattern, CPU PEC-sphere Mie
+scattering and broadband backscatter sweep, a finite-distance time-domain
+comparison with direct receivers, and CPU/accelerator time-domain parity.
+Results are written as JSON; an optional summary plot can be generated without
+storing simulation output.
+
+Examples::
+
+    python -m testing.validation.validate_ntff --case all --backend cpu
+    python -m testing.validation.validate_ntff --case dipole --backend cuda
+    python -m testing.validation.validate_ntff --case parity --backend opencl
+"""
+
+import argparse
+import json
+import logging
+import tempfile
+from pathlib import Path
+from time import perf_counter
+
+import h5py
+import numpy as np
+from scipy.constants import c
+from scipy.signal import find_peaks
+
+import gprMax
+from testing.validation.mie_pec import pec_sphere_bistatic_rcs
+
+ACCELERATOR_ARGUMENTS = {"cuda": "gpu", "opencl": "opencl", "metal": "metal"}
+
+MIE_FREQUENCY = 5e9
+MIE_RADIUS = 0.0096
+MIE_CENTRE = (0.048, 0.048, 0.048)
+MIE_ANGLES = np.arange(0.0, 181.0, 5.0)
+MIE_SWEEP_SIZE_PARAMETERS = np.arange(0.3, 4.0001, 0.1)
+MIE_SWEEP_FREQUENCIES = MIE_SWEEP_SIZE_PARAMETERS * c / (2 * np.pi * MIE_RADIUS)
+
+NEAR_FREQUENCY = 4e9
+NEAR_DL = 0.002
+NEAR_SOURCE = (0.05, 0.05, 0.05)
+NEAR_OBSERVATION_X = np.asarray((0.062, 0.070, 0.078))
+
+
+def _solver_options(backend, device, precision):
+    if backend == "cpu":
+        return {"cpu_precision": precision}
+    return {
+        ACCELERATOR_ARGUMENTS[backend]: [device],
+        "gpu_precision": precision,
+    }
+
+
+def _positive_int(value):
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be a positive integer")
+    return parsed
+
+
+def _nonnegative_int(value):
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("value must be a non-negative integer")
+    return parsed
+
+
+def _collection_backend(outputfile, path):
+    with h5py.File(outputfile.with_suffix(".h5"), "r") as output:
+        backend = output[path].attrs["collection_backend"]
+    return backend.decode() if isinstance(backend, bytes) else str(backend)
+
+
+def _run(scene, outputfile, *, backend, device, precision):
+    start = perf_counter()
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        outputfile=outputfile,
+        hide_progress_bars=True,
+        log_level=logging.WARNING,
+        **_solver_options(backend, device, precision),
+    )
+    return perf_counter() - start
+
+
+def dipole_scene(threads=4):
+    """Build the closed-form Hertzian-dipole validation scene."""
+
+    dl = 0.002
+    frequency = 5e9
+    centre = (0.05, 0.05, 0.05)
+    e_theta = np.arange(0.0, 181.0, 2.0)
+    h_phi = np.arange(0.0, 361.0, 2.0)
+
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl,) * 3))
+    scene.add(gprMax.Domain(p1=(0.1,) * 3))
+    scene.add(gprMax.TimeWindow(time=1e-9))
+    scene.add(gprMax.OMPThreads(n=threads))
+    scene.add(gprMax.PMLThickness(thickness=10))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=frequency, id="pulse"))
+    scene.add(gprMax.HertzianDipole(polarisation="z", p1=centre, waveform_id="pulse"))
+    scene.add(
+        gprMax.KSIRSurface(
+            p1=(0.034,) * 3,
+            p2=(0.066,) * 3,
+            id="dipole_surface",
+            origin=centre,
+        )
+    )
+    transform = gprMax.KSIRFrequencyTransform(
+        "dipole_surface",
+        "dipole_spectrum",
+        (frequency,),
+        save_surface_dft=False,
+    )
+    e_plane = gprMax.KSIRFarField(
+        theta=e_theta,
+        phi=np.zeros(e_theta.shape),
+        transform_id="dipole_spectrum",
+        id="e_plane",
+        outputs=("Etheta",),
+    )
+    h_plane = gprMax.KSIRFarField(
+        theta=np.full(h_phi.shape, 90.0),
+        phi=h_phi,
+        transform_id="dipole_spectrum",
+        id="h_plane",
+        outputs=("Etheta",),
+    )
+    for item in (transform, e_plane, h_plane):
+        scene.add(item)
+    return scene, transform, e_plane, h_plane, e_theta, h_phi
+
+
+def run_dipole_validation(workdir, *, backend, device, precision, threads):
+    scene, _, e_plane, h_plane, e_theta, h_phi = dipole_scene(threads)
+    outputfile = workdir / f"dipole_{backend}_{precision}"
+    runtime = _run(
+        scene,
+        outputfile,
+        backend=backend,
+        device=device,
+        precision=precision,
+    )
+
+    e_magnitude = np.abs(e_plane.result.fields["Etheta"][0])
+    peak = np.max(e_magnitude)
+    e_normalized = e_magnitude / peak
+    h_normalized = np.abs(h_plane.result.fields["Etheta"][0]) / peak
+    analytic = np.abs(np.sin(np.deg2rad(e_theta)))
+    interior = slice(1, -1)
+    nonzero_h = h_normalized[h_normalized > np.finfo(h_normalized.dtype).eps]
+
+    return {
+        "backend": backend,
+        "collection_backend": _collection_backend(
+            outputfile, "ntff/dipole_surface/frequency/dipole_spectrum"
+        ),
+        "runtime_seconds": runtime,
+        "theta_degrees": e_theta,
+        "e_plane_normalized_Etheta": e_normalized,
+        "analytic_abs_sin_theta": analytic,
+        "e_plane_rms_error": float(
+            np.sqrt(np.mean((e_normalized[interior] - analytic[interior]) ** 2))
+        ),
+        "e_plane_maximum_error": float(np.max(np.abs(e_normalized[interior] - analytic[interior]))),
+        "pole_maximum": float(max(e_normalized[0], e_normalized[-1])),
+        "phi_degrees": h_phi,
+        "h_plane_normalized_Etheta": h_normalized,
+        "h_plane_rms_deviation_from_unity": float(np.sqrt(np.mean((h_normalized - 1) ** 2))),
+        "h_plane_peak_to_peak_ripple_db": float(
+            20 * np.log10(np.max(nonzero_h) / np.min(nonzero_h))
+        ),
+    }
+
+
+def mie_scene(threads=4):
+    """Build the CPU TFSF/PEC-sphere Mie validation scene."""
+
+    dl = 0.0016
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl,) * 3))
+    scene.add(gprMax.Domain(p1=(0.096,) * 3))
+    scene.add(gprMax.TimeWindow(iterations=900))
+    scene.add(gprMax.OMPThreads(n=threads))
+    scene.add(gprMax.PMLThickness(thickness=10))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=MIE_FREQUENCY, id="plane_pulse"))
+    scene.add(
+        gprMax.DiscretePlaneWaveAxial(
+            p1=(0.032,) * 3,
+            p2=(0.064,) * 3,
+            axis="x",
+            psi=90,
+            waveform_id="plane_pulse",
+        )
+    )
+    scene.add(gprMax.Sphere(p1=MIE_CENTRE, r=MIE_RADIUS, material_id="pec"))
+    scene.add(
+        gprMax.KSIRSurface(
+            p1=(0.024,) * 3,
+            p2=(0.072,) * 3,
+            id="mie_surface",
+            origin=MIE_CENTRE,
+        )
+    )
+    transform = gprMax.KSIRFrequencyTransform(
+        "mie_surface",
+        "mie_spectrum",
+        (MIE_FREQUENCY,),
+        save_surface_dft=False,
+        plane_wave_index=0,
+    )
+    far_field = gprMax.KSIRFarField(
+        theta=np.full(MIE_ANGLES.shape, 90.0),
+        phi=MIE_ANGLES,
+        transform_id="mie_spectrum",
+        id="mie_pattern",
+        outputs=("Etheta", "Ephi", "rcs"),
+    )
+    scene.add(transform)
+    scene.add(far_field)
+    return scene, transform, far_field
+
+
+def run_mie_validation(workdir, *, precision, threads):
+    scene, _, far_field = mie_scene(threads)
+    outputfile = workdir / f"mie_cpu_{precision}"
+    runtime = _run(
+        scene,
+        outputfile,
+        backend="cpu",
+        device=0,
+        precision=precision,
+    )
+
+    simulated = np.asarray(far_field.result.fields["rcs"][0])
+    analytic = pec_sphere_bistatic_rcs(
+        MIE_FREQUENCY,
+        MIE_RADIUS,
+        np.deg2rad(MIE_ANGLES),
+        polarisation="perpendicular",
+    )
+    simulated_pattern = simulated / np.max(simulated)
+    analytic_pattern = analytic / np.max(analytic)
+    copolar = np.abs(far_field.result.fields["Etheta"][0])
+    crosspolar = np.abs(far_field.result.fields["Ephi"][0])
+
+    return {
+        "backend": "cpu",
+        "collection_backend": _collection_backend(
+            outputfile, "ntff/mie_surface/frequency/mie_spectrum"
+        ),
+        "runtime_seconds": runtime,
+        "scattering_angle_degrees": MIE_ANGLES,
+        "simulated_rcs_m2": simulated,
+        "analytic_mie_rcs_m2": analytic,
+        "simulated_normalized_pattern": simulated_pattern,
+        "analytic_normalized_pattern": analytic_pattern,
+        "pattern_rms_error": float(np.sqrt(np.mean((simulated_pattern - analytic_pattern) ** 2))),
+        "absolute_rcs_relative_l2_error": float(
+            np.linalg.norm(simulated - analytic) / np.linalg.norm(analytic)
+        ),
+        "forward_scatter_relative_error": float(abs(simulated[0] - analytic[0]) / analytic[0]),
+        "backscatter_relative_error": float(abs(simulated[-1] - analytic[-1]) / analytic[-1]),
+        "maximum_crosspolar_ratio": float(np.max(crosspolar) / np.max(copolar)),
+    }
+
+
+def mie_sweep_scene(threads=4):
+    """Build a broadband CPU backscatter-resonance validation scene."""
+
+    dl = 0.0016
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl,) * 3))
+    scene.add(gprMax.Domain(p1=(0.096,) * 3))
+    scene.add(gprMax.TimeWindow(iterations=900))
+    scene.add(gprMax.OMPThreads(n=threads))
+    scene.add(gprMax.PMLThickness(thickness=10))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=10e9, id="broadband_plane_pulse"))
+    scene.add(
+        gprMax.DiscretePlaneWaveAxial(
+            p1=(0.032,) * 3,
+            p2=(0.064,) * 3,
+            axis="x",
+            psi=90,
+            waveform_id="broadband_plane_pulse",
+        )
+    )
+    scene.add(gprMax.Sphere(p1=MIE_CENTRE, r=MIE_RADIUS, material_id="pec"))
+    scene.add(
+        gprMax.KSIRSurface(
+            p1=(0.024,) * 3,
+            p2=(0.072,) * 3,
+            id="mie_sweep_surface",
+            origin=MIE_CENTRE,
+        )
+    )
+    transform = gprMax.KSIRFrequencyTransform(
+        "mie_sweep_surface",
+        "mie_sweep_spectrum",
+        MIE_SWEEP_FREQUENCIES,
+        save_surface_dft=False,
+        plane_wave_index=0,
+    )
+    backscatter = gprMax.KSIRFarField(
+        theta=(90.0,),
+        phi=(180.0,),
+        transform_id="mie_sweep_spectrum",
+        id="backscatter",
+        outputs=("rcs",),
+    )
+    scene.add(transform)
+    scene.add(backscatter)
+    return scene, transform, backscatter
+
+
+def _mie_backscatter(frequencies):
+    return np.asarray(
+        [
+            pec_sphere_bistatic_rcs(
+                frequency,
+                MIE_RADIUS,
+                (np.pi,),
+                polarisation="perpendicular",
+            )[0]
+            for frequency in frequencies
+        ]
+    )
+
+
+def _resonance_locations(normalized_rcs, prominence_db=0.15):
+    values_db = 10 * np.log10(normalized_rcs)
+    peaks, _ = find_peaks(values_db, prominence=prominence_db)
+    nulls, _ = find_peaks(-values_db, prominence=prominence_db)
+    return {
+        "peaks": MIE_SWEEP_SIZE_PARAMETERS[peaks],
+        "nulls": MIE_SWEEP_SIZE_PARAMETERS[nulls],
+    }
+
+
+def _frequency_band_errors(error_db):
+    bands = ((0.3, 1.5), (1.5, 2.8), (2.8, 4.01))
+    results = []
+    for lower, upper in bands:
+        selected = (MIE_SWEEP_SIZE_PARAMETERS >= lower) & (MIE_SWEEP_SIZE_PARAMETERS < upper)
+        values = error_db[selected]
+        results.append(
+            {
+                "size_parameter_min": lower,
+                "size_parameter_max": min(upper, 4.0),
+                "rms_error_db": float(np.sqrt(np.mean(values**2))),
+                "maximum_absolute_error_db": float(np.max(np.abs(values))),
+            }
+        )
+    return results
+
+
+def run_mie_sweep_validation(workdir, *, precision, threads):
+    scene, _, backscatter = mie_sweep_scene(threads)
+    outputfile = workdir / f"mie_sweep_cpu_{precision}"
+    runtime = _run(
+        scene,
+        outputfile,
+        backend="cpu",
+        device=0,
+        precision=precision,
+    )
+
+    simulated = np.asarray(backscatter.result.fields["rcs"][:, 0])
+    analytic = _mie_backscatter(MIE_SWEEP_FREQUENCIES)
+    projected_area = np.pi * MIE_RADIUS**2
+    simulated_normalized = simulated / projected_area
+    analytic_normalized = analytic / projected_area
+    error_db = 10 * np.log10(simulated / analytic)
+
+    return {
+        "backend": "cpu",
+        "collection_backend": _collection_backend(
+            outputfile, "ntff/mie_sweep_surface/frequency/mie_sweep_spectrum"
+        ),
+        "runtime_seconds": runtime,
+        "size_parameter": MIE_SWEEP_SIZE_PARAMETERS,
+        "frequency_hz": MIE_SWEEP_FREQUENCIES,
+        "wavelength_cells": c / (MIE_SWEEP_FREQUENCIES * 0.0016),
+        "simulated_rcs_m2": simulated,
+        "analytic_mie_rcs_m2": analytic,
+        "simulated_normalized_rcs": simulated_normalized,
+        "analytic_normalized_rcs": analytic_normalized,
+        "error_db": error_db,
+        "overall_rms_error_db": float(np.sqrt(np.mean(error_db**2))),
+        "band_errors": _frequency_band_errors(error_db),
+        "simulated_resonances": _resonance_locations(simulated_normalized),
+        "analytic_resonances": _resonance_locations(analytic_normalized),
+    }
+
+
+def near_field_scene(threads=4, *, time_origin="simulation"):
+    """Build collocated direct-receiver and advanced-time KSIR outputs."""
+
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(NEAR_DL,) * 3))
+    scene.add(gprMax.Domain(p1=(0.1,) * 3))
+    scene.add(gprMax.TimeWindow(time=1e-9))
+    scene.add(gprMax.OMPThreads(n=threads))
+    scene.add(gprMax.PMLThickness(thickness=10))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=NEAR_FREQUENCY, id="pulse"))
+    scene.add(gprMax.HertzianDipole(polarisation="z", p1=NEAR_SOURCE, waveform_id="pulse"))
+
+    points = []
+    for index, x_position in enumerate(NEAR_OBSERVATION_X, start=1):
+        receiver_position = (float(x_position), NEAR_SOURCE[1], NEAR_SOURCE[2])
+        scene.add(
+            gprMax.Rx(
+                p1=receiver_position,
+                outputs=["Ez"],
+                id=f"near_field_{index}",
+            )
+        )
+        # Rx samples Ez at the z-directed Yee-edge centre.
+        points.append(
+            (
+                receiver_position[0],
+                receiver_position[1],
+                receiver_position[2] + 0.5 * NEAR_DL,
+            )
+        )
+
+    scene.add(
+        gprMax.KSIRSurface(
+            p1=(0.042,) * 3,
+            p2=(0.058,) * 3,
+            id="near_surface",
+            origin=NEAR_SOURCE,
+        )
+    )
+    receiver = gprMax.KSIRTimeRx(
+        position=points,
+        surface_id="near_surface",
+        id="near_field",
+        outputs=("Ez",),
+        time_origin=time_origin,
+    )
+    scene.add(receiver)
+    return scene, receiver, np.asarray(points)
+
+
+def _waveform_metrics(direct, reconstructed, dt):
+    peak = np.max(np.abs(direct))
+    significant = np.abs(direct) > 0.02 * peak
+    difference = reconstructed - direct
+    correlation = np.corrcoef(reconstructed[significant], direct[significant])[0, 1]
+    cross_correlation = np.correlate(reconstructed, direct, mode="full")
+    lag = int(np.argmax(cross_correlation) - (direct.size - 1))
+    return {
+        "relative_l2_error_significant": float(
+            np.linalg.norm(difference[significant]) / np.linalg.norm(direct[significant])
+        ),
+        "relative_l2_error_full": float(np.linalg.norm(difference) / np.linalg.norm(direct)),
+        "correlation_significant": float(correlation),
+        "peak_amplitude_relative_error": float(abs(np.max(np.abs(reconstructed)) - peak) / peak),
+        "cross_correlation_lag_samples": lag,
+        "cross_correlation_lag_seconds": float(lag * dt),
+    }
+
+
+def run_near_field_validation(workdir, *, backend, device, precision, threads):
+    scene, receiver, points = near_field_scene(threads, time_origin="simulation")
+    outputfile = workdir / f"near_field_{backend}_{precision}"
+    runtime = _run(
+        scene,
+        outputfile,
+        backend=backend,
+        device=device,
+        precision=precision,
+    )
+
+    direct = []
+    with h5py.File(outputfile.with_suffix(".h5"), "r") as output:
+        dt = float(output.attrs["dt"])
+        for index in range(1, NEAR_OBSERVATION_X.size + 1):
+            direct.append(output[f"rxs/rx{index}/Ez"][:])
+    direct = np.asarray(direct)
+    reconstructed = np.asarray(receiver.result.fields["Ez"][:, : direct.shape[1]])
+    metrics = [
+        _waveform_metrics(expected, actual, dt) for expected, actual in zip(direct, reconstructed)
+    ]
+    source_position = np.asarray((NEAR_SOURCE[0], NEAR_SOURCE[1], NEAR_SOURCE[2] + 0.5 * NEAR_DL))
+
+    return {
+        "backend": backend,
+        "collection_backend": _collection_backend(outputfile, "ntff/near_surface/time/near_field"),
+        "runtime_seconds": runtime,
+        "dt_seconds": dt,
+        "points_m": points,
+        "distance_m": np.linalg.norm(points - source_position, axis=1),
+        "distance_wavelengths": np.linalg.norm(points - source_position, axis=1)
+        / (c / NEAR_FREQUENCY),
+        "metrics": metrics,
+    }
+
+
+def _parity_metrics(expected, actual):
+    difference = actual - expected
+    scale = np.max(np.abs(expected))
+    return {
+        "relative_l2_error": float(np.linalg.norm(difference) / np.linalg.norm(expected)),
+        "maximum_error_normalized_to_peak": float(np.max(np.abs(difference)) / scale),
+    }
+
+
+def run_accelerator_parity(workdir, *, backend, device, precision, threads):
+    if backend == "cpu":
+        raise ValueError("accelerator parity requires cuda, opencl, or metal")
+
+    cpu_scene, cpu_receiver, _ = near_field_scene(threads, time_origin="first_arrival")
+    device_scene, device_receiver, _ = near_field_scene(threads, time_origin="first_arrival")
+    cpu_output = workdir / f"parity_cpu_{precision}"
+    device_output = workdir / f"parity_{backend}_{precision}"
+    cpu_runtime = _run(
+        cpu_scene,
+        cpu_output,
+        backend="cpu",
+        device=0,
+        precision=precision,
+    )
+    device_runtime = _run(
+        device_scene,
+        device_output,
+        backend=backend,
+        device=device,
+        precision=precision,
+    )
+
+    expected = cpu_receiver.result.fields["Ez"]
+    actual = device_receiver.result.fields["Ez"]
+    point_metrics = []
+    for point, valid_length in enumerate(cpu_receiver.result.valid_lengths):
+        stop = int(valid_length)
+        point_metrics.append(_parity_metrics(expected[point, :stop], actual[point, :stop]))
+
+    return {
+        "backend": backend,
+        "cpu_collection_backend": _collection_backend(
+            cpu_output, "ntff/near_surface/time/near_field"
+        ),
+        "device_collection_backend": _collection_backend(
+            device_output, "ntff/near_surface/time/near_field"
+        ),
+        "runtime_seconds": {"cpu": cpu_runtime, backend: device_runtime},
+        "valid_lengths": cpu_receiver.result.valid_lengths,
+        "time_origins_seconds": cpu_receiver.result.time_origins,
+        "point_metrics": point_metrics,
+    }
+
+
+def _json_ready(value):
+    if isinstance(value, dict):
+        return {str(key): _json_ready(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+def _plot(results, filename):
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    available = [
+        name for name in ("dipole", "mie", "mie_sweep", "near_field", "parity") if name in results
+    ]
+    figure, axes = plt.subplots(1, len(available), figsize=(5 * len(available), 4))
+    axes = np.atleast_1d(axes)
+    for axis, name in zip(axes, available):
+        result = results[name]
+        if name == "dipole":
+            axis.plot(
+                result["theta_degrees"],
+                result["e_plane_normalized_Etheta"],
+                label="gprMax",
+            )
+            axis.plot(
+                result["theta_degrees"],
+                result["analytic_abs_sin_theta"],
+                "--",
+                label="analytic",
+            )
+            axis.set(xlabel="Theta [deg]", ylabel="Normalized magnitude", title="Dipole")
+        elif name == "mie":
+            axis.semilogy(
+                result["scattering_angle_degrees"],
+                result["simulated_rcs_m2"],
+                label="gprMax",
+            )
+            axis.semilogy(
+                result["scattering_angle_degrees"],
+                result["analytic_mie_rcs_m2"],
+                "--",
+                label="Mie",
+            )
+            axis.set(xlabel="Scattering angle [deg]", ylabel="RCS [m2]", title="PEC sphere")
+        elif name == "mie_sweep":
+            axis.semilogy(
+                result["size_parameter"],
+                result["simulated_normalized_rcs"],
+                label="gprMax",
+            )
+            axis.semilogy(
+                result["size_parameter"],
+                result["analytic_normalized_rcs"],
+                "--",
+                label="Mie",
+            )
+            axis.set(
+                xlabel="Size parameter ka",
+                ylabel="Normalized backscatter RCS",
+                title="PEC-sphere sweep",
+            )
+        elif name == "near_field":
+            errors = [item["relative_l2_error_significant"] for item in result["metrics"]]
+            axis.plot(result["distance_wavelengths"], errors, "o-")
+            axis.set(
+                xlabel="Distance [wavelengths]",
+                ylabel="Relative L2 error",
+                title="Near field",
+            )
+        else:
+            errors = [item["relative_l2_error"] for item in result["point_metrics"]]
+            axis.bar(np.arange(len(errors)) + 1, errors)
+            axis.set(xlabel="Point", ylabel="Relative L2 error", title="CPU/device parity")
+        axis.grid(True, alpha=0.3)
+        if name in ("dipole", "mie", "mie_sweep"):
+            axis.legend()
+    figure.tight_layout()
+    filename.parent.mkdir(parents=True, exist_ok=True)
+    figure.savefig(filename, dpi=180, bbox_inches="tight")
+    plt.close(figure)
+
+
+def run_selected(args):
+    results = {
+        "configuration": {
+            "case": args.case,
+            "backend": args.backend,
+            "device": None if args.backend == "cpu" else args.device,
+            "precision": args.precision,
+            "threads": args.threads,
+        }
+    }
+    with tempfile.TemporaryDirectory(prefix="gprmax_ntff_validation_") as temporary:
+        workdir = Path(temporary)
+        if args.case in ("dipole", "all"):
+            results["dipole"] = run_dipole_validation(
+                workdir,
+                backend=args.backend,
+                device=args.device,
+                precision=args.precision,
+                threads=args.threads,
+            )
+        if args.case in ("mie", "all"):
+            if args.backend == "cpu":
+                results["mie"] = run_mie_validation(
+                    workdir, precision=args.precision, threads=args.threads
+                )
+            elif args.case == "mie":
+                raise ValueError("the TFSF Mie case is currently CPU-only")
+            else:
+                results["mie_skipped"] = "the TFSF Mie case is currently CPU-only"
+        if args.case in ("mie-sweep", "all"):
+            if args.backend == "cpu":
+                results["mie_sweep"] = run_mie_sweep_validation(
+                    workdir, precision=args.precision, threads=args.threads
+                )
+            elif args.case == "mie-sweep":
+                raise ValueError("the TFSF Mie sweep is currently CPU-only")
+            else:
+                results["mie_sweep_skipped"] = "the TFSF Mie sweep is currently CPU-only"
+        if args.case in ("near-field", "all"):
+            results["near_field"] = run_near_field_validation(
+                workdir,
+                backend=args.backend,
+                device=args.device,
+                precision=args.precision,
+                threads=args.threads,
+            )
+        if args.case in ("parity", "all"):
+            if args.backend != "cpu":
+                results["parity"] = run_accelerator_parity(
+                    workdir,
+                    backend=args.backend,
+                    device=args.device,
+                    precision=args.precision,
+                    threads=args.threads,
+                )
+            elif args.case == "parity":
+                raise ValueError("parity requires cuda, opencl, or metal")
+            else:
+                results["parity_skipped"] = "parity requires cuda, opencl, or metal"
+    return results
+
+
+def _parser():
+    parser = argparse.ArgumentParser(
+        description="Validate reusable KSIR outputs against closed-form or direct references."
+    )
+    parser.add_argument(
+        "--case",
+        choices=("dipole", "mie", "mie-sweep", "near-field", "parity", "all"),
+        default="all",
+    )
+    parser.add_argument("--backend", choices=("cpu", "cuda", "opencl", "metal"), default="cpu")
+    parser.add_argument("--device", type=_nonnegative_int, default=0)
+    parser.add_argument("--precision", choices=("single", "double"), default="double")
+    parser.add_argument("--threads", type=_positive_int, default=4)
+    parser.add_argument("--output", type=Path, default=Path("ntff_validation_results.json"))
+    parser.add_argument("--plot", type=Path)
+    return parser
+
+
+def main():
+    args = _parser().parse_args()
+    results = run_selected(args)
+    serialisable = _json_ready(results)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(serialisable, indent=2) + "\n", encoding="utf-8")
+    if args.plot is not None:
+        _plot(results, args.plot)
+    print(json.dumps(serialisable, indent=2))
+    print(f"Results written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ntff/test_benchmark_ntff.py
+++ b/tests/ntff/test_benchmark_ntff.py
@@ -1,0 +1,74 @@
+"""Configuration and execution checks for the reusable-KSIR benchmark."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from numpy.testing import assert_allclose
+
+from testing.benchmarking.benchmark_ntff import (
+    _frequencies,
+    _monitor_bounds,
+    _solver_options,
+    run_benchmark,
+)
+
+
+def test_monitor_bounds_are_centred_and_clear_of_pml():
+    lower, upper = _monitor_bounds(80, 24, 10, 0.002)
+
+    assert_allclose(lower, (0.056,) * 3)
+    assert_allclose(upper, (0.104,) * 3)
+
+
+@pytest.mark.parametrize("surface_cells", [23, 58, 80])
+def test_monitor_bounds_reject_invalid_benchmark_surfaces(surface_cells):
+    with pytest.raises(ValueError):
+        _monitor_bounds(80, surface_cells, 10, 0.002)
+
+
+def test_benchmark_frequency_count_is_exact_and_centred():
+    assert _frequencies(1, 4e9) == [4e9]
+    frequencies = _frequencies(10, 4e9)
+
+    assert len(frequencies) == 10
+    assert frequencies[0] == pytest.approx(2.4e9)
+    assert frequencies[-1] == pytest.approx(5.6e9)
+
+
+def test_solver_options_use_gprmax_precision_and_backend_arguments():
+    assert _solver_options("cpu", 3, "double") == {"cpu_precision": "double"}
+    assert _solver_options("cuda", 3, "single") == {
+        "gpu": [3],
+        "gpu_precision": "single",
+    }
+    assert _solver_options("opencl", 2, "double")["opencl"] == [2]
+    assert _solver_options("metal", 1, "single")["metal"] == [1]
+
+
+def test_cpu_benchmark_executes_production_collection_path():
+    args = SimpleNamespace(
+        backend="cpu",
+        device=0,
+        cells=24,
+        iterations=160,
+        dl=0.002,
+        pml_cells=3,
+        threads=2,
+        precision="double",
+        centre_frequency=4e9,
+        surface_cells=[8],
+        frequency_counts=[1],
+        repeats=1,
+        warmups=0,
+    )
+
+    result = run_benchmark(args)
+
+    assert result["configuration"]["backend"] == "cpu"
+    assert result["baseline"]["median_seconds"] > 0
+    assert len(result["cases"]) == 1
+    assert result["cases"][0]["component_patches"] > 0
+    assert result["cases"][0]["collection_backend"] == "cython_openmp"
+    assert result["cases"][0]["median_seconds"] > 0
+    json.dumps(result)

--- a/tests/ntff/test_mie_fdtd_validation.py
+++ b/tests/ntff/test_mie_fdtd_validation.py
@@ -7,72 +7,13 @@ from scipy.constants import c
 
 import gprMax
 from testing.validation.mie_pec import pec_mie_amplitudes, pec_sphere_bistatic_rcs
-
-FREQUENCY = 5e9
-SPHERE_RADIUS = 0.0096
-SPHERE_CENTRE = (0.048, 0.048, 0.048)
-SCATTERING_ANGLES = np.arange(0.0, 181.0, 10.0)
-
-
-def _mie_scene():
-    dl = 0.0016
-    scene = gprMax.Scene()
-    scene.add(gprMax.Discretisation(p1=(dl,) * 3))
-    scene.add(gprMax.Domain(p1=(0.096,) * 3))
-    scene.add(gprMax.TimeWindow(iterations=900))
-    scene.add(gprMax.OMPThreads(n=4))
-    scene.add(gprMax.PMLThickness(thickness=10))
-    scene.add(
-        gprMax.Waveform(
-            wave_type="ricker", amp=1, freq=FREQUENCY, id="plane_pulse"
-        )
-    )
-    scene.add(
-        gprMax.DiscretePlaneWaveAxial(
-            p1=(0.032,) * 3,
-            p2=(0.064,) * 3,
-            axis="x",
-            psi=90,
-            waveform_id="plane_pulse",
-        )
-    )
-    scene.add(
-        gprMax.Sphere(
-            p1=SPHERE_CENTRE,
-            r=SPHERE_RADIUS,
-            material_id="pec",
-        )
-    )
-    scene.add(
-        gprMax.KSIRSurface(
-            p1=(0.024,) * 3,
-            p2=(0.072,) * 3,
-            id="mie_surface",
-            origin=SPHERE_CENTRE,
-        )
-    )
-    transform = gprMax.KSIRFrequencyTransform(
-        surface_id="mie_surface",
-        id="mie_spectrum",
-        frequencies=(FREQUENCY,),
-        save_surface_dft=False,
-    )
-    far_field = gprMax.KSIRFarField(
-        theta=np.full(SCATTERING_ANGLES.shape, 90.0),
-        phi=SCATTERING_ANGLES,
-        transform_id="mie_spectrum",
-        id="mie_pattern",
-        outputs=("Etheta", "Ephi", "rcs"),
-    )
-    scene.add(transform)
-    scene.add(far_field)
-    return scene, transform, far_field
+from testing.validation.validate_ntff import MIE_ANGLES, MIE_FREQUENCY, MIE_RADIUS, mie_scene
 
 
 def test_cpu_tfsf_ksir_pec_sphere_matches_mie(tmp_path):
     """Exercise the production FDTD scattering and HDF5 paths."""
 
-    scene, transform, far_field = _mie_scene()
+    scene, transform, far_field = mie_scene(threads=4)
     outputfile = tmp_path / "mie_sphere"
     gprMax.run(
         scenes=[scene],
@@ -84,9 +25,9 @@ def test_cpu_tfsf_ksir_pec_sphere_matches_mie(tmp_path):
 
     simulated = np.asarray(far_field.result.fields["rcs"][0])
     analytic = pec_sphere_bistatic_rcs(
-        FREQUENCY,
-        SPHERE_RADIUS,
-        np.deg2rad(SCATTERING_ANGLES),
+        MIE_FREQUENCY,
+        MIE_RADIUS,
+        np.deg2rad(MIE_ANGLES),
         polarisation="perpendicular",
     )
     simulated_pattern = simulated / np.max(simulated)
@@ -97,19 +38,17 @@ def test_cpu_tfsf_ksir_pec_sphere_matches_mie(tmp_path):
 
     monitor = transform._compiled_outputs.transform_monitor(transform.ID)
     incident_electric = monitor.result.incident_electric[0, 2]
-    wavenumber = 2 * np.pi * FREQUENCY / c
+    wavenumber = 2 * np.pi * MIE_FREQUENCY / c
     perpendicular, _ = pec_mie_amplitudes(
-        wavenumber * SPHERE_RADIUS,
-        np.deg2rad(SCATTERING_ANGLES),
+        wavenumber * MIE_RADIUS,
+        np.deg2rad(MIE_ANGLES),
     )
     analytic_amplitude = -1j * np.conj(perpendicular) / wavenumber
     numerical_amplitude = far_field.result.fields["Etheta"][0] / incident_electric
     complex_relative_l2_error = np.linalg.norm(
         numerical_amplitude - analytic_amplitude
     ) / np.linalg.norm(analytic_amplitude)
-    phase_rms_error = np.sqrt(
-        np.mean(np.angle(numerical_amplitude / analytic_amplitude) ** 2)
-    )
+    phase_rms_error = np.sqrt(np.mean(np.angle(numerical_amplitude / analytic_amplitude) ** 2))
 
     assert np.all(np.isfinite(simulated))
     assert np.all(simulated > 0)

--- a/tests/ntff/test_validation_utilities.py
+++ b/tests/ntff/test_validation_utilities.py
@@ -1,0 +1,93 @@
+"""End-to-end checks for the reusable-KSIR validation utilities."""
+
+import numpy as np
+import pytest
+
+from testing.validation.validate_ntff import (
+    _solver_options,
+    run_accelerator_parity,
+    run_dipole_validation,
+    run_mie_sweep_validation,
+    run_near_field_validation,
+)
+
+try:
+    import pycuda.driver as _cuda_driver
+
+    _cuda_driver.init()
+    HAS_CUDA = _cuda_driver.Device.count() > 0
+except Exception:
+    HAS_CUDA = False
+
+
+def test_validation_solver_options_cover_all_backends():
+    assert _solver_options("cpu", 0, "double") == {"cpu_precision": "double"}
+    assert _solver_options("cuda", 2, "single")["gpu"] == [2]
+    assert _solver_options("opencl", 1, "single")["opencl"] == [1]
+    assert _solver_options("metal", 3, "single")["metal"] == [3]
+
+
+def test_cpu_dipole_validation_matches_closed_form(tmp_path):
+    result = run_dipole_validation(
+        tmp_path,
+        backend="cpu",
+        device=0,
+        precision="double",
+        threads=2,
+    )
+
+    assert result["collection_backend"] == "cython_openmp"
+    assert result["e_plane_rms_error"] < 0.01
+    assert result["e_plane_maximum_error"] < 0.02
+    assert result["pole_maximum"] < 1e-8
+    assert result["h_plane_rms_deviation_from_unity"] < 0.01
+
+
+def test_cpu_near_field_validation_matches_direct_receivers(tmp_path):
+    result = run_near_field_validation(
+        tmp_path,
+        backend="cpu",
+        device=0,
+        precision="double",
+        threads=2,
+    )
+
+    assert result["collection_backend"] == "cython_openmp"
+    assert np.all(np.diff(result["distance_m"]) > 0)
+    for metrics in result["metrics"]:
+        assert metrics["relative_l2_error_significant"] < 0.05
+        assert metrics["correlation_significant"] > 0.999
+        assert metrics["cross_correlation_lag_samples"] == 0
+
+
+def test_cpu_mie_sweep_exercises_backscatter_resonances(tmp_path):
+    result = run_mie_sweep_validation(
+        tmp_path,
+        precision="double",
+        threads=2,
+    )
+
+    assert result["collection_backend"] == "cython_openmp"
+    assert np.all(np.isfinite(result["simulated_rcs_m2"]))
+    assert np.all(result["simulated_rcs_m2"] > 0)
+    assert result["overall_rms_error_db"] < 5
+    assert result["band_errors"][0]["rms_error_db"] < 2
+    assert len(result["simulated_resonances"]["peaks"]) > 0
+    assert len(result["simulated_resonances"]["nulls"]) > 0
+
+
+@pytest.mark.skipif(not HAS_CUDA, reason="No CUDA device/pycuda available")
+def test_cuda_time_domain_validation_matches_cpu(tmp_path):
+    result = run_accelerator_parity(
+        tmp_path,
+        backend="cuda",
+        device=0,
+        precision="single",
+        threads=2,
+    )
+
+    assert result["cpu_collection_backend"] == "cython_openmp"
+    assert result["device_collection_backend"] == "cuda_device"
+    for metrics in result["point_metrics"]:
+        assert metrics["relative_l2_error"] < 1e-4
+        assert metrics["maximum_error_normalized_to_peak"] < 1e-4


### PR DESCRIPTION
# PR Description

## Summary

Adds working NTFF benchmarking and validation utilities using the reusable KSIR interface.

- Benchmarks CPU, CUDA, OpenCL, and Metal collection overhead.
- Uses gprMax-configured precision and device selection.
- Adds Hertzian-dipole principal-plane validation.
- Adds PEC-sphere angular RCS and broadband Mie-resonance validation.
- Adds near-field comparison with direct Yee-grid receivers.
- Adds CPU/accelerator time-domain parity validation.
- Writes JSON and optional plots 
- Documents commands and available cases.

## 🛠️ Related Issue (Number)

N/A

## Type of change

- [x] New developer/testing feature
- [x] This change requires a documentation update.


## Testing

- [x] Full NTFF suite: 224 passed.
- [x] CPU and CUDA execution verified.
- [x] Black 23.12.1 and isort 5.13.2 pass.
- [x] Sphinx documentation build succeeds.
- [x] Self-review completed.
- [x] No generated results or output files included.
- [ ] OpenCL and Metal hardware verification—not available on the testing server.