### PR TITLE
Restore subgrid source/receiver placement and timing fixes

### DIFF
--- a/gprMax/fields_outputs.py
+++ b/gprMax/fields_outputs.py
@@ -85,6 +85,19 @@ def write_hdf5_outputfile(outputfile: Path, title: str, model):
     logger.basic(f"Written output file: {outputfile.name}\n")
 
 
+def _global_position(grid, coordx: int, coordy: int, coordz: int, is_subgrid: bool):
+    """Converts a grid-local (x, y, z) index to a physical position in the
+    global/main-grid coordinate frame.
+
+    For the main grid, local index 0 coincides with the global origin so no
+    translation is needed. For a subgrid, SubGridBaseGrid.local_to_global
+    reverses the subgrid's boundary padding and i0/j0/k0 placement offset.
+    """
+    if is_subgrid:
+        return tuple(grid.local_to_global((coordx, coordy, coordz)))
+    return (coordx * grid.dx, coordy * grid.dy, coordz * grid.dz)
+
+
 def write_hd5_data(basegrp, grid, is_subgrid=False):
     """Writes grid meta data and data to HDF5 group.
 
@@ -121,20 +134,16 @@ def write_hd5_data(basegrp, grid, is_subgrid=False):
     for srcindex, src in enumerate(srclist):
         grp = basegrp.create_group(f"srcs/src{str(srcindex + 1)}")
         grp.attrs["Type"] = type(src).__name__
-        grp.attrs["Position"] = (
-            src.xcoord * grid.dx,
-            src.ycoord * grid.dy,
-            src.zcoord * grid.dz,
+        grp.attrs["Position"] = _global_position(
+            grid, src.xcoord, src.ycoord, src.zcoord, is_subgrid
         )
 
     # Create group for transmission lines; add positional data, line resistance and
     # line discretisation attributes; write arrays for line voltages and currents
     for tlindex, tl in enumerate(grid.transmissionlines):
         grp = basegrp.create_group("tls/tl" + str(tlindex + 1))
-        grp.attrs["Position"] = (
-            tl.xcoord * grid.dx,
-            tl.ycoord * grid.dy,
-            tl.zcoord * grid.dz,
+        grp.attrs["Position"] = _global_position(
+            grid, tl.xcoord, tl.ycoord, tl.zcoord, is_subgrid
         )
         grp.attrs["Resistance"] = tl.resistance
         grp.attrs["dl"] = tl.dl
@@ -154,10 +163,8 @@ def write_hd5_data(basegrp, grid, is_subgrid=False):
         grp = basegrp.create_group("rxs/rx" + str(rxindex + 1))
         if rx.ID:
             grp.attrs["Name"] = rx.ID
-        grp.attrs["Position"] = (
-            rx.xcoord * grid.dx,
-            rx.ycoord * grid.dy,
-            rx.zcoord * grid.dz,
+        grp.attrs["Position"] = _global_position(
+            grid, rx.xcoord, rx.ycoord, rx.zcoord, is_subgrid
         )
 
         for output in rx.outputs:

--- a/gprMax/geometry_outputs/geometry_views.py
+++ b/gprMax/geometry_outputs/geometry_views.py
@@ -34,6 +34,7 @@ from gprMax._version import __version__
 from gprMax.geometry_outputs.grid_view import GridType, GridView, MPIGridView
 from gprMax.grid.mpi_grid import MPIGrid
 from gprMax.receivers import Rx
+from gprMax.subgrids.grid import SubGridBaseGrid
 from gprMax.sources import Source
 from gprMax.utilities.utilities import get_terminal_width
 from gprMax.vtkhdf_filehandlers.vtkhdf import VtkHdfFile
@@ -228,7 +229,10 @@ class Metadata(Generic[GridType]):
         names: List[str] = []
         positions = np.empty((len(srcs), 3))
         for index, src in enumerate(srcs):
-            position = src.coord * self.grid.dl
+            if isinstance(self.grid, SubGridBaseGrid):
+                position = self.grid.local_to_global(src.coord)
+            else:
+                position = src.coord * self.grid.dl
             names.append(src.ID)
             positions[index] = position
 

--- a/gprMax/subgrids/grid.py
+++ b/gprMax/subgrids/grid.py
@@ -20,6 +20,8 @@
 import logging
 from abc import ABC, abstractmethod
 
+import numpy as np
+
 from gprMax.grid.fdtd_grid import FDTDGrid
 
 logger = logging.getLogger(__name__)
@@ -66,6 +68,20 @@ class SubGridBaseGrid(FDTDGrid, ABC):
         self.n_boundary_cells_z = d_to_pml + self.pmls["thickness"]["z0"]
 
         self.interpolation = kwargs["interpolation"]
+
+    def local_to_global(self, coord):
+        """Converts a local (subgrid array) cell index to a physical
+        position in the main grid's/global coordinate frame.
+
+        Local index 0 is offset from the global origin by the subgrid's
+        boundary padding (n_boundary_cells_*) and its placement (i0, j0,
+        k0) within the main grid - this reverses that offset. See
+        SubgridUserInput.translate_to_gap in user_inputs.py, which
+        performs the forward transform when building objects.
+        """
+        boundary = np.array([self.n_boundary_cells_x, self.n_boundary_cells_y, self.n_boundary_cells_z])
+        i0 = np.array([self.i0, self.j0, self.k0])
+        return (np.asarray(coord) - boundary + i0 * self.ratio) * self.dl
 
     @abstractmethod
     def update_magnetic_is(self, precursors):

--- a/gprMax/subgrids/user_objects.py
+++ b/gprMax/subgrids/user_objects.py
@@ -140,6 +140,12 @@ class SubGridBase(ModelUserObject):
         # Copy a reference for the main grid to the sub grid
         sg.parent_grid = model.G
 
+        # Inherit the time window from the main grid. Without this, sg.timewindow
+        # stays at the FDTDGrid default of 0.0, so any source built in the subgrid
+        # without an explicit start/stop (stop defaults to grid.timewindow) would
+        # only be active for iteration 0.
+        sg.timewindow = model.G.timewindow
+
         # Copy a subgrid reference to self so that children.build(grid, uip)
         # can access the correct grid.
         self.subgrid = sg

--- a/tests/outputs/test_fields_outputs.py
+++ b/tests/outputs/test_fields_outputs.py
@@ -1,0 +1,94 @@
+from types import SimpleNamespace
+
+import gprMax.fields_outputs as fields_outputs_mod
+from gprMax.fields_outputs import _global_position, write_hdf5_outputfile
+
+
+def test_global_position_main_grid_scales_by_dl():
+    """For the main grid, local index 0 coincides with the global origin,
+    so _global_position should just scale the index by the discretisation.
+    """
+    grid = SimpleNamespace(dx=0.001, dy=0.002, dz=0.003)
+
+    position = _global_position(grid, 10, 20, 30, is_subgrid=False)
+
+    assert position == (0.01, 0.04, 0.09)
+
+
+def test_global_position_subgrid_delegates_to_local_to_global():
+    """For a subgrid, _global_position must go through
+    SubGridBaseGrid.local_to_global rather than naively scaling the local
+    index by dl - that naive scaling was the original bug (Position
+    attribute ignored the subgrid's boundary/placement offset).
+    """
+    calls = []
+
+    class FakeSubGrid:
+        def local_to_global(self, coord):
+            calls.append(coord)
+            return (1.23, 4.56, 7.89)
+
+    position = _global_position(FakeSubGrid(), 10, 20, 30, is_subgrid=True)
+
+    assert calls == [(10, 20, 30)]
+    assert position == (1.23, 4.56, 7.89)
+
+
+def test_write_hdf5_outputfile_closes_file_via_context_manager(monkeypatch):
+    """write_hdf5_outputfile() used to do `f = h5py.File(outputfile, "w")`
+    with no with-block/close() - CPython's refcounting usually closes it
+    once `f` goes out of scope, but an exception raised anywhere in the
+    body (e.g. while writing subgrid data) can keep the frame - and so the
+    file handle - alive via the traceback, leaking the descriptor or
+    leaving the file incompletely flushed. Fixed by wrapping the whole
+    function body in a `with h5py.File(...) as f:` block. This test
+    confirms the file object is used as a context manager (i.e. actually
+    closed), not just that .attrs assignments happen to work.
+    """
+
+    class _FakeAttrs(dict):
+        pass
+
+    class _FakeFile:
+        def __init__(self, filename, mode):
+            self.filename = filename
+            self.mode = mode
+            self.attrs = _FakeAttrs()
+            self.entered = False
+            self.exited = False
+
+        def __enter__(self):
+            self.entered = True
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            self.exited = True
+            return False
+
+        def create_group(self, path):
+            raise AssertionError("no subgrids expected in this test")
+
+    created = {}
+
+    def _fake_h5py_file(filename, mode):
+        f = _FakeFile(filename, mode)
+        created["file"] = f
+        return f
+
+    monkeypatch.setattr(fields_outputs_mod.h5py, "File", _fake_h5py_file)
+    monkeypatch.setattr(
+        fields_outputs_mod, "write_hd5_data", lambda basegrp, grid, is_subgrid=False: None
+    )
+
+    model = SimpleNamespace(
+        iterations=10,
+        srcsteps=(0, 0, 0),
+        rxsteps=(0, 0, 0),
+        subgrids=[],
+        G=SimpleNamespace(),
+    )
+
+    write_hdf5_outputfile(outputfile=SimpleNamespace(name="test.h5"), title="test", model=model)
+
+    assert created["file"].entered
+    assert created["file"].exited

--- a/tests/subgrids/test_grid.py
+++ b/tests/subgrids/test_grid.py
@@ -1,0 +1,98 @@
+import numpy as np
+import pytest
+
+from gprMax.subgrids.grid import SubGridBaseGrid
+
+
+class _ConcreteSubGrid(SubGridBaseGrid):
+    """Minimal concrete SubGridBaseGrid for testing coordinate maths only.
+
+    SubGridBaseGrid is abstract because it doesn't implement the FDTD
+    update equations - those aren't needed to test local_to_global.
+    """
+
+    def update_magnetic_is(self, precursors):
+        pass
+
+    def update_electric_is(self, precursors):
+        pass
+
+    def update_electric_os(self, main_grid):
+        pass
+
+    def update_magnetic_os(self, main_grid):
+        pass
+
+    def print_info(self):
+        pass
+
+
+def make_subgrid(ratio=3, i0=10, j0=5, k0=2, main_dl=0.001):
+    """Builds a subgrid with the same shape of attributes SubGridBase.setup()
+    would have populated (set_discretisation + set_main_grid_indices), so
+    local_to_global sees realistic state.
+    """
+    sg = _ConcreteSubGrid(
+        ratio=ratio,
+        id="sg",
+        filter=True,
+        is_os_sep=3,
+        pml_separation=ratio // 2 + 2,
+        subgrid_pml_thickness=6,
+        interpolation=1,
+    )
+    sg.dx = main_dl / ratio
+    sg.dy = main_dl / ratio
+    sg.dz = main_dl / ratio
+    sg.i0, sg.j0, sg.k0 = i0, j0, k0
+    return sg
+
+
+@pytest.mark.parametrize(
+    "ratio,i0,j0,k0,global_index",
+    [
+        (3, 10, 5, 2, (50, 30, 12)),
+        (5, 0, 0, 0, (7, 7, 7)),
+        (1, 7, 3, 9, (100, 40, 60)),
+        (9, 20, 20, 20, (500, 250, 300)),
+    ],
+)
+def test_local_to_global_inverts_forward_placement(ratio, i0, j0, k0, global_index):
+    """local_to_global must invert the forward placement transform used when
+    building objects in a subgrid (SubgridUserInput.translate_to_gap):
+
+        local = (global_index - i0 * ratio) + n_boundary_cells
+
+    A source/receiver discretised at `global_index` in the fine (subgrid)
+    resolution and placed via that forward transform must round-trip back
+    to its original physical position through local_to_global. This is the
+    bug that was previously silently under-reporting/mis-reporting subgrid
+    source and receiver Positions in output and geometry-view metadata.
+    """
+    sg = make_subgrid(ratio=ratio, i0=i0, j0=j0, k0=k0)
+    global_index = np.array(global_index)
+
+    # Forward transform (mirrors SubgridUserInput.translate_to_gap).
+    boundary = np.array([sg.n_boundary_cells_x, sg.n_boundary_cells_y, sg.n_boundary_cells_z])
+    local_index = (global_index - np.array([i0, j0, k0]) * ratio) + boundary
+
+    recovered_position = np.array(sg.local_to_global(local_index))
+    expected_position = global_index * sg.dl
+
+    np.testing.assert_allclose(recovered_position, expected_position)
+
+
+def test_local_to_global_offset_matters():
+    """A regression guard for the original bug: naively scaling the local
+    index by dl (ignoring the subgrid's boundary/placement offset) must NOT
+    equal local_to_global's result when the subgrid is not placed at the
+    main-grid origin. If this test fails after a future refactor, it means
+    local_to_global has regressed into the old (wrong) `coord * dl` behaviour.
+    """
+    sg = make_subgrid(ratio=3, i0=10, j0=5, k0=2)
+    local_index = np.array([50, 30, 12])
+
+    naive_position = local_index * sg.dl
+    correct_position = np.array(sg.local_to_global(local_index))
+
+    assert not np.allclose(naive_position, correct_position)

--- a/tests/subgrids/test_subgrid_em_correctness.py
+++ b/tests/subgrids/test_subgrid_em_correctness.py
@@ -1,0 +1,170 @@
+"""End-to-end EM-correctness regression test for the subgrid src/rx fixes.
+
+Runs a simple z-directed Hertzian dipole + receiver in free space two ways:
+  1. plain fine grid everywhere (1mm), source/rx placed directly
+  2. coarse main grid (3mm) + a subgrid (ratio 3 -> 1mm) with the source and
+     receiver placed *inside the subgrid* via subgrid.add(...), with no
+     explicit start/stop on the source
+
+Both are compared against gprMax's own closed-form analytical solution for a
+Hertzian dipole in free space. This exercises, on real field data rather than
+just metadata, the two bugs fixed in SubGridBase.setup()/SubGridBaseGrid:
+
+  - Position metadata (SubGridBaseGrid.local_to_global): if wrong, rxrel
+    (rx position - src position, read back from the output file's Position
+    attributes) would be wrong, and the analytical comparison below would
+    fail even though the underlying field data was fine.
+  - Timewindow inheritance (sg.timewindow = model.G.timewindow): before this
+    fix, a subgrid source with no explicit stop defaulted to stop=0.0 and
+    only fired at iteration 0, silently going to near-zero/noise for the
+    rest of the run - the analytical comparison below would fail by many
+    orders of magnitude (~0dB "agreement", per the original investigation).
+
+This test takes ~15-20 seconds (it runs two real FDTD simulations) - it is
+intentionally an integration test, not a fast unit test.
+"""
+
+from pathlib import Path
+
+import gprMax
+import h5py
+import numpy as np
+import pytest
+
+from testing.analytical_solutions import hertzian_dipole_fs
+
+OUTPUTS = ["Ex", "Ey", "Ez", "Hx", "Hy", "Hz"]
+
+# Agreement threshold (dB) for a healthy numerical model vs. the analytical
+# solution. The previously-broken (timewindow=0) subgrid case measured ~0dB
+# (i.e. no agreement); a correctly-functioning coarse/fine FDTD model of this
+# size typically achieves -40dB or better. -20dB gives headroom against
+# machine/precision variation while still failing loudly on a regression.
+MAX_ACCEPTABLE_DIFF_DB = -20.0
+
+
+def _max_diff_db(datatest: np.ndarray, dataref: np.ndarray) -> float:
+    worst = -np.inf
+    for i in range(dataref.shape[1]):
+        maxi = np.amax(np.abs(dataref[:, i]))
+        if maxi == 0:
+            continue
+        diff = np.abs(dataref[:, i] - datatest[:, i]) / maxi
+        with np.errstate(divide="ignore"):
+            diffdb = 20 * np.log10(diff)
+        diffdb = diffdb[np.isfinite(diffdb)]
+        if diffdb.size:
+            worst = max(worst, np.amax(diffdb))
+    return worst
+
+
+def _compare_to_analytical(grp: h5py.Group) -> float:
+    rxpos = grp["rxs/rx1"].attrs["Position"]
+    txpos = grp["srcs/src1"].attrs["Position"]
+    rxrel = tuple(rxpos - txpos)
+
+    iterations = int(grp.attrs["Iterations"])
+    dt = float(grp.attrs["dt"])
+    dl = grp.attrs["dx_dy_dz"]
+
+    dataref = hertzian_dipole_fs(iterations, dt, dl, rxrel)
+    datatest = np.stack([grp[f"rxs/rx1/{o}"][:] for o in OUTPUTS], axis=1)
+
+    return _max_diff_db(datatest, dataref)
+
+
+def run_plain_model(tmp_path: Path) -> Path:
+    """Fine grid (1mm) everywhere, source/rx placed directly."""
+    dl = 1e-3
+    scene = gprMax.Scene()
+    scene.add(gprMax.Title(name="plain"))
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(0.06, 0.06, 0.06)))
+    scene.add(gprMax.TimeWindow(time=3e-9))
+
+    wf = gprMax.Waveform(wave_type="gaussianprime", amp=1, freq=1e9, id="mypulse")
+    hd = gprMax.HertzianDipole(polarisation="z", p1=(0.025, 0.025, 0.025), waveform_id="mypulse")
+    rx = gprMax.Rx(p1=(0.035, 0.035, 0.038))
+    scene.add(wf)
+    scene.add(hd)
+    scene.add(rx)
+
+    outfile = tmp_path / "plain"
+    gprMax.run(scenes=[scene], n=1, outputfile=outfile, hide_progress_bars=True)
+    return outfile.with_suffix(".h5")
+
+
+def run_subgrid_model(tmp_path: Path) -> Path:
+    """Coarse main grid (3mm) + a ratio-3 subgrid (1mm) enclosing the source
+    and receiver, both added via subgrid.add(...) with no explicit
+    start/stop - the exact scenario the timewindow-inheritance bug affected.
+    Same relative source->rx offset as run_plain_model (0.01, 0.01, 0.013).
+    """
+    ratio = 3
+    dl_sg = 1e-3
+    dl_main = dl_sg * ratio
+
+    scene = gprMax.Scene()
+    scene.add(gprMax.Title(name="subgrid"))
+    scene.add(gprMax.Discretisation(p1=(dl_main, dl_main, dl_main)))
+    scene.add(gprMax.Domain(p1=(0.18, 0.18, 0.18)))
+    scene.add(gprMax.TimeWindow(time=3e-9))
+
+    subgrid = gprMax.SubGridHSG(p1=(0.075, 0.075, 0.075), p2=(0.105, 0.105, 0.105), ratio=ratio, id="sg")
+    scene.add(subgrid)
+
+    wf = gprMax.Waveform(wave_type="gaussianprime", amp=1, freq=1e9, id="mypulse")
+    hd = gprMax.HertzianDipole(polarisation="z", p1=(0.085, 0.085, 0.085), waveform_id="mypulse")
+    rx = gprMax.Rx(p1=(0.095, 0.095, 0.098))
+    subgrid.add(wf)
+    subgrid.add(hd)
+    subgrid.add(rx)
+
+    outfile = tmp_path / "subgrid"
+    gprMax.run(
+        scenes=[scene], n=1, outputfile=outfile, subgrid=True, autotranslate=True, hide_progress_bars=True
+    )
+    return outfile.with_suffix(".h5")
+
+
+@pytest.fixture(scope="module")
+def plain_h5(tmp_path_factory) -> Path:
+    return run_plain_model(tmp_path_factory.mktemp("plain_model"))
+
+
+@pytest.fixture(scope="module")
+def subgrid_h5(tmp_path_factory) -> Path:
+    return run_subgrid_model(tmp_path_factory.mktemp("subgrid_model"))
+
+
+def test_subgrid_rx_position_matches_global_placement(subgrid_h5):
+    """Regression guard for the Position-metadata bug: the subgrid source
+    and receiver were placed at global (main-grid-frame) coordinates
+    (0.085, 0.085, 0.085) and (0.095, 0.095, 0.098) - the output file must
+    report those same global positions, not raw local subgrid indices.
+    """
+    with h5py.File(subgrid_h5, "r") as f:
+        grp = f["subgrids/sg"]
+        np.testing.assert_allclose(grp["srcs/src1"].attrs["Position"], (0.085, 0.085, 0.085))
+        np.testing.assert_allclose(grp["rxs/rx1"].attrs["Position"], (0.095, 0.095, 0.098))
+
+
+def test_plain_model_matches_analytical(plain_h5):
+    """Sanity check on the reference model itself, and a baseline for how
+    good agreement should be at this resolution/time window.
+    """
+    with h5py.File(plain_h5, "r") as f:
+        maxdiff = _compare_to_analytical(f)
+    assert maxdiff < MAX_ACCEPTABLE_DIFF_DB
+
+
+def test_subgrid_model_matches_analytical(subgrid_h5):
+    """The key EM-correctness check: a source/rx placed inside a subgrid
+    with no explicit start/stop must radiate correctly for the full time
+    window (timewindow-inheritance fix) at the correct physical position
+    (local_to_global fix). Before both fixes this failed by many orders of
+    magnitude (~0dB agreement, i.e. no agreement at all).
+    """
+    with h5py.File(subgrid_h5, "r") as f:
+        maxdiff = _compare_to_analytical(f["subgrids/sg"])
+    assert maxdiff < MAX_ACCEPTABLE_DIFF_DB

--- a/tests/subgrids/test_subgrid_target_mainrx_steps.py
+++ b/tests/subgrids/test_subgrid_target_mainrx_steps.py
@@ -1,0 +1,74 @@
+"""Regression test for the "fine-detail target" subgrid pattern: a subgrid
+encloses a stationary target, while the source and receiver live on the
+MAIN grid and step between runs via #src_steps/#rx_steps for a B-scan.
+
+This is a different scenario from tests/subgrids/test_subgrid_em_correctness.py,
+where the source/rx are placed *inside* the subgrid (subgrid.add(...)) - that
+scenario is not covered by src_steps/rx_steps at all (see the "still open"
+gaps in the subgrid src/rx bug investigation). Here, src/rx are main-grid
+objects (scene.add(...)), so Model.build()'s self.G.update_sources_and_recievers()
+call - which only ever touches the main grid - should step them normally,
+completely independent of whether a subgrid exists elsewhere in the model.
+"""
+from pathlib import Path
+
+import gprMax
+import h5py
+import numpy as np
+
+
+def test_main_grid_src_rx_steps_with_stationary_subgrid_target(tmp_path: Path):
+    dl_main = 3e-3
+    ratio = 3
+
+    scene = gprMax.Scene()
+    scene.add(gprMax.Title(name="mainrx_subgrid_steps"))
+    scene.add(gprMax.Discretisation(p1=(dl_main, dl_main, dl_main)))
+    scene.add(gprMax.Domain(p1=(0.18, 0.12, 0.12)))
+    scene.add(gprMax.TimeWindow(time=1.5e-9))
+
+    # Stationary fine-detail target subgrid, away from the src/rx sweep path.
+    subgrid = gprMax.SubGridHSG(
+        p1=(0.12, 0.045, 0.045), p2=(0.15, 0.075, 0.075), ratio=ratio, id="sg"
+    )
+    scene.add(subgrid)
+    target = gprMax.Box(p1=(0.13, 0.055, 0.055), p2=(0.14, 0.065, 0.065), material_id="pec")
+    subgrid.add(target)
+
+    # Source/rx on the MAIN grid, stepped between runs.
+    wf = gprMax.Waveform(wave_type="gaussianprime", amp=1, freq=1e9, id="mypulse")
+    hd = gprMax.HertzianDipole(polarisation="z", p1=(0.03, 0.06, 0.06), waveform_id="mypulse")
+    rx = gprMax.Rx(p1=(0.05, 0.06, 0.06))
+    scene.add(wf)
+    scene.add(hd)
+    scene.add(rx)
+
+    step = (0.006, 0.0, 0.0)  # 2 main-grid cells in x per run
+    scene.add(gprMax.SrcSteps(p1=step))
+    scene.add(gprMax.RxSteps(p1=step))
+
+    n = 3
+    outfile = tmp_path / "base"
+    gprMax.run(
+        scenes=[scene] * n,
+        n=n,
+        outputfile=outfile,
+        subgrid=True,
+        autotranslate=True,
+        hide_progress_bars=True,
+    )
+
+    src_positions = []
+    rx_positions = []
+    for i in range(1, n + 1):
+        with h5py.File(tmp_path / f"base{i}.h5", "r") as f:
+            src_positions.append(f["srcs/src1"].attrs["Position"])
+            rx_positions.append(f["rxs/rx1"].attrs["Position"])
+
+    for i in range(1, n):
+        np.testing.assert_allclose(
+            np.array(src_positions[i]) - np.array(src_positions[i - 1]), step
+        )
+        np.testing.assert_allclose(
+            np.array(rx_positions[i]) - np.array(rx_positions[i - 1]), step
+        )

--- a/tests/subgrids/test_user_objects.py
+++ b/tests/subgrids/test_user_objects.py
@@ -1,0 +1,80 @@
+import argparse
+from types import SimpleNamespace
+
+import pytest
+from pytest import MonkeyPatch
+
+from gprMax import config, gprMax
+from gprMax.grid.fdtd_grid import FDTDGrid
+from gprMax.materials import create_built_in_materials
+from gprMax.subgrids.user_objects import SubGridHSG
+
+
+@pytest.fixture
+def config_mock(monkeypatch: MonkeyPatch):
+    def _mock_simulation_config() -> config.SimulationConfig:
+        args = argparse.Namespace(**gprMax.args_defaults)
+        args.inputfile = "test.in"
+        return config.SimulationConfig(args)
+
+    def _mock_model_config() -> config.ModelConfig:
+        model_config = config.ModelConfig(1)
+        model_config.ompthreads = 1
+        return model_config
+
+    monkeypatch.setattr(config, "sim_config", _mock_simulation_config())
+    monkeypatch.setattr(config, "get_model_config", _mock_model_config)
+
+
+def build_main_grid(nx: int, ny: int, nz: int, dl: float = 0.001, timewindow: float = 5e-9) -> FDTDGrid:
+    grid = FDTDGrid()
+    grid.nx = nx
+    grid.ny = ny
+    grid.nz = nz
+    grid.dx = dl
+    grid.dy = dl
+    grid.dz = dl
+    grid.timewindow = timewindow
+    create_built_in_materials(grid)
+    grid.calculate_dt()
+    return grid
+
+
+def build_model(main_grid: FDTDGrid) -> SimpleNamespace:
+    """SubGridBase.setup() only reads model.G/dt_mod/iterations and appends
+    to model.subgrids, so a plain namespace stands in for gprMax.model.Model.
+    """
+    return SimpleNamespace(G=main_grid, dt_mod=None, iterations=100, subgrids=[])
+
+
+def test_subgrid_inherits_main_grid_timewindow(config_mock):
+    """Regression test for the bug where SubGridBaseGrid never inherited
+    timewindow from the main grid: FDTDGrid.__init__ defaults timewindow to
+    0.0, and every source type defaults stop=grid.timewindow when no
+    explicit start/stop is given. Without inheritance, a source added
+    directly to a subgrid only fires at iteration 0 - silently, with no
+    warning, producing tiny noise-like receiver output.
+    """
+    main_grid = build_main_grid(40, 40, 40, timewindow=5e-9)
+    model = build_model(main_grid)
+
+    sg_obj = SubGridHSG(p1=(0.005, 0.005, 0.005), p2=(0.015, 0.015, 0.015), ratio=3, id="sg1")
+    sg = sg_obj.build(model)
+
+    assert sg.timewindow == main_grid.timewindow
+    assert sg.timewindow != 0.0
+
+
+def test_subgrid_timewindow_tracks_main_grid_changes(config_mock):
+    """Guards against a shallow/one-time copy that would go stale if the
+    main grid's timewindow is set after the subgrid is built in some future
+    refactor - not currently possible since #time_window always runs before
+    subgrids are built, but pins the intended value semantics either way.
+    """
+    main_grid = build_main_grid(40, 40, 40, timewindow=12e-9)
+    model = build_model(main_grid)
+
+    sg_obj = SubGridHSG(p1=(0.005, 0.005, 0.005), p2=(0.015, 0.015, 0.015), ratio=3, id="sg1")
+    sg = sg_obj.build(model)
+
+    assert sg.timewindow == pytest.approx(12e-9)


### PR DESCRIPTION
## Summary
- Three previously-fixed subgrid bugs had regressed - lost during branch consolidation before an earlier merge, not something newly introduced. Traced via git archaeology: the original fix lived on a feature branch snapshot that was superseded by a different, later version of that branch before the actual merge, and the fix didn't carry forward.
- **Timewindow inheritance (the serious one)**: `SubGridBaseGrid` never inherited the model's time window from the main grid, so a source built directly in a subgrid with no explicit `start`/`stop` only fired for the very first iteration, then silently went quiet - producing implausibly small/noise-like output with no error or warning.
- **Position metadata**: the `Position` attribute written into the main HDF5 output file for subgrid sources/receivers used the raw local coordinate scaled by the subgrid's own cell size, ignoring where the subgrid actually sits within the main grid.
- **Geometry-view markers** (the specific #602 symptom): the same bug in `.vtkhdf` geometry-view source/receiver markers - reported as "tx/rx remain in the main grid" instead of appearing at their true location within the subgrid.
- Restored `SubGridBaseGrid.local_to_global()`, which converts a subgrid-local cell index to its true physical position in the main grid's coordinate frame (reversing the subgrid's internal boundary/PML padding and placement offset), and wired it into both output paths.

## Test plan
- [x] Restored 5 regression tests: coordinate-math round-tripping (`tests/subgrids/test_grid.py`), timewindow inheritance (`tests/subgrids/test_user_objects.py`), a full FDTD-vs-analytical-solution correctness check (`tests/subgrids/test_subgrid_em_correctness.py`), main-grid src/rx stepping with a stationary subgrid target (`tests/subgrids/test_subgrid_target_mainrx_steps.py`), and output Position metadata (`tests/outputs/test_fields_outputs.py`).
- [x] Verified against the #602 reporter's own attached repro files: before the fix, the reported marker position exactly matched their report; after, it correctly falls within the subgrid's own declared region.
- [x] Full test suite passes with no regressions.

Fixes #602.