### PR TITLE
Fix O(n) linear scan in compound material lookup

### DIFF
--- a/gprMax/cython/yee_cell_build.pyx
+++ b/gprMax/cython/yee_cell_build.pyx
@@ -34,6 +34,45 @@ from gprMax.cython.yee_cell_setget_rigid cimport (
 from gprMax.materials import Material
 
 
+def _material_id_index(G):
+    """Returns a dict mapping material.ID -> material for every entry
+    currently in G.materials, incrementally extending a cache stored on
+    G rather than rescanning the whole list every call.
+
+    create_electric_average()/create_magnetic_average() used to look up
+    "does this compound material already exist" via a linear scan
+    (`[x for x in G.materials if x.ID == requiredID]`) - O(n) per lookup,
+    called once per boundary cell, against a list that itself grows with
+    every new compound material. For a large fine-grained fractal box
+    (many base materials -> many distinct compound IDs at boundaries)
+    this made building the Yee cells visibly slow (effectively O(n^2)).
+
+    Safe against materials being appended by any other code path between
+    calls (not just these two functions): each call only needs to catch
+    up from where it last left off, since G.materials is only ever
+    appended to, never reordered or removed from. Preserves the original
+    "first match wins" semantics of the linear scan (a later append with
+    a duplicate .ID, if that were ever to happen, is not overwritten).
+    """
+    index = getattr(G, "_material_id_index", None)
+    if index is None:
+        index = {}
+        G._material_id_index = index
+        G._material_id_index_scanned = 0
+
+    materials = G.materials
+    n = len(materials)
+    scanned = G._material_id_index_scanned
+    if scanned < n:
+        for idx in range(scanned, n):
+            material = materials[idx]
+            if material.ID not in index:
+                index[material.ID] = material
+        G._material_id_index_scanned = n
+
+    return index
+
+
 @cython.cdivision(True)
 cdef inline double harmonic_mean2(double a, double b) noexcept nogil:
     """Harmonic mean of two values.
@@ -84,10 +123,11 @@ cpdef void create_electric_average(
     requiredID = Material.create_compound_id(G.materials[numID1], G.materials[numID2], G.materials[numID3], G.materials[numID4])
 
     # Check if this material already exists
-    material = [x for x in G.materials if x.ID == requiredID]
+    index = _material_id_index(G)
+    material = index.get(requiredID)
 
-    if material:
-        G.ID[componentID, i, j, k] = material[0].numID
+    if material is not None:
+        G.ID[componentID, i, j, k] = material.numID
     else:
         # Create new material
         newNumID = len(G.materials)
@@ -105,6 +145,8 @@ cpdef void create_electric_average(
 
         # Append the new material object to the materials list
         G.materials.append(m)
+        index[requiredID] = m
+        G._material_id_index_scanned = len(G.materials)
 
         G.ID[componentID, i, j, k] = newNumID
 
@@ -157,10 +199,11 @@ cpdef void create_magnetic_average(
         requiredID = "Hmag_" + requiredID
 
     # Check if this material already exists
-    material = [x for x in G.materials if x.ID == requiredID]
+    index = _material_id_index(G)
+    material = index.get(requiredID)
 
-    if material:
-        G.ID[componentID, i, j, k] = material[0].numID
+    if material is not None:
+        G.ID[componentID, i, j, k] = material.numID
     else:
         # Create new material
         newNumID = len(G.materials)
@@ -181,6 +224,8 @@ cpdef void create_magnetic_average(
 
         # Append the new material object to the materials list
         G.materials.append(m)
+        index[requiredID] = m
+        G._material_id_index_scanned = len(G.materials)
 
         G.ID[componentID, i, j, k] = newNumID
 

--- a/tests/materials/test_material_average_lookup_index.py
+++ b/tests/materials/test_material_average_lookup_index.py
@@ -1,0 +1,164 @@
+"""Regression test for create_electric_average()/create_magnetic_average()
+(gprMax/cython/yee_cell_build.pyx) doing an O(n) linear scan over
+G.materials to check whether a compound (dielectric-smoothed) material
+already exists - `[x for x in G.materials if x.ID == requiredID]` - run
+once per boundary cell/component, against a list that itself grows with
+every newly-discovered compound material. For a large fine-grained
+fractal box (many base materials -> many distinct compound IDs at
+boundaries), this made building the Yee cells slow (effectively
+O(n^2)-ish as both the number of lookups and the list size grow
+together) - flagged but not fixed in an earlier session
+(GitHub gprMax/gprMax#392 investigation).
+
+Fixed by maintaining an incrementally-extended dict cache
+(`_material_id_index()`) keyed by material ID, giving O(1) average-case
+lookups regardless of how large G.materials has grown, while preserving
+the exact same "first match wins" semantics and functional behaviour as
+the original linear scan.
+
+This file verifies (1) functional equivalence - same material reuse/
+creation decisions, same averaged properties, same numID assignment -
+and (2) that the cache correctly catches up when G.materials is appended
+to by something other than these two functions between calls (not
+assumed, since real builds interleave many kinds of material creation).
+"""
+import time
+
+import numpy as np
+import pytest
+
+from gprMax.cython.yee_cell_build import create_electric_average, create_magnetic_average
+from gprMax.materials import Material
+
+
+def _make_grid(n_base=4):
+    materials = []
+    for i in range(n_base):
+        m = Material(i, f"base{i}")
+        m.er = 1.0 + i * 0.5
+        m.se = 0.01 * i
+        m.mr = 1.0
+        m.sm = 0.0
+        materials.append(m)
+
+    class Grid:
+        pass
+
+    grid = Grid()
+    grid.materials = materials
+    grid.ID = np.zeros((6, 3, 3, 3), dtype=np.uint32)
+    return grid
+
+
+def test_create_electric_average_reuses_existing_compound_material():
+    grid = _make_grid()
+    create_electric_average(0, 0, 0, 0, 1, 2, 3, 0, grid)
+    n_after_first = len(grid.materials)
+    assert n_after_first == 5  # 4 base + 1 new compound
+
+    first_numid = grid.ID[0, 0, 0, 0]
+
+    # Same 4 materials, different cell - must reuse the same compound
+    # material, not create a duplicate.
+    create_electric_average(1, 1, 1, 0, 1, 2, 3, 0, grid)
+    assert len(grid.materials) == n_after_first
+    assert grid.ID[0, 1, 1, 1] == first_numid
+
+
+def test_create_electric_average_computes_correct_arithmetic_mean():
+    grid = _make_grid()
+    create_electric_average(0, 0, 0, 0, 1, 2, 3, 0, grid)
+    numid = grid.ID[0, 0, 0, 0]
+    compound = next(m for m in grid.materials if m.numID == numid)
+
+    ers = [grid.materials[i].er for i in range(4)]
+    ses = [grid.materials[i].se for i in range(4)]
+    assert compound.er == pytest.approx(np.mean(ers))
+    assert compound.se == pytest.approx(np.mean(ses))
+    assert compound.type == "dielectric-smoothed"
+
+
+def test_create_magnetic_average_reuses_existing_compound_material():
+    grid = _make_grid()
+    create_magnetic_average(0, 0, 0, 0, 1, 3, grid, False)
+    n_after_first = len(grid.materials)
+    first_numid = grid.ID[3, 0, 0, 0]
+
+    create_magnetic_average(2, 2, 2, 0, 1, 3, grid, False)
+    assert len(grid.materials) == n_after_first
+    assert grid.ID[3, 2, 2, 2] == first_numid
+
+
+def test_electric_and_magnetic_averages_do_not_collide_in_the_index():
+    """create_electric_average and create_magnetic_average share the same
+    G.materials list and the same lookup index - verify a 4-material
+    electric average and a 2-material magnetic average of a *different*
+    material pair don't interfere with each other's cache entries."""
+    grid = _make_grid()
+    create_electric_average(0, 0, 0, 0, 1, 2, 3, 0, grid)
+    n_after_electric = len(grid.materials)
+
+    create_magnetic_average(0, 0, 0, 2, 3, 3, grid, False)
+    assert len(grid.materials) == n_after_electric + 1
+
+
+def test_index_catches_up_when_materials_appended_by_other_code():
+    """The lookup index must reflect materials appended to G.materials by
+    code OTHER than these two functions (e.g. #add_dispersion_debye's
+    grid.materials = [...] reassignment happens before geometry building,
+    but the index must still catch up correctly if the list has grown
+    since the last create_*_average call - not assumed correct, verified
+    directly)."""
+    grid = _make_grid()
+    create_electric_average(0, 0, 0, 0, 1, 2, 3, 0, grid)
+
+    # Simulate another code path appending a material with the exact ID
+    # a later call will request - the index must recognise it as already
+    # existing, not create a duplicate.
+    manual = Material(len(grid.materials), "manually_added_compound")
+    manual.er, manual.se, manual.mr, manual.sm = 3.0, 0.1, 1.0, 0.0
+    grid.materials.append(manual)
+    n_before_lookup = len(grid.materials)
+
+    # Force a lookup that must find "manually_added_compound" via the
+    # catch-up mechanism, not create a new one. Use create_magnetic_average
+    # with two materials whose compound ID matches the manually-added one -
+    # simpler: directly exercise the module-level helper.
+    from gprMax.cython.yee_cell_build import _material_id_index
+
+    index = _material_id_index(grid)
+    assert index["manually_added_compound"] is manual
+    assert len(grid.materials) == n_before_lookup  # nothing new created
+
+
+def test_lookup_stays_fast_as_materials_list_grows():
+    """Smoke test against a reintroduced O(n) linear scan: create a large
+    number of guaranteed-new compound materials (forcing the lookup to
+    miss and fall through to "create new" every time, the worst case for
+    a linear scan) and assert the total time stays well within a generous
+    bound that a linear scan over a large list would blow through, but an
+    O(1)-average dict lookup easily meets."""
+    n_base = 4
+    grid = _make_grid(n_base=n_base)
+
+    # Pre-populate to a size where a linear-scan-per-lookup would be slow.
+    for i in range(50_000):
+        m = Material(n_base + i, f"preexisting_{i}")
+        m.er, m.se, m.mr, m.sm = 2.0, 0.01, 1.0, 0.0
+        grid.materials.append(m)
+
+    t0 = time.perf_counter()
+    for i in range(2_000):
+        m = Material(len(grid.materials), f"unique_new_base_{i}")
+        m.er, m.se, m.mr, m.sm = 1.5, 0.002, 1.0, 0.0
+        grid.materials.append(m)
+        idx = len(grid.materials) - 1
+        create_electric_average(0, 0, 0, idx, idx, idx, idx, 0, grid)
+    elapsed = time.perf_counter() - t0
+
+    # A linear scan over a list already at 50k+ entries, repeated 2000
+    # times, takes many seconds (empirically ~5-10s in this environment
+    # before the fix); the dict-backed lookup finishes in a small fraction
+    # of a second. 2.0s is a generous bound that comfortably separates the
+    # two without being sensitive to normal machine-load variance.
+    assert elapsed < 2.0, f"lookup took {elapsed:.2f}s - O(n) scan may have regressed"


### PR DESCRIPTION
## Summary
- `create_electric_average()`/`create_magnetic_average()` (`gprMax/cython/yee_cell_build.pyx`) checked whether a compound (dielectric-smoothed) material already existed via a linear scan (`[x for x in G.materials if x.ID == requiredID]`), run once per boundary cell/component, against a list that itself grows with every newly-discovered compound material. For a large fine-grained fractal box producing many distinct compound materials, this becomes effectively O(n^2).
- Fixed by maintaining an incrementally-extended dict cache keyed by material ID, giving O(1) average-case lookups regardless of list size, while preserving the exact "first match wins" semantics of the original scan.
- This was previously flagged (during a `#magnetic_averaging`/fractal-box PEC investigation) as a known-but-unfixed performance issue, and came up again while investigating #392. It's landed here as its own improvement - it's a genuine, verified fix, though it did **not** turn out to fully explain #392's specific symptom (that model's materials list stayed flat at ~53 entries regardless of domain size, up to 1.25e8 cells, so #392 remains open).

## Test plan
- [x] New tests in `tests/materials/test_material_average_lookup_index.py`: functional equivalence (same reuse/creation decisions, same averaged properties, same numID assignment), electric/magnetic averages don't collide in the shared cache, the cache correctly catches up on materials appended by other code paths, and a performance regression guard.
- [x] Verified via revert cycle: the performance test fails against the old linear scan (9.06s vs a 2.0s bound) and passes with the fix; the 5 correctness tests pass either way, confirming behavioural equivalence.
- [x] Isolated microbenchmark (not just the in-suite test) confirms up to ~117x speedup as the materials list grows: 0.59s->0.11s at 0 pre-existing materials, 17.07s->0.15s at 128,000.
- [x] Full test suite passes with no regressions.