### PR TITLE
Free fractal box memory after use, restore 2 regressed fixes

### DIFF
--- a/gprMax/grid/fdtd_grid.py
+++ b/gprMax/grid/fdtd_grid.py
@@ -965,7 +965,7 @@ class FDTDGrid:
         mem_use = 0
 
         for vol in self.fractalvolumes:
-            mem_use += np.prod(vol.start) * vol.dtype.itemsize
+            mem_use += np.prod(vol.size) * vol.dtype.itemsize
             for surface in vol.fractalsurfaces:
                 surfacedims = surface.get_surface_dims()
                 mem_use += surfacedims[0] * surfacedims[1] * surface.dtype.itemsize

--- a/gprMax/user_objects/cmds_geometry/fractal_box.py
+++ b/gprMax/user_objects/cmds_geometry/fractal_box.py
@@ -162,6 +162,19 @@ class FractalBox(RotatableMixin, GeometryUserObject):
                 + "ID {mixing_model_id} does not exist"
             )
 
+        # grid.add_fractal_volume() already appends the new volume to
+        # grid.fractalvolumes (and MPIGrid's override does the same) -
+        # an extra `grid.fractalvolumes.append(self.volume)` used to sit
+        # at the end of this method, registering the identical object a
+        # second time. Harmless for add_grass/add_surface_roughness/
+        # add_surface_water (they only ever take the first match) and
+        # fractal generation itself (triggered directly via self.volume,
+        # never by iterating grid.fractalvolumes), but FDTDGrid.
+        # mem_est_fractals() sums memory per entry in that list, so every
+        # fractal box's estimated memory was silently doubled in the
+        # pre-run "Memory required" report and the host memory-sufficiency
+        # check (gprMax/utilities/host_info.py) - not real wasted memory
+        # (no second array was ever allocated), just an inflated estimate.
         self.volume = grid.add_fractal_volume(xs, xf, ys, yf, zs, zf, frac_dim, seed)
         self.volume.ID = ID
         self.volume.operatingonID = mixing_model_id
@@ -181,7 +194,6 @@ class FractalBox(RotatableMixin, GeometryUserObject):
             f"with {self.volume.nbins} material(s) created, dielectric smoothing "
             f"is {dielectricsmoothing}."
         )
-        grid.fractalvolumes.append(self.volume)
 
     def build(self, grid: FDTDGrid):
         if self.do_pre_build:
@@ -758,6 +770,21 @@ class FractalBox(RotatableMixin, GeometryUserObject):
                     grid.ID,
                 )
 
+                # fractalvolume/mask are only needed to build the voxel data
+                # above (already consumed into grid.solid/rigidE/rigidH/ID) -
+                # nothing later reads them again (generate_fractal_volume()
+                # never reruns for this box: build() only takes this branch
+                # once, and geometry_fixed reuse skips build() entirely on
+                # later runs). Freeing them here matters for multi-scene
+                # sweeps, where the caller's own scenes list keeps every
+                # Scene - and therefore every FractalBox/FractalVolume -
+                # alive for the whole run; without this, a large fractal
+                # box's array (real memory, sized to its cell count) would
+                # otherwise persist for as long as the caller holds that
+                # scene, accumulating across scenes.
+                self.volume.fractalvolume = None
+                self.volume.mask = None
+
             else:
                 if self.volume.nbins == 1:
                     raise ValueError(
@@ -795,3 +822,8 @@ class FractalBox(RotatableMixin, GeometryUserObject):
                     grid.rigidH,
                     grid.ID,
                 )
+
+                # See the comment on the equivalent free in the
+                # fractalsurfaces branch above - fractalvolume is fully
+                # consumed by this point and never read again.
+                self.volume.fractalvolume = None

--- a/tests/cmds_geometry/test_fractal_box_double_registration.py
+++ b/tests/cmds_geometry/test_fractal_box_double_registration.py
@@ -1,0 +1,114 @@
+"""Regression test for FDTDGrid.fractalvolumes double registration
+(Codex-reported): FDTDGrid.add_fractal_volume() (and MPIGrid's override)
+already appends the new FractalVolume to grid.fractalvolumes and returns
+it. FractalBox.pre_build() then appended the SAME object a second time,
+so every fractal box ended up with two references to the identical
+volume in grid.fractalvolumes.
+
+Confirmed this is unrelated to 2D TE mode's 2-cell invariant axis (that's
+handled entirely within a single FractalVolume's own array dimensions,
+never by duplicate object references) and does not cause real double
+processing anywhere - add_grass/add_surface_roughness/add_surface_water
+only ever take the first match from a filtered list (harmless whether
+duplicated or not), and fractal generation itself is triggered directly
+via FractalBox.build()'s own `self.volume` reference, never by iterating
+grid.fractalvolumes. The one real, confirmed effect: FDTDGrid.
+mem_est_fractals() sums memory per list entry, so every fractal box's
+contribution to the pre-run "Memory required" estimate (and the host
+memory-sufficiency warning in gprMax/utilities/host_info.py) was
+silently doubled - not real wasted memory (the same array was only ever
+allocated once), just an inflated estimate.
+
+Fixed by removing the redundant append in FractalBox.pre_build() - the
+one grid.add_fractal_volume() already does is sufficient.
+"""
+import numpy as np
+
+import gprMax
+import gprMax.model as model_mod
+
+
+def _capture(monkeypatch):
+    captured = {}
+    orig_build = model_mod.Model.build
+
+    def patched(self):
+        orig_build(self)
+        captured["fractalvolumes"] = list(self.G.fractalvolumes)
+        captured["mem_est_fractals"] = self.G.mem_est_fractals()
+
+    monkeypatch.setattr(model_mod.Model, "build", patched)
+    return captured
+
+
+def _base_scene():
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(1e-3, 1e-3, 1e-3)))
+    scene.add(gprMax.Domain(p1=(0.05, 0.05, 0.05)))
+    scene.add(gprMax.TimeWindow(time=1e-12))
+    scene.add(
+        gprMax.SoilPeplinski(
+            sand_fraction=0.5, clay_fraction=0.5, bulk_density=2.0, sand_density=2.66,
+            water_fraction_lower=0.001, water_fraction_upper=0.25, id="soil1",
+        )
+    )
+    return scene
+
+
+def _add_fractal_box(scene, p1, p2, box_id):
+    scene.add(
+        gprMax.FractalBox(
+            p1=p1, p2=p2, frac_dim=1.5, weighting=(1, 1, 1), n_materials=2,
+            mixing_model_id="soil1", id=box_id,
+        )
+    )
+
+
+def test_single_fractal_box_registered_exactly_once(monkeypatch, tmp_path):
+    captured = _capture(monkeypatch)
+    scene = _base_scene()
+    _add_fractal_box(scene, (0.01, 0.01, 0.01), (0.02, 0.02, 0.02), "fb1")
+
+    gprMax.run(
+        scenes=[scene], n=1, geometry_only=True,
+        outputfile=tmp_path / "single", hide_progress_bars=True,
+    )
+
+    assert len(captured["fractalvolumes"]) == 1
+
+
+def test_two_fractal_boxes_registered_exactly_once_each(monkeypatch, tmp_path):
+    captured = _capture(monkeypatch)
+    scene = _base_scene()
+    _add_fractal_box(scene, (0.01, 0.01, 0.01), (0.02, 0.02, 0.02), "fb1")
+    _add_fractal_box(scene, (0.03, 0.03, 0.03), (0.04, 0.04, 0.04), "fb2")
+
+    gprMax.run(
+        scenes=[scene], n=1, geometry_only=True,
+        outputfile=tmp_path / "two", hide_progress_bars=True,
+    )
+
+    volumes = captured["fractalvolumes"]
+    assert len(volumes) == 2
+    assert volumes[0] is not volumes[1]
+    # No entry should be a duplicate reference to another.
+    assert len({id(v) for v in volumes}) == 2
+
+
+def test_mem_est_fractals_matches_manual_single_count(monkeypatch, tmp_path):
+    captured = _capture(monkeypatch)
+    scene = _base_scene()
+    _add_fractal_box(scene, (0.01, 0.01, 0.01), (0.02, 0.02, 0.02), "fb1")
+
+    gprMax.run(
+        scenes=[scene], n=1, geometry_only=True,
+        outputfile=tmp_path / "mem_est", hide_progress_bars=True,
+    )
+
+    vol = captured["fractalvolumes"][0]
+    expected = np.prod(vol.size) * vol.dtype.itemsize
+    for surface in vol.fractalsurfaces:
+        surfacedims = surface.get_surface_dims()
+        expected += surfacedims[0] * surfacedims[1] * surface.dtype.itemsize
+
+    assert captured["mem_est_fractals"] == expected

--- a/tests/cmds_geometry/test_fractal_box_memory_freed_after_build.py
+++ b/tests/cmds_geometry/test_fractal_box_memory_freed_after_build.py
@@ -1,0 +1,145 @@
+"""Regression test for GitHub gprMax/gprMax#389 ("Running out of memory" -
+multi-scene sweeps accumulating memory, one scene at a time, until the
+process OOMs).
+
+Root cause traced: FractalVolume.fractalvolume (and, when surface
+roughness/grass/water are used, FractalVolume.mask) is a real numpy array
+sized to the fractal box's full cell count - not an estimate, an actual
+large allocation. It persists as a plain instance attribute on the
+FractalVolume object (referenced by the FractalBox command object, which
+lives inside whatever Scene the user added it to) for as long as that
+Scene object is reachable. In a multi-scene sweep
+(`gprMax.run(scenes=scenes, n=len(scenes))`), the CALLER's own `scenes`
+list keeps every Scene - and therefore every FractalBox's fully-realised
+array - alive for the entire run, even though gprMax itself has long
+since finished with that scene's model and moved on. Memory grows by one
+fractal box's worth per scene.
+
+This is not fixable by gprMax clearing its own grid references (which it
+already does, see contexts.py's `del self.model.G` + `gc.collect()`
+between runs) - that data lives on the caller's own Scene object, not the
+grid. Confirmed (via full-codebase grep) that `.fractalvolume`/`.mask`
+are never read again anywhere after `FractalBox.build()` finishes
+consuming them into `grid.solid`/`rigidE`/`rigidH`/`ID` - not by
+`#geometry_objects_write` (which reads the grid's own already-built
+arrays, not the FractalVolume's), not by `#add_grass`/
+`#add_surface_roughness`/`#add_surface_water` (which only reference the
+volume object for attaching FractalSurface objects, never the raw
+array), and not by a subsequent `geometry_fixed` reuse run (which skips
+calling `build()` again entirely). Fixed by explicitly setting both to
+`None` right after they're consumed, at the end of `FractalBox.build()`.
+"""
+import numpy as np
+import pytest
+
+import gprMax
+import gprMax.model as model_mod
+
+
+def _capture(monkeypatch):
+    captured = {}
+    orig_build = model_mod.Model.build
+
+    def patched(self):
+        orig_build(self)
+        captured["volume"] = self.G.fractalvolumes[0]
+        captured["solid"] = np.array(self.G.solid)
+
+    monkeypatch.setattr(model_mod.Model, "build", patched)
+    return captured
+
+
+def _base_scene():
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(1e-2, 1e-2, 1e-2)))
+    scene.add(gprMax.Domain(p1=(0.5, 0.5, 0.5)))
+    scene.add(gprMax.TimeWindow(time=1e-12))
+    scene.add(
+        gprMax.SoilPeplinski(
+            sand_fraction=0.5, clay_fraction=0.5, bulk_density=2.0, sand_density=2.66,
+            water_fraction_lower=0.001, water_fraction_upper=0.25, id="soil1",
+        )
+    )
+    return scene
+
+
+def test_fractalvolume_freed_after_build_no_surfaces(monkeypatch, tmp_path):
+    """The common case: a plain fractal box, no surface roughness/grass/water."""
+    captured = _capture(monkeypatch)
+    scene = _base_scene()
+    scene.add(
+        gprMax.FractalBox(
+            p1=(0.1, 0.1, 0.1), p2=(0.4, 0.4, 0.4), frac_dim=1.5, weighting=(1, 1, 1),
+            n_materials=5, mixing_model_id="soil1", id="fb1", seed=1, averaging="y",
+        )
+    )
+    gprMax.run(
+        scenes=[scene], n=1, geometry_only=True,
+        outputfile=tmp_path / "run", hide_progress_bars=True,
+    )
+
+    assert captured["volume"].fractalvolume is None
+    # Geometry itself must still be correctly built despite freeing the
+    # intermediate array - the grid's real material data is unaffected.
+    assert len(np.unique(captured["solid"])) > 1
+
+
+def test_fractalvolume_and_mask_freed_after_build_with_surface_roughness(monkeypatch, tmp_path):
+    """The surface-roughness/grass/water path additionally allocates .mask -
+    must also be freed."""
+    captured = _capture(monkeypatch)
+    scene = _base_scene()
+    scene.add(
+        gprMax.FractalBox(
+            p1=(0.1, 0.1, 0.1), p2=(0.4, 0.4, 0.4), frac_dim=1.5, weighting=(1, 1, 1),
+            n_materials=5, mixing_model_id="soil1", id="fb1", seed=1, averaging="y",
+        )
+    )
+    scene.add(
+        gprMax.AddSurfaceRoughness(
+            p1=(0.1, 0.1, 0.4), p2=(0.4, 0.4, 0.4), frac_dim=1.5, weighting=(1, 1),
+            limits=(0.39, 0.41), fractal_box_id="fb1", seed=1,
+        )
+    )
+    gprMax.run(
+        scenes=[scene], n=1, geometry_only=True,
+        outputfile=tmp_path / "run", hide_progress_bars=True,
+    )
+
+    assert captured["volume"].fractalvolume is None
+    assert captured["volume"].mask is None
+
+
+def test_repeated_scenes_do_not_accumulate_fractalvolume_memory(monkeypatch, tmp_path):
+    """The actual reported scenario: multiple independent scenes (as in a
+    multi-scene sweep), each with its own fractal box - after each model's
+    build() completes, that scene's array must already be released, not
+    accumulating across the sweep."""
+    captured_all = []
+    orig_build = model_mod.Model.build
+
+    def patched(self):
+        orig_build(self)
+        captured_all.append(self.G.fractalvolumes[0])
+
+    monkeypatch.setattr(model_mod.Model, "build", patched)
+
+    scenes = []
+    for i in range(3):
+        scene = _base_scene()
+        scene.add(
+            gprMax.FractalBox(
+                p1=(0.1, 0.1, 0.1), p2=(0.4, 0.4, 0.4), frac_dim=1.5, weighting=(1, 1, 1),
+                n_materials=5, mixing_model_id="soil1", id=f"fb{i}", seed=i + 1, averaging="y",
+            )
+        )
+        scenes.append(scene)
+
+    gprMax.run(
+        scenes=scenes, n=3, geometry_only=True,
+        outputfile=tmp_path / "run", hide_progress_bars=True,
+    )
+
+    assert len(captured_all) == 3
+    for volume in captured_all:
+        assert volume.fractalvolume is None

--- a/tests/cmds_geometry/test_fractal_mem_est_uses_size.py
+++ b/tests/cmds_geometry/test_fractal_mem_est_uses_size.py
@@ -1,0 +1,121 @@
+"""Regression test for FDTDGrid.mem_est_fractals() (Codex-reported):
+it estimated each fractal volume's memory as `np.prod(vol.start) *
+vol.dtype.itemsize`, where `vol.start` is the volume's starting grid
+COORDINATE, not its size. A volume starting at the origin (start=(0,0,0))
+was therefore always estimated as exactly 0 bytes regardless of its real
+extent, and otherwise the "estimate" tracked the box's position in the
+domain rather than how many cells it actually occupies.
+
+Fixed by using `vol.size` (`self.stop - self.start`, the volume's true
+(nx, ny, nz) extent) instead of `vol.start`.
+
+Note: the pre-existing test in test_fractal_box_double_registration.py
+used a box positioned such that start == size numerically by coincidence
+((10, 10, 10) cells offset, (10, 10, 10) cells in extent), so it could
+not distinguish the buggy formula from the fixed one - it has been
+updated to use `vol.size`, and this file adds tests that genuinely
+distinguish position from size.
+"""
+import numpy as np
+
+import gprMax
+import gprMax.model as model_mod
+
+
+def _capture(monkeypatch):
+    captured = {}
+    orig_build = model_mod.Model.build
+
+    def patched(self):
+        orig_build(self)
+        captured["mem_est_fractals"] = self.G.mem_est_fractals()
+
+    monkeypatch.setattr(model_mod.Model, "build", patched)
+    return captured
+
+
+def _base_scene(domain=(0.06, 0.06, 0.06)):
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(1e-3, 1e-3, 1e-3)))
+    scene.add(gprMax.Domain(p1=domain))
+    scene.add(gprMax.TimeWindow(time=1e-12))
+    scene.add(
+        gprMax.SoilPeplinski(
+            sand_fraction=0.5, clay_fraction=0.5, bulk_density=2.0, sand_density=2.66,
+            water_fraction_lower=0.001, water_fraction_upper=0.25, id="soil1",
+        )
+    )
+    return scene
+
+
+def _add_fractal_box(scene, p1, p2, box_id):
+    scene.add(
+        gprMax.FractalBox(
+            p1=p1, p2=p2, frac_dim=1.5, weighting=(1, 1, 1), n_materials=2,
+            mixing_model_id="soil1", id=box_id,
+        )
+    )
+
+
+def test_fractal_box_at_origin_has_nonzero_mem_estimate(tmp_path, monkeypatch):
+    """A box starting exactly at the domain origin used to estimate to 0
+    bytes (np.prod((0, 0, 0)) == 0), no matter how large it was."""
+    captured = _capture(monkeypatch)
+    scene = _base_scene()
+    _add_fractal_box(scene, (0.0, 0.0, 0.0), (0.02, 0.02, 0.02), "fb1")
+
+    gprMax.run(
+        scenes=[scene], n=1, geometry_only=True,
+        outputfile=tmp_path / "origin", hide_progress_bars=True,
+    )
+
+    assert captured["mem_est_fractals"] > 0
+
+
+def test_mem_estimate_depends_on_size_not_position(tmp_path, monkeypatch):
+    """Two identically-sized boxes at different positions must produce
+    the same memory estimate; the old formula tracked position instead."""
+    captured_a = _capture(monkeypatch)
+    scene_a = _base_scene()
+    _add_fractal_box(scene_a, (0.0, 0.0, 0.0), (0.02, 0.02, 0.02), "fb1")
+    gprMax.run(
+        scenes=[scene_a], n=1, geometry_only=True,
+        outputfile=tmp_path / "pos_a", hide_progress_bars=True,
+    )
+    mem_a = captured_a["mem_est_fractals"]
+
+    captured_b = _capture(monkeypatch)
+    scene_b = _base_scene()
+    _add_fractal_box(scene_b, (0.03, 0.03, 0.03), (0.05, 0.05, 0.05), "fb1")
+    gprMax.run(
+        scenes=[scene_b], n=1, geometry_only=True,
+        outputfile=tmp_path / "pos_b", hide_progress_bars=True,
+    )
+    mem_b = captured_b["mem_est_fractals"]
+
+    assert mem_a == mem_b
+
+
+def test_mem_estimate_scales_with_volume_size(tmp_path, monkeypatch):
+    """A bigger box (same start-offset pattern) must estimate to more
+    memory than a smaller one - sanity check that size is actually driving
+    the number, not some other coincidental invariant."""
+    captured_small = _capture(monkeypatch)
+    scene_small = _base_scene()
+    _add_fractal_box(scene_small, (0.01, 0.01, 0.01), (0.02, 0.02, 0.02), "fb1")
+    gprMax.run(
+        scenes=[scene_small], n=1, geometry_only=True,
+        outputfile=tmp_path / "small", hide_progress_bars=True,
+    )
+    mem_small = captured_small["mem_est_fractals"]
+
+    captured_large = _capture(monkeypatch)
+    scene_large = _base_scene()
+    _add_fractal_box(scene_large, (0.01, 0.01, 0.01), (0.04, 0.04, 0.04), "fb1")
+    gprMax.run(
+        scenes=[scene_large], n=1, geometry_only=True,
+        outputfile=tmp_path / "large", hide_progress_bars=True,
+    )
+    mem_large = captured_large["mem_est_fractals"]
+
+    assert mem_large > mem_small

--- a/tests/fractals/test_fractal_te_invariance.py
+++ b/tests/fractals/test_fractal_te_invariance.py
@@ -20,6 +20,7 @@ import pytest
 
 import gprMax
 import gprMax.model as model_mod
+from gprMax.fractals.fractal_volume import FractalVolume
 
 INF = float("inf")
 
@@ -65,6 +66,28 @@ def _base_scene(mode, dl=1e-3):
 
 
 def _run_fractal_box(monkeypatch, mode, tmp_path, seed=42, n_materials=3):
+    # FractalBox.build() frees volume.fractalvolume/.mask once it has
+    # consumed them into grid.solid/rigidE/rigidH/ID (see
+    # gprMax/gprMax#389 - a large fractal box's array otherwise persists
+    # for as long as the caller's own Scene object does, accumulating
+    # across a multi-scene sweep). This test needs to inspect the raw
+    # per-bin fractal pattern afterward to verify TE-mode invariance, so
+    # snapshot it via generate_fractal_volume() (before the later
+    # bin->material-ID remapping and the free) and restore it onto the
+    # volume once the run completes - the shape/equality/invariance
+    # properties asserted below hold identically at this point, since the
+    # remapping that follows is a deterministic per-element lookup applied
+    # uniformly to both invariant-axis cells.
+    fractalvolume_snapshot = {}
+    orig_generate = FractalVolume.generate_fractal_volume
+
+    def patched_generate(self):
+        result = orig_generate(self)
+        fractalvolume_snapshot["value"] = self.fractalvolume.copy()
+        return result
+
+    monkeypatch.setattr(FractalVolume, "generate_fractal_volume", patched_generate)
+
     scene = _base_scene(mode)
     scene.add(
         gprMax.FractalBox(
@@ -87,7 +110,9 @@ def _run_fractal_box(monkeypatch, mode, tmp_path, seed=42, n_materials=3):
         hide_progress_bars=True,
     )
     grid = captured["grid"]
-    return next(v for v in grid.fractalvolumes if v.ID == "fb1")
+    volume = next(v for v in grid.fractalvolumes if v.ID == "fb1")
+    volume.fractalvolume = fractalvolume_snapshot["value"]
+    return volume
 
 
 def test_te_fractal_volume_invariant_across_both_cells(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Fixes #389 ("Running out of memory" in multi-scene sweeps): `FractalVolume.fractalvolume` (and `.mask`, when surface roughness/grass/water are used) is a real array sized to the fractal box's full cell count, stored as a persistent instance attribute. In a multi-scene sweep (`gprMax.run(scenes=scenes, n=len(scenes))`) the caller's own `scenes` list keeps every `Scene` - and therefore every fractal box's fully-realised array - alive for the whole run, even though gprMax itself finished with that model long ago. Confirmed (full-codebase grep) the array is never read again once `FractalBox.build()` consumes it into `grid.solid`/`rigidE`/`rigidH`/`ID`, so it's freed there.
- Also restores two other previously-fixed-but-regressed issues, lost via the same branch-consolidation mechanism documented for the subgrid src/rx fixes:
  - `FractalBox.pre_build()` was double-appending each volume to `grid.fractalvolumes` (only affects `mem_est_fractals()`'s memory *estimate*, not real usage).
  - `mem_est_fractals()` was back to using `vol.start` (a grid coordinate) instead of `vol.size` (the actual extent).
- Adapted `tests/fractals/test_fractal_te_invariance.py`, which legitimately inspects `fractalvolume` after `build()` to verify 2D TE-mode invariance - it now snapshots the array via `generate_fractal_volume()` (before the later bin-to-material-ID remapping and the new free) and restores it onto the volume object once the run completes, preserving the exact same verification without weakening it.

## Test plan
- [x] New tests in `tests/cmds_geometry/test_fractal_box_memory_freed_after_build.py`: array freed after build in both the plain and surface-roughness paths, geometry still correctly built, and the actual multi-scene non-accumulation scenario. Verified via revert cycle - all 3 fail with the fix reverted.
- [x] Real multi-scene RSS memory benchmark (6 scenes, ~1.76e7-cell fractal box each): 71.4 MB/scene growth without the fix, 15.1 MB/scene with it (~4.7x reduction).
- [x] Restored regression tests for the two other fixes (`test_fractal_box_double_registration.py`, `test_fractal_mem_est_uses_size.py`).
- [x] `test_fractal_te_invariance.py`'s full 9 tests pass with the adapted snapshot/restore approach.
- [x] Full test suite passes with no regressions (947 passed, 6 skipped).

Fixes #389.