### PR TITLE
Fix swapped token-count checks in plane_wave full-form hash commands

### DIFF
--- a/gprMax/hash_cmds_multiuse.py
+++ b/gprMax/hash_cmds_multiuse.py
@@ -249,7 +249,7 @@ def process_multicmds(multicmds):
                     waveform_id=tmp[9],
                     material_id=tmp[10],
                 )
-            elif len(tmp) == 14:
+            elif len(tmp) == 13:
                 plWave = DiscretePlaneWaveAngles(
                     p1=(float(tmp[0]), float(tmp[1]), float(tmp[2])),
                     p2=(float(tmp[3]), float(tmp[4]), float(tmp[5])),
@@ -297,7 +297,7 @@ def process_multicmds(multicmds):
                     waveform_id=tmp[10],
                     material_id=tmp[11],
                 )
-            elif len(tmp) == 13:
+            elif len(tmp) == 14:
                 plWave = DiscretePlaneWaveVector(
                     p1=(float(tmp[0]), float(tmp[1]), float(tmp[2])),
                     p2=(float(tmp[3]), float(tmp[4]), float(tmp[5])),

--- a/tests/cmds_multiuse/test_plane_wave_hash_command_full_form.py
+++ b/tests/cmds_multiuse/test_plane_wave_hash_command_full_form.py
@@ -1,0 +1,88 @@
+"""Regression test for a real bug found while auditing the 2D TE mode PR
+(#699) against an orphaned pre-merge snapshot: the token-count checks for
+the FULL form (background material_id + start/stop) of `#plane_wave_angles`
+and `#plane_wave_vector` in `process_multicmds()`
+(gprMax/hash_cmds_multiuse.py) had been swapped.
+
+`#plane_wave_angles` full form is
+p1(3) + p2(3) + theta,phi,psi(3) + waveform_id(1) + material_id(1) +
+start,stop(2) = 13 tokens - the code checked `elif len(tmp) == 14:`, so a
+real 13-token command fell through to the `else` branch and raised
+"too many parameters".
+
+`#plane_wave_vector` full form is
+p1(3) + p2(3) + m_vec(3) + psi(1) + waveform_id(1) + material_id(1) +
+start,stop(2) = 14 tokens - the code checked `elif len(tmp) == 13:`, which
+is worse: a 13-token string would have entered that branch and then raised
+IndexError accessing tmp[13] (out of range for a 13-element list), while
+the correct 14-token form fell through to "too many parameters" instead.
+
+Existing tests (tests/cmds_multiuse/test_plane_wave_2d.py) only exercise
+the Python API objects (DiscretePlaneWaveAngles/Vector) directly, never
+the `#plane_wave_angles`/`#plane_wave_vector` hash-command string parser,
+which is exactly why this went undetected - these tests use a real `.in`
+text file, parsed end-to-end via gprMax.run(inputfile=...), to close that
+gap.
+"""
+from pathlib import Path
+
+import gprMax
+import gprMax.model as model_mod
+
+
+def _capture_grid(monkeypatch):
+    captured = {}
+    orig_build = model_mod.Model.build
+
+    def patched_build(self):
+        orig_build(self)
+        captured["grid"] = self.G
+
+    monkeypatch.setattr(model_mod.Model, "build", patched_build)
+    return captured
+
+
+def test_plane_wave_angles_full_form_hash_command_parses(monkeypatch, tmp_path: Path):
+    infile = tmp_path / "plane_wave_angles_full.in"
+    infile.write_text(
+        "#title: plane_wave_angles full-form hash command\n"
+        "#dx_dy_dz: 0.001 0.001 0.001\n"
+        "#domain: 0.03 0.03 0.03\n"
+        "#time_window: 1e-11\n"
+        "#waveform: ricker 1 10e9 w\n"
+        "#plane_wave_angles: 0.007 0.007 0.007 0.021 0.021 0.021 90 26.565051177 90 w free_space 0 1e-11\n"
+    )
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(
+        inputfile=str(infile), n=1, geometry_only=True,
+        outputfile=tmp_path / "run", hide_progress_bars=True,
+    )
+    grid = captured["grid"]
+    assert len(grid.discreteplanewaves) == 1
+    dpw = grid.discreteplanewaves[0]
+    assert dpw.start == 0.0
+    assert dpw.stop == 1e-11
+
+
+def test_plane_wave_vector_full_form_hash_command_parses(monkeypatch, tmp_path: Path):
+    infile = tmp_path / "plane_wave_vector_full.in"
+    infile.write_text(
+        "#title: plane_wave_vector full-form hash command\n"
+        "#dx_dy_dz: 0.001 0.001 0.001\n"
+        "#domain: 0.03 0.03 0.03\n"
+        "#time_window: 1e-11\n"
+        "#waveform: ricker 1 10e9 w\n"
+        "#plane_wave_vector: 0.007 0.007 0.007 0.021 0.021 0.021 1 1 1 90 w free_space 0 1e-11\n"
+    )
+
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(
+        inputfile=str(infile), n=1, geometry_only=True,
+        outputfile=tmp_path / "run", hide_progress_bars=True,
+    )
+    grid = captured["grid"]
+    assert len(grid.discreteplanewaves) == 1
+    dpw = grid.discreteplanewaves[0]
+    assert dpw.start == 0.0
+    assert dpw.stop == 1e-11


### PR DESCRIPTION
## Summary
- `process_multicmds()` in `gprMax/hash_cmds_multiuse.py` had the full-form token-count checks for `#plane_wave_angles` and `#plane_wave_vector` swapped between each other.
- `#plane_wave_angles` full form (p1 + p2 + theta/phi/psi + waveform_id + material_id + start/stop) is 13 tokens, but the code checked `elif len(tmp) == 14:`, so a correctly-formed 13-token command fell through to "too many parameters".
- `#plane_wave_vector` full form (p1 + p2 + m_vec + psi + waveform_id + material_id + start/stop) is 14 tokens, but the code checked `elif len(tmp) == 13:` — worse, since a malformed 13-token string would enter that branch and raise an unhandled `IndexError` on `tmp[13]`, while the correct 14-token form fell through to "too many parameters" instead.
- Found while auditing the 2D TE mode PR (#699) against its pre-merge development snapshot for silently dropped fixes during branch consolidation — this is a genuine regression, not new functionality.
- Existing plane-wave tests only ever exercised the Python API objects (`DiscretePlaneWaveAngles`/`DiscretePlaneWaveVector`) directly, never the actual hash-command string parser, which is why this went undetected through 211+ passing tests.

## Test plan
- [x] New `tests/cmds_multiuse/test_plane_wave_hash_command_full_form.py` writes real `.in` files exercising the full 13/14-token hash-command forms end-to-end via `gprMax.run(inputfile=...)`.
- [x] Verified via revert cycle: both new tests fail with the predicted "too many parameters" error when the swap is reintroduced, pass with the fix.
- [x] Full test suite: 949 passed, 6 skipped, 0 failed.