### PR TITLE
Raise clear error in geometry_objects_read for incomplete materials file

### DIFF
--- a/gprMax/geometry_outputs/geometry_objects_read.py
+++ b/gprMax/geometry_outputs/geometry_objects_read.py
@@ -150,6 +150,31 @@ class ReadGeometryObject(AbstractContextManager):
         reps[axis] = self.target_invariant_size + 1
         return np.tile(canonical, reps)
 
+    def _check_material_coverage(self, data: npt.NDArray[np.int16]) -> None:
+        """Raises a clear error if `data` references a file-local material
+        index this file's materials file never declared, rather than
+        letting numpy fancy-indexing fail with a bare IndexError. This
+        happens whenever the materials file supplied to
+        #geometry_objects_read omits a material that was actually present
+        (and so given an index) when the geometry file was originally
+        written - most commonly the implicit background material (e.g.
+        free_space) of the written region, if the user only listed the
+        material(s) they specifically cared about.
+        """
+        max_index = int(data.max()) if data.size else -1
+        n_declared = len(self.material_id_map)
+        if max_index >= n_declared:
+            raise ValueError(
+                f"'{self.file_handler.filename}' references material index "
+                f"{max_index}, but the accompanying materials file only "
+                f"declares {n_declared} "
+                "material(s). The materials file must list every material "
+                "present in the written region (including any implicit "
+                "background material, e.g. free_space) in the same order "
+                "they appeared when the geometry object file was written, "
+                "not just the ones of interest."
+            )
+
     def _remap(
         self, data: npt.NDArray[np.int16], existing: npt.NDArray[np.uint32]
     ) -> npt.NDArray[np.int32]:
@@ -162,6 +187,7 @@ class ReadGeometryObject(AbstractContextManager):
         and, in a model with prior geometry (e.g. a fractal soil built
         before an imported target), isn't the same thing as free_space.
         """
+        self._check_material_coverage(data)
         safe_indices = np.where(data < 0, 0, data)
         mapped = self.material_id_map[safe_indices]
         return np.where(data < 0, existing, mapped)
@@ -253,6 +279,7 @@ class ReadGeometryObject(AbstractContextManager):
         if data.dtype != "int16":
             data = data.astype("int16")
 
+        self._check_material_coverage(data)
         safe_indices = np.where(data < 0, 0, data)
         mapped = self.material_id_map[safe_indices].astype(data.dtype)
         return np.where(data < 0, data, mapped)

--- a/tests/geometry_objects/test_geometry_objects_read.py
+++ b/tests/geometry_objects/test_geometry_objects_read.py
@@ -298,3 +298,39 @@ def test_reads_genuinely_external_materials_file(tmp_path, monkeypatch):
     assert aorta_material.ID.startswith("Aorta")
     assert aorta_material.er == pytest.approx(44.77)
     assert background_material.ID == "free_space"
+
+
+def test_incomplete_materials_file_raises_clear_error(tmp_path, monkeypatch):
+    """GitHub #497: a written region using two materials (pec + the
+    implicit free_space background) paired with a hand-edited materials
+    file that only declares one of them (matching the reporter's own
+    materials.txt, which listed just "pec") used to crash deep inside numpy
+    fancy-indexing with a bare `IndexError: index 1 is out of bounds for
+    axis 0 with size 1` - confirmed still reproducible against current code
+    before this fix. Must now raise a clear, actionable ValueError instead.
+    """
+    geofile, matfile = _write_geometry(
+        tmp_path, [((0.005, 0.005, 0.005), (0.015, 0.015, 0.015), "pec")]
+    )
+    # Reproduce the reporter's own materials.txt: only "pec" declared, even
+    # though the written region also used free_space as its background.
+    incomplete_matfile = tmp_path / "incomplete_materials.txt"
+    incomplete_matfile.write_text("#material: 1 inf 1 0 pec\n")
+
+    scene = gprMax.Scene()
+    scene.add(gprMax.Title(name="read"))
+    scene.add(gprMax.Discretisation(p1=(1e-3, 1e-3, 1e-3)))
+    scene.add(gprMax.Domain(p1=(0.02, 0.02, 0.02)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=1e-12))
+    scene.add(
+        gprMax.GeometryObjectsRead(
+            p1=(0.0, 0.0, 0.0), geofile=str(geofile), matfile=str(incomplete_matfile)
+        )
+    )
+
+    with pytest.raises(ValueError, match="only declares 1 material"):
+        gprMax.run(
+            scenes=[scene], n=1, geometry_only=True,
+            outputfile=tmp_path / "read", hide_progress_bars=True,
+        )


### PR DESCRIPTION
## Summary
Fixes #497.

- `#geometry_objects_read` raised a bare `IndexError: index N is out of bounds for axis 0 with size M` deep inside numpy fancy-indexing whenever the supplied materials file didn't declare every material index actually used in the geometry file - most commonly when a user only lists the material(s) they care about (e.g. just `pec`) and omits the implicit background material (e.g. `free_space`) of the exported region, exactly as in the reporter's own materials.txt.
- The originally reported traceback pointed at different, now-removed code (a hardcoded `materials[0] == pec and materials[1] == free_space` positional check) - `geometry_objects_read.py` was rewritten in an earlier fix to match materials by ID name instead of position. But the same underlying class of bug (materials file not covering every index the geofile actually uses) survived in a new form - confirmed by directly reproducing the reporter's exact materials.txt content against current `devel` before writing any fix.
- New `ReadGeometryObject._check_material_coverage()` computes the max index actually referenced in the data and compares it against how many materials were declared, raising a clear, actionable `ValueError` instead. Called from both `_remap()` (used by `read_data()`/`read_ID()`) and the separate inline remap in `get_data()` - the only two places the material index map is ever indexed.

## Test plan
- [x] New `tests/geometry_objects/test_geometry_objects_read.py::test_incomplete_materials_file_raises_clear_error` - reproduces the reporter's exact scenario (a written pec box + implicit free_space background, paired with a materials.txt declaring only `pec`) and asserts the clear `ValueError` is raised.
- [x] Verified the correct/complete materials file (as `#geometry_objects_write` itself produces) still reads back with no behaviour change.
- [x] Verified via revert cycle: reverting only the new check's call site makes the new test fail with the original bare `IndexError`.
- [x] Full test suite: 953 passed (was 952), 6 skipped, 0 failed.