### PR TITLE
Raise default rational-angle tolerance for #plane_wave_angles to 3 arcmin

### DIFF
--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1031,6 +1031,7 @@ For example, to specify a discrete plane wave in a TFSF box (0.010, 0.010, 0.010
 
     * Currently a plane wave can be supported for dielectric and mulit-Debye media backgrounds and not for user defined waveforms.
     * This plane wave implementation was based on an intitial implementation made possible by a `Google Summer of Code <https://summerofcode.withgoogle.com/>`_ (GSoC) project and `more details can be found in the original pull request <https://github.com/gprMax/gprMax/pull/373>`_.
+    * Internally, theta and phi are approximated by an integer direction vector (Mx, My, Mz) found to within a maximum acceptable angular difference of 3 arc minutes (0.05 degrees) by default. This tolerance can be relaxed or tightened using the ``max_angle_diff`` parameter (in degrees) when using the Python API.
 
 #plane_wave_vector:
 ---------------------

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -1131,7 +1131,8 @@ class DiscretePlaneWaveAngles(GridUserObject):
         phi: float required for propagation angle (degrees) of wave.
         psi: float required for polarisation of wave.
         max_angle_diff: float optional for tolerance of maximum acceptable angular difference between the
-                        desired direction of the wavevector and the estimated direction of it (degrees)
+                        desired direction of the wavevector and the estimated direction of it (degrees).
+                        Default is 3 arc minutes (0.05 degrees).
         p1: tuple required for the lower left position (x, y, z) of the total
             field, scattered field (TFSF) box.
         p2: tuple required for the upper right position (x, y, z) of the total
@@ -1168,8 +1169,21 @@ class DiscretePlaneWaveAngles(GridUserObject):
         try:
             max_angle_diff = self.kwargs["max_angle_diff"]
         except KeyError:
-            # Set default to 1 minute of arc
-            max_angle_diff = 0.017
+            # 1 arcminute (0.017) is tighter than the rounding error already
+            # introduced by writing theta/phi to just 1 decimal place - the
+            # normal way angles are specified - so a "nice" direction like
+            # (1, 2, 3) (theta=36.699.., phi=63.435..) rounds to 36.7/63.4,
+            # whose true angular error (~0.021 deg) then falls just outside
+            # a 0.017 deg tolerance. That silently rejects the small,
+            # obviously-intended integer vector and falls through to a far
+            # larger, far more expensive one satisfying the tolerance by
+            # chance, with no indication a much simpler solution existed.
+            # Default to 3 arc minutes (0.05 deg), which comfortably
+            # recovers 1-decimal-place "nice" vectors (verified against
+            # several, up to size 8) while still being a small fraction of
+            # a degree - well beyond what matters for practical FDTD
+            # propagation-direction accuracy.
+            max_angle_diff = 0.05
 
         try:
             material_id = self.kwargs["material_id"]


### PR DESCRIPTION
## Summary
Found while verifying the fix for #553 (which corrected the outdated `discrete_plane_wave_fs.in` test to use `#plane_wave_angles`): the newly-fixed test used the documented example angles (theta=36.7, phi=63.4 - matching `docs/source/input_hash_cmds.rst`'s own worked example) and unexpectedly produced a huge internal direction vector `[801, 1600, 2400]` (a 1D line of ~12 million cells) instead of the obviously-intended small vector `[1, 2, 3]` (744 cells).

Root cause: `DiscretePlaneWaveAngles.build()`'s default `max_angle_diff` tolerance (1 arcminute, 0.017 degrees) is tighter than the rounding error already introduced by writing angles to just 1 decimal place - the normal way angles are specified. `(1, 2, 3)`'s true angles are `theta=36.699.., phi=63.435..`, which round to `36.7/63.4`; the resulting true angular error (~0.021 degrees) then falls just outside the old 0.017 degree tolerance, silently rejecting the small, obviously-intended vector and falling through to a far larger, far more expensive one that happens to satisfy the tolerance by chance - with no indication to the user that a much simpler solution existed.

This isn't limited to this one example - verified against 7 different "nice" 1-decimal-place-rounded integer vectors (`(1,1,1)`, `(1,2,2)`, `(1,2,3)`, `(2,3,4)`, `(1,1,2)`, `(3,4,5)`, `(1,4,8)`); every single one failed to be recovered at the old default, several blowing up to vector sizes in the thousands. All 7 are recovered correctly at the new default of 3 arcminutes (0.05 degrees), which is still a small fraction of a degree - well beyond what matters for practical FDTD propagation-direction accuracy.

This is a default-tuning change to a documented tolerance parameter, not a fix to broken/incorrect behaviour - no test included per that judgment call. Also documents the previously-undocumented `max_angle_diff` default in both the class docstring and the RST docs.

## Test plan
- [x] Verified the discrete_plane_wave_fs.in reframe test now discretizes to `[1, 2, 3]` (744-cell internal vector) instead of `[801, 1600, 2400]` (12.1M cells), and completes a full solve successfully.
- [x] Verified against 7 different "nice" integer direction vectors, confirming the new default recovers all of them correctly where the old default failed on all 7.