### PR TITLE
GSoC / Component 3: B-scan dashboard (live monitoring and load-files assembly)

### DIFF
--- a/tests/test_h5_reader.py
+++ b/tests/test_h5_reader.py
@@ -1,0 +1,342 @@
+"""
+tests/test_h5_reader.py: unit tests for toolboxes/Marimo/h5_reader.py
+
+Run from repo root:
+    pytest tests/test_h5_reader.py -v
+
+Uses a synthetic HDF5 fixture built in memory — no real gprMax output
+file required. Tests cover metadata extraction, component reading,
+utility functions, and error handling.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from toolboxes.Marimo.h5_reader import (
+    build_label,
+    format_metadata_text,
+    get_time_axis,
+    get_trace,
+    get_unit_label,
+    list_components,
+    list_receivers,
+    load_file,
+    load_files,
+)
+
+# Fixtures
+
+
+DT = 4.717308673499368e-12  # seconds (from real cylinder_Ascan_2D.h5)
+ITERATIONS = 637
+NRX = 1
+NSRC = 1
+
+COMPONENTS = {
+    "Ex": np.zeros(ITERATIONS, dtype=np.float64),
+    "Ey": np.zeros(ITERATIONS, dtype=np.float64),
+    "Ez": np.linspace(-1000, 1000, ITERATIONS, dtype=np.float64),
+    "Hx": np.ones(ITERATIONS, dtype=np.float64) * 0.5,
+    "Hy": np.ones(ITERATIONS, dtype=np.float64) * -0.5,
+    "Hz": np.zeros(ITERATIONS, dtype=np.float64),
+}
+
+
+def _write_synthetic_h5(path: Path, title: str = "Test A-scan") -> None:
+    """Write a minimal valid gprMax v4 HDF5 file for testing."""
+    with h5py.File(path, "w") as f:
+        # Root attributes
+        f.attrs["Title"] = title
+        f.attrs["dt"] = DT
+        f.attrs["dx_dy_dz"] = np.array([0.002, 0.002, 0.002])
+        f.attrs["Iterations"] = ITERATIONS
+        f.attrs["nrx"] = NRX
+        f.attrs["nsrc"] = NSRC
+        f.attrs["nx_ny_nz"] = np.array([120, 105, 1])
+        f.attrs["gprMax"] = "4.0.0b0"
+
+        # Receiver
+        rx1 = f.require_group("rxs/rx1")
+        rx1.attrs["Name"] = "Rx(70,85,0)"
+        rx1.attrs["Position"] = np.array([0.14, 0.17, 0.0])
+        for comp, data in COMPONENTS.items():
+            rx1.create_dataset(comp, data=data)
+
+        # Source
+        src1 = f.require_group("srcs/src1")
+        src1.attrs["Type"] = "HertzianDipole"
+        src1.attrs["Position"] = np.array([0.10, 0.17, 0.0])
+
+
+@pytest.fixture
+def h5_file(tmp_path: Path) -> Path:
+    """Single synthetic HDF5 file."""
+    p = tmp_path / "test_ascan.h5"
+    _write_synthetic_h5(p)
+    return p
+
+
+@pytest.fixture
+def h5_file_b(tmp_path: Path) -> Path:
+    """Second synthetic HDF5 file with a different title."""
+    p = tmp_path / "test_ascan_freespace.h5"
+    _write_synthetic_h5(p, title="Free space A-scan")
+    return p
+
+
+@pytest.fixture
+def loaded(h5_file: Path):
+    """Pre-loaded FileData dict."""
+    return load_file(h5_file)
+
+
+# load_file — metadata
+
+
+class TestLoadFileMeta:
+    def test_title(self, loaded):
+        assert loaded["meta"]["title"] == "Test A-scan"
+
+    def test_dt(self, loaded):
+        assert loaded["meta"]["dt"] == pytest.approx(DT)
+
+    def test_iterations(self, loaded):
+        assert loaded["meta"]["iterations"] == ITERATIONS
+
+    def test_nrx(self, loaded):
+        assert loaded["meta"]["nrx"] == NRX
+
+    def test_nsrc(self, loaded):
+        assert loaded["meta"]["nsrc"] == NSRC
+
+    def test_dx_dy_dz(self, loaded):
+        assert loaded["meta"]["dx_dy_dz"] == pytest.approx([0.002, 0.002, 0.002])
+
+    def test_nx_ny_nz(self, loaded):
+        assert loaded["meta"]["nx_ny_nz"] == [120, 105, 1]
+
+    def test_gprmax_version(self, loaded):
+        assert loaded["meta"]["gprmax_version"] == "4.0.0b0"
+
+
+# load_file — receiver structure
+
+
+class TestLoadFileReceivers:
+    def test_receiver_keys(self, loaded):
+        assert "rx1" in loaded["receivers"]
+
+    def test_receiver_name(self, loaded):
+        assert loaded["receivers"]["rx1"]["name"] == "Rx(70,85,0)"
+
+    def test_receiver_position(self, loaded):
+        assert loaded["receivers"]["rx1"]["position"] == pytest.approx([0.14, 0.17, 0.0])
+
+    def test_all_components_present(self, loaded):
+        components = loaded["receivers"]["rx1"]["components"]
+        for comp in COMPONENTS:
+            assert comp in components
+
+    def test_component_shape(self, loaded):
+        ez = loaded["receivers"]["rx1"]["components"]["Ez"]
+        assert ez.shape == (ITERATIONS,)
+
+    def test_component_values(self, loaded):
+        ez = loaded["receivers"]["rx1"]["components"]["Ez"]
+        assert ez[0] == pytest.approx(COMPONENTS["Ez"][0])
+        assert ez[-1] == pytest.approx(COMPONENTS["Ez"][-1])
+
+
+# load_file — source structure
+
+
+class TestLoadFileSources:
+    def test_source_keys(self, loaded):
+        assert "src1" in loaded["sources"]
+
+    def test_source_type(self, loaded):
+        assert loaded["sources"]["src1"]["type"] == "HertzianDipole"
+
+    def test_source_position(self, loaded):
+        assert loaded["sources"]["src1"]["position"] == pytest.approx([0.10, 0.17, 0.0])
+
+
+# load_file — time axis
+
+
+class TestLoadFileTimeAxis:
+    def test_time_ns_length(self, loaded):
+        assert len(loaded["time_ns"]) == ITERATIONS
+
+    def test_time_ns_starts_at_zero(self, loaded):
+        assert loaded["time_ns"][0] == pytest.approx(0.0)
+
+    def test_time_ns_end_value(self, loaded):
+        expected_end = (ITERATIONS - 1) * DT * 1e9
+        assert loaded["time_ns"][-1] == pytest.approx(expected_end)
+
+
+# load_file — error handling
+
+
+class TestLoadFileErrors:
+    def test_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            load_file("/nonexistent/path/file.h5")
+
+    def test_invalid_hdf5(self, tmp_path):
+        bad = tmp_path / "bad.h5"
+        bad.write_text("not an hdf5 file")
+        with pytest.raises(OSError):
+            load_file(bad)
+
+
+# load_files — multi-file
+
+
+class TestLoadFiles:
+    def test_returns_both_files(self, h5_file, h5_file_b):
+        result = load_files([h5_file, h5_file_b])
+        assert len(result) == 2
+
+    def test_keyed_by_filename(self, h5_file):
+        result = load_files([h5_file])
+        assert "test_ascan.h5" in result
+
+    def test_collision_uses_full_path(self, tmp_path):
+        # Two files with identical names in different directories
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+        p_a = dir_a / "ascan.h5"
+        p_b = dir_b / "ascan.h5"
+        _write_synthetic_h5(p_a)
+        _write_synthetic_h5(p_b)
+        result = load_files([p_a, p_b])
+        # One entry will be the short name, one will be the full path
+        assert len(result) == 2
+
+
+# get_time_axis
+
+
+class TestGetTimeAxis:
+    def test_ns_unit(self, loaded):
+        t = get_time_axis(loaded, unit="ns")
+        assert t[-1] == pytest.approx((ITERATIONS - 1) * DT * 1e9)
+
+    def test_s_unit(self, loaded):
+        t = get_time_axis(loaded, unit="s")
+        assert t[-1] == pytest.approx((ITERATIONS - 1) * DT)
+
+    def test_iter_unit(self, loaded):
+        t = get_time_axis(loaded, unit="iter")
+        assert t[-1] == pytest.approx(ITERATIONS - 1)
+
+    def test_invalid_unit(self, loaded):
+        with pytest.raises(ValueError, match="Unknown unit"):
+            get_time_axis(loaded, unit="ms")
+
+
+# list_components
+
+
+class TestListComponents:
+    def test_returns_all_components(self, loaded):
+        comps = list_components(loaded)
+        assert set(comps) == set(COMPONENTS.keys())
+
+    def test_sorted(self, loaded):
+        comps = list_components(loaded)
+        assert comps == sorted(comps)
+
+    def test_missing_receiver_returns_empty(self, loaded):
+        comps = list_components(loaded, receiver="rx99")
+        assert comps == []
+
+
+# list_receivers
+
+
+class TestListReceivers:
+    def test_returns_rx1(self, loaded):
+        assert list_receivers(loaded) == ["rx1"]
+
+
+# get_trace
+
+
+class TestGetTrace:
+    def test_ez_values(self, loaded):
+        trace = get_trace(loaded, "Ez")
+        np.testing.assert_array_almost_equal(trace, COMPONENTS["Ez"])
+
+    def test_positive_polarity(self, loaded):
+        trace = get_trace(loaded, "Hx", polarity=1)
+        assert trace[0] == pytest.approx(COMPONENTS["Hx"][0])
+
+    def test_negative_polarity_arg(self, loaded):
+        trace = get_trace(loaded, "Hx", polarity=-1)
+        assert trace[0] == pytest.approx(-COMPONENTS["Hx"][0])
+
+    def test_negative_polarity_suffix(self, loaded):
+        trace = get_trace(loaded, "Hx-")
+        assert trace[0] == pytest.approx(-COMPONENTS["Hx"][0])
+
+    def test_missing_component_raises(self, loaded):
+        with pytest.raises(KeyError, match="Iz"):
+            get_trace(loaded, "Iz")
+
+
+# get_unit_label
+
+
+class TestGetUnitLabel:
+    def test_electric_field(self):
+        assert get_unit_label("Ez") == "V/m"
+
+    def test_magnetic_field(self):
+        assert get_unit_label("Hx") == "A/m"
+
+    def test_current(self):
+        assert get_unit_label("Ix") == "A"
+
+    def test_polarity_suffix_stripped(self):
+        assert get_unit_label("Ez-") == "V/m"
+
+
+# build_label
+
+
+class TestBuildLabel:
+    def test_label_format(self):
+        label = build_label("cylinder_Ascan_2D.h5", "rx1", "Ez")
+        assert label == "cylinder_Ascan_2D · rx1 · Ez"
+
+    def test_stem_only(self):
+        label = build_label("examples/cylinder_Ascan_2D.h5", "rx1", "Ez")
+        assert label == "cylinder_Ascan_2D · rx1 · Ez"
+
+
+# format_metadata_text
+
+
+class TestFormatMetadataText:
+    def test_contains_title(self, loaded):
+        text = format_metadata_text(loaded)
+        assert "Test A-scan" in text
+
+    def test_contains_iterations(self, loaded):
+        text = format_metadata_text(loaded)
+        assert str(ITERATIONS) in text
+
+    def test_contains_receiver_info(self, loaded):
+        text = format_metadata_text(loaded)
+        assert "rx1" in text
+        assert "Rx(70,85,0)" in text

--- a/tests/test_trace_matrix.py
+++ b/tests/test_trace_matrix.py
@@ -1,0 +1,198 @@
+"""Tests for trace_matrix.py against synthetic single-trace HDF5 files."""
+
+import h5py
+import numpy as np
+import pytest
+
+from toolboxes.Marimo.h5_reader import load_file
+from toolboxes.Marimo.trace_matrix import process_trace, stack_traces
+
+DT = 4.717308673499368e-12
+ITERATIONS = 100
+
+
+def _write_trace(path, x_pos, amplitude=1.0, iterations=ITERATIONS, components=("Ez",)):
+    with h5py.File(path, "w") as f:
+        f.attrs["Title"] = "synthetic"
+        f.attrs["dt"] = DT
+        f.attrs["dx_dy_dz"] = [0.002, 0.002, 0.002]
+        f.attrs["Iterations"] = iterations
+        f.attrs["nrx"] = 1
+        f.attrs["nsrc"] = 1
+        f.attrs["nx_ny_nz"] = [120, 105, 1]
+        f.attrs["gprMax"] = "4.0.0"
+
+        rx = f.create_group("rxs/rx1")
+        rx.attrs["Name"] = "Rx(70,85,0)"
+        rx.attrs["Position"] = [0.14, 0.17, 0.0]
+        for comp in components:
+            rx.create_dataset(comp, data=np.sin(np.linspace(0, 6.28, iterations)) * amplitude)
+
+        src = f.create_group("srcs/src1")
+        src.attrs["Type"] = "HertzianDipole"
+        src.attrs["Position"] = [x_pos, 0.17, 0.0]
+    return path
+
+
+def _write_trace_no_source(path, iterations=ITERATIONS):
+    with h5py.File(path, "w") as f:
+        f.attrs["Title"] = "no-source"
+        f.attrs["dt"] = DT
+        f.attrs["dx_dy_dz"] = [0.002, 0.002, 0.002]
+        f.attrs["Iterations"] = iterations
+        f.attrs["nrx"] = 1
+        f.attrs["nsrc"] = 0
+        f.attrs["nx_ny_nz"] = [120, 105, 1]
+        f.attrs["gprMax"] = "4.0.0"
+        rx = f.create_group("rxs/rx1")
+        rx.attrs["Name"] = "Rx(70,85,0)"
+        rx.attrs["Position"] = [0.14, 0.17, 0.0]
+        rx.create_dataset("Ez", data=np.zeros(iterations))
+    return path
+
+
+def _write_trace_two_receivers(path, x_pos, iterations=ITERATIONS):
+    with h5py.File(path, "w") as f:
+        f.attrs["Title"] = "two-rx"
+        f.attrs["dt"] = DT
+        f.attrs["dx_dy_dz"] = [0.002, 0.002, 0.002]
+        f.attrs["Iterations"] = iterations
+        f.attrs["nrx"] = 2
+        f.attrs["nsrc"] = 1
+        f.attrs["nx_ny_nz"] = [120, 105, 1]
+        f.attrs["gprMax"] = "4.0.0"
+
+        rx1 = f.create_group("rxs/rx1")
+        rx1.attrs["Name"] = "Rx(70,85,0)"
+        rx1.attrs["Position"] = [0.14, 0.17, 0.0]
+        rx1.create_dataset("Ez", data=np.ones(iterations) * 1.0)
+
+        rx2 = f.create_group("rxs/rx2")
+        rx2.attrs["Name"] = "Rx(90,85,0)"
+        rx2.attrs["Position"] = [0.18, 0.17, 0.0]
+        rx2.create_dataset("Ez", data=np.ones(iterations) * 2.0)
+
+        src = f.create_group("srcs/src1")
+        src.attrs["Type"] = "HertzianDipole"
+        src.attrs["Position"] = [x_pos, 0.17, 0.0]
+    return path
+
+
+class TestProcessTrace:
+    def test_success_extracts_component_and_position(self, tmp_path):
+        fdata = load_file(_write_trace(tmp_path / "t1.h5", x_pos=0.05, amplitude=3.0))
+        result = process_trace(fdata, "Ez", expected_len=None)
+        assert result["ok"] is True
+        assert result["component"] == "Ez"
+        assert result["receiver"] == "rx1"
+        assert result["x"] == pytest.approx(0.05)
+        assert len(result["array"]) == ITERATIONS
+
+    def test_falls_back_to_ez_when_preferred_missing(self, tmp_path):
+        fdata = load_file(_write_trace(tmp_path / "t1.h5", x_pos=0.05))
+        result = process_trace(fdata, "Hx", expected_len=None)
+        assert result["ok"] is True
+        assert result["component"] == "Ez"
+
+    def test_falls_back_to_first_available_when_no_ez(self, tmp_path):
+        fdata = load_file(
+            _write_trace(tmp_path / "t1.h5", x_pos=0.05, components=("Hx", "Hy"))
+        )
+        result = process_trace(fdata, "Ez", expected_len=None)
+        assert result["ok"] is True
+        assert result["component"] in ("Hx", "Hy")
+
+    def test_mismatched_length_rejected(self, tmp_path):
+        fdata = load_file(_write_trace(tmp_path / "t1.h5", x_pos=0.05, iterations=50))
+        result = process_trace(fdata, "Ez", expected_len=100)
+        assert result["ok"] is False
+        assert "50 samples" in result["reason"]
+
+    def test_missing_source_gives_none_position(self, tmp_path):
+        fdata = load_file(_write_trace_no_source(tmp_path / "t1.h5"))
+        result = process_trace(fdata, "Ez", expected_len=None)
+        assert result["ok"] is True
+        assert result["x"] is None
+
+    def test_defaults_to_first_receiver_when_no_preference(self, tmp_path):
+        fdata = load_file(_write_trace_two_receivers(tmp_path / "t1.h5", x_pos=0.05))
+        result = process_trace(fdata, "Ez", expected_len=None)
+        assert result["receiver"] == "rx1"
+        assert result["array"][0] == pytest.approx(1.0)
+
+    def test_honours_preferred_receiver(self, tmp_path):
+        fdata = load_file(_write_trace_two_receivers(tmp_path / "t1.h5", x_pos=0.05))
+        result = process_trace(fdata, "Ez", expected_len=None, preferred_receiver="rx2")
+        assert result["receiver"] == "rx2"
+        assert result["array"][0] == pytest.approx(2.0)
+
+    def test_falls_back_to_first_receiver_if_preferred_not_present(self, tmp_path):
+        fdata = load_file(_write_trace_two_receivers(tmp_path / "t1.h5", x_pos=0.05))
+        result = process_trace(fdata, "Ez", expected_len=None, preferred_receiver="rx99")
+        assert result["receiver"] == "rx1"
+
+
+class TestStackTraces:
+    def test_stacks_in_given_order(self, tmp_path):
+        files = [
+            load_file(_write_trace(tmp_path / f"t{i}.h5", x_pos=0.04 + i * 0.002, amplitude=i + 1))
+            for i in range(5)
+        ]
+        result = stack_traces(files, preferred_component="Ez")
+        assert result["matrix"].shape == (ITERATIONS, 5)
+        assert result["positions_x"] == [pytest.approx(0.04 + i * 0.002) for i in range(5)]
+        assert result["warnings"] == []
+        assert result["all_positions_physical"] is True
+
+    def test_amplitude_scaling_preserved_per_column(self, tmp_path):
+        files = [
+            load_file(_write_trace(tmp_path / f"t{i}.h5", x_pos=float(i), amplitude=i + 1))
+            for i in range(4)
+        ]
+        result = stack_traces(files)
+        peaks = [round(float(np.max(np.abs(result["matrix"][:, j])))) for j in range(4)]
+        assert peaks == [1, 2, 3, 4]
+
+    def test_empty_input_returns_none_matrix(self):
+        result = stack_traces([])
+        assert result["matrix"] is None
+        assert result["positions_x"] == []
+        assert result["warnings"] == []
+
+    def test_mismatched_file_skipped_with_warning_rest_still_stacked(self, tmp_path):
+        good = [
+            load_file(_write_trace(tmp_path / "a.h5", x_pos=0.0)),
+            load_file(_write_trace(tmp_path / "b.h5", x_pos=0.01)),
+        ]
+        bad = load_file(_write_trace(tmp_path / "c.h5", x_pos=0.02, iterations=50))
+        result = stack_traces([good[0], bad, good[1]])
+        assert result["matrix"].shape == (ITERATIONS, 2)
+        assert len(result["warnings"]) == 1
+        assert "trace 1" in result["warnings"][0]
+
+    def test_missing_source_falls_back_to_index_and_flags_non_physical(self, tmp_path):
+        files = [
+            load_file(_write_trace(tmp_path / "a.h5", x_pos=0.0)),
+            load_file(_write_trace_no_source(tmp_path / "b.h5")),
+        ]
+        result = stack_traces(files)
+        assert result["all_positions_physical"] is False
+        assert result["positions_x"][1] == 1.0  # fell back to index
+
+    def test_component_choice_is_consistent_across_stack(self, tmp_path):
+        files = [
+            load_file(_write_trace(tmp_path / f"t{i}.h5", x_pos=float(i), components=("Ez", "Hx")))
+            for i in range(3)
+        ]
+        result = stack_traces(files, preferred_component="Hx")
+        assert result["component"] == "Hx"
+        assert result["matrix"].shape == (ITERATIONS, 3)
+
+    def test_preferred_receiver_threads_through_stack(self, tmp_path):
+        files = [
+            load_file(_write_trace_two_receivers(tmp_path / f"t{i}.h5", x_pos=float(i)))
+            for i in range(3)
+        ]
+        result = stack_traces(files, preferred_component="Ez", preferred_receiver="rx2")
+        assert result["receiver"] == "rx2"
+        assert np.all(result["matrix"] == 2.0)

--- a/toolboxes/Marimo/ascan_dashboard.py
+++ b/toolboxes/Marimo/ascan_dashboard.py
@@ -1,0 +1,732 @@
+import marimo
+
+__generated_with = "0.23.8"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import csv
+    import io
+    from pathlib import Path
+
+    import marimo as mo
+    import numpy as np
+    import plotly.graph_objects as go
+
+    from toolboxes.Marimo.h5_reader import (
+        build_label,
+        format_metadata_text,
+        get_time_axis,
+        get_trace,
+        get_unit_label,
+        list_components,
+        list_receivers,
+        load_files,
+    )
+
+    # Research-quality colour palette (Matplotlib tab10, colorblind-friendly)
+    PALETTE = [
+        "#1f77b4",
+        "#d62728",
+        "#2ca02c",
+        "#ff7f0e",
+        "#9467bd",
+        "#8c564b",
+        "#e377c2",
+        "#17becf",
+        "#bcbd22",
+        "#7f7f7f",
+    ]
+
+    COLOUR_NAMES = {
+        "Blue": "#1f77b4",
+        "Red": "#d62728",
+        "Green": "#2ca02c",
+        "Orange": "#ff7f0e",
+        "Purple": "#9467bd",
+        "Brown": "#8c564b",
+        "Pink": "#e377c2",
+        "Teal": "#17becf",
+        "Olive": "#bcbd22",
+        "Grey": "#7f7f7f",
+        "Cyan": "#4FC3F7",
+        "Black": "#111111",
+    }
+
+    return (
+        COLOUR_NAMES,
+        PALETTE,
+        Path,
+        build_label,
+        csv,
+        format_metadata_text,
+        get_time_axis,
+        get_trace,
+        get_unit_label,
+        go,
+        io,
+        list_components,
+        list_receivers,
+        load_files,
+        mo,
+        np,
+    )
+
+
+# ── SECTION 1: File loading ────────────────────────────────────────────────
+@app.cell
+def _(mo):
+    file_browser = mo.ui.file_browser(
+        filetypes=[".h5"],
+        label="",
+        multiple=True,
+    )
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("# gprMax A-Scan Post-Processing Dashboard"),
+                mo.md(
+                    "Load one or more `.h5` output files, select field components, "
+                    "and build publication-quality overlay plots with SVG, PDF, "
+                    "and CSV export."
+                ),
+                mo.md("---"),
+                mo.md("### Step 1 — Load output files"),
+                mo.md(
+                    "_Select one or more gprMax `.h5` output files. "
+                    "All field components (Ex, Ey, Ez, Hx, Hy, Hz) "
+                    "are detected automatically from each file._"
+                ),
+                file_browser,
+            ],
+            gap="0.4rem",
+        )
+    )
+    return (file_browser,)
+
+
+# ── SECTION 2: Data loading + metadata banner ──────────────────────────────
+@app.cell
+def _(file_browser, format_metadata_text, load_files, mo):
+    if not file_browser.value:
+        mo.stop(True, mo.md(""))
+
+    _paths = [f.path for f in file_browser.value]
+    _loaded = load_files(_paths)
+    get_data, set_data = mo.state({"files": _loaded})
+
+    _cards = [
+        mo.callout(
+            mo.md(f"**{_fname}**\n\n{format_metadata_text(_fdata)}"),
+            kind="info",
+        )
+        for _fname, _fdata in _loaded.items()
+    ]
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md(f"### {len(_loaded)} file(s) loaded"),
+                *_cards,
+                mo.md("---"),
+            ],
+            gap="0.4rem",
+        )
+    )
+    return get_data, set_data
+
+
+# ── STATE: isolated — no UI dependencies ──────────────────────────────────
+@app.cell
+def _(mo):
+    get_traces, set_traces = mo.state([])
+    return get_traces, set_traces
+
+
+# ── SECTION 3: Trace picker ────────────────────────────────────────────────
+@app.cell
+def _(
+    COLOUR_NAMES,
+    PALETTE,
+    get_data,
+    get_traces,
+    list_components,
+    list_receivers,
+    mo,
+):
+    _state = get_data()
+    _files = _state["files"]
+
+    if not _files:
+        mo.stop(True, mo.md("No files loaded."))
+
+    _file_options = list(_files.keys())
+    _first_file = _file_options[0]
+    _first_rx = list_receivers(_files[_first_file])[0]
+    _first_comps = list_components(_files[_first_file], _first_rx)
+
+    _next_hex = PALETTE[len(get_traces()) % len(PALETTE)]
+    _auto_name = next((name for name, h in COLOUR_NAMES.items() if h == _next_hex), "Blue")
+
+    file_selector = mo.ui.dropdown(
+        options=_file_options,
+        value=_first_file,
+        label="File",
+    )
+    receiver_selector = mo.ui.dropdown(
+        options=list_receivers(_files[_first_file]),
+        value=_first_rx,
+        label="Receiver",
+    )
+    component_selector = mo.ui.dropdown(
+        options=_first_comps,
+        value="Ez" if "Ez" in _first_comps else _first_comps[0],
+        label="Component",
+    )
+    colour_selector = mo.ui.dropdown(
+        options=COLOUR_NAMES,
+        value=_auto_name,
+        label="Trace colour",
+    )
+    add_button = mo.ui.run_button(label="＋  Add trace")
+    clear_button = mo.ui.run_button(label="✕  Clear all")
+
+    _traces_now = get_traces()
+    if _traces_now:
+        _remove_opts = {t["label"]: i for i, t in enumerate(_traces_now)}
+        remove_selector = mo.ui.dropdown(
+            options=_remove_opts,
+            value=list(_remove_opts.keys())[0],
+            label="Remove a trace",
+        )
+        remove_button = mo.ui.run_button(label="－  Remove selected")
+        _remove_section = mo.vstack(
+            [
+                mo.md("**Remove a trace**"),
+                mo.hstack([remove_selector, remove_button], gap="1rem"),
+            ],
+            gap="0.3rem",
+        )
+    else:
+        remove_selector = None
+        remove_button = None
+        _remove_section = mo.md("")
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 2 — Build your plot"),
+                mo.md(
+                    "_Select a file, receiver, and field component. "
+                    "Colour auto-advances through the research palette — "
+                    "override before clicking Add._"
+                ),
+                mo.md("**Select source**"),
+                mo.hstack([file_selector, receiver_selector], gap="2rem"),
+                mo.md("**Select component and colour**"),
+                mo.hstack([component_selector, colour_selector], gap="2rem"),
+                mo.hstack([add_button, clear_button], gap="1rem"),
+                mo.md("---"),
+                _remove_section,
+            ],
+            gap="0.5rem",
+        )
+    )
+    return (
+        add_button,
+        clear_button,
+        colour_selector,
+        component_selector,
+        file_selector,
+        receiver_selector,
+        remove_button,
+        remove_selector,
+    )
+
+
+# ── BUTTON HANDLER ─────────────────────────────────────────────────────────
+@app.cell
+def _(
+    add_button,
+    build_label,
+    clear_button,
+    colour_selector,
+    component_selector,
+    file_selector,
+    get_data,
+    get_traces,
+    list_components,
+    mo,
+    receiver_selector,
+    remove_button,
+    remove_selector,
+    set_traces,
+):
+    if add_button.value:
+        _fname = file_selector.value
+        _rx = receiver_selector.value
+        _comp = component_selector.value
+        _available = list_components(get_data()["files"][_fname], _rx)
+        if _comp not in _available:
+            mo.output.replace(
+                mo.callout(
+                    mo.md(
+                        f"**Component not found.** "
+                        f"`{_comp}` is not in `{_fname}` / `{_rx}`. "
+                        f"Available: {', '.join(_available)}"
+                    ),
+                    kind="danger",
+                )
+            )
+        else:
+            _new = {
+                "filename": _fname,
+                "receiver": _rx,
+                "component": _comp,
+                "colour": colour_selector.value,
+                "label": build_label(_fname, _rx, _comp),
+            }
+            _cur = get_traces()
+            _dup = any(
+                t["filename"] == _new["filename"]
+                and t["receiver"] == _new["receiver"]
+                and t["component"] == _new["component"]
+                for t in _cur
+            )
+            if not _dup:
+                set_traces(_cur + [_new])
+
+    if remove_button is not None and remove_button.value and remove_selector is not None:
+        _idx = remove_selector.value
+        set_traces([t for i, t in enumerate(get_traces()) if i != _idx])
+
+    if clear_button.value:
+        set_traces([])
+
+    _traces = get_traces()
+    if _traces:
+        _header = "| # | Colour | Component | File | Receiver |"
+        _sep = "|---|--------|-----------|------|----------|"
+        _rows = "\n".join(
+            f"| {i + 1} "
+            f"| <span style='background:{t['colour']};display:inline-block;"
+            f"width:32px;height:14px;border-radius:3px;'></span> "
+            f"| `{t['component']}` "
+            f"| `{t['filename']}` "
+            f"| `{t['receiver']}` |"
+            for i, t in enumerate(_traces)
+        )
+        mo.output.replace(
+            mo.vstack(
+                [
+                    mo.md(f"**{len(_traces)} active trace(s)**"),
+                    mo.md(f"{_header}\n{_sep}\n{_rows}"),
+                    mo.md("---"),
+                ],
+                gap="0.3rem",
+            )
+        )
+    else:
+        mo.output.replace(
+            mo.vstack(
+                [
+                    mo.callout(
+                        mo.md(
+                            "No traces added yet. "
+                            "Use the picker above and click **＋ Add trace**."
+                        ),
+                        kind="neutral",
+                    ),
+                    mo.md("---"),
+                ],
+                gap="0.25rem",
+            )
+        )
+
+
+# ── SECTION 4: Plot appearance controls ───────────────────────────────────
+@app.cell
+def _(mo):
+    bg_colour = mo.ui.dropdown(
+        options={
+            "Light": "#ffffff",
+            "Paper white": "#f8f9fa",
+            "Dark": "#0e1117",
+        },
+        value="Light",
+        label="Background",
+    )
+    line_width = mo.ui.slider(
+        start=0.5,
+        stop=4.0,
+        step=0.5,
+        value=1.5,
+        label="Line width",
+    )
+    font_size = mo.ui.slider(
+        start=10,
+        stop=22,
+        step=1,
+        value=13,
+        label="Font size",
+    )
+    show_grid = mo.ui.checkbox(label="Show grid", value=True)
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 3 — Adjust appearance"),
+                mo.hstack(
+                    [bg_colour, line_width, font_size, show_grid],
+                    gap="1.5rem",
+                    justify="start",
+                ),
+            ],
+            gap="0.5rem",
+        )
+    )
+    return bg_colour, font_size, line_width, show_grid
+
+
+# ── SECTION 5: Time zoom slider ────────────────────────────────────────────
+@app.cell
+def _(get_data, get_traces, mo):
+    if not get_traces():
+        mo.stop(True, mo.md(""))
+
+    _files = get_data()["files"]
+    _max_ns = max(
+        round(f["meta"]["iterations"] * f["meta"]["dt"] * 1e9, 4) for f in _files.values()
+    )
+    _step = round(_max_ns / 600, 4)
+
+    time_slider = mo.ui.range_slider(
+        start=0.0,
+        stop=_max_ns,
+        step=_step,
+        value=[0.0, _max_ns],
+        label="Time window (ns)",
+        full_width=True,
+    )
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 4 — Zoom time window"),
+                mo.md(
+                    "_Drag handles to focus on a specific time range. "
+                    "CSV export always contains the full unzoomed data._"
+                ),
+                time_slider,
+                mo.md("---"),
+            ],
+            gap="0.4rem",
+        )
+    )
+    return (time_slider,)
+
+
+# ── SECTION 6: Figure renderer + export ───────────────────────────────────
+@app.cell
+def _(
+    bg_colour,
+    csv,
+    font_size,
+    get_data,
+    get_time_axis,
+    get_trace,
+    get_traces,
+    get_unit_label,
+    go,
+    io,
+    line_width,
+    mo,
+    show_grid,
+    time_slider,
+):
+    _traces = get_traces()
+    if not _traces:
+        mo.stop(
+            True,
+            mo.callout(
+                mo.md("Add at least one trace using the picker above " "to render the plot."),
+                kind="warn",
+            ),
+        )
+
+    _files = get_data()["files"]
+    _bg = bg_colour.value
+    _is_dark = _bg == "#0e1117"
+    _fc = "#e8e8e8" if _is_dark else "#1a1a1a"
+    _gc = "rgba(255,255,255,0.1)" if _is_dark else "rgba(0,0,0,0.07)"
+    _lc = "rgba(255,255,255,0.25)" if _is_dark else "rgba(0,0,0,0.18)"
+
+    # ── Build figure ────────────────────────────────────────────────────────
+    _fig = go.Figure()
+    _has_e = False
+    _has_h = False
+    _comps_seen = []
+    _files_seen = []
+
+    # Store full arrays for CSV export (unaffected by zoom)
+    _csv_time: dict = {}
+    _csv_data: dict = {}
+
+    for _t in _traces:
+        _fdata = _files[_t["filename"]]
+        _arr = get_trace(_fdata, _t["component"], _t["receiver"])
+        _time = get_time_axis(_fdata, unit="ns")
+        _unit = get_unit_label(_t["component"])
+        _on_y2 = _unit == "A/m"
+
+        if _on_y2:
+            _has_h = True
+        else:
+            _has_e = True
+
+        # Track unique time axes by (n_steps, dt) tuple
+        _fmeta = _fdata["meta"]
+        _tax_key = (_fmeta["iterations"], round(_fmeta["dt"], 15))
+        if _tax_key not in _csv_time:
+            _csv_time[_tax_key] = _time
+        _csv_data[_t["label"]] = (_tax_key, _arr)
+
+        _fig.add_trace(
+            go.Scatter(
+                x=_time,
+                y=_arr,
+                mode="lines",
+                name=_t["label"],
+                line=dict(
+                    color=_t["colour"],
+                    width=line_width.value,
+                    dash="dash" if _on_y2 else "solid",
+                ),
+                yaxis="y2" if _on_y2 else "y",
+                hovertemplate=(
+                    "%{x:.4f} ns<br>%{y:.5g} " + _unit + "<extra>" + _t["label"] + "</extra>"
+                ),
+            )
+        )
+
+        if _t["component"] not in _comps_seen:
+            _comps_seen.append(_t["component"])
+        if _t["filename"] not in _files_seen:
+            _files_seen.append(_t["filename"])
+
+    _title = ", ".join(_comps_seen) + "  ·  " + "  +  ".join(_files_seen)
+    _dual = _has_e and _has_h
+
+    _axis_base = dict(
+        showgrid=show_grid.value,
+        gridcolor=_gc,
+        gridwidth=0.5,
+        showline=True,
+        linecolor=_lc,
+        linewidth=1,
+        tickfont=dict(size=font_size.value - 1, color=_fc),
+        title_font=dict(size=font_size.value, color=_fc),
+        zeroline=True,
+        zerolinecolor=_lc,
+        zerolinewidth=1,
+    )
+
+    if _dual:
+        _y1_label = "E-field [V/m]"
+    elif _has_e:
+        _y1_label = "Field strength [V/m]"
+    else:
+        _y1_label = "Field strength [A/m]"
+
+    _t_start, _t_end = time_slider.value
+
+    _layout = dict(
+        title=dict(
+            text=_title,
+            font=dict(size=font_size.value + 1, color=_fc),
+            x=0.0,
+            xanchor="left",
+        ),
+        xaxis=dict(
+            title="Time (ns)",
+            range=[_t_start, _t_end],
+            **_axis_base,
+        ),
+        yaxis=dict(title=_y1_label, **_axis_base),
+        paper_bgcolor=_bg,
+        plot_bgcolor=_bg,
+        legend=dict(
+            font=dict(size=font_size.value - 1, color=_fc),
+            bgcolor="rgba(0,0,0,0.0)",
+            bordercolor=_lc,
+            borderwidth=1,
+        ),
+        height=500,
+        margin=dict(l=72, r=80 if _dual else 32, t=55, b=60),
+        hovermode="x unified",
+    )
+
+    if _dual:
+        _layout["yaxis2"] = dict(
+            title="H-field [A/m]",
+            overlaying="y",
+            side="right",
+            showgrid=False,
+            showline=True,
+            linecolor=_lc,
+            linewidth=1,
+            tickfont=dict(size=font_size.value - 1, color=_fc),
+            title_font=dict(size=font_size.value, color=_fc),
+            zeroline=False,
+        )
+
+    _fig.update_layout(**_layout)
+
+    # ── CSV export ──────────────────────────────────────────────────────────
+    # Always exports FULL data (not the zoomed window).
+    # If all traces share the same time axis: one time column.
+    # If traces come from files with different dt/iterations: paired columns.
+    try:
+        _buf = io.StringIO()
+        _writer = csv.writer(_buf)
+
+        _single_axis = len(_csv_time) == 1
+
+        if _single_axis:
+            _shared_time = list(_csv_time.values())[0]
+            _header_row = ["time_ns"] + [t["label"] for t in _traces]
+            _writer.writerow(_header_row)
+            for _i in range(len(_shared_time)):
+                _row = [f"{_shared_time[_i]:.8g}"] + [
+                    f"{_csv_data[t['label']][1][_i]:.10g}" for t in _traces
+                ]
+                _writer.writerow(_row)
+        else:
+            # Paired time + value columns per trace
+            _header_row = []
+            for _t in _traces:
+                _header_row.extend([f"time_ns ({_t['label']})", _t["label"]])
+            _writer.writerow(_header_row)
+            _max_len = max(len(_csv_data[t["label"]][1]) for t in _traces)
+            for _i in range(_max_len):
+                _row = []
+                for _t in _traces:
+                    _tax_key, _arr = _csv_data[_t["label"]]
+                    _time = _csv_time[_tax_key]
+                    if _i < len(_arr):
+                        _row.extend([f"{_time[_i]:.8g}", f"{_arr[_i]:.10g}"])
+                    else:
+                        _row.extend(["", ""])
+                _writer.writerow(_row)
+
+        _csv_bytes = _buf.getvalue().encode("utf-8")
+        _csv_btn = mo.download(
+            data=_csv_bytes,
+            filename="gprmax_ascan.csv",
+            label="Download CSV (full data)",
+            mimetype="text/csv",
+        )
+    except Exception as _e:
+        _csv_btn = mo.md(f"_CSV export error: `{_e}`_")
+
+    # ── SVG export ──────────────────────────────────────────────────────────
+    try:
+        import plotly.io as _pio
+
+        _svg_bytes = _pio.to_image(_fig, format="svg", width=1200, height=600, scale=2)
+        _svg_btn = mo.download(
+            data=_svg_bytes,
+            filename="gprmax_ascan.svg",
+            label="Download SVG",
+            mimetype="image/svg+xml",
+        )
+    except Exception as _e:
+        _svg_btn = mo.md(
+            f"_SVG: `{type(_e).__name__}` — "
+            f"run `plotly_get_chrome` to install kaleido's Chrome, "
+            f"or use the camera icon in the plot toolbar._"
+        )
+
+    # ── PDF export ──────────────────────────────────────────────────────────
+    try:
+        import plotly.io as _pio
+
+        _pdf_bytes = _pio.to_image(_fig, format="pdf", width=1200, height=600, scale=2)
+        _pdf_btn = mo.download(
+            data=_pdf_bytes,
+            filename="gprmax_ascan.pdf",
+            label="Download PDF",
+            mimetype="application/pdf",
+        )
+    except Exception as _e:
+        _pdf_btn = mo.md(f"_PDF: `{type(_e).__name__}` — run `plotly_get_chrome` first._")
+
+    # ── Interactive HTML — no kaleido needed ────────────────────────────────
+    try:
+        _html_bytes = _fig.to_html(full_html=True, include_plotlyjs=True).encode("utf-8")
+        _html_btn = mo.download(
+            data=_html_bytes,
+            filename="gprmax_ascan.html",
+            label="Download HTML (interactive)",
+            mimetype="text/html",
+        )
+    except Exception:
+        _html_btn = mo.md("")
+
+    # ── Notes ────────────────────────────────────────────────────────────────
+    _notes = []
+    if _dual:
+        _notes.append(
+            "_Solid lines → E-field (left axis, V/m)  ·  "
+            "Dashed lines → H-field (right axis, A/m)_"
+        )
+    _notes.append(
+        "_Hover for exact values. "
+        "Camera icon in toolbar → SVG (no kaleido needed via toolbar). "
+        "Run `plotly_get_chrome` once to enable SVG/PDF download buttons._"
+    )
+
+    mo.vstack(
+        [
+            mo.md("### Plot"),
+            mo.ui.plotly(
+                _fig,
+                config={
+                    "toImageButtonOptions": {
+                        "format": "svg",
+                        "filename": "gprmax_ascan",
+                        "height": 600,
+                        "width": 1200,
+                        "scale": 2,
+                    },
+                    "displaylogo": False,
+                    "modeBarButtonsToRemove": ["lasso2d", "select2d"],
+                },
+            ),
+            mo.md("  \n".join(_notes)),
+            mo.md("**Export**"),
+            mo.hstack(
+                [_csv_btn, _html_btn, _svg_btn, _pdf_btn],
+                gap="1rem",
+                justify="start",
+            ),
+            mo.md("---"),
+            mo.callout(
+                mo.md(
+                    "**Upcoming features**\n\n"
+                    "- Background subtraction "
+                    "(target trace minus free-space trace)\n"
+                    "- FFT frequency spectrum toggle\n"
+                    "- Assemble multiple A-scan files → B-scan radargram\n"
+                    "- 3D surface viewer from multi-position A-scan data"
+                ),
+                kind="neutral",
+            ),
+        ],
+        gap="0.5rem",
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/toolboxes/Marimo/ascan_dashboard.py
+++ b/toolboxes/Marimo/ascan_dashboard.py
@@ -204,7 +204,7 @@ def _(
         _remove_section = mo.vstack(
             [
                 mo.md("**Remove a trace**"),
-                mo.hstack([remove_selector, remove_button], gap="1rem"),
+                mo.hstack([remove_selector, remove_button], gap="1rem", justify="start"),
             ],
             gap="0.3rem",
         )
@@ -223,10 +223,10 @@ def _(
                     "override before clicking Add._"
                 ),
                 mo.md("**Select source**"),
-                mo.hstack([file_selector, receiver_selector], gap="2rem"),
+                mo.hstack([file_selector, receiver_selector], gap="2rem", justify="start"),
                 mo.md("**Select component and colour**"),
-                mo.hstack([component_selector, colour_selector], gap="2rem"),
-                mo.hstack([add_button, clear_button], gap="1rem"),
+                mo.hstack([component_selector, colour_selector], gap="2rem", justify="start"),
+                mo.hstack([add_button, clear_button], gap="1rem", justify="start"),
                 mo.md("---"),
                 _remove_section,
             ],
@@ -363,6 +363,7 @@ def _(mo):
         step=0.5,
         value=1.5,
         label="Line width",
+        debounce=True,
     )
     font_size = mo.ui.slider(
         start=10,
@@ -370,6 +371,7 @@ def _(mo):
         step=1,
         value=13,
         label="Font size",
+        debounce=True,
     )
     show_grid = mo.ui.checkbox(label="Show grid", value=True)
 
@@ -408,6 +410,7 @@ def _(get_data, get_traces, mo):
         value=[0.0, _max_ns],
         label="Time window (ns)",
         full_width=True,
+        debounce=True,
     )
     mo.output.replace(
         mo.vstack(
@@ -629,49 +632,44 @@ def _(
     except Exception as _e:
         _csv_btn = mo.md(f"_CSV export error: `{_e}`_")
 
-    # ── SVG export ──────────────────────────────────────────────────────────
-    try:
+    # ── SVG/PDF export ─────────────────────────────────────────────────────
+    # Lazy on purpose: mo.download accepts a zero-arg callable and only
+    # calls it when the button is clicked. kaleido spins up headless
+    # Chrome per export, which is slow — computing it eagerly here meant
+    # this cell paid that cost twice (SVG + PDF) on every re-render, which
+    # includes every appearance-control change and every drag tick of an
+    # undebounced slider. Same bug and same fix as bscan_dashboard.py.
+    def _make_svg():
         import plotly.io as _pio
+        return _pio.to_image(_fig, format="svg", width=1200, height=600, scale=2)
 
-        _svg_bytes = _pio.to_image(_fig, format="svg", width=1200, height=600, scale=2)
-        _svg_btn = mo.download(
-            data=_svg_bytes,
-            filename="gprmax_ascan.svg",
-            label="Download SVG",
-            mimetype="image/svg+xml",
-        )
-    except Exception as _e:
-        _svg_btn = mo.md(
-            f"_SVG: `{type(_e).__name__}` — "
-            f"run `plotly_get_chrome` to install kaleido's Chrome, "
-            f"or use the camera icon in the plot toolbar._"
-        )
-
-    # ── PDF export ──────────────────────────────────────────────────────────
-    try:
+    def _make_pdf():
         import plotly.io as _pio
+        return _pio.to_image(_fig, format="pdf", width=1200, height=600, scale=2)
 
-        _pdf_bytes = _pio.to_image(_fig, format="pdf", width=1200, height=600, scale=2)
-        _pdf_btn = mo.download(
-            data=_pdf_bytes,
-            filename="gprmax_ascan.pdf",
-            label="Download PDF",
-            mimetype="application/pdf",
-        )
-    except Exception as _e:
-        _pdf_btn = mo.md(f"_PDF: `{type(_e).__name__}` — run `plotly_get_chrome` first._")
+    _svg_btn = mo.download(
+        data=_make_svg, filename="gprmax_ascan.svg", label="Download SVG", mimetype="image/svg+xml"
+    )
+    _pdf_btn = mo.download(
+        data=_make_pdf, filename="gprmax_ascan.pdf", label="Download PDF", mimetype="application/pdf"
+    )
 
-    # ── Interactive HTML — no kaleido needed ────────────────────────────────
-    try:
-        _html_bytes = _fig.to_html(full_html=True, include_plotlyjs=True).encode("utf-8")
-        _html_btn = mo.download(
-            data=_html_bytes,
-            filename="gprmax_ascan.html",
-            label="Download HTML (interactive)",
-            mimetype="text/html",
-        )
-    except Exception:
-        _html_btn = mo.md("")
+    # ── Interactive HTML — no kaleido needed, but still lazy ───────────────
+    # to_html(include_plotlyjs=True) embeds the entire Plotly.js library
+    # (several MB) as base64 into the button's data on every render,
+    # regardless of how much actual trace data there is. Not slow like
+    # kaleido since there's no external process, but still pure waste to
+    # recompute on every appearance/zoom change for a download that may
+    # never be clicked.
+    def _make_html():
+        return _fig.to_html(full_html=True, include_plotlyjs=True).encode("utf-8")
+
+    _html_btn = mo.download(
+        data=_make_html,
+        filename="gprmax_ascan.html",
+        label="Download HTML (interactive)",
+        mimetype="text/html",
+    )
 
     # ── Notes ────────────────────────────────────────────────────────────────
     _notes = []

--- a/toolboxes/Marimo/bscan_dashboard.py
+++ b/toolboxes/Marimo/bscan_dashboard.py
@@ -1,0 +1,866 @@
+import marimo
+
+__generated_with = "0.23.8"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import csv
+    import io
+    import re
+    import time
+    from pathlib import Path
+
+    import marimo as mo
+    import numpy as np
+    import plotly.graph_objects as go
+
+    from toolboxes.Marimo.h5_reader import (
+        format_metadata_text,
+        get_unit_label,
+        list_components,
+        list_receivers,
+        load_file,
+    )
+    from toolboxes.Marimo.trace_matrix import process_trace, stack_traces
+
+    # gprMax per-trace B-scan naming: <base><N>.h5, e.g. cylinder_Bscan_2D1.h5
+    # .. cylinder_Bscan_2D60.h5 for a -n 60 run. \d+ is greedy, so multi-digit
+    # trace numbers parse correctly.
+    TRACE_FILE_RE = re.compile(r"^(.*?)(\d+)\.h5$")
+
+    def discover_bases(directory: str) -> dict[str, int]:
+        """Group .h5 trace files in `directory` by inferred base name."""
+        d = Path(directory)
+        if not directory or not d.is_dir():
+            return {}
+        bases: dict[str, int] = {}
+        for p in sorted(d.glob("*.h5")):
+            if "merged" in p.name.lower():
+                continue
+            m = TRACE_FILE_RE.match(p.name)
+            if m:
+                bases[m.group(1)] = bases.get(m.group(1), 0) + 1
+        return bases
+
+    def find_trace_files(directory: str, base: str) -> list[tuple[int, Path]]:
+        """Trace files for `base` in `directory`, sorted by trace number."""
+        d = Path(directory)
+        if not directory or not base or not d.is_dir():
+            return []
+        found = []
+        for p in d.glob(f"{base}*.h5"):
+            if "merged" in p.name.lower():
+                continue
+            m = TRACE_FILE_RE.match(p.name)
+            if m and m.group(1) == base:
+                found.append((int(m.group(2)), p))
+        found.sort(key=lambda t: t[0])
+        return found
+
+    def build_bscan_figure(matrix, x, y, x_title, unit, colourscale, bg, font_size, view_mode, title_text, time_range=None, normalize=False):
+        """Heatmap or 3D Surface from an assembled (time x position) matrix."""
+        if normalize:
+            peak = np.max(np.abs(matrix), axis=0)
+            peak[peak == 0] = 1.0
+            matrix = matrix / peak
+            unit = "normalized"
+
+        is_dark = bg == "#0e1117"
+        fc = "#e8e8e8" if is_dark else "#1a1a1a"
+        lc = "rgba(255,255,255,0.25)" if is_dark else "rgba(0,0,0,0.18)"
+        amp = float(np.max(np.abs(matrix))) or 1.0
+
+        # Time axis always drawn with early time at top (GPR convention).
+        # Plotly's "reversed" autorange doesn't combine cleanly with an
+        # explicit zoom range, so this always sets an explicit descending
+        # range instead of relying on autorange.
+        lo, hi = time_range if time_range is not None else (float(np.min(y)), float(np.max(y)))
+        time_axis_range = [hi, lo]
+
+        if view_mode == "3D Surface":
+            fig = go.Figure(
+                data=go.Surface(
+                    z=matrix,
+                    x=x,
+                    y=y,
+                    colorscale=colourscale,
+                    cmin=-amp,
+                    cmax=amp,
+                    colorbar=dict(title=dict(text=unit, font=dict(color=fc)), tickfont=dict(color=fc)),
+                )
+            )
+            fig.update_layout(
+                scene=dict(
+                    xaxis=dict(title=x_title, color=fc),
+                    yaxis=dict(title="Time (ns)", range=time_axis_range, color=fc),
+                    zaxis=dict(title=unit, color=fc),
+                ),
+                height=600,
+            )
+        else:
+            fig = go.Figure(
+                data=go.Heatmap(
+                    z=matrix,
+                    x=x,
+                    y=y,
+                    colorscale=colourscale,
+                    zmid=0,
+                    zmin=-amp,
+                    zmax=amp,
+                    colorbar=dict(title=dict(text=unit, font=dict(color=fc)), tickfont=dict(color=fc)),
+                )
+            )
+            fig.update_layout(
+                xaxis=dict(
+                    title=x_title,
+                    tickfont=dict(size=font_size - 1, color=fc),
+                    title_font=dict(size=font_size, color=fc),
+                    showline=True,
+                    linecolor=lc,
+                ),
+                yaxis=dict(
+                    title="Time (ns)",
+                    range=time_axis_range,
+                    tickfont=dict(size=font_size - 1, color=fc),
+                    title_font=dict(size=font_size, color=fc),
+                    showline=True,
+                    linecolor=lc,
+                ),
+                height=550,
+                margin=dict(l=72, r=32, t=55, b=55),
+            )
+
+        fig.update_layout(
+            title=dict(text=title_text, font=dict(size=font_size + 1, color=fc), x=0.0, xanchor="left"),
+            paper_bgcolor=bg,
+            plot_bgcolor=bg,
+        )
+        return fig
+
+    def render_bscan_section(matrix, positions_x, time_ns, component, all_positions_physical, index_label, colourscale, bg, font_size, view_mode, normalize, title_text, csv_filename, time_range=None, sample_file=None):
+        """Metadata banner + plot + CSV/SVG/PDF export. Shared by both the
+        live and load-files renderer cells so the two don't drift apart.
+        """
+        if matrix is None:
+            return mo.callout(mo.md("No traces to show yet."), kind="neutral")
+
+        x_title = (
+            "Source x-position (m)"
+            if all_positions_physical
+            else f"{index_label} (source position unavailable in one or more files)"
+        )
+        fig = build_bscan_figure(
+            matrix, positions_x, time_ns, x_title, get_unit_label(component or "Ez"),
+            colourscale, bg, font_size, view_mode, title_text,
+            time_range=time_range, normalize=normalize,
+        )
+
+        # CSV always exports the full, unzoomed, un-normalized matrix —
+        # same convention ascan_dashboard.py uses for its time-zoom slider.
+        try:
+            buf = io.StringIO()
+            writer = csv.writer(buf)
+            writer.writerow(["time_ns"] + [f"x={p:.4f}" for p in positions_x])
+            for i in range(len(time_ns)):
+                writer.writerow([f"{time_ns[i]:.8g}"] + [f"{matrix[i, j]:.10g}" for j in range(matrix.shape[1])])
+            csv_btn = mo.download(
+                data=buf.getvalue().encode("utf-8"), filename=csv_filename,
+                label="Download CSV (full matrix)", mimetype="text/csv",
+            )
+        except Exception as e:
+            csv_btn = mo.md(f"_CSV export error: `{e}`_")
+
+        stem = csv_filename.rsplit(".", 1)[0]
+
+        # Lazy on purpose: mo.download accepts a zero-arg callable and only
+        # calls it when the button is clicked. kaleido spins up headless
+        # Chrome per export, which is slow — computing it eagerly here
+        # meant every poll tick (every 1-2s with live polling on) paid that
+        # cost twice for a download nobody asked for yet. That was the
+        # actual cause of the "reloads every couple seconds" slowness.
+        def _make_svg():
+            import plotly.io as pio
+            return pio.to_image(fig, format="svg", width=1200, height=600, scale=2)
+
+        def _make_pdf():
+            import plotly.io as pio
+            return pio.to_image(fig, format="pdf", width=1200, height=600, scale=2)
+
+        svg_btn = mo.download(data=_make_svg, filename=f"{stem}.svg", label="Download SVG", mimetype="image/svg+xml")
+        pdf_btn = mo.download(data=_make_pdf, filename=f"{stem}.pdf", label="Download PDF", mimetype="application/pdf")
+
+        elements = []
+        if sample_file is not None:
+            elements.append(mo.callout(mo.md(format_metadata_text(sample_file)), kind="info"))
+        elements += [
+            mo.md("### Radargram"),
+            mo.ui.plotly(
+                fig,
+                config={
+                    "toImageButtonOptions": {"format": "svg", "filename": stem, "height": 600, "width": 1200, "scale": 2},
+                    "displaylogo": False,
+                },
+            ),
+            mo.md("**Export**"),
+            mo.hstack([csv_btn, svg_btn, pdf_btn], gap="1rem", justify="start"),
+            mo.md(
+                "_SVG/PDF need `plotly_get_chrome` run once. If either "
+                "fails, the camera icon in the plot toolbar above always "
+                "works and needs no setup._"
+            ),
+        ]
+        return mo.vstack(elements, gap="0.5rem")
+
+    return (
+        Path,
+        discover_bases,
+        find_trace_files,
+        list_components,
+        list_receivers,
+        load_file,
+        mo,
+        np,
+        process_trace,
+        render_bscan_section,
+        stack_traces,
+        time,
+    )
+
+
+# ══ PART 1 — LIVE MONITORING ═══════════════════════════════════════════════
+# Watches a directory while a B-scan is actively running.
+
+
+# ── Step 1: Output directory ────────────────────────────────────────────
+# Widget creation and reading its .value must be in separate cells in this
+# marimo version, so the base-name scan happens in the next cell.
+@app.cell
+def _(mo):
+    directory_input = mo.ui.text(
+        label="",
+        placeholder="/absolute/path/to/gprMax/output/directory",
+        full_width=True,
+    )
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("# gprMax B-Scan Dashboard"),
+                mo.md(
+                    "Two ways to build a radargram: watch a B-scan while "
+                    "it's still running (Part 1), or assemble one from "
+                    "A-scan files you already have (Part 2)."
+                ),
+                mo.md("---"),
+                mo.md("## Part 1 — Live monitoring"),
+                mo.md(
+                    "Watches a directory while gprMax writes one closed "
+                    "`.h5` file per trace, building the radargram as each "
+                    "one completes. Safe to point at a directory before "
+                    "the simulation starts."
+                ),
+                mo.md("### Step 1 — Output directory"),
+                directory_input,
+            ],
+            gap="0.4rem",
+        )
+    )
+    return (directory_input,)
+
+
+# ── Step 2: Base filename ───────────────────────────────────────────────
+@app.cell
+def _(Path, directory_input, discover_bases, mo):
+    _dir = directory_input.value
+    _bases = discover_bases(_dir)
+
+    if _dir and not Path(_dir).is_dir():
+        _status = mo.callout(mo.md(f"`{_dir}` is not a directory."), kind="danger")
+        base_selector = mo.ui.dropdown(options=["—"], value="—", label="Base filename")
+    elif not _bases:
+        _status = mo.md(
+            "_Waiting for `.h5` trace files matching gprMax's per-trace "
+            "naming (`<basename><N>.h5`) to appear in this directory._"
+            if _dir
+            else ""
+        )
+        base_selector = mo.ui.dropdown(options=["—"], value="—", label="Base filename")
+    else:
+        _options = {
+            f"{b}   ({n} file{'s' if n != 1 else ''} so far)": b
+            for b, n in sorted(_bases.items())
+        }
+        base_selector = mo.ui.dropdown(
+            options=_options, value=list(_options.keys())[0], label="Base filename"
+        )
+        _status = mo.md(f"_Detected {len(_bases)} distinct base name(s)._")
+
+    mo.output.replace(
+        mo.vstack([mo.md("### Step 2 — Base filename"), _status, base_selector], gap="0.4rem")
+    )
+    return (base_selector,)
+
+
+# ── State: isolated, no UI params — must only ever run once. Sharing this
+# cell with a widget caused a state-reset bug in ascan_dashboard.py
+# (Component 3) — don't repeat that here.
+@app.cell
+def _(mo):
+    get_bscan_state, set_bscan_state = mo.state(
+        {
+            "seen": set(),
+            "matrix_cols": [],
+            "positions_x": [],
+            "trace_nums": [],
+            "time_ns": None,
+            "component": None,
+            "receiver": None,
+            "base_name": None,
+            "known_components": ["Ez"],
+            "all_positions_physical": True,
+            "warnings": [],
+            "last_poll": None,
+            "sample_file": None,
+        }
+    )
+    return get_bscan_state, set_bscan_state
+
+
+# ── Step 3: Polling ──────────────────────────────────────────────────────
+@app.cell
+def _(mo):
+    live_toggle = mo.ui.switch(label="Live polling", value=True)
+    refresh = mo.ui.refresh(options=["1s", "2s", "5s", "10s", "30s"], default_interval="2s")
+    poll_now_button = mo.ui.run_button(label="⟳  Poll now")
+    reset_button = mo.ui.run_button(label="↺  Reset accumulated data")
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 3 — Polling"),
+                mo.hstack([live_toggle, refresh, poll_now_button, reset_button], gap="1.5rem", justify="start"),
+                mo.md(
+                    "_Each tick only reads unseen files and appends them — "
+                    "never rebuilds from scratch. Changing base filename, "
+                    "field component, or receiver resets accumulated data "
+                    "automatically._"
+                ),
+            ],
+            gap="0.4rem",
+        )
+    )
+    return live_toggle, poll_now_button, refresh, reset_button
+
+
+# ── Step 4: Field component & receiver ──────────────────────────────────
+# Independent of get_bscan_state() on purpose. The poll cell below writes
+# that state and depends on these widgets — reading state here to build
+# the options caused an infinite loop (poll writes -> this reruns -> new
+# widgets -> poll reruns -> ...). Peeking at the file directly instead
+# means this only reruns when directory/base actually change.
+@app.cell
+def _(base_selector, directory_input, find_trace_files, list_components, list_receivers, load_file, mo):
+    _known_comps = ["Ez"]
+    _known_rx = ["rx1"]
+    _files = find_trace_files(directory_input.value, base_selector.value)
+
+    if _files:
+        try:
+            _fdata = load_file(_files[0][1])
+            _known_rx = list_receivers(_fdata) or _known_rx
+            _known_comps = list_components(_fdata, _known_rx[0]) or _known_comps
+        except (FileNotFoundError, OSError, KeyError):
+            pass  # file may still be mid-write — the poll cell retries it
+
+    _default_comp = "Ez" if "Ez" in _known_comps else _known_comps[0]
+    component_selector = mo.ui.dropdown(options=_known_comps, value=_default_comp, label="Field component")
+    receiver_selector = mo.ui.dropdown(options=_known_rx, value=_known_rx[0], label="Receiver")
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 4 — Field component & receiver"),
+                mo.md("_Read from the first trace file found, not assumed._"),
+                mo.hstack([component_selector, receiver_selector], gap="2rem", justify="start"),
+            ],
+            gap="0.4rem",
+        )
+    )
+    return component_selector, receiver_selector
+
+
+# ── Poll / load ──────────────────────────────────────────────────────────
+@app.cell
+def _(
+    Path,
+    base_selector,
+    component_selector,
+    directory_input,
+    find_trace_files,
+    get_bscan_state,
+    live_toggle,
+    load_file,
+    mo,
+    poll_now_button,
+    process_trace,
+    receiver_selector,
+    refresh,
+    reset_button,
+    set_bscan_state,
+    time,
+):
+    _ = refresh.value  # reactive dependency on the polling timer
+
+    _prev = get_bscan_state()
+    _base = base_selector.value
+    _current_component = component_selector.value
+    _current_receiver = receiver_selector.value
+
+    if not directory_input.value or _base in (None, "—"):
+        mo.stop(
+            True,
+            mo.callout(
+                mo.md("Enter a directory and select a base filename above to start watching."),
+                kind="neutral",
+            ),
+        )
+
+    _needs_reset = (
+        reset_button.value
+        or _prev["base_name"] != _base
+        or _prev["component"] != _current_component
+        or _prev["receiver"] != _current_receiver
+    )
+
+    # Fresh dict for set_bscan_state() rather than mutating _prev in place —
+    # matches the append-a-new-list pattern in ascan_dashboard.py's handler.
+    if _needs_reset:
+        _seen, _cols, _xpos, _nums = set(), [], [], []
+        _time_ns, _all_physical, _warnings, _sample_file = None, True, [], None
+    else:
+        _seen = set(_prev["seen"])
+        _cols = list(_prev["matrix_cols"])
+        _xpos = list(_prev["positions_x"])
+        _nums = list(_prev["trace_nums"])
+        _time_ns = _prev["time_ns"]
+        _all_physical = _prev["all_positions_physical"]
+        _warnings = list(_prev["warnings"])
+        _sample_file = _prev["sample_file"]
+
+    _known_components = _prev["known_components"]
+    _new_warnings = []
+    _new_trace_count = 0
+    _should_scan = live_toggle.value or poll_now_button.value or _needs_reset
+
+    if _should_scan and Path(directory_input.value).is_dir():
+        for _num, _path in find_trace_files(directory_input.value, _base):
+            _key = str(_path.resolve())
+            if _key in _seen:
+                continue
+
+            try:
+                _fdata = load_file(_path)
+            except (FileNotFoundError, OSError, KeyError):
+                continue  # still being written — retry next tick, don't mark seen
+
+            _result = process_trace(_fdata, _current_component, len(_cols[0]) if _cols else None, _current_receiver)
+            if _result["known_components"]:
+                _known_components = _result["known_components"]
+
+            if not _result["ok"]:
+                _new_warnings.append(f"{_path.name}: {_result['reason']} — skipped")
+                _seen.add(_key)
+                continue
+
+            if _time_ns is None:
+                _time_ns = _result["time_ns"]
+            if _sample_file is None:
+                _sample_file = _fdata
+            if _result["x"] is None:
+                _all_physical = False
+
+            _cols.append(_result["array"])
+            _xpos.append(_result["x"] if _result["x"] is not None else float(_num))
+            _nums.append(_num)
+            _seen.add(_key)
+            _new_trace_count += 1
+
+    _scan_time = time.strftime("%H:%M:%S") if _should_scan else _prev["last_poll"]
+    _all_warnings = (_warnings + _new_warnings)[-10:]
+
+    # Only touch shared state when something real happened — a reset, a
+    # newly loaded trace, or a new warning. An empty poll (the common case
+    # once caught up) leaves state untouched, so the time-window slider and
+    # renderer downstream don't rebuild every tick for no reason. The
+    # status line below still updates the displayed poll time every tick
+    # regardless, since that's local to this cell's own output and doesn't
+    # trigger anything downstream.
+    _changed = _needs_reset or _new_trace_count > 0 or bool(_new_warnings)
+    if _changed:
+        set_bscan_state(
+            {
+                "seen": _seen,
+                "matrix_cols": _cols,
+                "positions_x": _xpos,
+                "trace_nums": _nums,
+                "time_ns": _time_ns,
+                "component": _current_component,
+                "receiver": _current_receiver,
+                "base_name": _base,
+                "known_components": _known_components,
+                "all_positions_physical": _all_physical,
+                "warnings": _all_warnings,
+                "last_poll": _scan_time,
+                "sample_file": _sample_file,
+            }
+        )
+
+    _parts = [f"**{len(_cols)} trace(s) loaded**"]
+    if _current_component:
+        _parts.append(f"component `{_current_component}`")
+    if _current_receiver:
+        _parts.append(f"receiver `{_current_receiver}`")
+    _parts.append(f"last poll {_scan_time or '—'}")
+    _summary = [mo.md("  ·  ".join(_parts))]
+    if _all_warnings:
+        _summary.append(
+            mo.callout(
+                mo.md("**Skipped files:**\n\n" + "\n".join(f"- {w}" for w in _all_warnings)),
+                kind="warn",
+            )
+        )
+    mo.output.replace(mo.vstack(_summary, gap="0.3rem"))
+    return
+
+
+
+# ── Step 5: Time window ─────────────────────────────────────────────────
+@app.cell
+def _(get_bscan_state, mo):
+    _state = get_bscan_state()
+    if not _state["matrix_cols"]:
+        mo.stop(True, mo.md(""))
+
+    _max_ns = float(_state["time_ns"][-1])
+    live_time_range = mo.ui.range_slider(
+        start=0.0, stop=_max_ns, step=round(_max_ns / 600, 4),
+        value=[0.0, _max_ns], label="Time window (ns)", full_width=True, debounce=True,
+    )
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 5 — Time window"),
+                mo.md("_Zooms the plot only — CSV export always contains the full unzoomed data._"),
+                live_time_range,
+            ],
+            gap="0.4rem",
+        )
+    )
+    return (live_time_range,)
+
+
+# ── Step 6: Appearance ───────────────────────────────────────────────────
+@app.cell
+def _(mo):
+    live_view_mode = mo.ui.dropdown(options=["Heatmap", "3D Surface"], value="Heatmap", label="View")
+    live_colourscale = mo.ui.dropdown(
+        options=["RdBu", "Viridis", "Greys", "Turbo"], value="RdBu", label="Colourscale"
+    )
+    live_bg = mo.ui.dropdown(
+        options={"Light": "#ffffff", "Paper white": "#f8f9fa", "Dark": "#0e1117"},
+        value="Light",
+        label="Background",
+    )
+    live_font_size = mo.ui.slider(start=10, stop=22, step=1, value=13, label="Font size", debounce=True)
+    live_normalize = mo.ui.checkbox(label="Normalize each trace (view only — CSV stays raw)", value=False)
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 6 — Appearance"),
+                mo.hstack([live_view_mode, live_colourscale, live_bg, live_font_size], gap="1.5rem", justify="start"),
+                live_normalize,
+            ],
+            gap="0.5rem",
+        )
+    )
+    return live_bg, live_colourscale, live_font_size, live_normalize, live_view_mode
+
+
+# ── Live renderer + export ──────────────────────────────────────────────
+@app.cell
+def _(
+    get_bscan_state,
+    live_bg,
+    live_colourscale,
+    live_font_size,
+    live_normalize,
+    live_time_range,
+    live_view_mode,
+    mo,
+    np,
+    render_bscan_section,
+):
+    _state = get_bscan_state()
+    _cols = _state["matrix_cols"]
+
+    if not _cols:
+        mo.stop(
+            True,
+            mo.callout(
+                mo.md("No traces loaded yet. Point Step 1 at a directory containing gprMax B-scan output."),
+                kind="neutral",
+            ),
+        )
+
+    mo.output.replace(
+        render_bscan_section(
+            matrix=np.column_stack(_cols),
+            positions_x=_state["positions_x"],
+            time_ns=_state["time_ns"],
+            component=_state["component"],
+            all_positions_physical=_state["all_positions_physical"],
+            index_label="Trace index",
+            colourscale=live_colourscale.value,
+            bg=live_bg.value,
+            font_size=live_font_size.value,
+            view_mode=live_view_mode.value,
+            normalize=live_normalize.value,
+            title_text=f"B-scan radargram — {_state['component']} ({len(_cols)} traces)",
+            csv_filename="gprmax_bscan_live.csv",
+            time_range=tuple(live_time_range.value),
+            sample_file=_state["sample_file"],
+        )
+    )
+    return
+
+
+# ══ PART 2 — LOAD FILES ═════════════════════════════════════════════════════
+# Assembles a radargram from A-scan files you already have — not
+# necessarily from a live-running B-scan, and not necessarily numbered
+# sequentially. Ordered by source x-position when available, falling back
+# to selection order. Independent of Part 1's state entirely.
+
+
+# ── Step 7: Pick files ───────────────────────────────────────────────────
+@app.cell
+def _(mo):
+    file_picker = mo.ui.file_browser(filetypes=[".h5"], multiple=True, label="")
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("## Part 2 — Load files"),
+                mo.md(
+                    "Pick any set of single-trace `.h5` files — a finished "
+                    "B-scan, or hand-picked A-scans from different runs — "
+                    "and assemble them into a radargram or 3D surface."
+                ),
+                mo.md("### Step 7 — Select files"),
+                file_picker,
+            ],
+            gap="0.4rem",
+        )
+    )
+    return (file_picker,)
+
+
+# ── Step 8: Field component & receiver ──────────────────────────────────
+# Same independent-peek pattern as Part 1's Step 4, for the same reason:
+# this must not depend on the assemble cell's output, since the assemble
+# cell depends on these widgets.
+@app.cell
+def _(file_picker, list_components, list_receivers, load_file, mo):
+    _known_comps = ["Ez"]
+    _known_rx = ["rx1"]
+
+    if file_picker.value:
+        try:
+            _fdata = load_file(file_picker.value[0].path)
+            _known_rx = list_receivers(_fdata) or _known_rx
+            _known_comps = list_components(_fdata, _known_rx[0]) or _known_comps
+        except (FileNotFoundError, OSError, KeyError):
+            pass
+
+    _default_comp = "Ez" if "Ez" in _known_comps else _known_comps[0]
+    load_component_selector = mo.ui.dropdown(options=_known_comps, value=_default_comp, label="Field component")
+    load_receiver_selector = mo.ui.dropdown(options=_known_rx, value=_known_rx[0], label="Receiver")
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 8 — Field component & receiver"),
+                mo.md("_Read from the first selected file, not assumed._"),
+                mo.hstack([load_component_selector, load_receiver_selector], gap="2rem", justify="start"),
+            ],
+            gap="0.4rem",
+        )
+    )
+    return load_component_selector, load_receiver_selector
+
+
+# ── Assemble ─────────────────────────────────────────────────────────────
+@app.cell
+def _(file_picker, load_component_selector, load_file, load_receiver_selector, mo, stack_traces):
+    if not file_picker.value:
+        mo.stop(True, mo.md(""))
+
+    _loaded = []
+    _load_warnings = []
+    for _f in file_picker.value:
+        try:
+            _loaded.append((len(_loaded), load_file(_f.path)))
+        except (FileNotFoundError, OSError, KeyError) as _e:
+            _load_warnings.append(f"{_f.path}: {type(_e).__name__} — skipped")
+
+    def _sort_key(item):
+        _idx, _fdata = item
+        _sources = _fdata.get("sources", {})
+        if "src1" in _sources:
+            return (0, _sources["src1"]["position"][0])
+        return (1, _idx)  # no position: keep original selection order, after positioned ones
+
+    _ordered = [fdata for _, fdata in sorted(_loaded, key=_sort_key)]
+    load_result = stack_traces(_ordered, load_component_selector.value, load_receiver_selector.value)
+    load_result["warnings"] = _load_warnings + load_result["warnings"]
+    load_result["sample_file"] = _ordered[0] if _ordered else None
+
+    _msg = f"**{len(_ordered)} file(s) loaded**"
+    if load_result["component"]:
+        _msg += f"  ·  component `{load_result['component']}`"
+    if load_result["receiver"]:
+        _msg += f"  ·  receiver `{load_result['receiver']}`"
+    _out = [mo.md(_msg)]
+    if load_result["warnings"]:
+        _out.append(
+            mo.callout(
+                mo.md("**Skipped:**\n\n" + "\n".join(f"- {w}" for w in load_result["warnings"])),
+                kind="warn",
+            )
+        )
+    mo.output.replace(mo.vstack(_out, gap="0.3rem"))
+    return (load_result,)
+
+
+# ── Step 9: Time window ─────────────────────────────────────────────────
+@app.cell
+def _(load_result, mo):
+    if load_result["matrix"] is None:
+        mo.stop(True, mo.md(""))
+
+    _max_ns = float(load_result["time_ns"][-1])
+    load_time_range = mo.ui.range_slider(
+        start=0.0, stop=_max_ns, step=round(_max_ns / 600, 4),
+        value=[0.0, _max_ns], label="Time window (ns)", full_width=True, debounce=True,
+    )
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 9 — Time window"),
+                mo.md("_Zooms the plot only — CSV export always contains the full unzoomed data._"),
+                load_time_range,
+            ],
+            gap="0.4rem",
+        )
+    )
+    return (load_time_range,)
+
+
+# ── Step 10: Appearance ──────────────────────────────────────────────────
+@app.cell
+def _(mo):
+    load_view_mode = mo.ui.dropdown(options=["Heatmap", "3D Surface"], value="Heatmap", label="View")
+    load_colourscale = mo.ui.dropdown(
+        options=["RdBu", "Viridis", "Greys", "Turbo"], value="RdBu", label="Colourscale"
+    )
+    load_bg = mo.ui.dropdown(
+        options={"Light": "#ffffff", "Paper white": "#f8f9fa", "Dark": "#0e1117"},
+        value="Light",
+        label="Background",
+    )
+    load_font_size = mo.ui.slider(start=10, stop=22, step=1, value=13, label="Font size", debounce=True)
+    load_normalize = mo.ui.checkbox(label="Normalize each trace (view only — CSV stays raw)", value=False)
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 10 — Appearance"),
+                mo.hstack([load_view_mode, load_colourscale, load_bg, load_font_size], gap="1.5rem", justify="start"),
+                load_normalize,
+            ],
+            gap="0.5rem",
+        )
+    )
+    return load_bg, load_colourscale, load_font_size, load_normalize, load_view_mode
+
+
+# ── Load-files renderer + export ────────────────────────────────────────
+@app.cell
+def _(
+    load_bg,
+    load_colourscale,
+    load_font_size,
+    load_normalize,
+    load_result,
+    load_time_range,
+    load_view_mode,
+    mo,
+    render_bscan_section,
+):
+    if load_result["matrix"] is None:
+        mo.stop(
+            True,
+            mo.callout(mo.md("No usable traces in the current selection."), kind="neutral"),
+        )
+
+    mo.output.replace(
+        render_bscan_section(
+            matrix=load_result["matrix"],
+            positions_x=load_result["positions_x"],
+            time_ns=load_result["time_ns"],
+            component=load_result["component"],
+            all_positions_physical=load_result["all_positions_physical"],
+            index_label="File index",
+            colourscale=load_colourscale.value,
+            bg=load_bg.value,
+            font_size=load_font_size.value,
+            view_mode=load_view_mode.value,
+            normalize=load_normalize.value,
+            title_text=f"Assembled radargram — {load_result['component']} ({load_result['matrix'].shape[1]} traces)",
+            csv_filename="gprmax_bscan_assembled.csv",
+            time_range=tuple(load_time_range.value),
+            sample_file=load_result["sample_file"],
+        )
+    )
+    return
+
+
+# ── Known gaps ────────────────────────────────────────────────────────────
+@app.cell
+def _(mo):
+    mo.callout(
+        mo.md(
+            "**Known gaps — deliberate, not oversights**\n\n"
+            "- No fallback yet to a merged output file if gprMax stops "
+            "writing fully-closed per-trace files. Deferred: current "
+            "behaviour (one closed file per trace) has been confirmed "
+            "against real runs, so this defends against a scenario with "
+            "no indication it's coming.\n"
+            "- Part 2 orders by source x-position when available; files "
+            "without that metadata fall back to selection order, which "
+            "may not reflect physical position.\n"
+            "- No invert-polarity or time-shift controls. Antonis's "
+            "\"manipulate\" scope wasn't fully pinned down — zoom and "
+            "normalize are built, the rest is worth clarifying before "
+            "guessing further.\n"
+            "- Background subtraction and FFT are intentionally not here "
+            "— deferred for ascan_dashboard.py too, staying consistent "
+            "with that call."
+        ),
+        kind="neutral",
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/toolboxes/Marimo/h5_reader.py
+++ b/toolboxes/Marimo/h5_reader.py
@@ -1,0 +1,371 @@
+"""
+h5_reader.py: gprMax HDF5 output file reader for the Marimo dashboard.
+
+Reads one or more gprMax v4 .h5 output files into a structured dict.
+No marimo dependency — pure h5py + numpy. Designed to be the foundation
+layer that all dashboard cells import from.
+
+Usage:
+    from toolboxes.Marimo.h5_reader import load_files, load_file
+
+    data = load_files([
+        "examples/cylinder_Ascan_2D.h5",
+        "examples/cylinder_Ascan_2D_freespace.h5",
+    ])
+
+    # Access a specific trace
+    ez = data["cylinder_Ascan_2D.h5"]["receivers"]["rx1"]["components"]["Ez"]
+    dt = data["cylinder_Ascan_2D.h5"]["meta"]["dt"]
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import h5py
+import numpy as np
+
+# ComponentMap: {"Ez": np.ndarray, "Hx": np.ndarray, ...}
+ComponentMap = dict[str, np.ndarray]
+
+# ReceiverInfo: full data for one receiver point
+ReceiverInfo = dict[str, Any]
+# {
+#   "name":       str              e.g. "Rx(70,85,0)"
+#   "position":   list[float]      e.g. [0.14, 0.17, 0.0]
+#   "components": ComponentMap
+# }
+
+# FileMeta: root-level attributes from the HDF5 file
+FileMeta = dict[str, Any]
+# {
+#   "title":       str
+#   "dt":          float           time step in seconds
+#   "dx_dy_dz":    list[float]     spatial discretisation [m, m, m]
+#   "iterations":  int
+#   "nrx":         int             number of receivers
+#   "nsrc":        int             number of sources
+#   "nx_ny_nz":    list[int]       grid dimensions in cells
+#   "gprmax_version": str
+# }
+
+# SourceInfo: metadata for one source point
+SourceInfo = dict[str, Any]
+# {
+#   "type":     str   e.g. "HertzianDipole"
+#   "position": list[float]
+# }
+
+# FileData: everything read from one .h5 file
+FileData = dict[str, Any]
+# {
+#   "path":      str               absolute path to the file
+#   "meta":      FileMeta
+#   "receivers": dict[str, ReceiverInfo]   keyed by "rx1", "rx2", ...
+#   "sources":   dict[str, SourceInfo]     keyed by "src1", "src2", ...
+#   "time_ns":   np.ndarray                time axis in nanoseconds
+# }
+
+
+# Core reader
+
+
+def load_file(path: str | Path) -> FileData:
+    """Read a single gprMax v4 HDF5 output file.
+
+    Args:
+        path: Path to the .h5 file.
+
+    Returns:
+        FileData dict containing metadata, all receiver traces, and
+        a precomputed nanosecond time axis.
+
+    Raises:
+        FileNotFoundError: if the path does not exist.
+        KeyError: if the file is missing expected gprMax structure.
+        OSError: if the file cannot be opened (not a valid HDF5 file).
+    """
+    path = Path(path).resolve()
+    if not path.exists():
+        raise FileNotFoundError(f"HDF5 file not found: {path}")
+
+    with h5py.File(path, "r") as f:
+        meta = _read_meta(f)
+        receivers = _read_receivers(f, path)
+        sources = _read_sources(f)
+
+    # Build nanosecond time axis from root dt
+    iterations = meta["iterations"]
+    dt = meta["dt"]
+    time_ns = np.arange(iterations) * dt * 1e9  # seconds → nanoseconds
+
+    return {
+        "path": str(path),
+        "meta": meta,
+        "receivers": receivers,
+        "sources": sources,
+        "time_ns": time_ns,
+    }
+
+
+def load_files(paths: list[str | Path]) -> dict[str, FileData]:
+    """Read multiple gprMax HDF5 output files.
+
+    Args:
+        paths: List of paths to .h5 files.
+
+    Returns:
+        Dict keyed by filename (not full path) mapping to FileData.
+        If two files share the same filename, the second is keyed by
+        its full path to avoid collision.
+
+    Raises:
+        FileNotFoundError: if any path does not exist.
+    """
+    result: dict[str, FileData] = {}
+    seen_names: set[str] = set()
+
+    for p in paths:
+        data = load_file(p)
+        name = Path(p).name
+
+        # Avoid key collision when two files share the same filename
+        if name in seen_names:
+            name = str(Path(p).resolve())
+        seen_names.add(name)
+
+        result[name] = data
+
+    return result
+
+
+# Time axis utility
+
+
+def get_time_axis(file_data: FileData, unit: str = "ns") -> np.ndarray:
+    """Return the time axis for a loaded file.
+
+    Args:
+        file_data: FileData dict from load_file().
+        unit: "ns" (nanoseconds, default), "s" (seconds), or "iter" (iterations).
+
+    Returns:
+        1D numpy array.
+    """
+    iterations = file_data["meta"]["iterations"]
+    dt = file_data["meta"]["dt"]
+
+    if unit == "ns":
+        return np.arange(iterations) * dt * 1e9
+    elif unit == "s":
+        return np.arange(iterations) * dt
+    elif unit == "iter":
+        return np.arange(iterations, dtype=float)
+    else:
+        raise ValueError(f"Unknown unit '{unit}'. Use 'ns', 's', or 'iter'.")
+
+
+# Component and receiver utilities
+
+
+def list_components(file_data: FileData, receiver: str = "rx1") -> list[str]:
+    """Return available field component names for a given receiver.
+
+    Args:
+        file_data: FileData dict from load_file().
+        receiver: Receiver key, e.g. "rx1".
+
+    Returns:
+        Sorted list of component names, e.g. ["Ex", "Ey", "Ez", "Hx", "Hy", "Hz"].
+    """
+    try:
+        return sorted(file_data["receivers"][receiver]["components"].keys())
+    except KeyError:
+        return []
+
+
+def list_receivers(file_data: FileData) -> list[str]:
+    """Return receiver keys available in the file.
+
+    Returns:
+        List of receiver keys, e.g. ["rx1", "rx2"].
+    """
+    return list(file_data["receivers"].keys())
+
+
+def get_trace(
+    file_data: FileData,
+    component: str,
+    receiver: str = "rx1",
+    polarity: int = 1,
+) -> np.ndarray:
+    """Return a single field component array.
+
+    Args:
+        file_data: FileData dict from load_file().
+        component: Field component name, e.g. "Ez". Append "-" for negative
+                   polarity, e.g. "Ez-".
+        receiver: Receiver key, e.g. "rx1".
+        polarity: +1 or -1. If component ends with "-", polarity is forced to -1.
+
+    Returns:
+        1D numpy array of field values.
+    """
+    # Handle polarity suffix convention from plot_Ascan.py
+    if component.endswith("-"):
+        component = component[:-1]
+        polarity = -1
+
+    try:
+        arr = file_data["receivers"][receiver]["components"][component]
+    except KeyError:
+        available = list_components(file_data, receiver)
+        raise KeyError(
+            f"Component '{component}' not found in {receiver}. "
+            f"Available: {available}"
+        )
+
+    return arr * polarity
+
+
+def get_unit_label(component: str) -> str:
+    """Return the SI unit label for a field component.
+
+    Args:
+        component: Component name, e.g. "Ez", "Hx", "Ix".
+
+    Returns:
+        Unit string for axis labelling.
+    """
+    component = component.rstrip("-")
+    if component.startswith("E"):
+        return "V/m"
+    elif component.startswith("H"):
+        return "A/m"
+    elif component.startswith("I"):
+        return "A"
+    return ""
+
+
+def build_label(filename: str, receiver: str, component: str) -> str:
+    """Build a descriptive trace label for plot legends.
+
+    Args:
+        filename: Key from load_files() dict (usually the filename).
+        receiver: Receiver key, e.g. "rx1".
+        component: Component name, e.g. "Ez".
+
+    Returns:
+        Human-readable label, e.g. "cylinder_Ascan_2D · rx1 · Ez".
+    """
+    stem = Path(filename).stem
+    return f"{stem} · {receiver} · {component}"
+
+
+# Metadata formatting
+
+
+def format_metadata_text(file_data: FileData) -> str:
+    """Format file metadata as a human-readable markdown string.
+
+    Intended for use in mo.md() metadata banners.
+
+    Args:
+        file_data: FileData dict from load_file().
+
+    Returns:
+        Markdown-formatted metadata string.
+    """
+    m = file_data["meta"]
+    dx, dy, dz = m["dx_dy_dz"]
+    nx, ny, nz = m["nx_ny_nz"]
+    dt_ps = m["dt"] * 1e12  # seconds → picoseconds
+    total_ns = m["iterations"] * m["dt"] * 1e9
+
+    lines = [
+        f"**{m['title']}**",
+        f"gprMax {m['gprmax_version']} · "
+        f"{m['iterations']} iterations · "
+        f"{total_ns:.3f} ns total window",
+        f"dt = {dt_ps:.4f} ps · "
+        f"dx/dy/dz = {dx*1000:.1f}/{dy*1000:.1f}/{dz*1000:.1f} mm · "
+        f"grid = {nx}×{ny}×{nz} cells",
+        f"{m['nrx']} receiver(s) · {m['nsrc']} source(s)",
+    ]
+
+    # Add receiver positions
+    for rx_key, rx_info in file_data["receivers"].items():
+        pos = rx_info["position"]
+        name = rx_info["name"]
+        lines.append(
+            f"  {rx_key}: {name} at "
+            f"({pos[0]:.3f}, {pos[1]:.3f}, {pos[2]:.3f}) m"
+        )
+
+    return "\n\n".join(lines[:3]) + "\n\n" + "\n".join(lines[3:])
+
+
+# Private helpers
+
+
+def _read_meta(f: h5py.File) -> FileMeta:
+    """Extract root-level metadata attributes."""
+    attrs = dict(f.attrs)
+    return {
+        "title": str(attrs.get("Title", "Untitled")),
+        "dt": float(attrs["dt"]),
+        "dx_dy_dz": list(map(float, attrs["dx_dy_dz"])),
+        "iterations": int(attrs["Iterations"]),
+        "nrx": int(attrs.get("nrx", 0)),
+        "nsrc": int(attrs.get("nsrc", 0)),
+        "nx_ny_nz": list(map(int, attrs.get("nx_ny_nz", [0, 0, 0]))),
+        "gprmax_version": str(attrs.get("gprMax", "unknown")),
+    }
+
+
+def _read_receivers(f: h5py.File, path: Path) -> dict[str, ReceiverInfo]:
+    """Read all receiver data from the HDF5 file."""
+    receivers: dict[str, ReceiverInfo] = {}
+
+    if "rxs" not in f:
+        return receivers
+
+    for rx_key in f["rxs"].keys():
+        rx_group = f["rxs"][rx_key]
+        rx_attrs = dict(rx_group.attrs)
+
+        components: ComponentMap = {}
+        for comp_name in rx_group.keys():
+            dataset = rx_group[comp_name]
+            if isinstance(dataset, h5py.Dataset):
+                components[comp_name] = dataset[:]
+
+        position = list(map(float, rx_attrs.get("Position", [0.0, 0.0, 0.0])))
+
+        receivers[rx_key] = {
+            "name": str(rx_attrs.get("Name", rx_key)),
+            "position": position,
+            "components": components,
+        }
+
+    return receivers
+
+
+def _read_sources(f: h5py.File) -> dict[str, SourceInfo]:
+    """Read all source metadata from the HDF5 file."""
+    sources: dict[str, SourceInfo] = {}
+
+    if "srcs" not in f:
+        return sources
+
+    for src_key in f["srcs"].keys():
+        src_attrs = dict(f["srcs"][src_key].attrs)
+        sources[src_key] = {
+            "type": str(src_attrs.get("Type", "unknown")),
+            "position": list(
+                map(float, src_attrs.get("Position", [0.0, 0.0, 0.0]))
+            ),
+        }
+
+    return sources

--- a/toolboxes/Marimo/requirements.txt
+++ b/toolboxes/Marimo/requirements.txt
@@ -1,0 +1,5 @@
+marimo>=0.9.0
+h5py>=3.0
+plotly>=5.0
+numpy>=1.21
+kaleido>=1.0

--- a/toolboxes/Marimo/trace_matrix.py
+++ b/toolboxes/Marimo/trace_matrix.py
@@ -1,0 +1,133 @@
+"""
+trace_matrix.py: stacks single-trace gprMax HDF5 files into a
+position x time matrix — the shared core behind both the B-scan heatmap
+and 3D surface views.
+
+No marimo dependency, same design principle as h5_reader.py: pure logic,
+testable with plain pytest, importable from any dashboard cell that needs
+it. Used by bscan_dashboard.py's live-polling path (one new trace per
+tick) and its load-files path (all traces at once).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from toolboxes.Marimo.h5_reader import (
+    FileData,
+    get_time_axis,
+    get_trace,
+    list_components,
+    list_receivers,
+)
+
+ProcessedTrace = dict[str, Any]
+# success: {"ok": True, "component", "receiver", "array", "time_ns", "x",
+#           "known_components"}
+# failure: {"ok": False, "reason", "known_components"}
+
+StackResult = dict[str, Any]
+# {"matrix": np.ndarray | None, "positions_x": list[float],
+#  "time_ns": np.ndarray | None, "component": str | None,
+#  "receiver": str | None, "all_positions_physical": bool,
+#  "warnings": list[str]}
+
+
+def process_trace(
+    file_data: FileData,
+    preferred_component: str | None,
+    expected_len: int | None,
+    preferred_receiver: str | None = None,
+) -> ProcessedTrace:
+    """Validate and extract one column from a loaded single-trace file.
+
+    `expected_len`, if given, must match the trace's sample count — this
+    is what catches a run where dt or iteration count drifted mid-sequence.
+    `preferred_receiver` picks a specific receiver key when the file has
+    more than one; falls back to the first receiver found otherwise.
+    """
+    rxs = list_receivers(file_data)
+    rx = preferred_receiver if preferred_receiver in rxs else (rxs[0] if rxs else "rx1")
+    comps = list_components(file_data, rx)
+
+    if not comps:
+        return {"ok": False, "reason": "no field components found", "known_components": comps}
+
+    comp = preferred_component if preferred_component in comps else (
+        "Ez" if "Ez" in comps else comps[0]
+    )
+    arr = get_trace(file_data, comp, rx)
+
+    if expected_len is not None and len(arr) != expected_len:
+        return {
+            "ok": False,
+            "reason": f"{len(arr)} samples vs expected {expected_len}",
+            "known_components": comps,
+        }
+
+    sources = file_data.get("sources", {})
+    x = sources["src1"]["position"][0] if "src1" in sources else None
+
+    return {
+        "ok": True,
+        "component": comp,
+        "receiver": rx,
+        "array": arr,
+        "time_ns": get_time_axis(file_data, unit="ns"),
+        "x": x,
+        "known_components": comps,
+    }
+
+
+def stack_traces(
+    file_datas: list[FileData],
+    preferred_component: str | None = None,
+    preferred_receiver: str | None = None,
+) -> StackResult:
+    """Stack already-loaded single-trace files into a matrix, in the order
+    given. Ordering is the caller's decision — by trace number for a live
+    sequential run, by physical position for a hand-picked file set.
+
+    Skips traces with no usable component or a sample-count mismatch
+    against the first accepted trace, recording why in `warnings` rather
+    than raising, since one bad file shouldn't kill the whole assembly.
+    """
+    cols: list[np.ndarray] = []
+    xpos: list[float] = []
+    warnings: list[str] = []
+    time_ns = None
+    component = preferred_component
+    receiver = None
+    all_physical = True
+
+    for i, fdata in enumerate(file_datas):
+        expected_len = len(cols[0]) if cols else None
+        result = process_trace(fdata, component, expected_len, preferred_receiver)
+
+        if not result["ok"]:
+            warnings.append(f"trace {i}: {result['reason']} — skipped")
+            continue
+
+        component = result["component"]
+        receiver = result["receiver"]
+        if time_ns is None:
+            time_ns = result["time_ns"]
+
+        x = result["x"]
+        if x is None:
+            all_physical = False
+
+        cols.append(result["array"])
+        xpos.append(x if x is not None else float(i))
+
+    return {
+        "matrix": np.column_stack(cols) if cols else None,
+        "positions_x": xpos,
+        "time_ns": time_ns,
+        "component": component,
+        "receiver": receiver,
+        "all_positions_physical": all_physical,
+        "warnings": warnings,
+    }


### PR DESCRIPTION
**Builds on #696 (please merge that first).**

This branch is stacked on gsoc/component-3-ascan-dashboard, so the diff below also shows the 4 files from #696 (h5_reader.py, ascan_dashboard.py, test_h5_reader.py, requirements.txt). New in this PR: bscan_dashboard.py, trace_matrix.py, tests/test_trace_matrix.py.

## Summary

Adds `toolboxes/Marimo/bscan_dashboard.py` and `toolboxes/Marimo/trace_matrix.py`. Two ways to build a radargram from single-trace `.h5` files: watch one while gprMax is still writing it, or assemble one from files you already have.

- Live: `mo.ui.refresh` polls a directory on a selectable interval, reads only unseen `<basename><N>.h5` files each tick, appends to an accumulated matrix. Never rebuilds from scratch: checked by re-polling with no new files present and confirming zero traces get re-read.
- Load: any set of single-trace `.h5` files, ordered by source x-position read from each file's `srcs/src1` metadata. Falls back to file-selection order when position metadata isn't present.
- Core logic (`trace_matrix.py`) has no marimo dependency, same pattern as `h5_reader.py`. `process_trace()` validates and extracts one column, `stack_traces()` assembles an ordered list into a matrix. 15 tests in `tests/test_trace_matrix.py`, including a fixture set that specifically catches lexicographic-vs-numeric filename sorting (`1, 10, 11, 12, 2...` vs `1, 2, 3...12`) and a test that shuffles file-selection order and checks the assembled matrix is identical regardless.
- Both modes render Heatmap and 3D Surface (`go.Surface`) from the same matrix, plus receiver/component selection, a metadata banner (reuses `h5_reader.format_metadata_text`), time-window zoom, per-trace normalize (view only, CSV export stays unnormalized), and CSV/SVG/PDF export.

Found and fixed a real bug while building this: SVG/PDF export was computed eagerly on every render, which meant every poll tick during live monitoring re-ran two kaleido/Chrome invocations. 
`mo.download`'s `data` param takes a lazy callable. Fixed here, and the same bug turned out to be in `ascan_dashboard.py `too (its export code is where this file's was copied from), fixed separately in #696.

<img width="1081" height="600" alt="Bscan Dashboard (4)" src="https://github.com/user-attachments/assets/14ed6077-6d58-4bbe-bf93-e09d2de67171" />
<img width="2768" height="6784" alt="Bscan Dashboard (3)" src="https://github.com/user-attachments/assets/add5b62f-8d46-4f9a-9f71-a8645eb170ba" />

## How to test

1. `marimo run toolboxes/Marimo/bscan_dashboard.py`
2. In another terminal: `python -m gprMax examples/cylinder_Bscan_2D.in -n 20 --show-progress-bars`
3. Point Part 1 at the output directory before or during the run, confirm trace count climbs as `.h5` files land and the radargram updates.
4. Once finished, select the same files in Part 2, confirm it matches Part 1's view regardless of the order you click them in.
5. `pytest tests/test_trace_matrix.py -v`: 15 passed.

Part of GSoC 2026 Component 3, extending #696 per Antonis's review: "multiple files - bscan" and "3d". Next: background subtraction + FFT for `ascan_dashboard.py`.