### PR TITLE
Fix Lorentz and Drude dispersive updates

### DIFF
--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -535,7 +535,10 @@ total-field box. For example, choose one of:
     ))
 
 Here ``pulse`` must identify a built-in analytic waveform. Discrete plane waves
-currently use the CPU solver.
+currently use the CPU solver. Homogeneous angle/vector plane waves and layered
+axial plane waves support non-dispersive materials and multi-pole Debye,
+Lorentz, and Drude materials. Their auxiliary dispersive state uses the same
+real or complex precision selected for the main grid.
 
 Excitation File
 ---------------

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1029,7 +1029,7 @@ For example, to specify a discrete plane wave in a TFSF box (0.010, 0.010, 0.010
 
 .. note::
 
-    * Currently a plane wave can be supported for dielectric and mulit-Debye media backgrounds and not for user defined waveforms.
+    * Plane waves support non-dispersive dielectric backgrounds and multi-pole Debye, Lorentz, and Drude media. They do not currently support ``user``-defined waveforms.
     * This plane wave implementation was based on an intitial implementation made possible by a `Google Summer of Code <https://summerofcode.withgoogle.com/>`_ (GSoC) project and `more details can be found in the original pull request <https://github.com/gprMax/gprMax/pull/373>`_.
     * Internally, theta and phi are approximated by an integer direction vector (Mx, My, Mz) found to within a maximum acceptable angular difference of 3 arc minutes (0.05 degrees) by default. This tolerance can be relaxed or tightened using the ``max_angle_diff`` parameter (in degrees) when using the Python API.
 
@@ -1053,7 +1053,7 @@ For example, to specify a discrete plane wave in a TFSF box (0.010, 0.010, 0.010
 
 .. note::
 
-    * Currently a plane wave can be supported for dielectric and mulit-Debye media backgrounds and do not use for ``user`` defined waveforms.
+    * Plane waves support non-dispersive dielectric backgrounds and multi-pole Debye, Lorentz, and Drude media. They do not currently support ``user``-defined waveforms.
     * This plane wave implementation was based on an intitial implementation made possible by a `Google Summer of Code <https://summerofcode.withgoogle.com/>`_ (GSoC) project and `more details can be found in the original pull request <https://github.com/gprMax/gprMax/pull/373>`_.
 
 
@@ -1078,7 +1078,7 @@ For example, to specify a discrete plane wave in a TFSF box (0.010, 0.010, 0.010
 .. note::
 
     * For simulations that do not involve half-space setups it is recommended to use either the ``#plane_wave_angles`` or ``#plane_wave_vector`` commands instead as the formualtions are more efficient and faster if the background medium of propagation for the plane wave is homogeneous.
-    * Currently a plane wave can be supported for dielectric and mulit-Debye media backgrounds and do not use for ``user`` defined waveforms.
+    * Plane waves support non-dispersive dielectric layers and multi-pole Debye, Lorentz, and Drude layers. They do not currently support ``user``-defined waveforms.
     * This plane wave implementation was based on an intitial implementation made possible by a `Google Summer of Code <https://summerofcode.withgoogle.com/>`_ (GSoC) project and `more details can be found in the original pull request <https://github.com/gprMax/gprMax/pull/373>`_.
 
 

--- a/gprMax/config.py
+++ b/gprMax/config.py
@@ -499,7 +499,7 @@ class SimulationConfig:
             if self.general["solver"] == "cuda":
                 self.dtypes["C_complex"] = "pycuda::complex<float>"
             elif self.general["solver"] == "opencl":
-                self.dtypes["C_complex"] = "cfloat"
+                self.dtypes["C_complex"] = "cfloat_t"
             elif self.general["solver"] == "metal":
                 # Metal Shading Language has no native complex type - a
                 # small custom struct (gprMaxComplex, with the needed
@@ -519,7 +519,7 @@ class SimulationConfig:
             if self.general["solver"] == "cuda":
                 self.dtypes["C_complex"] = "pycuda::complex<double>"
             elif self.general["solver"] == "opencl":
-                self.dtypes["C_complex"] = "cdouble"
+                self.dtypes["C_complex"] = "cdouble_t"
             elif self.general["solver"] == "metal":
                 # Unreachable in practice - the Metal branch above already
                 # raises ValueError for double precision - kept consistent

--- a/gprMax/cuda_opencl/knl_common_cuda.tmpl
+++ b/gprMax/cuda_opencl/knl_common_cuda.tmpl
@@ -2,6 +2,19 @@
 
 {% block header %}
 #include <pycuda-complex.hpp>
+
+// Uniform dispersive arithmetic used by the shared CUDA/OpenCL/Metal
+// field-update kernel. CUDA's scalar and pycuda::complex types both provide
+// the required operators.
+#define GPRMAX_CMUL(a, b) ((a) * (b))
+#define GPRMAX_CRMUL(a, b) ((a) * (b))
+#define GPRMAX_CADD(a, b) ((a) + (b))
+#define GPRMAX_CSUB(a, b) ((a) - (b))
+{% if DRUDELORENTZ %}
+#define GPRMAX_CREAL(a) ((a).real())
+{% else %}
+#define GPRMAX_CREAL(a) (a)
+{% endif %}
 {% endblock header %}
 
 

--- a/gprMax/cuda_opencl/knl_common_metal.tmpl
+++ b/gprMax/cuda_opencl/knl_common_metal.tmpl
@@ -35,6 +35,18 @@ inline gprMaxComplex operator*(gprMaxComplex a, gprMaxComplex b) {
 inline gprMaxComplex operator*(gprMaxComplex a, float b) {
     return gprMaxComplex{a.re * b, a.im * b};
 }
+
+// Uniform dispersive arithmetic used by the shared CUDA/OpenCL/Metal
+// field-update kernel. Metal's custom complex type provides these operators.
+#define GPRMAX_CMUL(a, b) ((a) * (b))
+#define GPRMAX_CRMUL(a, b) ((a) * (b))
+#define GPRMAX_CADD(a, b) ((a) + (b))
+#define GPRMAX_CSUB(a, b) ((a) - (b))
+{% if DRUDELORENTZ %}
+#define GPRMAX_CREAL(a) ((a).real())
+{% else %}
+#define GPRMAX_CREAL(a) (a)
+{% endif %}
 {% endblock header %}
 
 

--- a/gprMax/cuda_opencl/knl_common_opencl.tmpl
+++ b/gprMax/cuda_opencl/knl_common_opencl.tmpl
@@ -1,7 +1,35 @@
 {% extends "knl_common_base.tmpl" %}
 
 {% block header %}
+{% if DRUDELORENTZ and REAL == "double" %}
+#define PYOPENCL_DEFINE_CDOUBLE
+{% endif %}
 #include <pyopencl-complex.h>
+
+// OpenCL C has no native complex arithmetic. PyOpenCL deliberately exposes
+// complex values as structs, so operator * and + must not be used for
+// Lorentz/Drude pole state.
+{% if DRUDELORENTZ %}
+{% if REAL == "double" %}
+#define GPRMAX_CMUL(a, b) cdouble_mul((a), (b))
+#define GPRMAX_CRMUL(a, b) cdouble_mulr((a), (b))
+#define GPRMAX_CADD(a, b) cdouble_add((a), (b))
+#define GPRMAX_CSUB(a, b) cdouble_sub((a), (b))
+#define GPRMAX_CREAL(a) cdouble_real(a)
+{% else %}
+#define GPRMAX_CMUL(a, b) cfloat_mul((a), (b))
+#define GPRMAX_CRMUL(a, b) cfloat_mulr((a), (b))
+#define GPRMAX_CADD(a, b) cfloat_add((a), (b))
+#define GPRMAX_CSUB(a, b) cfloat_sub((a), (b))
+#define GPRMAX_CREAL(a) cfloat_real(a)
+{% endif %}
+{% else %}
+#define GPRMAX_CMUL(a, b) ((a) * (b))
+#define GPRMAX_CRMUL(a, b) ((a) * (b))
+#define GPRMAX_CADD(a, b) ((a) + (b))
+#define GPRMAX_CSUB(a, b) ((a) - (b))
+#define GPRMAX_CREAL(a) (a)
+{% endif %}
 {% endblock header %}
 
 

--- a/gprMax/cuda_opencl/knl_fields_updates.py
+++ b/gprMax/cuda_opencl/knl_fields_updates.py
@@ -297,9 +297,10 @@ update_electric_dispersive_A = {
         int materialEx = ID[IDX4D_ID(0,x_ID,y_ID,z_ID)];
         $REAL phi = 0;
         for (int pole = 0; pole < MAXPOLES; pole++) {
-            phi = phi + updatecoeffsdispersive[IDX2D_MATDISP(materialEx,pole*3)]$REALFUNC * Tx[IDX4D_T(pole,x_T,y_T,z_T)]$REALFUNC;
-            Tx[IDX4D_T(pole,x_T,y_T,z_T)] = updatecoeffsdispersive[IDX2D_MATDISP(materialEx,1+(pole*3))] * Tx[IDX4D_T(pole,x_T,y_T,z_T)] +
-                                            updatecoeffsdispersive[IDX2D_MATDISP(materialEx,2+(pole*3))] * Ex[IDX3D_FIELDS(x,y,z)];
+            phi = phi + GPRMAX_CREAL(GPRMAX_CMUL(updatecoeffsdispersive[IDX2D_MATDISP(materialEx,pole*3)], Tx[IDX4D_T(pole,x_T,y_T,z_T)]));
+            Tx[IDX4D_T(pole,x_T,y_T,z_T)] = GPRMAX_CADD(
+                GPRMAX_CMUL(updatecoeffsdispersive[IDX2D_MATDISP(materialEx,1+(pole*3))], Tx[IDX4D_T(pole,x_T,y_T,z_T)]),
+                GPRMAX_CRMUL(updatecoeffsdispersive[IDX2D_MATDISP(materialEx,2+(pole*3))], Ex[IDX3D_FIELDS(x,y,z)]));
         }
         Ex[IDX3D_FIELDS(x,y,z)] = updatecoeffsE[IDX2D_MAT(materialEx,0)] * Ex[IDX3D_FIELDS(x,y,z)] +
                                     updatecoeffsE[IDX2D_MAT(materialEx,2)] * (Hz[IDX3D_FIELDS(x,y,z)] - Hz[IDX3D_FIELDS(x,y-1,z)]) -
@@ -312,9 +313,10 @@ update_electric_dispersive_A = {
         int materialEy = ID[IDX4D_ID(1,x_ID,y_ID,z_ID)];
         $REAL phi = 0;
         for (int pole = 0; pole < MAXPOLES; pole++) {
-            phi = phi + updatecoeffsdispersive[IDX2D_MATDISP(materialEy,pole*3)]$REALFUNC * Ty[IDX4D_T(pole,x_T,y_T,z_T)]$REALFUNC;
-            Ty[IDX4D_T(pole,x_T,y_T,z_T)] = updatecoeffsdispersive[IDX2D_MATDISP(materialEy,1+(pole*3))] * Ty[IDX4D_T(pole,x_T,y_T,z_T)] +
-                                            updatecoeffsdispersive[IDX2D_MATDISP(materialEy,2+(pole*3))] * Ey[IDX3D_FIELDS(x,y,z)];
+            phi = phi + GPRMAX_CREAL(GPRMAX_CMUL(updatecoeffsdispersive[IDX2D_MATDISP(materialEy,pole*3)], Ty[IDX4D_T(pole,x_T,y_T,z_T)]));
+            Ty[IDX4D_T(pole,x_T,y_T,z_T)] = GPRMAX_CADD(
+                GPRMAX_CMUL(updatecoeffsdispersive[IDX2D_MATDISP(materialEy,1+(pole*3))], Ty[IDX4D_T(pole,x_T,y_T,z_T)]),
+                GPRMAX_CRMUL(updatecoeffsdispersive[IDX2D_MATDISP(materialEy,2+(pole*3))], Ey[IDX3D_FIELDS(x,y,z)]));
         }
         Ey[IDX3D_FIELDS(x,y,z)] = updatecoeffsE[IDX2D_MAT(materialEy,0)] * Ey[IDX3D_FIELDS(x,y,z)] +
                                     updatecoeffsE[IDX2D_MAT(materialEy,3)] * (Hx[IDX3D_FIELDS(x,y,z)] - Hx[IDX3D_FIELDS(x,y,z-1)]) -
@@ -327,9 +329,10 @@ update_electric_dispersive_A = {
         int materialEz = ID[IDX4D_ID(2,x_ID,y_ID,z_ID)];
         $REAL phi = 0;
         for (int pole = 0; pole < MAXPOLES; pole++) {
-            phi = phi + updatecoeffsdispersive[IDX2D_MATDISP(materialEz,pole*3)]$REALFUNC * Tz[IDX4D_T(pole,x_T,y_T,z_T)]$REALFUNC;
-            Tz[IDX4D_T(pole,x_T,y_T,z_T)] = updatecoeffsdispersive[IDX2D_MATDISP(materialEz,1+(pole*3))] * Tz[IDX4D_T(pole,x_T,y_T,z_T)] +
-                                            updatecoeffsdispersive[IDX2D_MATDISP(materialEz,2+(pole*3))] * Ez[IDX3D_FIELDS(x,y,z)];
+            phi = phi + GPRMAX_CREAL(GPRMAX_CMUL(updatecoeffsdispersive[IDX2D_MATDISP(materialEz,pole*3)], Tz[IDX4D_T(pole,x_T,y_T,z_T)]));
+            Tz[IDX4D_T(pole,x_T,y_T,z_T)] = GPRMAX_CADD(
+                GPRMAX_CMUL(updatecoeffsdispersive[IDX2D_MATDISP(materialEz,1+(pole*3))], Tz[IDX4D_T(pole,x_T,y_T,z_T)]),
+                GPRMAX_CRMUL(updatecoeffsdispersive[IDX2D_MATDISP(materialEz,2+(pole*3))], Ez[IDX3D_FIELDS(x,y,z)]));
         }
         Ez[IDX3D_FIELDS(x,y,z)] = updatecoeffsE[IDX2D_MAT(materialEz,0)] * Ez[IDX3D_FIELDS(x,y,z)] +
                                     updatecoeffsE[IDX2D_MAT(materialEz,1)] * (Hy[IDX3D_FIELDS(x,y,z)] - Hy[IDX3D_FIELDS(x-1,y,z)]) -
@@ -425,8 +428,9 @@ update_electric_dispersive_B = {
     if ((NY != 1 || NZ != 1) && x >= 0 && x < NX && y > 0 && y < NY && z > 0 && z < NZ) {
         int materialEx = ID[IDX4D_ID(0,x_ID,y_ID,z_ID)];
         for (int pole = 0; pole < MAXPOLES; pole++) {
-            Tx[IDX4D_T(pole,x_T,y_T,z_T)] = Tx[IDX4D_T(pole,x_T,y_T,z_T)] -
-                                                updatecoeffsdispersive[IDX2D_MATDISP(materialEx,2+(pole*3))] * Ex[IDX3D_FIELDS(x,y,z)];
+            Tx[IDX4D_T(pole,x_T,y_T,z_T)] = GPRMAX_CSUB(
+                Tx[IDX4D_T(pole,x_T,y_T,z_T)],
+                GPRMAX_CRMUL(updatecoeffsdispersive[IDX2D_MATDISP(materialEx,2+(pole*3))], Ex[IDX3D_FIELDS(x,y,z)]));
         }
     }
 
@@ -434,8 +438,9 @@ update_electric_dispersive_B = {
     if ((NX != 1 || NZ != 1) && x > 0 && x < NX && y >= 0 && y < NY && z > 0 && z < NZ) {
         int materialEy = ID[IDX4D_ID(1,x_ID,y_ID,z_ID)];
         for (int pole = 0; pole < MAXPOLES; pole++) {
-            Ty[IDX4D_T(pole,x_T,y_T,z_T)] = Ty[IDX4D_T(pole,x_T,y_T,z_T)] -
-                                                updatecoeffsdispersive[IDX2D_MATDISP(materialEy,2+(pole*3))] * Ey[IDX3D_FIELDS(x,y,z)];
+            Ty[IDX4D_T(pole,x_T,y_T,z_T)] = GPRMAX_CSUB(
+                Ty[IDX4D_T(pole,x_T,y_T,z_T)],
+                GPRMAX_CRMUL(updatecoeffsdispersive[IDX2D_MATDISP(materialEy,2+(pole*3))], Ey[IDX3D_FIELDS(x,y,z)]));
         }
     }
 
@@ -443,8 +448,9 @@ update_electric_dispersive_B = {
     if ((NX != 1 || NY != 1) && x > 0 && x < NX && y > 0 && y < NY && z >= 0 && z < NZ) {
         int materialEz = ID[IDX4D_ID(2,x_ID,y_ID,z_ID)];
         for (int pole = 0; pole < MAXPOLES; pole++) {
-            Tz[IDX4D_T(pole,x_T,y_T,z_T)] = Tz[IDX4D_T(pole,x_T,y_T,z_T)] -
-                                                updatecoeffsdispersive[IDX2D_MATDISP(materialEz,2+(pole*3))] * Ez[IDX3D_FIELDS(x,y,z)];
+            Tz[IDX4D_T(pole,x_T,y_T,z_T)] = GPRMAX_CSUB(
+                Tz[IDX4D_T(pole,x_T,y_T,z_T)],
+                GPRMAX_CRMUL(updatecoeffsdispersive[IDX2D_MATDISP(materialEz,2+(pole*3))], Ez[IDX3D_FIELDS(x,y,z)]));
         }
     }
     """

--- a/gprMax/cython/fields_updates_dispersive_template.jinja
+++ b/gprMax/cython/fields_updates_dispersive_template.jinja
@@ -33,6 +33,10 @@ cdef extern from "complex.h" nogil:
     float crealf(float complex z)
 {% endif %}
 
+# For complex Lorentz/Drude pole state the physical apparent current is the
+# real part of the complete coefficient-state product. The imaginary cross
+# term must not be discarded by multiplying the real parts separately.
+
 
 ###############################################################
 # Electric field updates - dispersive materials - multipole A #
@@ -89,11 +93,11 @@ cpdef void {{ item.name_a }}(
                     for pole in range(maxpoles):
                         {% if 'complex' in item.dispersive_type %}
                         {% if item.iswin %}
-                        phi = (phi + updatecoeffsdispersive[material, pole * 3].real
-                               * Tx[pole, i, j, k].real)
+                        phi = (phi + (updatecoeffsdispersive[material, pole * 3]
+                               * Tx[pole, i, j, k]).real)
                         {% else %}
-                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3])
-                               * {{ item.real_part }}(Tx[pole, i, j, k]))
+                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3]
+                               * Tx[pole, i, j, k]))
                         {% endif %}
                         {% else %}
                         phi = phi + updatecoeffsdispersive[material, pole * 3] * Tx[pole, i, j, k]
@@ -115,11 +119,11 @@ cpdef void {{ item.name_a }}(
                     for pole in range(maxpoles):
                         {% if 'complex' in item.dispersive_type %}
                         {% if item.iswin %}
-                        phi = (phi + updatecoeffsdispersive[material, pole * 3].real
-                               * Ty[pole, i, j, k].real)
+                        phi = (phi + (updatecoeffsdispersive[material, pole * 3]
+                               * Ty[pole, i, j, k]).real)
                         {% else %}
-                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3])
-                               * {{ item.real_part }}(Ty[pole, i, j, k]))
+                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3]
+                               * Ty[pole, i, j, k]))
                         {% endif %}
                         {% else %}
                         phi = phi + updatecoeffsdispersive[material, pole * 3] * Ty[pole, i, j, k]
@@ -141,11 +145,11 @@ cpdef void {{ item.name_a }}(
                     for pole in range(maxpoles):
                         {% if 'complex' in item.dispersive_type %}
                         {% if item.iswin %}
-                        phi = (phi + updatecoeffsdispersive[material, pole * 3].real
-                               * Tz[pole, i, j, k].real)
+                        phi = (phi + (updatecoeffsdispersive[material, pole * 3]
+                               * Tz[pole, i, j, k]).real)
                         {% else %}
-                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3])
-                               * {{ item.real_part }}(Tz[pole, i, j, k]))
+                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3]
+                               * Tz[pole, i, j, k]))
                         {% endif %}
                         {% else %}
                         phi = phi + updatecoeffsdispersive[material, pole * 3] * Tz[pole, i, j, k]
@@ -167,11 +171,11 @@ cpdef void {{ item.name_a }}(
                     for pole in range(maxpoles):
                         {% if 'complex' in item.dispersive_type %}
                         {% if item.iswin %}
-                        phi = (phi + updatecoeffsdispersive[material, pole * 3].real
-                               * Ty[pole, i, j, k].real)
+                        phi = (phi + (updatecoeffsdispersive[material, pole * 3]
+                               * Ty[pole, i, j, k]).real)
                         {% else %}
-                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3])
-                               * {{ item.real_part }}(Ty[pole, i, j, k]))
+                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3]
+                               * Ty[pole, i, j, k]))
                         {% endif %}
                         {% else %}
                         phi = phi + updatecoeffsdispersive[material, pole * 3] * Ty[pole, i, j, k]
@@ -190,11 +194,11 @@ cpdef void {{ item.name_a }}(
                     for pole in range(maxpoles):
                         {% if 'complex' in item.dispersive_type %}
                         {% if item.iswin %}
-                        phi = (phi + updatecoeffsdispersive[material, pole * 3].real
-                               * Tz[pole, i, j, k].real)
+                        phi = (phi + (updatecoeffsdispersive[material, pole * 3]
+                               * Tz[pole, i, j, k]).real)
                         {% else %}
-                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3])
-                               * {{ item.real_part }}(Tz[pole, i, j, k]))
+                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3]
+                               * Tz[pole, i, j, k]))
                         {% endif %}
                         {% else %}
                         phi = phi + updatecoeffsdispersive[material, pole * 3] * Tz[pole, i, j, k]
@@ -216,11 +220,11 @@ cpdef void {{ item.name_a }}(
                     for pole in range(maxpoles):
                         {% if 'complex' in item.dispersive_type %}
                         {% if item.iswin %}
-                        phi = (phi + updatecoeffsdispersive[material, pole * 3].real
-                               * Tx[pole, i, j, k].real)
+                        phi = (phi + (updatecoeffsdispersive[material, pole * 3]
+                               * Tx[pole, i, j, k]).real)
                         {% else %}
-                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3])
-                               * {{ item.real_part }}(Tx[pole, i, j, k]))
+                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3]
+                               * Tx[pole, i, j, k]))
                         {% endif %}
                         {% else %}
                         phi = phi + updatecoeffsdispersive[material, pole * 3] * Tx[pole, i, j, k]
@@ -239,11 +243,11 @@ cpdef void {{ item.name_a }}(
                     for pole in range(maxpoles):
                         {% if 'complex' in item.dispersive_type %}
                         {% if item.iswin %}
-                        phi = (phi + updatecoeffsdispersive[material, pole * 3].real
-                               * Tz[pole, i, j, k].real)
+                        phi = (phi + (updatecoeffsdispersive[material, pole * 3]
+                               * Tz[pole, i, j, k]).real)
                         {% else %}
-                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3])
-                               * {{ item.real_part }}(Tz[pole, i, j, k]))
+                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3]
+                               * Tz[pole, i, j, k]))
                         {% endif %}
                         {% else %}
                         phi = phi + updatecoeffsdispersive[material, pole * 3] * Tz[pole, i, j, k]
@@ -265,11 +269,11 @@ cpdef void {{ item.name_a }}(
                     for pole in range(maxpoles):
                         {% if 'complex' in item.dispersive_type %}
                         {% if item.iswin %}
-                        phi = (phi + updatecoeffsdispersive[material, pole * 3].real
-                               * Tx[pole, i, j, k].real)
+                        phi = (phi + (updatecoeffsdispersive[material, pole * 3]
+                               * Tx[pole, i, j, k]).real)
                         {% else %}
-                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3])
-                               * {{ item.real_part }}(Tx[pole, i, j, k]))
+                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3]
+                               * Tx[pole, i, j, k]))
                         {% endif %}
                         {% else %}
                         phi = phi + updatecoeffsdispersive[material, pole * 3] * Tx[pole, i, j, k]
@@ -288,11 +292,11 @@ cpdef void {{ item.name_a }}(
                     for pole in range(maxpoles):
                         {% if 'complex' in item.dispersive_type %}
                         {% if item.iswin %}
-                        phi = (phi + updatecoeffsdispersive[material, pole * 3].real
-                               * Ty[pole, i, j, k].real)
+                        phi = (phi + (updatecoeffsdispersive[material, pole * 3]
+                               * Ty[pole, i, j, k]).real)
                         {% else %}
-                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3])
-                               * {{ item.real_part }}(Ty[pole, i, j, k]))
+                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3]
+                               * Ty[pole, i, j, k]))
                         {% endif %}
                         {% else %}
                         phi = phi + updatecoeffsdispersive[material, pole * 3] * Ty[pole, i, j, k]
@@ -314,11 +318,11 @@ cpdef void {{ item.name_a }}(
                     for pole in range(maxpoles):
                         {% if 'complex' in item.dispersive_type %}
                         {% if item.iswin %}
-                        phi = (phi + updatecoeffsdispersive[material, pole * 3].real
-                               * Tx[pole, i, j, k].real)
+                        phi = (phi + (updatecoeffsdispersive[material, pole * 3]
+                               * Tx[pole, i, j, k]).real)
                         {% else %}
-                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3])
-                               * {{ item.real_part }}(Tx[pole, i, j, k]))
+                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3]
+                               * Tx[pole, i, j, k]))
                         {% endif %}
                         {% else %}
                         phi = phi + updatecoeffsdispersive[material, pole * 3] * Tx[pole, i, j, k]
@@ -337,11 +341,11 @@ cpdef void {{ item.name_a }}(
                     for pole in range(maxpoles):
                         {% if 'complex' in item.dispersive_type %}
                         {% if item.iswin %}
-                        phi = (phi + updatecoeffsdispersive[material, pole * 3].real
-                               * Ty[pole, i, j, k].real)
+                        phi = (phi + (updatecoeffsdispersive[material, pole * 3]
+                               * Ty[pole, i, j, k]).real)
                         {% else %}
-                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3])
-                               * {{ item.real_part }}(Ty[pole, i, j, k]))
+                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3]
+                               * Ty[pole, i, j, k]))
                         {% endif %}
                         {% else %}
                         phi = phi + updatecoeffsdispersive[material, pole * 3] * Ty[pole, i, j, k]
@@ -360,11 +364,11 @@ cpdef void {{ item.name_a }}(
                     for pole in range(maxpoles):
                         {% if 'complex' in item.dispersive_type %}
                         {% if item.iswin %}
-                        phi = (phi + updatecoeffsdispersive[material, pole * 3].real
-                               * Tz[pole, i, j, k].real)
+                        phi = (phi + (updatecoeffsdispersive[material, pole * 3]
+                               * Tz[pole, i, j, k]).real)
                         {% else %}
-                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3])
-                               * {{ item.real_part }}(Tz[pole, i, j, k]))
+                        phi = (phi + {{ item.real_part }}(updatecoeffsdispersive[material, pole * 3]
+                               * Tz[pole, i, j, k]))
                         {% endif %}
                         {% else %}
                         phi = phi + updatecoeffsdispersive[material, pole * 3] * Tz[pole, i, j, k]
@@ -590,11 +594,11 @@ cpdef void {{ item.name_a_1 }}(
                     material = ID[0, i, j, k]
                     {% if 'complex' in item.dispersive_type %}
                     {% if item.iswin %}
-                    phi = (updatecoeffsdispersive[material, 0].real
-                           * Tx[0, i, j, k].real)
+                    phi = ((updatecoeffsdispersive[material, 0]
+                           * Tx[0, i, j, k]).real)
                     {% else %}
-                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0])
-                           * {{ item.real_part }}(Tx[0, i, j, k]))
+                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0]
+                           * Tx[0, i, j, k]))
                     {% endif %}
                     {% else %}
                     phi = updatecoeffsdispersive[material, 0] * Tx[0, i, j, k]
@@ -613,11 +617,11 @@ cpdef void {{ item.name_a_1 }}(
                     material = ID[1, i, j, k]
                     {% if 'complex' in item.dispersive_type %}
                     {% if item.iswin %}
-                    phi = (updatecoeffsdispersive[material, 0].real
-                           * Ty[0, i, j, k].real)
+                    phi = ((updatecoeffsdispersive[material, 0]
+                           * Ty[0, i, j, k]).real)
                     {% else %}
-                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0])
-                           * {{ item.real_part }}(Ty[0, i, j, k]))
+                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0]
+                           * Ty[0, i, j, k]))
                     {% endif %}
                     {% else %}
                     phi = updatecoeffsdispersive[material, 0] * Ty[0, i, j, k]
@@ -636,11 +640,11 @@ cpdef void {{ item.name_a_1 }}(
                     material = ID[2, i, j, k]
                     {% if 'complex' in item.dispersive_type %}
                     {% if item.iswin %}
-                    phi = (updatecoeffsdispersive[material, 0].real
-                           * Tz[0, i, j, k].real)
+                    phi = ((updatecoeffsdispersive[material, 0]
+                           * Tz[0, i, j, k]).real)
                     {% else %}
-                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0])
-                           * {{ item.real_part }}(Tz[0, i, j, k]))
+                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0]
+                           * Tz[0, i, j, k]))
                     {% endif %}
                     {% else %}
                     phi = updatecoeffsdispersive[material, 0] * Tz[0, i, j, k]
@@ -659,11 +663,11 @@ cpdef void {{ item.name_a_1 }}(
                     material = ID[1, i, j, k]
                     {% if 'complex' in item.dispersive_type %}
                     {% if item.iswin %}
-                    phi = (updatecoeffsdispersive[material, 0].real
-                           * Ty[0, i, j, k].real)
+                    phi = ((updatecoeffsdispersive[material, 0]
+                           * Ty[0, i, j, k]).real)
                     {% else %}
-                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0])
-                           * {{ item.real_part }}(Ty[0, i, j, k]))
+                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0]
+                           * Ty[0, i, j, k]))
                     {% endif %}
                     {% else %}
                     phi = updatecoeffsdispersive[material, 0] * Ty[0, i, j, k]
@@ -679,11 +683,11 @@ cpdef void {{ item.name_a_1 }}(
                     material = ID[2, i, j, k]
                     {% if 'complex' in item.dispersive_type %}
                     {% if item.iswin %}
-                    phi = (updatecoeffsdispersive[material, 0].real
-                           * Tz[0, i, j, k].real)
+                    phi = ((updatecoeffsdispersive[material, 0]
+                           * Tz[0, i, j, k]).real)
                     {% else %}
-                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0])
-                           * {{ item.real_part }}(Tz[0, i, j, k]))
+                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0]
+                           * Tz[0, i, j, k]))
                     {% endif %}
                     {% else %}
                     phi = updatecoeffsdispersive[material, 0] * Tz[0, i, j, k]
@@ -702,11 +706,11 @@ cpdef void {{ item.name_a_1 }}(
                     material = ID[0, i, j, k]
                     {% if 'complex' in item.dispersive_type %}
                     {% if item.iswin %}
-                    phi = (updatecoeffsdispersive[material, 0].real
-                           * Tx[0, i, j, k].real)
+                    phi = ((updatecoeffsdispersive[material, 0]
+                           * Tx[0, i, j, k]).real)
                     {% else %}
-                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0])
-                           * {{ item.real_part }}(Tx[0, i, j, k]))
+                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0]
+                           * Tx[0, i, j, k]))
                     {% endif %}
                     {% else %}
                     phi = updatecoeffsdispersive[material, 0] * Tx[0, i, j, k]
@@ -722,11 +726,11 @@ cpdef void {{ item.name_a_1 }}(
                     material = ID[2, i, j, k]
                     {% if 'complex' in item.dispersive_type %}
                     {% if item.iswin %}
-                    phi = (updatecoeffsdispersive[material, 0].real
-                           * Tz[0, i, j, k].real)
+                    phi = ((updatecoeffsdispersive[material, 0]
+                           * Tz[0, i, j, k]).real)
                     {% else %}
-                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0])
-                           * {{ item.real_part }}(Tz[0, i, j, k]))
+                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0]
+                           * Tz[0, i, j, k]))
                     {% endif %}
                     {% else %}
                     phi = updatecoeffsdispersive[material, 0] * Tz[0, i, j, k]
@@ -745,11 +749,11 @@ cpdef void {{ item.name_a_1 }}(
                     material = ID[0, i, j, k]
                     {% if 'complex' in item.dispersive_type %}
                     {% if item.iswin %}
-                    phi = (updatecoeffsdispersive[material, 0].real
-                           * Tx[0, i, j, k].real)
+                    phi = ((updatecoeffsdispersive[material, 0]
+                           * Tx[0, i, j, k]).real)
                     {% else %}
-                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0])
-                           * {{ item.real_part }}(Tx[0, i, j, k]))
+                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0]
+                           * Tx[0, i, j, k]))
                     {% endif %}
                     {% else %}
                     phi = updatecoeffsdispersive[material, 0] * Tx[0, i, j, k]
@@ -765,11 +769,11 @@ cpdef void {{ item.name_a_1 }}(
                     material = ID[1, i, j, k]
                     {% if 'complex' in item.dispersive_type %}
                     {% if item.iswin %}
-                    phi = (updatecoeffsdispersive[material, 0].real
-                           * Ty[0, i, j, k].real)
+                    phi = ((updatecoeffsdispersive[material, 0]
+                           * Ty[0, i, j, k]).real)
                     {% else %}
-                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0])
-                           * {{ item.real_part }}(Ty[0, i, j, k]))
+                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0]
+                           * Ty[0, i, j, k]))
                     {% endif %}
                     {% else %}
                     phi = updatecoeffsdispersive[material, 0] * Ty[0, i, j, k]
@@ -788,11 +792,11 @@ cpdef void {{ item.name_a_1 }}(
                     material = ID[0, i, j, k]
                     {% if 'complex' in item.dispersive_type %}
                     {% if item.iswin %}
-                    phi = (updatecoeffsdispersive[material, 0].real
-                           * Tx[0, i, j, k].real)
+                    phi = ((updatecoeffsdispersive[material, 0]
+                           * Tx[0, i, j, k]).real)
                     {% else %}
-                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0])
-                           * {{ item.real_part }}(Tx[0, i, j, k]))
+                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0]
+                           * Tx[0, i, j, k]))
                     {% endif %}
                     {% else %}
                     phi = updatecoeffsdispersive[material, 0] * Tx[0, i, j, k]
@@ -808,11 +812,11 @@ cpdef void {{ item.name_a_1 }}(
                     material = ID[1, i, j, k]
                     {% if 'complex' in item.dispersive_type %}
                     {% if item.iswin %}
-                    phi = (updatecoeffsdispersive[material, 0].real
-                           * Ty[0, i, j, k].real)
+                    phi = ((updatecoeffsdispersive[material, 0]
+                           * Ty[0, i, j, k]).real)
                     {% else %}
-                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0])
-                           * {{ item.real_part }}(Ty[0, i, j, k]))
+                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0]
+                           * Ty[0, i, j, k]))
                     {% endif %}
                     {% else %}
                     phi = updatecoeffsdispersive[material, 0] * Ty[0, i, j, k]
@@ -828,11 +832,11 @@ cpdef void {{ item.name_a_1 }}(
                     material = ID[2, i, j, k]
                     {% if 'complex' in item.dispersive_type %}
                     {% if item.iswin %}
-                    phi = (updatecoeffsdispersive[material, 0].real
-                           * Tz[0, i, j, k].real)
+                    phi = ((updatecoeffsdispersive[material, 0]
+                           * Tz[0, i, j, k]).real)
                     {% else %}
-                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0])
-                           * {{ item.real_part }}(Tz[0, i, j, k]))
+                    phi = ({{ item.real_part }}(updatecoeffsdispersive[material, 0]
+                           * Tz[0, i, j, k]))
                     {% endif %}
                     {% else %}
                     phi = updatecoeffsdispersive[material, 0] * Tz[0, i, j, k]

--- a/gprMax/cython/plane_wave.pyx
+++ b/gprMax/cython/plane_wave.pyx
@@ -28,7 +28,21 @@ from libc.string cimport strcmp
 from cython.parallel import prange
 
 from gprMax.config cimport float_or_double
-from gprMax.config cimport float_or_double_complex
+
+
+# The plane-wave electric and magnetic fields remain real, while auxiliary
+# dispersive state is real for Debye-only models and complex when any Lorentz
+# or Drude material is present. This mirrors the main-grid dispersive solver.
+# For complex poles the apparent current is Re(a*T), including the imaginary
+# cross term; Re(a)*Re(T) does not implement the requested Lorentz response.
+ctypedef float complex complex_float
+ctypedef double complex complex_double
+
+ctypedef fused dispersive_float_or_double:
+    float
+    double
+    complex_float
+    complex_double
 
 
 @cython.wraparound(False)
@@ -1671,9 +1685,9 @@ cdef void updateElectricFields_dispersive(
     int p,
     float_or_double[:, ::1] H_fields,
     float_or_double[:, ::1] E_fields,
-    float_or_double[:, ::1] Px,
-    float_or_double[:, ::1] Py,
-    float_or_double[:, ::1] Pz,
+    dispersive_float_or_double[:, ::1] Px,
+    dispersive_float_or_double[:, ::1] Py,
+    dispersive_float_or_double[:, ::1] Pz,
     float_or_double[:, ::1] Ix,
     float_or_double[:, ::1] Iy,
     float_or_double[:, ::1] Iz,
@@ -1684,7 +1698,7 @@ cdef void updateElectricFields_dispersive(
     float_or_double dy,
     float_or_double dz,
     float_or_double[:] updatecoeffsE,
-    float_or_double[:] updatecoeffsdispersive,
+    dispersive_float_or_double[:] updatecoeffsdispersive,
     int num_poles,
     int[:] m
 ):
@@ -1717,7 +1731,7 @@ cdef void updateElectricFields_dispersive(
             max(m_x, m_y, m_z).
     """
 
-    cdef Py_ssize_t j, i = 0
+    cdef Py_ssize_t j, i, pole = 0
 
     cdef float_or_double[:] E_x = E_fields[0, :]
     cdef float_or_double[:] E_y = E_fields[1, :]
@@ -1725,9 +1739,9 @@ cdef void updateElectricFields_dispersive(
     cdef float_or_double[:] H_x = H_fields[0, :]
     cdef float_or_double[:] H_y = H_fields[1, :]
     cdef float_or_double[:] H_z = H_fields[2, :]
-    cdef float_or_double[:, ::1] T_x = Px
-    cdef float_or_double[:, ::1] T_y = Py
-    cdef float_or_double[:, ::1] T_z = Pz
+    cdef dispersive_float_or_double[:, ::1] T_x = Px
+    cdef dispersive_float_or_double[:, ::1] T_y = Py
+    cdef dispersive_float_or_double[:, ::1] T_z = Pz
 
 
     cdef float_or_double coef_E_xt = updatecoeffsE[0]
@@ -1744,7 +1758,7 @@ cdef void updateElectricFields_dispersive(
 
     cdef float_or_double coef_E_D = updatecoeffsE[4]  
     
-    cdef float_or_double[:] coef_D = updatecoeffsdispersive
+    cdef dispersive_float_or_double[:] coef_D = updatecoeffsdispersive
 
     cdef float_or_double[:] Ixjyz = Ix[0, :]
     cdef float_or_double[:] Ixjzy = Ix[1, :]
@@ -1784,7 +1798,11 @@ cdef void updateElectricFields_dispersive(
 
         phi = 0
         for pole in range(num_poles):
-            phi = phi + coef_D[pole * 3] * T_x[pole, j]
+            if (dispersive_float_or_double is complex_float or
+                    dispersive_float_or_double is complex_double):
+                phi = phi + (coef_D[pole * 3] * T_x[pole, j]).real
+            else:
+                phi = phi + coef_D[pole * 3] * T_x[pole, j]
 
             T_x[pole, j] = coef_D[1 + (pole * 3)] * T_x[pole, j] + coef_D[2 + (pole * 3)] * E_x[j]
             
@@ -1795,7 +1813,11 @@ cdef void updateElectricFields_dispersive(
         
         phi = 0
         for pole in range(num_poles):
-            phi = phi + coef_D[pole * 3] * T_y[pole, j]
+            if (dispersive_float_or_double is complex_float or
+                    dispersive_float_or_double is complex_double):
+                phi = phi + (coef_D[pole * 3] * T_y[pole, j]).real
+            else:
+                phi = phi + coef_D[pole * 3] * T_y[pole, j]
 
             T_y[pole, j] = coef_D[1 + (pole * 3)] * T_y[pole, j] + coef_D[2 + (pole * 3)]* E_y[j]
             
@@ -1807,7 +1829,11 @@ cdef void updateElectricFields_dispersive(
         
         phi = 0
         for pole in range(num_poles):
-            phi = phi + coef_D[pole * 3] * T_z[pole, j]
+            if (dispersive_float_or_double is complex_float or
+                    dispersive_float_or_double is complex_double):
+                phi = phi + (coef_D[pole * 3] * T_z[pole, j]).real
+            else:
+                phi = phi + coef_D[pole * 3] * T_z[pole, j]
 
             T_z[pole,j] = coef_D[1 + (pole * 3)] * T_z[pole, j] + coef_D[2 + (pole * 3)]* E_z[j]
             
@@ -1883,12 +1909,12 @@ cdef void updateElectricFields_dispersive_axial(
     float_or_double[:, ::1] E_fields,
     float_or_double[:, ::1] H_fields_s,
     float_or_double[:, ::1] E_fields_s,
-    float_or_double[:, ::1] Px,
-    float_or_double[:, ::1] Py,
-    float_or_double[:, ::1] Pz,
-    float_or_double[:, ::1] Px_s,
-    float_or_double[:, ::1] Py_s,
-    float_or_double[:, ::1] Pz_s,
+    dispersive_float_or_double[:, ::1] Px,
+    dispersive_float_or_double[:, ::1] Py,
+    dispersive_float_or_double[:, ::1] Pz,
+    dispersive_float_or_double[:, ::1] Px_s,
+    dispersive_float_or_double[:, ::1] Py_s,
+    dispersive_float_or_double[:, ::1] Pz_s,
     float_or_double[:, ::1] Ix,
     float_or_double[:, ::1] Iy,
     float_or_double[:, ::1] Iz,
@@ -1908,7 +1934,7 @@ cdef void updateElectricFields_dispersive_axial(
     float_or_double dy,
     float_or_double dz,
     float_or_double[:, ::1] updatecoeffsE,
-    float_or_double[:, ::1] updatecoeffsdispersive,
+    dispersive_float_or_double[:, ::1] updatecoeffsdispersive,
     np.uint32_t[:, ::1] GID,
     int num_poles,
     int[:] m
@@ -1942,7 +1968,7 @@ cdef void updateElectricFields_dispersive_axial(
             max(m_x, m_y, m_z).
     """
 
-    cdef Py_ssize_t j, i = 0
+    cdef Py_ssize_t j, i, pole = 0
 
     cdef float_or_double[:] E_x = E_fields[0, :]
     cdef float_or_double[:] E_y = E_fields[1, :]
@@ -1958,12 +1984,12 @@ cdef void updateElectricFields_dispersive_axial(
     cdef float_or_double[:] E_y_s = E_fields_s[1, :]
     cdef float_or_double[:] E_z_s = E_fields_s[2, :]
 
-    cdef float_or_double[:, ::1] T_x = Px
-    cdef float_or_double[:, ::1] T_y = Py
-    cdef float_or_double[:, ::1] T_z = Pz
-    cdef float_or_double[:, ::1] T_x_s = Px_s
-    cdef float_or_double[:, ::1] T_y_s = Py_s
-    cdef float_or_double[:, ::1] T_z_s = Pz_s
+    cdef dispersive_float_or_double[:, ::1] T_x = Px
+    cdef dispersive_float_or_double[:, ::1] T_y = Py
+    cdef dispersive_float_or_double[:, ::1] T_z = Pz
+    cdef dispersive_float_or_double[:, ::1] T_x_s = Px_s
+    cdef dispersive_float_or_double[:, ::1] T_y_s = Py_s
+    cdef dispersive_float_or_double[:, ::1] T_z_s = Pz_s
 
     cdef float_or_double[:] Ixjyz = Ix[0, :]
     cdef float_or_double[:] Ixjzy = Ix[1, :]
@@ -2037,7 +2063,12 @@ cdef void updateElectricFields_dispersive_axial(
         mat = GID[0,2]
         phi = 0
         for pole in range(num_poles):
-            phi = phi + updatecoeffsdispersive[mat,pole * 3] * T_x_s[pole, j]
+            if (dispersive_float_or_double is complex_float or
+                    dispersive_float_or_double is complex_double):
+                phi = (phi + (updatecoeffsdispersive[mat, pole * 3]
+                       * T_x_s[pole, j]).real)
+            else:
+                phi = phi + updatecoeffsdispersive[mat, pole * 3] * T_x_s[pole, j]
             T_x_s[pole, j] = updatecoeffsdispersive[mat,1 + (pole * 3)] * T_x_s[pole, j] + updatecoeffsdispersive[mat,2 + (pole * 3)] * E_x_s[j]
             
         # equation 9 of Tan, Potter paper modified for dispersive materials
@@ -2046,7 +2077,12 @@ cdef void updateElectricFields_dispersive_axial(
         mat=GID[1,2]
         phi = 0
         for pole in range(num_poles):
-            phi = phi + updatecoeffsdispersive[mat,pole * 3] * T_y_s[pole, j]
+            if (dispersive_float_or_double is complex_float or
+                    dispersive_float_or_double is complex_double):
+                phi = (phi + (updatecoeffsdispersive[mat, pole * 3]
+                       * T_y_s[pole, j]).real)
+            else:
+                phi = phi + updatecoeffsdispersive[mat, pole * 3] * T_y_s[pole, j]
             T_y_s[pole, j] = updatecoeffsdispersive[mat,1 + (pole * 3)] * T_y_s[pole, j] + updatecoeffsdispersive[mat,2 + (pole * 3)]* E_y_s[j]
 
         # equation 9 of Tan, Potter paper modified for dispersive materials
@@ -2055,7 +2091,12 @@ cdef void updateElectricFields_dispersive_axial(
         mat=GID[2,2]       
         phi = 0
         for pole in range(num_poles):
-            phi = phi + updatecoeffsdispersive[mat,pole * 3] * T_z_s[pole, j]
+            if (dispersive_float_or_double is complex_float or
+                    dispersive_float_or_double is complex_double):
+                phi = (phi + (updatecoeffsdispersive[mat, pole * 3]
+                       * T_z_s[pole, j]).real)
+            else:
+                phi = phi + updatecoeffsdispersive[mat, pole * 3] * T_z_s[pole, j]
             T_z_s[pole,j] = updatecoeffsdispersive[mat, 1 + (pole * 3)] * T_z_s[pole, j] + updatecoeffsdispersive[mat,2 + (pole * 3)]* E_z_s[j]
 
         # equation 9 of Tan, Potter paper modified for dispersive materials
@@ -2130,7 +2171,12 @@ cdef void updateElectricFields_dispersive_axial(
         mat = GID[0,j]
         phi = 0
         for pole in range(num_poles):
-            phi = phi + updatecoeffsdispersive[mat,pole * 3] * T_x[pole, j]
+            if (dispersive_float_or_double is complex_float or
+                    dispersive_float_or_double is complex_double):
+                phi = (phi + (updatecoeffsdispersive[mat, pole * 3]
+                       * T_x[pole, j]).real)
+            else:
+                phi = phi + updatecoeffsdispersive[mat, pole * 3] * T_x[pole, j]
             T_x[pole, j] = updatecoeffsdispersive[mat,1 + (pole * 3)] * T_x[pole, j] + updatecoeffsdispersive[mat,2 + (pole * 3)] * E_x[j]
             
         # equation 9 of Tan, Potter paper modified for dispersive materials
@@ -2139,7 +2185,12 @@ cdef void updateElectricFields_dispersive_axial(
         mat=GID[1,j]
         phi = 0
         for pole in range(num_poles):
-            phi = phi + updatecoeffsdispersive[mat,pole * 3] * T_y[pole, j]
+            if (dispersive_float_or_double is complex_float or
+                    dispersive_float_or_double is complex_double):
+                phi = (phi + (updatecoeffsdispersive[mat, pole * 3]
+                       * T_y[pole, j]).real)
+            else:
+                phi = phi + updatecoeffsdispersive[mat, pole * 3] * T_y[pole, j]
             T_y[pole, j] = updatecoeffsdispersive[mat,1 + (pole * 3)] * T_y[pole, j] + updatecoeffsdispersive[mat,2 + (pole * 3)]* E_y[j]
             
         # equation 9 of Tan, Potter paper modified for dispersive materials
@@ -2148,7 +2199,12 @@ cdef void updateElectricFields_dispersive_axial(
         mat=GID[2,j]       
         phi = 0
         for pole in range(num_poles):
-            phi = phi + updatecoeffsdispersive[mat,pole * 3] * T_z[pole, j]
+            if (dispersive_float_or_double is complex_float or
+                    dispersive_float_or_double is complex_double):
+                phi = (phi + (updatecoeffsdispersive[mat, pole * 3]
+                       * T_z[pole, j]).real)
+            else:
+                phi = phi + updatecoeffsdispersive[mat, pole * 3] * T_z[pole, j]
             T_z[pole,j] = updatecoeffsdispersive[mat, 1 + (pole * 3)] * T_z[pole, j] + updatecoeffsdispersive[mat,2 + (pole * 3)]* E_z[j]
             
         # equation 9 of Tan, Potter paper modified for dispersive materials
@@ -2653,15 +2709,15 @@ cpdef void updatePlaneWave_electric_dispersive(
     int skip_axis,
     float_or_double[:, ::1] H_fields,
     float_or_double[:, ::1] E_fields,
-    float_or_double[:, ::1] Px,
-    float_or_double[:, ::1] Py,
-    float_or_double[:, ::1] Pz,
+    dispersive_float_or_double[:, ::1] Px,
+    dispersive_float_or_double[:, ::1] Py,
+    dispersive_float_or_double[:, ::1] Pz,
     float_or_double[:, ::1] Ix,
     float_or_double[:, ::1] Iy,
     float_or_double[:, ::1] Iz,
     float_or_double[:] updatecoeffsE,
     float_or_double[:] updatecoeffsH,
-    float_or_double[:] updatecoeffsdispersive,
+    dispersive_float_or_double[:] updatecoeffsdispersive,
     int num_poles,
     float_or_double[:, ::1] rcEx,
     float_or_double[:, ::1] rcEy,
@@ -2709,12 +2765,12 @@ cpdef void updatePlaneWave_electric_dispersive_axial(
     float_or_double[:, ::1] E_fields,
     float_or_double[:, ::1] H_fields_s,
     float_or_double[:, ::1] E_fields_s,
-    float_or_double[:, ::1] Px,
-    float_or_double[:, ::1] Py,
-    float_or_double[:, ::1] Pz,
-    float_or_double[:, ::1] Px_s,
-    float_or_double[:, ::1] Py_s,
-    float_or_double[:, ::1] Pz_s,
+    dispersive_float_or_double[:, ::1] Px,
+    dispersive_float_or_double[:, ::1] Py,
+    dispersive_float_or_double[:, ::1] Pz,
+    dispersive_float_or_double[:, ::1] Px_s,
+    dispersive_float_or_double[:, ::1] Py_s,
+    dispersive_float_or_double[:, ::1] Pz_s,
     float_or_double[:, ::1] Ix,
     float_or_double[:, ::1] Iy,
     float_or_double[:, ::1] Iz,
@@ -2726,7 +2782,7 @@ cpdef void updatePlaneWave_electric_dispersive_axial(
     float_or_double[:, ::1] Iz_s,
     float_or_double[:, ::1] updatecoeffsE,
     float_or_double[:, ::1] updatecoeffsH,
-    float_or_double[:, ::1] updatecoeffsdispersive,
+    dispersive_float_or_double[:, ::1] updatecoeffsdispersive,
     np.uint32_t[:, ::1] ID,
     np.uint32_t[:, :, :, ::1] GID,
     int num_poles,

--- a/gprMax/cython/symmetry_boundaries_dispersive_complex.pyx
+++ b/gprMax/cython/symmetry_boundaries_dispersive_complex.pyx
@@ -32,14 +32,11 @@ from gprMax.config cimport float_or_double_complex
 # the real-pole file is the phi accumulation: Tx/Ty/Tz and
 # updatecoeffsdispersive are complex (float_or_double_complex) here, so phi
 # (which must stay real - it feeds directly into a real E-field update)
-# accumulates Real(updatecoeffsdispersive[...]) * Real(T[...]) per pole,
-# exactly matching fields_updates_dispersive_template.jinja's own complex
-# branch (`{{ item.real_part }}(updatecoeffsdispersive[...]) *
-# {{ item.real_part }}(Tx[...])`) - the real part of each factor
-# individually, not the real part of their complex product. This is the
-# same formula the bulk kernel already uses; replicating it exactly here
-# (rather than "fixing" it to Re(a*b)) is what keeps the boundary correction
-# consistent with the bulk kernel's own (already-established) numerics.
+# accumulates Real(updatecoeffsdispersive[...] * T[...]) per pole, exactly
+# matching fields_updates_dispersive_template.jinja's complex branch. The
+# imaginary cross term is essential for Lorentz poles: taking the real part
+# of each factor separately changes the implemented susceptibility and gives
+# the wrong phase and loss around a resonance.
 # The T-array recursion itself (Tx[pole,i,j,k] = beta*Tx_old + gamma*E_old)
 # and Phase B's correction are unchanged in form from the real-pole file -
 # ordinary complex arithmetic (complex*complex, complex*real, complex-complex)
@@ -113,7 +110,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_x0(
             materialEy = ID[1, 0, j, k]
             phi = 0
             for pole in range(maxpoles):
-                phi = phi + updatecoeffsdispersive[materialEy, pole * 3].real * Ty[pole, 0, j, k].real
+                phi = phi + (updatecoeffsdispersive[materialEy, pole * 3] * Ty[pole, 0, j, k]).real
                 Ty[pole, 0, j, k] = (updatecoeffsdispersive[materialEy, 1 + (pole * 3)] * Ty[pole, 0, j, k]
                                      + updatecoeffsdispersive[materialEy, 2 + (pole * 3)] * Ey[0, j, k])
             Ey[0, j, k] = (updatecoeffsE[materialEy, 0] * Ey[0, j, k] +
@@ -126,7 +123,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_x0(
             materialEz = ID[2, 0, j, k]
             phi = 0
             for pole in range(maxpoles):
-                phi = phi + updatecoeffsdispersive[materialEz, pole * 3].real * Tz[pole, 0, j, k].real
+                phi = phi + (updatecoeffsdispersive[materialEz, pole * 3] * Tz[pole, 0, j, k]).real
                 Tz[pole, 0, j, k] = (updatecoeffsdispersive[materialEz, 1 + (pole * 3)] * Tz[pole, 0, j, k]
                                      + updatecoeffsdispersive[materialEz, 2 + (pole * 3)] * Ez[0, j, k])
             Ez[0, j, k] = (updatecoeffsE[materialEz, 0] * Ez[0, j, k] -
@@ -164,7 +161,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_xmax(
             materialEy = ID[1, nx, j, k]
             phi = 0
             for pole in range(maxpoles):
-                phi = phi + updatecoeffsdispersive[materialEy, pole * 3].real * Ty[pole, nx, j, k].real
+                phi = phi + (updatecoeffsdispersive[materialEy, pole * 3] * Ty[pole, nx, j, k]).real
                 Ty[pole, nx, j, k] = (updatecoeffsdispersive[materialEy, 1 + (pole * 3)] * Ty[pole, nx, j, k]
                                       + updatecoeffsdispersive[materialEy, 2 + (pole * 3)] * Ey[nx, j, k])
             Ey[nx, j, k] = (updatecoeffsE[materialEy, 0] * Ey[nx, j, k] +
@@ -177,7 +174,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_xmax(
             materialEz = ID[2, nx, j, k]
             phi = 0
             for pole in range(maxpoles):
-                phi = phi + updatecoeffsdispersive[materialEz, pole * 3].real * Tz[pole, nx, j, k].real
+                phi = phi + (updatecoeffsdispersive[materialEz, pole * 3] * Tz[pole, nx, j, k]).real
                 Tz[pole, nx, j, k] = (updatecoeffsdispersive[materialEz, 1 + (pole * 3)] * Tz[pole, nx, j, k]
                                       + updatecoeffsdispersive[materialEz, 2 + (pole * 3)] * Ez[nx, j, k])
             Ez[nx, j, k] = (updatecoeffsE[materialEz, 0] * Ez[nx, j, k] -
@@ -215,7 +212,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_y0(
             materialEx = ID[0, i, 0, k]
             phi = 0
             for pole in range(maxpoles):
-                phi = phi + updatecoeffsdispersive[materialEx, pole * 3].real * Tx[pole, i, 0, k].real
+                phi = phi + (updatecoeffsdispersive[materialEx, pole * 3] * Tx[pole, i, 0, k]).real
                 Tx[pole, i, 0, k] = (updatecoeffsdispersive[materialEx, 1 + (pole * 3)] * Tx[pole, i, 0, k]
                                      + updatecoeffsdispersive[materialEx, 2 + (pole * 3)] * Ex[i, 0, k])
             Ex[i, 0, k] = (updatecoeffsE[materialEx, 0] * Ex[i, 0, k] -
@@ -228,7 +225,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_y0(
             materialEz = ID[2, i, 0, k]
             phi = 0
             for pole in range(maxpoles):
-                phi = phi + updatecoeffsdispersive[materialEz, pole * 3].real * Tz[pole, i, 0, k].real
+                phi = phi + (updatecoeffsdispersive[materialEz, pole * 3] * Tz[pole, i, 0, k]).real
                 Tz[pole, i, 0, k] = (updatecoeffsdispersive[materialEz, 1 + (pole * 3)] * Tz[pole, i, 0, k]
                                      + updatecoeffsdispersive[materialEz, 2 + (pole * 3)] * Ez[i, 0, k])
             Ez[i, 0, k] = (updatecoeffsE[materialEz, 0] * Ez[i, 0, k] +
@@ -266,7 +263,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_ymax(
             materialEx = ID[0, i, ny, k]
             phi = 0
             for pole in range(maxpoles):
-                phi = phi + updatecoeffsdispersive[materialEx, pole * 3].real * Tx[pole, i, ny, k].real
+                phi = phi + (updatecoeffsdispersive[materialEx, pole * 3] * Tx[pole, i, ny, k]).real
                 Tx[pole, i, ny, k] = (updatecoeffsdispersive[materialEx, 1 + (pole * 3)] * Tx[pole, i, ny, k]
                                       + updatecoeffsdispersive[materialEx, 2 + (pole * 3)] * Ex[i, ny, k])
             Ex[i, ny, k] = (updatecoeffsE[materialEx, 0] * Ex[i, ny, k] -
@@ -279,7 +276,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_ymax(
             materialEz = ID[2, i, ny, k]
             phi = 0
             for pole in range(maxpoles):
-                phi = phi + updatecoeffsdispersive[materialEz, pole * 3].real * Tz[pole, i, ny, k].real
+                phi = phi + (updatecoeffsdispersive[materialEz, pole * 3] * Tz[pole, i, ny, k]).real
                 Tz[pole, i, ny, k] = (updatecoeffsdispersive[materialEz, 1 + (pole * 3)] * Tz[pole, i, ny, k]
                                       + updatecoeffsdispersive[materialEz, 2 + (pole * 3)] * Ez[i, ny, k])
             Ez[i, ny, k] = (updatecoeffsE[materialEz, 0] * Ez[i, ny, k] +
@@ -317,7 +314,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_z0(
             materialEx = ID[0, i, j, 0]
             phi = 0
             for pole in range(maxpoles):
-                phi = phi + updatecoeffsdispersive[materialEx, pole * 3].real * Tx[pole, i, j, 0].real
+                phi = phi + (updatecoeffsdispersive[materialEx, pole * 3] * Tx[pole, i, j, 0]).real
                 Tx[pole, i, j, 0] = (updatecoeffsdispersive[materialEx, 1 + (pole * 3)] * Tx[pole, i, j, 0]
                                      + updatecoeffsdispersive[materialEx, 2 + (pole * 3)] * Ex[i, j, 0])
             Ex[i, j, 0] = (updatecoeffsE[materialEx, 0] * Ex[i, j, 0] +
@@ -330,7 +327,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_z0(
             materialEy = ID[1, i, j, 0]
             phi = 0
             for pole in range(maxpoles):
-                phi = phi + updatecoeffsdispersive[materialEy, pole * 3].real * Ty[pole, i, j, 0].real
+                phi = phi + (updatecoeffsdispersive[materialEy, pole * 3] * Ty[pole, i, j, 0]).real
                 Ty[pole, i, j, 0] = (updatecoeffsdispersive[materialEy, 1 + (pole * 3)] * Ty[pole, i, j, 0]
                                      + updatecoeffsdispersive[materialEy, 2 + (pole * 3)] * Ey[i, j, 0])
             Ey[i, j, 0] = (updatecoeffsE[materialEy, 0] * Ey[i, j, 0] -
@@ -368,7 +365,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_zmax(
             materialEx = ID[0, i, j, nz]
             phi = 0
             for pole in range(maxpoles):
-                phi = phi + updatecoeffsdispersive[materialEx, pole * 3].real * Tx[pole, i, j, nz].real
+                phi = phi + (updatecoeffsdispersive[materialEx, pole * 3] * Tx[pole, i, j, nz]).real
                 Tx[pole, i, j, nz] = (updatecoeffsdispersive[materialEx, 1 + (pole * 3)] * Tx[pole, i, j, nz]
                                       + updatecoeffsdispersive[materialEx, 2 + (pole * 3)] * Ex[i, j, nz])
             Ex[i, j, nz] = (updatecoeffsE[materialEx, 0] * Ex[i, j, nz] +
@@ -381,7 +378,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_zmax(
             materialEy = ID[1, i, j, nz]
             phi = 0
             for pole in range(maxpoles):
-                phi = phi + updatecoeffsdispersive[materialEy, pole * 3].real * Ty[pole, i, j, nz].real
+                phi = phi + (updatecoeffsdispersive[materialEy, pole * 3] * Ty[pole, i, j, nz]).real
                 Ty[pole, i, j, nz] = (updatecoeffsdispersive[materialEy, 1 + (pole * 3)] * Ty[pole, i, j, nz]
                                       + updatecoeffsdispersive[materialEy, 2 + (pole * 3)] * Ey[i, j, nz])
             Ey[i, j, nz] = (updatecoeffsE[materialEy, 0] * Ey[i, j, nz] -
@@ -420,7 +417,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_Ez_X0_Y0(
         mat = ID[2, 0, 0, k]
         phi = 0
         for pole in range(maxpoles):
-            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Tz[pole, 0, 0, k].real
+            phi = phi + (updatecoeffsdispersive[mat, pole * 3] * Tz[pole, 0, 0, k]).real
             Tz[pole, 0, 0, k] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tz[pole, 0, 0, k]
                                  + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ez[0, 0, k])
         if x0_pmc or y0_pmc:
@@ -456,7 +453,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_Ez_X0_YMax(
         mat = ID[2, 0, ny, k]
         phi = 0
         for pole in range(maxpoles):
-            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Tz[pole, 0, ny, k].real
+            phi = phi + (updatecoeffsdispersive[mat, pole * 3] * Tz[pole, 0, ny, k]).real
             Tz[pole, 0, ny, k] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tz[pole, 0, ny, k]
                                   + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ez[0, ny, k])
         if x0_pmc or ymax_pmc:
@@ -492,7 +489,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_Ez_XMax_Y0(
         mat = ID[2, nx, 0, k]
         phi = 0
         for pole in range(maxpoles):
-            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Tz[pole, nx, 0, k].real
+            phi = phi + (updatecoeffsdispersive[mat, pole * 3] * Tz[pole, nx, 0, k]).real
             Tz[pole, nx, 0, k] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tz[pole, nx, 0, k]
                                   + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ez[nx, 0, k])
         if xmax_pmc or y0_pmc:
@@ -528,7 +525,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_Ez_XMax_YMax(
         mat = ID[2, nx, ny, k]
         phi = 0
         for pole in range(maxpoles):
-            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Tz[pole, nx, ny, k].real
+            phi = phi + (updatecoeffsdispersive[mat, pole * 3] * Tz[pole, nx, ny, k]).real
             Tz[pole, nx, ny, k] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tz[pole, nx, ny, k]
                                    + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ez[nx, ny, k])
         if xmax_pmc or ymax_pmc:
@@ -564,7 +561,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_Ey_X0_Z0(
         mat = ID[1, 0, j, 0]
         phi = 0
         for pole in range(maxpoles):
-            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Ty[pole, 0, j, 0].real
+            phi = phi + (updatecoeffsdispersive[mat, pole * 3] * Ty[pole, 0, j, 0]).real
             Ty[pole, 0, j, 0] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Ty[pole, 0, j, 0]
                                  + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ey[0, j, 0])
         if x0_pmc or z0_pmc:
@@ -600,7 +597,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_Ey_X0_ZMax(
         mat = ID[1, 0, j, nz]
         phi = 0
         for pole in range(maxpoles):
-            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Ty[pole, 0, j, nz].real
+            phi = phi + (updatecoeffsdispersive[mat, pole * 3] * Ty[pole, 0, j, nz]).real
             Ty[pole, 0, j, nz] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Ty[pole, 0, j, nz]
                                   + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ey[0, j, nz])
         if x0_pmc or zmax_pmc:
@@ -636,7 +633,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_Ey_XMax_Z0(
         mat = ID[1, nx, j, 0]
         phi = 0
         for pole in range(maxpoles):
-            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Ty[pole, nx, j, 0].real
+            phi = phi + (updatecoeffsdispersive[mat, pole * 3] * Ty[pole, nx, j, 0]).real
             Ty[pole, nx, j, 0] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Ty[pole, nx, j, 0]
                                   + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ey[nx, j, 0])
         if xmax_pmc or z0_pmc:
@@ -672,7 +669,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_Ey_XMax_ZMax(
         mat = ID[1, nx, j, nz]
         phi = 0
         for pole in range(maxpoles):
-            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Ty[pole, nx, j, nz].real
+            phi = phi + (updatecoeffsdispersive[mat, pole * 3] * Ty[pole, nx, j, nz]).real
             Ty[pole, nx, j, nz] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Ty[pole, nx, j, nz]
                                    + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ey[nx, j, nz])
         if xmax_pmc or zmax_pmc:
@@ -708,7 +705,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_Ex_Y0_Z0(
         mat = ID[0, i, 0, 0]
         phi = 0
         for pole in range(maxpoles):
-            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Tx[pole, i, 0, 0].real
+            phi = phi + (updatecoeffsdispersive[mat, pole * 3] * Tx[pole, i, 0, 0]).real
             Tx[pole, i, 0, 0] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tx[pole, i, 0, 0]
                                  + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ex[i, 0, 0])
         if y0_pmc or z0_pmc:
@@ -744,7 +741,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_Ex_Y0_ZMax(
         mat = ID[0, i, 0, nz]
         phi = 0
         for pole in range(maxpoles):
-            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Tx[pole, i, 0, nz].real
+            phi = phi + (updatecoeffsdispersive[mat, pole * 3] * Tx[pole, i, 0, nz]).real
             Tx[pole, i, 0, nz] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tx[pole, i, 0, nz]
                                   + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ex[i, 0, nz])
         if y0_pmc or zmax_pmc:
@@ -780,7 +777,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_Ex_YMax_Z0(
         mat = ID[0, i, ny, 0]
         phi = 0
         for pole in range(maxpoles):
-            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Tx[pole, i, ny, 0].real
+            phi = phi + (updatecoeffsdispersive[mat, pole * 3] * Tx[pole, i, ny, 0]).real
             Tx[pole, i, ny, 0] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tx[pole, i, ny, 0]
                                   + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ex[i, ny, 0])
         if ymax_pmc or z0_pmc:
@@ -816,7 +813,7 @@ cpdef void update_symmetry_boundary_electric_dispersive_Ex_YMax_ZMax(
         mat = ID[0, i, ny, nz]
         phi = 0
         for pole in range(maxpoles):
-            phi = phi + updatecoeffsdispersive[mat, pole * 3].real * Tx[pole, i, ny, nz].real
+            phi = phi + (updatecoeffsdispersive[mat, pole * 3] * Tx[pole, i, ny, nz]).real
             Tx[pole, i, ny, nz] = (updatecoeffsdispersive[mat, 1 + (pole * 3)] * Tx[pole, i, ny, nz]
                                    + updatecoeffsdispersive[mat, 2 + (pole * 3)] * Ex[i, ny, nz])
         if ymax_pmc or zmax_pmc:

--- a/gprMax/materials.py
+++ b/gprMax/materials.py
@@ -264,6 +264,13 @@ class DispersiveMaterial(Material):
             dtype=config.get_model_config().materials["dispersivedtype"],
         )
 
+        # The Drude susceptibility contains a constant causal term whose
+        # time derivative is equivalent to an electric conductivity. Keep
+        # that numerical conductivity local: ``self.se`` is the physical
+        # conductivity supplied by the user and must neither be overwritten
+        # nor accumulated if coefficients are calculated more than once.
+        effective_se = self.se
+
         for x in range(self.poles):
             if "debye" in self.type:
                 self.w[x] = self.deltaer[x] / self.tau[x]
@@ -278,7 +285,9 @@ class DispersiveMaterial(Material):
                 # tau for Drude materials are pole frequencies
                 # alpha for Drude materials are the inverse of relaxation times
                 wp2 = (2 * np.pi * self.tau[x]) ** 2
-                self.se += wp2 / self.alpha[x]
+                effective_se += (
+                    config.sim_config.em_consts["e0"] * wp2 / self.alpha[x]
+                )
                 self.w[x] = -(wp2 / self.alpha[x])
                 self.q[x] = -self.alpha[x]
 
@@ -289,12 +298,12 @@ class DispersiveMaterial(Material):
 
         EA = (
             (config.sim_config.em_consts["e0"] * self.er / G.dt)
-            + 0.5 * self.se
+            + 0.5 * effective_se
             - (config.sim_config.em_consts["e0"] / G.dt) * np.sum(self.zt2.real)
         )
         EB = (
             (config.sim_config.em_consts["e0"] * self.er / G.dt)
-            - 0.5 * self.se
+            - 0.5 * effective_se
             - (config.sim_config.em_consts["e0"] / G.dt) * np.sum(self.zt2.real)
         )
 
@@ -333,20 +342,20 @@ class DispersiveMaterial(Material):
         er = self.er
 
         w = 2 * np.pi * freq
-        er += self.se / (1j * w * config.sim_config.em_consts["e0"])
+        er += self.se / (1j * w * config.e0)
         if "debye" in self.type:
             for pole in range(self.poles):
                 er += self.deltaer[pole] / (1 + 1j * w * self.tau[pole])
         elif "lorentz" in self.type:
             for pole in range(self.poles):
-                er += (self.deltaer[pole] * self.tau[pole] ** 2) / (
-                    self.tau[pole] ** 2 + 2j * w * self.alpha[pole] - w**2
+                pole_omega = 2 * np.pi * self.tau[pole]
+                er += (self.deltaer[pole] * pole_omega**2) / (
+                    pole_omega**2 + 2j * w * self.alpha[pole] - w**2
                 )
         elif "drude" in self.type:
-            ersum = 0
             for pole in range(self.poles):
-                ersum += self.tau[pole] ** 2 / (w**2 - 1j * w * self.alpha[pole])
-                er -= ersum
+                pole_omega = 2 * np.pi * self.tau[pole]
+                er -= pole_omega**2 / (w**2 - 1j * w * self.alpha[pole])
 
         return er
 

--- a/gprMax/sources.py
+++ b/gprMax/sources.py
@@ -738,6 +738,7 @@ class DiscretePlaneWave(Source):
         self.ds = 0
         self.speed = config.c
         self.axial = 0
+        self.dispersive = False
         self.pml_cells = 20
         self.buffercells_axial = 5
         self.psi= 0.0
@@ -865,6 +866,12 @@ class DiscretePlaneWave(Source):
         self.theta_est_rad = math.radians(self.actual_angles[0])
         self.psi_rad = math.radians(self.psi)
 
+        # The dispersive background setup below needs the source frequency
+        # to evaluate the material impedance and propagation speed. Resolve
+        # the waveform before that setup, rather than at the end of this
+        # method after its first use.
+        self.waveform = next(x for x in G.waveforms if x.ID == self.waveformID)
+
         # Calculate the direction cosines
         px = math.sin(self.theta_est_rad)*math.cos(self.phi_est_rad)
         py = math.sin(self.theta_est_rad)*math.sin(self.phi_est_rad)
@@ -979,19 +986,19 @@ class DiscretePlaneWave(Source):
             self.material = next((x for x in G.materials if x.ID == self.materialID), None)
         
             
-            # Find if the source material is dispersive
-            if self.material.type == "debye":
+            # A homogeneous DPW can use any electric dispersion supported by
+            # the main grid. The real part of eps_r at the waveform centre
+            # frequency sets the reference speed and impedance; the complete
+            # time-domain response is evolved by the auxiliary pole state.
+            if getattr(self.material, "poles", 0) > 0:
                 self.dispersive = True
-                self.materialZ = math.sqrt(config.m0 * self.material.mr / (config.e0 * np.real(self.material.calculate_er(self.waveform.freq))))  # Impedance in the material
-                self.speed = config.c / math.sqrt(np.real(self.material.calculate_er(self.waveform.freq)) * self.material.mr)  # Speed in the material
+                material_er = np.real(self.material.calculate_er(self.waveform.freq))
+                self.materialZ = math.sqrt(
+                    config.m0 * self.material.mr / (config.e0 * material_er)
+                )
+                self.speed = config.c / math.sqrt(material_er * self.material.mr)
                 self.max_poles = self.material.poles
-                # Allocate memory for the polarization terms for dispersive materials
-                self.Px = np.zeros((self.max_poles,self.length), order="C", dtype=config.sim_config.dtypes["float_or_double"])
-                self.Py = np.zeros((self.max_poles,self.length), order="C", dtype=config.sim_config.dtypes["float_or_double"])
-                self.Pz = np.zeros((self.max_poles,self.length), order="C", dtype=config.sim_config.dtypes["float_or_double"])
-              
             else:
-                self.dispersive = False
                 self.materialZ = math.sqrt(config.m0 * self.material.mr / (config.e0 * self.material.er)) # Impedance in the material
                 self.speed = config.c / math.sqrt(self.material.er * self.material.mr)  # Speed in the material
              
@@ -1028,9 +1035,6 @@ class DiscretePlaneWave(Source):
             # (they need the grid-sampled background material) - it runs
             # this same validation there instead.
             self._validate_2d_projections()
-
-        # Get the waveform object with the matching ID and add it to the PlaneWave object
-        self.waveform = next(x for x in G.waveforms if x.ID == self.waveformID)
 
         if self.axial == 0:
             self._get_pml_parameters(G)
@@ -1122,6 +1126,14 @@ class DiscretePlaneWave(Source):
                 for idx in range(n_prop + self.origin_axial, self.length):
                     self.ID[c, idx] = _gid(c, n_prop - 1)
 
+            sampled_material_ids = set(np.unique(self.ID))
+            sampled_dispersive_materials = [
+                material
+                for material in G.materials
+                if material.numID in sampled_material_ids
+                and getattr(material, "poles", 0) > 0
+            ]
+
             # Get the background material near the origin (used for the
             # speed and impedance of the DPW) and near the far PML (used
             # for the PML parameters). Sampled from G.solid - the
@@ -1147,13 +1159,16 @@ class DiscretePlaneWave(Source):
                 (x for x in G.materials if x.numID == G.solid[tuple(pos_solid)]), None
             )
 
-            # Find if the source material is dispersive
-            if self.material.type == "debye":
-                self.materialZ = math.sqrt(config.m0 * self.material.mr / (config.e0 * np.real(self.material.calculate_er(self.waveform.freq))))  # Impedance in the material
-                self.speed = config.c / math.sqrt(np.real(self.material.calculate_er(self.waveform.freq)) * self.material.mr)  # Speed in the material
-               
+            # Reference material properties for the source-side auxiliary
+            # grid. All Debye, Lorentz, and Drude pole dynamics are handled
+            # by the same recurrence as the main grid below.
+            if getattr(self.material, "poles", 0) > 0:
+                material_er = np.real(self.material.calculate_er(self.waveform.freq))
+                self.materialZ = math.sqrt(
+                    config.m0 * self.material.mr / (config.e0 * material_er)
+                )
+                self.speed = config.c / math.sqrt(material_er * self.material.mr)
             else:
-                self.dispersive = False
                 self.materialZ = math.sqrt(config.m0 * self.material.mr / (config.e0 * self.material.er)) # Impedance in the material
                 self.speed = config.c / math.sqrt(self.material.er * self.material.mr)  # Speed in the material
 
@@ -1162,38 +1177,26 @@ class DiscretePlaneWave(Source):
             self.materialPML0Z = self.materialZ
             self.PML0speed = self.speed        
 
-            # Find if the PML material is dispersive
-            if self.materialPML.type == "debye":
-                self.materialPMLZ = math.sqrt(config.m0 * self.materialPML.mr / (config.e0 * np.real(self.materialPML.calculate_er(self.waveform.freq))))  # Impedance in the material
-                self.PMLspeed = config.c / math.sqrt(np.real(self.materialPML.calculate_er(self.waveform.freq)) * self.materialPML.mr)  # Speed in the material
-
+            # Reference properties at the far-side DPW PML.
+            if getattr(self.materialPML, "poles", 0) > 0:
+                material_pml_er = np.real(
+                    self.materialPML.calculate_er(self.waveform.freq)
+                )
+                self.materialPMLZ = math.sqrt(
+                    config.m0 * self.materialPML.mr / (config.e0 * material_pml_er)
+                )
+                self.PMLspeed = config.c / math.sqrt(
+                    material_pml_er * self.materialPML.mr
+                )
             else:
-                self.dispersive = False
                 self.materialPMLZ = math.sqrt(config.m0 * self.materialPML.mr / (config.e0 * self.materialPML.er)) # Impedance in the material
                 self.PMLspeed = config.c / math.sqrt(self.materialPML.er * self.materialPML.mr)  # Speed in the material
-               
 
-            #find if the grid has any debye materials which can determine if we need dispersive updates even if the source material is non-dispersive
-            has_debye = any(getattr(x, "type", None) == "debye" for x in G.materials)
-
-            # If axial propagation and has any debye materials in the grid then need to use dispersive updates for all materials in the main grid        
-            if has_debye:
-                self.dispersive = True
-                print("Axial DPW propagation: will use dispersive updates for all materials in the main grid")
-                self.max_poles = 0
-                for material in G.materials:
-                    poles = getattr(material, "poles", 0)  # Default to 0 if 'poles' doesn't exist
-                    if poles is not None:
-                        self.max_poles = max(self.max_poles, poles)
-
-            # Allocate memory for the polarization arrays for the DPW updates if dispersive materials are present in the grid
-            if self.dispersive:
-                self.Px = np.zeros((self.max_poles,self.length), order="C", dtype=config.sim_config.dtypes["float_or_double"])
-                self.Py = np.zeros((self.max_poles,self.length), order="C", dtype=config.sim_config.dtypes["float_or_double"])
-                self.Pz = np.zeros((self.max_poles,self.length), order="C", dtype=config.sim_config.dtypes["float_or_double"])
-                self.Px_s = np.zeros((self.max_poles,self.length), order="C", dtype=config.sim_config.dtypes["float_or_double"])
-                self.Py_s = np.zeros((self.max_poles,self.length), order="C", dtype=config.sim_config.dtypes["float_or_double"])
-                self.Pz_s = np.zeros((self.max_poles,self.length), order="C", dtype=config.sim_config.dtypes["float_or_double"])
+            self.dispersive = bool(sampled_dispersive_materials)
+            self.max_poles = max(
+                (material.poles for material in sampled_dispersive_materials),
+                default=0,
+            )
 
         
             # Calculate the projections for sourcing the electric and magnetic fields
@@ -1233,8 +1236,19 @@ class DiscretePlaneWave(Source):
             + f" , grid origin = ({self.origin[0]}, {self.origin[1]}, {self.origin[2]})"
             + f" and 1D vector length = {self.length} cells.")
 
-        else:
-            pass
+        # Allocate the DPW auxiliary state after the model-wide dispersive
+        # dtype has been resolved. Debye-only models use real storage;
+        # Lorentz/Drude models use complex storage, exactly as the main grid.
+        if self.dispersive:
+            dispersive_dtype = config.get_model_config().materials["dispersivedtype"]
+            state_shape = (self.max_poles, self.length)
+            self.Px = np.zeros(state_shape, order="C", dtype=dispersive_dtype)
+            self.Py = np.zeros(state_shape, order="C", dtype=dispersive_dtype)
+            self.Pz = np.zeros(state_shape, order="C", dtype=dispersive_dtype)
+            if self.axial != 0:
+                self.Px_s = np.zeros(state_shape, order="C", dtype=dispersive_dtype)
+                self.Py_s = np.zeros(state_shape, order="C", dtype=dispersive_dtype)
+                self.Pz_s = np.zeros(state_shape, order="C", dtype=dispersive_dtype)
 
 
     def calculate_waveform_values(self, G, cythonize=True):

--- a/gprMax/updates/cuda_updates.py
+++ b/gprMax/updates/cuda_updates.py
@@ -153,6 +153,7 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
         self.knl_common = self.env.get_template("knl_common_cuda.tmpl").render(
             REAL=config.sim_config.dtypes["C_float_or_double"],
+            DRUDELORENTZ=config.get_model_config().materials["drudelorentz"],
             N_updatecoeffsE=self.grid.updatecoeffsE.size,
             N_updatecoeffsH=self.grid.updatecoeffsH.size,
             NY_MATCOEFFS=self.grid.updatecoeffsE.shape[1],

--- a/gprMax/updates/metal_updates.py
+++ b/gprMax/updates/metal_updates.py
@@ -152,6 +152,7 @@ class MetalUpdates:
 
         self.knl_common = self.env.get_template("knl_common_metal.tmpl").render(
             REAL=config.sim_config.dtypes["C_float_or_double"],
+            DRUDELORENTZ=config.get_model_config().materials["drudelorentz"],
             N_updatecoeffsE=self.grid.updatecoeffsE.size,
             N_updatecoeffsH=self.grid.updatecoeffsH.size,
             NY_MATCOEFFS=self.grid.updatecoeffsE.shape[1],

--- a/gprMax/updates/opencl_updates.py
+++ b/gprMax/updates/opencl_updates.py
@@ -115,6 +115,7 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
             updatecoeffsE=self.grid.updatecoeffsE.ravel(),
             updatecoeffsH=self.grid.updatecoeffsH.ravel(),
             REAL=config.sim_config.dtypes["C_float_or_double"],
+            DRUDELORENTZ=config.get_model_config().materials["drudelorentz"],
             N_updatecoeffsE=self.grid.updatecoeffsE.size,
             N_updatecoeffsH=self.grid.updatecoeffsH.size,
             NY_MATCOEFFS=self.grid.updatecoeffsE.shape[1],

--- a/tests/cmds_multiuse/test_plane_wave_dispersive_dtype.py
+++ b/tests/cmds_multiuse/test_plane_wave_dispersive_dtype.py
@@ -1,0 +1,350 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+
+"""Regression tests for dispersive discrete-plane-wave auxiliary state.
+
+Lorentz or Drude materials make the model-wide dispersive coefficient array
+complex, including otherwise-real Debye rows. The DPW must consequently use
+the same real/complex auxiliary-state dtype as the main grid and apply the
+same real-field projection of the complex pole recurrence. These tests cover
+the original mixed-material dtype failure and direct, multipole Lorentz/Drude
+propagation in both homogeneous and axial DPWs.
+"""
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+from gprMax.cython.plane_wave import updatePlaneWave_electric_dispersive
+
+
+def _add_dispersion(scene, kind, material_id, poles=1):
+    if kind == "debye":
+        scene.add(
+            gprMax.AddDebyeDispersion(
+                poles=poles,
+                er_delta=[2.0, 0.75][:poles],
+                tau=[1e-11, 2e-11][:poles],
+                material_ids=[material_id],
+            )
+        )
+    elif kind == "lorentz":
+        scene.add(
+            gprMax.AddLorentzDispersion(
+                poles=poles,
+                er_delta=[1.0, 0.5][:poles],
+                omega=[8e9, 15e9][:poles],
+                delta=[1e9, 1.5e9][:poles],
+                material_ids=[material_id],
+            )
+        )
+    elif kind == "drude":
+        scene.add(
+            gprMax.AddDrudeDispersion(
+                poles=poles,
+                # Keep epsilon positive around the 10 GHz source while still
+                # exercising non-negligible, multi-pole Drude dispersion.
+                omega=[1e9, 2e9][:poles],
+                alpha=[0.8e9, 1.2e9][:poles],
+                material_ids=[material_id],
+            )
+        )
+    else:
+        raise ValueError(f"Unknown dispersion type: {kind}")
+
+
+def _debye_plane_wave_scene(extra_dispersion=None):
+    scene = gprMax.Scene()
+    scene.add(gprMax.OMPThreads(n=1))
+    scene.add(gprMax.Discretisation(p1=(1e-3, 1e-3, 1e-3)))
+    scene.add(gprMax.Domain(p1=(20e-3, 20e-3, 20e-3)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=5e-11))
+
+    scene.add(gprMax.Material(er=2, se=0, mr=1, sm=0, id="debye_bg"))
+    _add_dispersion(scene, "debye", "debye_bg")
+    if extra_dispersion in ("lorentz", "drude"):
+        scene.add(gprMax.Material(er=3, se=0, mr=1, sm=0, id="unused"))
+        _add_dispersion(scene, extra_dispersion, "unused")
+
+    scene.add(
+        gprMax.Box(
+            p1=(0, 0, 0),
+            p2=(20e-3, 20e-3, 20e-3),
+            material_id="debye_bg",
+        )
+    )
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=10e9, id="w"))
+    scene.add(
+        gprMax.DiscretePlaneWaveVector(
+            p1=(4e-3, 4e-3, 4e-3),
+            p2=(16e-3, 16e-3, 16e-3),
+            m_vec=(1, 0, 0),
+            psi=0,
+            waveform_id="w",
+            material_id="debye_bg",
+        )
+    )
+    scene.add(gprMax.Rx(p1=(10e-3, 10e-3, 10e-3)))
+    return scene
+
+
+def _lorentz_drude_plane_wave_scene(kind, axial):
+    scene = gprMax.Scene()
+    scene.add(gprMax.OMPThreads(n=1))
+    scene.add(gprMax.Discretisation(p1=(1e-3, 1e-3, 1e-3)))
+    scene.add(gprMax.Domain(p1=(20e-3, 20e-3, 20e-3)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=3e-10))
+
+    scene.add(gprMax.Material(er=3, se=0, mr=1, sm=0, id="dispersive_bg"))
+    _add_dispersion(scene, kind, "dispersive_bg", poles=2)
+    scene.add(
+        gprMax.Box(
+            p1=(0, 0, 0),
+            p2=(20e-3, 20e-3, 20e-3),
+            material_id="dispersive_bg",
+        )
+    )
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=10e9, id="w"))
+    if axial:
+        scene.add(
+            gprMax.DiscretePlaneWaveAxial(
+                p1=(4e-3, 4e-3, 4e-3),
+                p2=(16e-3, 16e-3, 16e-3),
+                axis="x",
+                psi=0,
+                waveform_id="w",
+            )
+        )
+    else:
+        scene.add(
+            gprMax.DiscretePlaneWaveVector(
+                p1=(4e-3, 4e-3, 4e-3),
+                p2=(16e-3, 16e-3, 16e-3),
+                m_vec=(1, 0, 0),
+                psi=0,
+                waveform_id="w",
+                material_id="dispersive_bg",
+            )
+        )
+    scene.add(gprMax.Rx(p1=(10e-3, 10e-3, 10e-3)))
+    return scene
+
+
+def _free_space_plane_wave_scene(extra_dispersion=None):
+    """Free-space DPW in a model whose global pole storage may be complex."""
+
+    scene = gprMax.Scene()
+    scene.add(gprMax.OMPThreads(n=1))
+    scene.add(gprMax.Discretisation(p1=(1e-3,) * 3))
+    scene.add(gprMax.Domain(p1=(20e-3,) * 3))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=5e-11))
+    if extra_dispersion in ("lorentz", "drude"):
+        scene.add(gprMax.Material(er=3, se=0, mr=1, sm=0, id="unused"))
+        _add_dispersion(scene, extra_dispersion, "unused")
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=10e9, id="w"))
+    scene.add(
+        gprMax.DiscretePlaneWaveVector(
+            p1=(4e-3,) * 3,
+            p2=(16e-3,) * 3,
+            m_vec=(1, 0, 0),
+            psi=0,
+            waveform_id="w",
+            material_id="free_space",
+        )
+    )
+    scene.add(gprMax.Rx(p1=(10e-3,) * 3))
+    return scene
+
+
+def _run_trace(tmp_path, name, extra_dispersion=None):
+    output = Path(tmp_path, name)
+    gprMax.run(
+        scenes=[_debye_plane_wave_scene(extra_dispersion)],
+        outputfile=output,
+        hide_progress_bars=True,
+    )
+    with h5py.File(output.with_suffix(".h5"), "r") as h5:
+        return np.asarray(h5["rxs/rx1/Ey"])
+
+
+def test_homogeneous_complex_pole_current_uses_complete_product():
+    """The homogeneous DPW must retain the Lorentz imaginary cross term."""
+
+    n = 3
+    pml_cells = 0
+    auxiliary_fields = np.zeros((3, n), dtype=np.float64)
+    magnetic_fields = np.zeros_like(auxiliary_fields)
+    px = np.zeros((1, n), dtype=np.complex128)
+    py = np.zeros_like(px)
+    pz = np.zeros_like(px)
+    px[0, 1] = 3 + 4j
+    pml_integrals = np.zeros((2, pml_cells), dtype=np.float64)
+    pml_coefficients = np.zeros((4, pml_cells), dtype=np.float64)
+    updatecoeffs_e = np.array([1, 0, 0, 0, 1], dtype=np.float64)
+    updatecoeffs_h = np.zeros(5, dtype=np.float64)
+    updatecoeffs_dispersive = np.array([1 + 2j, 1, 0], dtype=np.complex128)
+    main_fields = np.zeros((1, 1, 1), dtype=np.float64)
+    projections = np.zeros(6, dtype=np.float64)
+    waveform_values = np.zeros((2, 3, 1), dtype=np.float64)
+    mapping = np.array([1, 0, 0, 1], dtype=np.int32)
+    origin = np.zeros(3, dtype=np.int32)
+    corners = np.zeros(6, dtype=np.int32)
+
+    updatePlaneWave_electric_dispersive(
+        n,
+        pml_cells,
+        1,
+        0,
+        magnetic_fields,
+        auxiliary_fields,
+        px,
+        py,
+        pz,
+        pml_integrals.copy(),
+        pml_integrals.copy(),
+        pml_integrals.copy(),
+        updatecoeffs_e,
+        updatecoeffs_h,
+        updatecoeffs_dispersive,
+        1,
+        pml_coefficients.copy(),
+        pml_coefficients.copy(),
+        pml_coefficients.copy(),
+        pml_coefficients.copy(),
+        pml_coefficients.copy(),
+        pml_coefficients.copy(),
+        main_fields.copy(),
+        main_fields.copy(),
+        main_fields.copy(),
+        main_fields.copy(),
+        main_fields.copy(),
+        main_fields.copy(),
+        projections,
+        waveform_values,
+        waveform_values,
+        mapping,
+        origin,
+        corners,
+        True,
+        0,  # iteration
+        1,  # dt
+        1,  # dx
+        1,  # dy
+        1,  # dz
+        1,  # ds
+        1,  # c
+        0,  # waveform start
+        0,  # waveform stop
+        1,  # waveform frequency
+        b"ricker",
+    )
+
+    # Re((1 + 2j) * (3 + 4j)) = -5, hence E_new = -phi = +5.
+    # The former Re(a) * Re(T) implementation produced -3.
+    assert auxiliary_fields[0, 1] == 5
+
+
+@pytest.mark.parametrize("extra_dispersion", ["lorentz", "drude"])
+def test_debye_plane_wave_accepts_model_wide_complex_storage(tmp_path, extra_dispersion):
+    real_storage = _run_trace(tmp_path, "debye_only")
+    complex_storage = _run_trace(
+        tmp_path, f"debye_plus_{extra_dispersion}", extra_dispersion
+    )
+
+    assert np.max(np.abs(real_storage)) > 0
+    assert np.all(np.isfinite(complex_storage))
+    np.testing.assert_allclose(complex_storage, real_storage, rtol=1e-6, atol=1e-7)
+
+
+def test_debye_plane_wave_double_precision(tmp_path):
+    output = Path(tmp_path, "debye_double")
+    gprMax.run(
+        scenes=[_debye_plane_wave_scene()],
+        outputfile=output,
+        cpu_precision="double",
+        hide_progress_bars=True,
+    )
+    with h5py.File(output.with_suffix(".h5"), "r") as h5:
+        trace = np.asarray(h5["rxs/rx1/Ey"])
+
+    assert trace.dtype == np.float64
+    assert np.all(np.isfinite(trace))
+    assert np.max(np.abs(trace)) > 0
+
+
+@pytest.mark.parametrize("extra_dispersion", ["lorentz", "drude"])
+def test_free_space_plane_wave_keeps_simple_update_with_complex_main_grid(
+    tmp_path, extra_dispersion
+):
+    reference_path = Path(tmp_path, "free_space_only")
+    mixed_path = Path(tmp_path, f"free_space_plus_{extra_dispersion}")
+    gprMax.run(
+        scenes=[_free_space_plane_wave_scene()],
+        outputfile=reference_path,
+        hide_progress_bars=True,
+    )
+    gprMax.run(
+        scenes=[_free_space_plane_wave_scene(extra_dispersion)],
+        outputfile=mixed_path,
+        hide_progress_bars=True,
+    )
+    with h5py.File(reference_path.with_suffix(".h5"), "r") as reference_h5:
+        reference = np.asarray(reference_h5["rxs/rx1/Ey"])
+    with h5py.File(mixed_path.with_suffix(".h5"), "r") as mixed_h5:
+        mixed = np.asarray(mixed_h5["rxs/rx1/Ey"])
+
+    np.testing.assert_allclose(mixed, reference, rtol=1e-6, atol=1e-7)
+
+
+@pytest.mark.parametrize("kind", ["lorentz", "drude"])
+@pytest.mark.parametrize("axial", [False, True], ids=["homogeneous", "axial"])
+def test_multipole_lorentz_drude_plane_wave(tmp_path, kind, axial):
+    output = Path(tmp_path, f"{kind}_{'axial' if axial else 'homogeneous'}")
+    gprMax.run(
+        scenes=[_lorentz_drude_plane_wave_scene(kind, axial)],
+        outputfile=output,
+        hide_progress_bars=True,
+    )
+    with h5py.File(output.with_suffix(".h5"), "r") as h5:
+        trace = np.asarray(h5["rxs/rx1/Ey"])
+
+    assert np.all(np.isfinite(trace))
+    assert np.max(np.abs(trace)) > 0
+
+
+def test_multipole_lorentz_plane_wave_double_precision(tmp_path):
+    output = Path(tmp_path, "lorentz_homogeneous_double")
+    gprMax.run(
+        scenes=[_lorentz_drude_plane_wave_scene("lorentz", axial=False)],
+        outputfile=output,
+        cpu_precision="double",
+        hide_progress_bars=True,
+    )
+    with h5py.File(output.with_suffix(".h5"), "r") as h5:
+        trace = np.asarray(h5["rxs/rx1/Ey"])
+
+    assert trace.dtype == np.float64
+    assert np.all(np.isfinite(trace))
+    assert np.max(np.abs(trace)) > 0

--- a/tests/materials/test_complex_permittivity.py
+++ b/tests/materials/test_complex_permittivity.py
@@ -1,0 +1,186 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+
+"""Analytical-permittivity regressions for Lorentz and Drude materials."""
+
+import numpy as np
+
+import gprMax
+import gprMax.config as config
+import gprMax.model as model_module
+from gprMax.cython.fields_updates_dispersive import (
+    update_electric_dispersive_1pole_A_double_complex,
+)
+from gprMax.materials import DispersiveMaterial
+
+
+def _material(kind):
+    material = DispersiveMaterial(0, kind)
+    material.type = kind
+    material.er = 3.25
+    material.se = 0
+    material.poles = 2
+    material.tau = [1.2e9, 3.2e9]
+    material.alpha = [0.4e9, 0.8e9]
+    material.deltaer = [1.5, 0.8]
+    return material
+
+
+def test_lorentz_calculate_er_uses_pole_frequencies_in_hertz():
+    material = _material("lorentz")
+    frequency = 2e9
+    omega = 2 * np.pi * frequency
+    expected = complex(material.er)
+    for delta_er, pole_frequency, damping in zip(
+        material.deltaer, material.tau, material.alpha
+    ):
+        pole_omega = 2 * np.pi * pole_frequency
+        expected += delta_er * pole_omega**2 / (
+            pole_omega**2 + 2j * omega * damping - omega**2
+        )
+
+    np.testing.assert_allclose(material.calculate_er(frequency), expected)
+
+
+def test_multipole_drude_calculate_er_converts_and_sums_each_pole_once():
+    material = _material("drude")
+    frequency = 2e9
+    omega = 2 * np.pi * frequency
+    expected = complex(material.er)
+    for pole_frequency, damping in zip(material.tau, material.alpha):
+        pole_omega = 2 * np.pi * pole_frequency
+        expected -= pole_omega**2 / (omega**2 - 1j * omega * damping)
+
+    np.testing.assert_allclose(material.calculate_er(frequency), expected)
+
+
+def test_complex_pole_current_uses_real_part_of_complete_product():
+    """The Lorentz imaginary cross term must contribute to apparent current."""
+
+    nx, ny, nz = 1, 2, 2
+    shape = (nx + 1, ny + 1, nz + 1)
+    updatecoeffs_e = np.zeros((1, 5), dtype=np.float64)
+    updatecoeffs_e[0, 0] = 1
+    updatecoeffs_e[0, 4] = 1
+    updatecoeffs_dispersive = np.zeros((1, 3), dtype=np.complex128)
+    updatecoeffs_dispersive[0] = (1 + 2j, 1, 0)
+    material_ids = np.zeros((6, *shape), dtype=np.uint32)
+    pole_shape = (1, *shape)
+    tx = np.zeros(pole_shape, dtype=np.complex128)
+    ty = np.zeros_like(tx)
+    tz = np.zeros_like(tx)
+    tx[0, 0, 1, 1] = 3 + 4j
+    ex = np.zeros(shape, dtype=np.float64)
+    ey = np.zeros_like(ex)
+    ez = np.zeros_like(ex)
+    hx = np.zeros_like(ex)
+    hy = np.zeros_like(ex)
+    hz = np.zeros_like(ex)
+
+    update_electric_dispersive_1pole_A_double_complex(
+        nx,
+        ny,
+        nz,
+        0,
+        1,
+        1,
+        updatecoeffs_e,
+        updatecoeffs_dispersive,
+        material_ids,
+        tx,
+        ty,
+        tz,
+        ex,
+        ey,
+        ez,
+        hx,
+        hy,
+        hz,
+    )
+
+    # Re((1 + 2j) * (3 + 4j)) = -5, so E_new = -phi = +5.
+    # The former Re(a) * Re(T) implementation incorrectly produced -3.
+    assert ex[0, 1, 1] == 5
+
+
+def test_drude_update_uses_dimensioned_effective_conductivity_without_mutation(
+    monkeypatch, tmp_path
+):
+    captured = {}
+    original_build = model_module.Model.build
+
+    def capture_build(model):
+        original_build(model)
+        captured["grid"] = model.G
+
+    monkeypatch.setattr(model_module.Model, "build", capture_build)
+
+    physical_conductivity = 0.125
+    pole_frequencies = (1e9, 2e9)
+    damping = (0.8e9, 1.2e9)
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(1e-3,) * 3))
+    scene.add(gprMax.Domain(p1=(10e-3,) * 3))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=1e-11))
+    scene.add(
+        gprMax.Material(
+            er=3.25,
+            se=physical_conductivity,
+            mr=1,
+            sm=0,
+            id="drude",
+        )
+    )
+    scene.add(
+        gprMax.AddDrudeDispersion(
+            poles=2,
+            omega=pole_frequencies,
+            alpha=damping,
+            material_ids=["drude"],
+        )
+    )
+    gprMax.run(
+        scenes=[scene],
+        geometry_only=True,
+        outputfile=tmp_path / "drude_coefficients",
+        hide_progress_bars=True,
+    )
+
+    grid = captured["grid"]
+    material = next(item for item in grid.materials if item.ID == "drude")
+    assert material.se == physical_conductivity
+
+    e0 = config.e0
+    effective_conductivity = physical_conductivity + e0 * sum(
+        (2 * np.pi * frequency) ** 2 / rate
+        for frequency, rate in zip(pole_frequencies, damping)
+    )
+    ea = (
+        e0 * material.er / grid.dt
+        + 0.5 * effective_conductivity
+        - e0 / grid.dt * np.sum(material.zt2.real)
+    )
+    eb = (
+        e0 * material.er / grid.dt
+        - 0.5 * effective_conductivity
+        - e0 / grid.dt * np.sum(material.zt2.real)
+    )
+    np.testing.assert_allclose(material.CA, eb / ea)
+    np.testing.assert_allclose(material.srce, 1 / ea)

--- a/tests/materials/test_symmetry_boundary_pmc_dispersive_complex_edges.py
+++ b/tests/materials/test_symmetry_boundary_pmc_dispersive_complex_edges.py
@@ -9,9 +9,8 @@ Same design decision under test as the real-pole edge file (see
 gprMax/cython/symmetry_boundaries_dispersive_complex.pyx's module
 docstring): phi/T bookkeeping runs unconditionally regardless of the
 a_pmc/b_pmc flags; only phi's accumulation formula differs from the
-real-pole case (Real(coeff)*Real(T) per pole, not the full complex
-product's real part - matching the bulk dispersive kernel's own complex
-branch exactly).
+real-pole case: it is the real part of the complete complex product
+Real(coeff*T) per pole, matching the bulk dispersive update.
 """
 import numpy as np
 import pytest
@@ -58,7 +57,7 @@ def _phi_and_new_t(t_old_poles, e_old):
     phi = 0.0
     t_new = []
     for p in range(maxpoles):
-        phi += alpha[p].real * t_old_poles[p].real
+        phi += (alpha[p] * t_old_poles[p]).real
         t_new.append(beta[p] * t_old_poles[p] + gamma[p] * e_old)
     return phi, t_new
 

--- a/tests/materials/test_symmetry_boundary_pmc_dispersive_complex_updates.py
+++ b/tests/materials/test_symmetry_boundary_pmc_dispersive_complex_updates.py
@@ -6,14 +6,10 @@ materials with complex ADE poles.
 
 The only difference from the real-pole file: Tx/Ty/Tz and
 updatecoeffsdispersive are complex here, so phi (which must stay real - it
-feeds directly into a real E-field update) accumulates
-Real(updatecoeffsdispersive[...]) * Real(T[...]) per pole - the real part of
-each factor individually, matching
-fields_updates_dispersive_template.jinja's own complex branch exactly (not
-"fixed" to Real(a*b), which would be a different, not-implemented, formula -
-see gprMax/cython/symmetry_boundaries_dispersive_complex.pyx's module
-docstring). The T-array recursion itself and Phase B are unchanged in form
-from the real-pole case - ordinary complex arithmetic handles them directly.
+feeds directly into a real E-field update) accumulates the real part of the
+complete complex product Real(updatecoeffsdispersive[...] * T[...]) per pole.
+The T-array recursion itself and Phase B are unchanged in form from the
+real-pole case - ordinary complex arithmetic handles them directly.
 
 maxpoles=2 with genuinely complex (non-zero imaginary part) per-pole
 coefficients is used throughout, specifically to exercise that the .real
@@ -113,13 +109,11 @@ def _make_grid():
 
 
 def _phi_and_new_t(t_old_poles, e_old):
-    """Independently re-derives phi (real: Re(alpha)*Re(T) per pole, NOT
-    Re(alpha*T)) and the new per-pole complex T values for a single grid
-    position - matches the Cython pole loop exactly."""
+    """Independently derive phi and the new complex T values at one point."""
     phi = 0.0
     t_new = []
     for p in range(maxpoles):
-        phi += alpha[p].real * t_old_poles[p].real
+        phi += (alpha[p] * t_old_poles[p]).real
         t_new.append(beta[p] * t_old_poles[p] + gamma[p] * e_old)
     return phi, t_new
 

--- a/tests/updates/test_dispersive_gpu_kernel_source.py
+++ b/tests/updates/test_dispersive_gpu_kernel_source.py
@@ -1,0 +1,102 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+
+"""Source-generation regressions for complex dispersive GPU updates."""
+
+import pytest
+from jinja2 import Environment, PackageLoader
+
+from gprMax.config import SimulationConfig
+from gprMax.cuda_opencl import knl_fields_updates
+
+
+def _render_common(backend, real, drudelorentz):
+    env = Environment(loader=PackageLoader("gprMax", "cuda_opencl"))
+    return env.get_template(f"knl_common_{backend}.tmpl").render(
+        REAL=real,
+        DRUDELORENTZ=drudelorentz,
+    )
+
+
+@pytest.mark.parametrize(
+    ("real", "complex_type", "prefix"),
+    [
+        ("float", "cfloat_t", "cfloat"),
+        ("double", "cdouble_t", "cdouble"),
+    ],
+)
+def test_opencl_complex_kernel_uses_pyopencl_struct_arithmetic(
+    real, complex_type, prefix
+):
+    source = _render_common("opencl", real, drudelorentz=True)
+
+    assert f"#define GPRMAX_CMUL(a, b) {prefix}_mul((a), (b))" in source
+    assert f"#define GPRMAX_CRMUL(a, b) {prefix}_mulr((a), (b))" in source
+    assert f"#define GPRMAX_CADD(a, b) {prefix}_add((a), (b))" in source
+    assert f"#define GPRMAX_CSUB(a, b) {prefix}_sub((a), (b))" in source
+    assert f"#define GPRMAX_CREAL(a) {prefix}_real(a)" in source
+
+    args = knl_fields_updates.update_electric_dispersive_A[
+        "args_opencl"
+    ].substitute(REAL=real, COMPLEX=complex_type)
+    assert f"__global const {complex_type}* restrict updatecoeffsdispersive" in args
+
+    if real == "double":
+        assert "#define PYOPENCL_DEFINE_CDOUBLE" in source
+
+
+def test_opencl_debye_kernel_keeps_scalar_arithmetic():
+    source = _render_common("opencl", "float", drudelorentz=False)
+
+    assert "#define GPRMAX_CMUL(a, b) ((a) * (b))" in source
+    assert "#define GPRMAX_CADD(a, b) ((a) + (b))" in source
+    assert "#define GPRMAX_CREAL(a) (a)" in source
+    assert "cfloat_mul" not in source
+
+
+@pytest.mark.parametrize("backend", ["cuda", "metal"])
+def test_cpp_gpu_backends_extract_real_part_after_complete_product(backend):
+    source = _render_common(backend, "float", drudelorentz=True)
+
+    assert "#define GPRMAX_CMUL(a, b) ((a) * (b))" in source
+    assert "#define GPRMAX_CREAL(a) ((a).real())" in source
+
+
+def test_shared_gpu_kernel_uses_backend_complex_operations_in_both_phases():
+    phase_a = knl_fields_updates.update_electric_dispersive_A["func"].template
+    phase_b = knl_fields_updates.update_electric_dispersive_B["func"].template
+
+    assert phase_a.count("GPRMAX_CREAL(GPRMAX_CMUL(") == 3
+    assert phase_a.count("GPRMAX_CADD(") == 3
+    assert phase_a.count("GPRMAX_CRMUL(") == 3
+    assert phase_b.count("GPRMAX_CSUB(") == 3
+    assert phase_b.count("GPRMAX_CRMUL(") == 3
+
+
+@pytest.mark.parametrize(
+    ("precision", "expected"),
+    [("single", "cfloat_t"), ("double", "cdouble_t")],
+)
+def test_opencl_complex_dtype_names_match_pyopencl_header(precision, expected):
+    sim_config = SimulationConfig.__new__(SimulationConfig)
+    sim_config.general = {"solver": "opencl", "precision": precision}
+
+    sim_config._set_precision()
+
+    assert sim_config.dtypes["C_complex"] == expected


### PR DESCRIPTION
## Summary

This PR corrects and extends the dispersive-material implementation used by the main FDTD grid and CPU discrete plane waves.

- Correct the Giannakis–Giannopoulos current-density coupling (Equation 38) from `Re(a) * Re(T)` to `Re(a * T)`, retaining the imaginary cross-term required by Lorentz poles.
- Apply the same expression consistently to CPU bulk updates, complex PMC symmetry updates, homogeneous and axial discrete plane waves, and CUDA/OpenCL/Metal main-grid kernels.
- Add backend-neutral GPU complex arithmetic. In particular, OpenCL now uses the `cfloat_t`/`cdouble_t` types and arithmetic helpers defined by `pyopencl-complex.h` instead of invalid struct operators.
- Support multi-pole Debye, Lorentz, and Drude materials in homogeneous and axial CPU discrete plane waves while preserving the simpler non-dispersive update when the plane-wave path itself contains no dispersive material.
- Correct Drude effective-conductivity dimensions without mutating the user-specified physical conductivity, and correct Lorentz/Drude analytical permittivity frequency conversion and multipole summation.
- Document the supported plane-wave material models and precision behaviour.


## Related Issue

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking support for Lorentz/Drude discrete plane waves)
- [ ] Breaking change
- [x] This change requires a documentation update

## Verification

- 301 focused unit/regression tests passed (dispersion, plane waves, PMC symmetry, GPU source generation, Metal dispatch, and precision configuration).
- Cython extensions rebuilt successfully.
- Sphinx HTML build completed successfully; its 10 warnings are pre-existing and unrelated.
- CUDA/OpenCL/Metal complex kernel source generation is unit-tested. GPU hardware execution was not available on this server.

## Checklist

- [ ] Pre-commit was not available in the active environment; `git diff --check` and Python compilation passed.
- [x] I have performed a self-review of my code.
- [x] I have added comments for hard-to-understand areas.
- [x] I have made corresponding documentation changes.
- [x] My changes generate no new warnings.
- [x] The pull-request title is a short description of the changes.
