### PR TITLE
Add source port outputs and transmission lines on CUDA solver

### DIFF
--- a/docs/source/examples_antennas.rst
+++ b/docs/source/examples_antennas.rst
@@ -19,7 +19,11 @@ This example demonstrates a model of a half-wavelength wire dipole antenna in fr
 
 The wire is modelled using an edge which specifies the properties of the edge of the Yee cell. The antenna is fed using a transmission line The one-dimensional transmission line model virtually attaches to the dipole at the gap between the arms. The antenna has an input resistance :math:`Z_{in} = 73~\Omega` specified in the transmissions, and uses a Gaussian waveform with a centre frequency of 1GHz. A time window of 60ns is used: firstly, to give enough time for the response to decay down to zero; and secondly, to allow a reasonable resolution (17MHz) for calculating antenna parameters that involve taking an FFT (:math:`\Delta f=1/T` where :math:`\Delta f` is the frequency bin spacing and :math:`T` is the time window).
 
-Time histories of voltage and current values in the transmission line are saved to the output file. These are documented in the :ref:`output` section. These parameters are useful for calculating characteristics of the antenna such as the input impedance or S-parameters. gprMax includes a Python module (in the ``toolboxes\Plotting`` package) to help you view the input impedance and admittance and s11 parameter from an antenna model fed using a transmission line. Details of how to use this module are given in the README.rst for that package.
+Time histories of voltage and current values in the transmission line are
+saved to the output file together with automatically calculated S11, input
+impedance, and input admittance spectra. These are documented in the
+:ref:`output` section. The modules in the ``toolboxes\Plotting`` package can
+also be used to plot the histories and derived antenna parameters.
 
 Results
 -------

--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -474,6 +474,14 @@ Transmission Line
 -----------------
 .. autoclass:: gprMax.user_objects.cmds_multiuse.TransmissionLine
 
+Every transmission-line source automatically writes its incident and terminal
+voltage/current histories together with ``frequency``, ``S11``, ``Zin``, and
+``Yin`` beneath ``/tls/tlN`` in the model HDF5 output. ``Zin`` is derived from
+the voltage-wave S11 result; ``Zin_current`` is an independent, stagger-aware
+current-wave check. An additional :class:`RxPort` is only needed for a
+resistive voltage source, not for a transmission line. See
+:ref:`Simulation Output <output>` for the equations and validity masks.
+
 All local sources refer to the ID of a waveform that has already been added to
 the scene. The following illustrates their required arguments; a model would
 normally contain only the source or sources that it needs:
@@ -557,6 +565,43 @@ Receiver
 Receiver Array
 --------------
 .. autoclass:: gprMax.user_objects.cmds_multiuse.RxArray
+
+Voltage-source S11 and input impedance
+--------------------------------------
+.. autoclass:: gprMax.user_objects.cmds_output.RxPort
+
+``RxPort`` binds to one resistive, single-Yee-edge ``VoltageSource`` at the
+same discretised coordinate. It creates its electric-field monitor
+automatically and calculates corrected complex ``S11``, ``Zin``, and ``Yin``
+after the solve:
+
+.. code-block:: python
+
+    port = gprMax.RxPort(
+        p1=(0.050, 0.050, 0.020),
+        id='feed',
+        spectrum_limit=10,
+    )
+    scene.add(port)
+
+The default ``spectrum_limit=10`` retains frequencies having at least ten
+cells per shortest material wavelength. Because optional hash-command
+arguments are positional, an ``id`` is required when the Python object uses a
+non-default spectrum limit. A research run can explicitly request all native
+non-negative FFT bins while retaining the normal validity metadata:
+
+.. code-block:: python
+
+    scene.add(gprMax.RxPort(
+        p1=(0.050, 0.050, 0.020),
+        id='feed_full',
+        spectrum_limit='nyquist',
+    ))
+
+After ``gprMax.run`` completes, ``port.result`` provides the same numerical
+arrays that are stored under ``/ports/feed`` in the model HDF5 file. No current
+receiver is required; input impedance is calculated from the corrected S11
+and the voltage-source resistance.
 
 Source Steps
 ------------

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -990,7 +990,7 @@ For example, to specify a y directed voltage source with an internal resistance 
 #transmission_line:
 -------------------
 
-Allows you to introduce a one-dimensional transmission line model [MAL1994]_ at an electric field location. The transmission line can have a specified resistance greater than zero and less than the impedance of free space (376.73 Ohms). It is useful for exciting antennas when the physical properties of the antenna are included in the model. The syntax of the command is:
+Allows you to introduce a one-dimensional transmission line model [MAL1994]_ at an electric field location. The transmission line can have a specified resistance greater than zero and less than the impedance of free space (376.73 Ohms). It is useful for exciting antennas when the physical properties of the antenna are included in the model. Transmission lines are supported by the CPU and CUDA solvers; OpenCL and Metal support is not currently enabled. The syntax of the command is:
 
 .. code-block:: none
 
@@ -1002,7 +1002,15 @@ Allows you to introduce a one-dimensional transmission line model [MAL1994]_ at 
 * ``f5 f6`` are optional parameters. ``f5`` is a time delay in starting the excitation of the transmission line. ``f6`` is a time to remove the excitation of the transmission line. If the time window is longer than the excitation of the transmission line removal time then the excitation of the transmission line will stop after the excitation of the transmission line removal time. If the excitation of the transmission line removal time is longer than the time window then the excitation of the transmission line will be active for the entire time window. If ``f5 f6`` are omitted the excitation of the transmission line will start at the beginning of time window and stop at the end of the time window.
 * ``str1`` is the identifier of the waveform that should be used with the source.
 
-Time histories of voltage and current values in the transmission line are saved to the output file. These are documented in the :ref:`Simulation Output <output>` section. These parameters are useful for calculating characteristics of an antenna such as the input impedance or S-parameters. gprMax includes a Python module (in the ``toolboxes/Plotting`` package) to help you view the input impedance and s11 parameter from an antenna model fed using a transmission line.
+Time histories of incident and total voltage and current are saved to the
+output file. gprMax also calculates S11, input impedance, and input admittance
+automatically after the simulation. The line resistance is used as the S11
+reference impedance; ``Zin`` is derived from S11, while an independently
+de-embedded current result is saved as ``Zin_current`` for verification. The
+frequency axis, validity masks, and lambda/10 mesh limit are stored with the
+results. No separate ``#rx_port`` command is required for a transmission-line
+source. The complete schema and equations are documented in the
+:ref:`Simulation Output <output>` section.
 
 For example, to specify a z directed transmission line source with a resistance of 75 Ohms, an amplitude of five, and a 1.2 GHz centre frequency Gaussian waveform use: ``#waveform: gaussian 5 1.2e9 my_gauss_pulse`` and ``#transmission_line: z 0.05 0.05 0.05 75 my_gauss_pulse``.
 
@@ -1111,6 +1119,86 @@ Provides a simple method of defining multiple output points in the model. The sy
 
 * ``f1 f2 f3`` are the lower left (x,y,z) coordinates of the output line/rectangle/volume, and ``f4 f5 f6`` are the upper right (x,y,z) coordinates of the output line/rectangle/volume.
 * ``f7 f8 f9`` are the increments (x,y,z) which define the number of output points in each direction. ``f7``, ``f8``, or  ``f9`` can be set to zero to prevent any output points in a particular direction. Otherwise, the minimum value of ``f7`` is :math:`\Delta x`, the minimum value of ``f8`` is :math:`\Delta y`, and the minimum value of ``f9`` is :math:`\Delta z`.
+
+#rx_port:
+---------
+
+Calculates the complex reflection coefficient and input impedance of a
+single-cell resistive voltage-source port. The output point must coincide
+exactly with one ``#voltage_source`` after both positions have been resolved to
+the Yee grid. A separate ``#rx`` command is not required. The syntax is:
+
+.. code-block:: none
+
+    #rx_port: f1 f2 f3 [str1 [str2]]
+
+* ``f1 f2 f3`` are the source coordinates (x,y,z).
+* ``str1`` is the optional port/output identifier. If omitted, ``port1``,
+  ``port2``, and so on are generated.
+* ``str2`` is the optional spectrum limit. A number specifies the minimum
+  cells per shortest material wavelength; the default is 10. The keyword
+  ``nyquist`` requests every native non-negative FFT bin for research and
+  diagnostic use.
+
+Because optional hash-command arguments are positional, ``str1`` must be
+given before ``str2``. For example:
+
+.. code-block:: none
+
+    #voltage_source: z 0.050 0.050 0.020 50 source_wave
+    #rx_port: 0.050 0.050 0.020 feed
+    #rx_port: 0.050 0.050 0.020 feed nyquist
+
+The voltage-source resistance is the reference impedance :math:`Z_0`. At the
+source plane, the known generator spectrum :math:`V_g` and sampled total gap
+voltage :math:`V` give
+
+.. math::
+
+    S_{11,\mathrm{source}} = \frac{2V-V_g}{V_g}.
+
+No current calculation is required. gprMax removes the parallel capacitance
+and background conductance of the source Yee edge before reporting the
+antenna-terminal result. With :math:`c=Z_0Y_\mathrm{gap}`, this correction and
+the input impedance are
+
+.. math::
+
+    S_{11} =
+    \frac{2S_{11,\mathrm{source}}+c(1+S_{11,\mathrm{source}})}
+         {2-c(1+S_{11,\mathrm{source}})},
+    \qquad
+    Z_\mathrm{in}=Z_0\frac{1+S_{11}}{1-S_{11}}.
+
+The gap capacitance and conductance use the effective electric-edge material
+before the artificial source resistance is added. The discrete capacitive
+admittance is used so the correction is consistent with the trapezoidal Yee
+update.
+
+By default, output stops at the first native FFT bin that does not have at
+least 10 cells per shortest wavelength in the model. For nonmagnetic,
+nondispersive media this is the material with the largest :math:`\epsilon_r`.
+A numeric ``str2`` changes this sampling requirement; values below 10 produce
+a warning and values below 3 are rejected. ``nyquist`` deliberately retains
+the full spectrum but does not claim it is accurate: the lambda/10 limit and
+per-bin mesh/source validity masks are still written to HDF5. The actual
+stored range, native frequency resolution, Nyquist bound, and limiting
+material are reported when the model is built.
+
+.. note::
+
+    * The initial implementation supports one finite, non-zero-resistance
+      voltage source on the main 3D grid with the CPU, CUDA, OpenCL, or Metal
+      solver.
+    * MPI, subgrids, 2D modes, geometry-fixed runs, grouped sources, sources
+      inside a PML, and dispersive material on the source edge are currently
+      rejected. Dispersive materials elsewhere in the model are supported.
+    * ``S11`` remains the primary result. ``Zin`` is singular near an open
+      circuit (:math:`S_{11}=1`), so gprMax also stores ``Yin`` and separate
+      validity masks.
+    * A time trace that has not decayed before the end of the model window can
+      contaminate the spectrum. gprMax reports a tail-level warning rather
+      than hiding or clipping the result.
 
 #src_steps: and #rx_steps:
 --------------------------

--- a/docs/source/output.rst
+++ b/docs/source/output.rst
@@ -24,10 +24,12 @@ The output file has the following HDF5 attributes at the root (``/``):
 - ``rxsteps`` is the spatial increment used to move all receivers between model runs.
 - ``nsrc`` is the total number of sources in the model.
 - ``nrx`` is the total number of receievers in the model.
+- ``nports`` is the number of voltage-source S11/impedance outputs.
 
 The output file contains HDF5 groups for sources (``srcs``), transmission lines
-(``tls``), receivers (``rxs``), and KSIR outputs (``ntff``) when requested.
-Within these are further groups for each named or numbered output.
+(``tls``), receivers (``rxs``), voltage-source ports (``ports``), and KSIR
+outputs (``ntff``) when requested. Within these are further groups for each
+named or numbered output.
 
 .. code-block:: none
 
@@ -63,10 +65,24 @@ Within these are further groups for each named or numbered output.
                 Iinc
                 Vtotal
                 Itotal
+                frequency
+                S11
+                Zin
+                Yin
+                S11_current
+                Zin_current
+                ...
             tl2/
                 ...
         ntff/ [optional]
             <monitor name>/
+                ...
+        ports/ [optional]
+            <port ID>/
+                frequency
+                S11
+                Zin
+                Yin
                 ...
 
 Within each individual ``rx`` group are the following attributes:
@@ -96,6 +112,14 @@ Within each individual ``tl`` group are the following attributes:
 * ``Position`` is the x, y, z position (in metres) of the source in the model.
 * ``Resistance`` is the resistance of the transmission line.
 * ``dl`` is the spatial discretisation of the transmission line.
+* ``ReferenceImpedance`` is the real reference impedance used for S11 and is
+  equal to ``Resistance``.
+* ``SpectrumLimitMode``, ``MinimumWavelengthCells``,
+  ``MeshFrequencyLimit``, ``NyquistFrequency``, and ``LimitingMaterial``
+  describe the automatically selected frequency band.
+* ``ZinPrimaryMethod`` identifies the voltage-wave S11 result as the primary
+  impedance calculation. ``CurrentCheckMethod`` identifies the independent
+  discrete-line current-wave calculation.
 
 Within each individual ``tl`` group are the following datasets:
 
@@ -103,6 +127,143 @@ Within each individual ``tl`` group are the following datasets:
 * ``Iinc`` is an array containing the time history (for the model time window) of the values of the incident current in the transmission line.
 * ``Vtotal`` is an array containing the time history (for the model time window) of the values of the total (field) voltage in the transmission line.
 * ``Itotal`` is an array containing the time history (for the model time window) of the values of the total (field) current in the transmission line.
+* ``frequency`` is the authoritative non-negative frequency axis in Hz.
+* ``Vincident_spectrum``, ``Vreflected_spectrum``, and ``Vtotal_spectrum``
+  are the complex voltage spectra.
+* ``Iincident_spectrum`` and ``Itotal_spectrum`` are the complex current
+  spectra after accounting for the current's half-time-step staggering.
+* ``S11`` is the voltage-wave reflection coefficient
+  :math:`(V_\mathrm{total}-V_\mathrm{inc})/V_\mathrm{inc}`.
+* ``Zin`` and ``Yin`` are the input impedance and admittance derived from
+  ``S11`` and the line resistance.
+* ``S11_current`` and ``Zin_current`` are independent checks calculated from
+  the line current. The current is displaced from the voltage node by both
+  half a time step and half a line cell; gprMax removes both offsets using the
+  discrete 1D transmission-line dispersion relation. A simple phase shift of
+  the total current alone is not sufficient because incident and reflected
+  current waves require opposite spatial corrections.
+* ``valid_S11``, ``valid_Zin``, ``valid_Yin``, ``valid_S11_current``, and
+  ``valid_Zin_current`` are per-bin integer masks. ``source_valid``,
+  ``mesh_valid``, ``line_propagation_valid``, ``incident_relative_dB``, and
+  ``cells_per_minimum_wavelength`` provide the corresponding diagnostics.
+
+Transmission-line S11 and impedance output
+-------------------------------------------
+
+S11, input impedance, and input admittance are generated automatically for
+every transmission-line source; no ``#rx_port`` command or additional
+receiver is required. With the real line resistance :math:`Z_0` as the
+reference impedance, the primary results are
+
+.. math::
+
+    S_{11}=\frac{V_\mathrm{total}-V_\mathrm{inc}}{V_\mathrm{inc}},
+    \qquad
+    Z_\mathrm{in}=Z_0\frac{1+S_{11}}{1-S_{11}},
+    \qquad
+    Y_\mathrm{in}=\frac{1-S_{11}}{Z_0(1+S_{11})}.
+
+This S11-based ``Zin`` is the primary result because direct division by the
+terminal current becomes ill-conditioned at frequencies where that current
+approaches zero. The independently de-embedded current result remains in
+``Zin_current`` so that the line coupling and the voltage-wave result can be
+checked. Algebraically undefined open- or short-circuit quantities are stored
+as complex NaNs and identified by their validity masks.
+
+The stored spectrum uses the native resolution :math:`\Delta f=1/T` and is
+capped automatically at the lambda/10 mesh limit of the most restrictive
+material in the model. The original ``Vinc``, ``Iinc``, ``Vtotal``, and
+``Itotal`` histories remain available for users who need to reprocess a wider
+research band.
+
+For example, the valid S11 and impedance bins can be read directly:
+
+.. code-block:: python
+
+    import h5py
+    import numpy as np
+
+    with h5py.File('model.h5', 'r') as output:
+        line = output['tls/tl1']
+        frequency = line['frequency'][...]
+        s11 = line['S11'][...]
+        zin = line['Zin'][...]
+        valid = (
+            line['valid_S11'][...].astype(bool)
+            & line['valid_Zin'][...].astype(bool)
+        )
+
+    s11_db = 20 * np.log10(np.abs(s11[valid]))
+    resistance = zin.real[valid]
+    reactance = zin.imag[valid]
+
+Voltage-source S11 and impedance output
+---------------------------------------
+
+The ``#rx_port`` command and ``RxPort`` Python object write one group per port at
+``/ports/<port ID>``. The source resistance is the reference impedance
+:math:`Z_0`. The source-plane reflection coefficient is calculated directly
+from the known generator voltage and sampled total gap voltage; the reported
+``S11`` then removes the effective Yee-edge background capacitance and
+conductance. ``Zin`` and ``Yin`` are derived from that corrected result:
+
+.. math::
+
+    Z_\mathrm{in}=Z_0\frac{1+S_{11}}{1-S_{11}},
+    \qquad
+    Y_\mathrm{in}=\frac{1-S_{11}}{Z_0(1+S_{11})}.
+
+Important attributes include:
+
+* ``ReferenceImpedance``, ``Polarisation``, ``Position``, and ``GridPosition``;
+* ``BackgroundMaterial``, ``GapCapacitance``, and
+  ``BackgroundConductance``;
+* ``SpectrumLimitMode``, ``MinimumWavelengthCells``,
+  ``MeshFrequencyLimit``, ``NyquistFrequency``, and ``LimitingMaterial``;
+* ``FrequencyRange`` (the first and last stored bins),
+  ``ValidFrequencyRange`` (a convenience summary), and
+  ``IndependentFrequencyResolution``;
+* ``phasor_time_sign=exp(+j*omega*t)`` and
+  ``forward_transform_sign=exp(-j*omega*t)``.
+
+The principal datasets are:
+
+* ``frequency``: the authoritative plotting axis in Hz;
+* ``S11``, ``Zin``, and ``Yin``: corrected complex terminal quantities;
+* ``S11_source`` and ``Zin_source``: uncorrected source-plane quantities;
+* ``Vincident_spectrum``, ``Vreflected_source_spectrum``, and
+  ``Vtotal_spectrum``: complex voltage spectra;
+* ``time``, ``Vgenerator``, and ``Vtotal``: half-time-step-aligned audit
+  histories;
+* ``valid_S11``, ``valid_Zin``, ``valid_Yin``, ``source_valid``,
+  ``mesh_valid``, and ``gap_correction_valid``: per-bin integer masks;
+* ``incident_relative_dB`` and ``cells_per_minimum_wavelength``: diagnostics
+  behind the masks.
+
+The normal output is capped by the requested cells-per-wavelength criterion.
+With ``spectrum_limit='nyquist'``, all native non-negative bins are retained
+for research, including finite values outside the recommended band, while the
+validity masks and lambda/10 advisory ceiling remain present. Algebraically
+undefined values are stored as complex NaNs; finite invalid values are not
+silently clipped.
+
+The frequency dataset and validity mask can be plotted directly:
+
+.. code-block:: python
+
+    import h5py
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    with h5py.File('model.h5', 'r') as output:
+        port = output['ports/feed']
+        frequency = port['frequency'][...]
+        s11 = port['S11'][...]
+        valid = port['valid_S11'][...].astype(bool)
+
+    plt.plot(frequency[valid], 20 * np.log10(np.abs(s11[valid])))
+    plt.xlabel('Frequency [Hz]')
+    plt.ylabel(r'$|S_{11}|$ [dB]')
 
 KSIR field-transformation output
 --------------------------------

--- a/gprMax/__init__.py
+++ b/gprMax/__init__.py
@@ -69,6 +69,7 @@ from .user_objects.cmds_output import (
     KSIRTimeRx,
     KSIRTimeRxArray,
     KSIRTimeRxSpherical,
+    RxPort,
     Snapshot,
 )
 from .user_objects.cmds_singleuse import (

--- a/gprMax/cuda_opencl/knl_transmission_line.py
+++ b/gprMax/cuda_opencl/knl_transmission_line.py
@@ -1,0 +1,284 @@
+# Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Shared CUDA/OpenCL/Metal kernels for transmission-line feeds.
+
+One work-item owns one complete one-dimensional line. The coupled line has
+only a small number of active cells, so a serial loop within a work-item is
+both cheaper and easier to keep numerically consistent with the CPU source
+than coordinating a workgroup for each line.
+"""
+
+from string import Template
+
+update_transmission_line_magnetic = {
+    "args_cuda": Template(
+        """
+        __global__ void update_transmission_line_magnetic(
+            int NTL,
+            int iteration,
+            $REAL dx,
+            $REAL dy,
+            $REAL dz,
+            $REAL line_coefficient,
+            const int* __restrict__ tl_info,
+            const $REAL* __restrict__ resistance,
+            const $REAL* __restrict__ waveform_half,
+            const $REAL* __restrict__ voltage,
+            $REAL* current,
+            $REAL* Vtotal,
+            $REAL* Itotal,
+            const $REAL* __restrict__ Hx,
+            const $REAL* __restrict__ Hy,
+            const $REAL* __restrict__ Hz)
+        """
+    ),
+    "args_opencl": Template(
+        """
+            int NTL,
+            int iteration,
+            $REAL dx,
+            $REAL dy,
+            $REAL dz,
+            $REAL line_coefficient,
+            __global const int* restrict tl_info,
+            __global const $REAL* restrict resistance,
+            __global const $REAL* restrict waveform_half,
+            __global const $REAL* restrict voltage,
+            __global $REAL* current,
+            __global $REAL* Vtotal,
+            __global $REAL* Itotal,
+            __global const $REAL* restrict Hx,
+            __global const $REAL* restrict Hy,
+            __global const $REAL* restrict Hz
+        """
+    ),
+    "args_metal": Template(
+        """
+        kernel void update_transmission_line_magnetic(
+            device const int& NTL,
+            device const int& iteration,
+            device const $REAL& dx,
+            device const $REAL& dy,
+            device const $REAL& dz,
+            device const $REAL& line_coefficient,
+            device const int* tl_info,
+            device const $REAL* resistance,
+            device const $REAL* waveform_half,
+            device const $REAL* voltage,
+            device $REAL* current,
+            device $REAL* Vtotal,
+            device $REAL* Itotal,
+            device const $REAL* Hx,
+            device const $REAL* Hy,
+            device const $REAL* Hz,
+            uint i [[thread_position_in_grid]])
+        """
+    ),
+    "func": Template(
+        """
+    // tl_info columns: x, y, z, polarisation, state offset, line length,
+    // source position, antenna position, first active iteration, last active
+    // iteration. One work-item advances one complete line.
+
+    $CUDA_IDX
+
+    if (i < NTL) {
+        int x = tl_info[i * $NY_TLINFO + 0];
+        int y = tl_info[i * $NY_TLINFO + 1];
+        int z = tl_info[i * $NY_TLINFO + 2];
+        int polarisation = tl_info[i * $NY_TLINFO + 3];
+        int offset = tl_info[i * $NY_TLINFO + 4];
+        int nl = tl_info[i * $NY_TLINFO + 5];
+        int srcpos = tl_info[i * $NY_TLINFO + 6];
+        int antpos = tl_info[i * $NY_TLINFO + 7];
+        int first_active = tl_info[i * $NY_TLINFO + 8];
+        int last_active = tl_info[i * $NY_TLINFO + 9];
+        int antenna = offset + antpos;
+
+        // CPU output is sampled at the start of the time step. The line state
+        // has not changed during the bulk H update, so storing it here is
+        // equivalent and avoids an additional device-kernel launch.
+        Vtotal[i * $NY_TLOUTPUTS + iteration] = voltage[antenna];
+        Itotal[i * $NY_TLOUTPUTS + iteration] = current[antenna];
+
+        if (iteration >= first_active && iteration <= last_active) {
+            // Replace the terminal current with the Ampere-loop current from
+            // the four magnetic Yee edges surrounding the source E edge.
+            if (polarisation == 0) {
+                if (y == 0 || z == 0) {
+                    current[antenna] = 0;
+                }
+                else {
+                    current[antenna] =
+                        dy * (Hy[IDX3D_FIELDS(x,y,z-1)] - Hy[IDX3D_FIELDS(x,y,z)]) +
+                        dz * (Hz[IDX3D_FIELDS(x,y,z)] - Hz[IDX3D_FIELDS(x,y-1,z)]);
+                }
+            }
+            else if (polarisation == 1) {
+                if (x == 0 || z == 0) {
+                    current[antenna] = 0;
+                }
+                else {
+                    current[antenna] =
+                        dx * (Hx[IDX3D_FIELDS(x,y,z)] - Hx[IDX3D_FIELDS(x,y,z-1)]) +
+                        dz * (Hz[IDX3D_FIELDS(x-1,y,z)] - Hz[IDX3D_FIELDS(x,y,z)]);
+                }
+            }
+            else {
+                if (x == 0 || y == 0) {
+                    current[antenna] = 0;
+                }
+                else {
+                    current[antenna] =
+                        dx * (Hx[IDX3D_FIELDS(x,y-1,z)] - Hx[IDX3D_FIELDS(x,y,z)]) +
+                        dy * (Hy[IDX3D_FIELDS(x,y,z)] - Hy[IDX3D_FIELDS(x-1,y,z)]);
+                }
+            }
+
+            // Advance all non-terminal transmission-line current samples.
+            for (int linepos = 0; linepos < nl - 1; linepos++) {
+                int pos = offset + linepos;
+                current[pos] -= (line_coefficient / resistance[i]) *
+                    (voltage[pos + 1] - voltage[pos]);
+            }
+            current[offset + srcpos - 1] +=
+                (line_coefficient / resistance[i]) *
+                waveform_half[i * $NY_TLWAVES + iteration];
+        }
+    }
+"""
+    ),
+}
+
+
+update_transmission_line_electric = {
+    "args_cuda": Template(
+        """
+        __global__ void update_transmission_line_electric(
+            int NTL,
+            int iteration,
+            $REAL dx,
+            $REAL dy,
+            $REAL dz,
+            $REAL line_coefficient,
+            $REAL abc_coefficient,
+            const int* __restrict__ tl_info,
+            const $REAL* __restrict__ resistance,
+            const $REAL* __restrict__ waveform_whole,
+            $REAL* voltage,
+            const $REAL* __restrict__ current,
+            $REAL* abcv0,
+            $REAL* abcv1,
+            $REAL* Ex,
+            $REAL* Ey,
+            $REAL* Ez)
+        """
+    ),
+    "args_opencl": Template(
+        """
+            int NTL,
+            int iteration,
+            $REAL dx,
+            $REAL dy,
+            $REAL dz,
+            $REAL line_coefficient,
+            $REAL abc_coefficient,
+            __global const int* restrict tl_info,
+            __global const $REAL* restrict resistance,
+            __global const $REAL* restrict waveform_whole,
+            __global $REAL* voltage,
+            __global const $REAL* restrict current,
+            __global $REAL* abcv0,
+            __global $REAL* abcv1,
+            __global $REAL* Ex,
+            __global $REAL* Ey,
+            __global $REAL* Ez
+        """
+    ),
+    "args_metal": Template(
+        """
+        kernel void update_transmission_line_electric(
+            device const int& NTL,
+            device const int& iteration,
+            device const $REAL& dx,
+            device const $REAL& dy,
+            device const $REAL& dz,
+            device const $REAL& line_coefficient,
+            device const $REAL& abc_coefficient,
+            device const int* tl_info,
+            device const $REAL* resistance,
+            device const $REAL* waveform_whole,
+            device $REAL* voltage,
+            device const $REAL* current,
+            device $REAL* abcv0,
+            device $REAL* abcv1,
+            device $REAL* Ex,
+            device $REAL* Ey,
+            device $REAL* Ez,
+            uint i [[thread_position_in_grid]])
+        """
+    ),
+    "func": Template(
+        """
+    $CUDA_IDX
+
+    if (i < NTL) {
+        int x = tl_info[i * $NY_TLINFO + 0];
+        int y = tl_info[i * $NY_TLINFO + 1];
+        int z = tl_info[i * $NY_TLINFO + 2];
+        int polarisation = tl_info[i * $NY_TLINFO + 3];
+        int offset = tl_info[i * $NY_TLINFO + 4];
+        int nl = tl_info[i * $NY_TLINFO + 5];
+        int srcpos = tl_info[i * $NY_TLINFO + 6];
+        int antpos = tl_info[i * $NY_TLINFO + 7];
+        int first_active = tl_info[i * $NY_TLINFO + 8];
+        int last_active = tl_info[i * $NY_TLINFO + 9];
+
+        if (iteration >= first_active && iteration <= last_active) {
+            for (int linepos = 1; linepos < nl; linepos++) {
+                int pos = offset + linepos;
+                voltage[pos] -= resistance[i] * line_coefficient *
+                    (current[pos] - current[pos - 1]);
+            }
+            voltage[offset + srcpos] +=
+                line_coefficient * waveform_whole[i * $NY_TLWAVES + iteration];
+
+            // First-order absorbing boundary at the remote end of the line.
+            $REAL boundary_voltage = abc_coefficient *
+                (voltage[offset + 1] - abcv0[i]) + abcv1[i];
+            voltage[offset] = boundary_voltage;
+            abcv0[i] = boundary_voltage;
+            abcv1[i] = voltage[offset + 1];
+
+            $REAL terminal_voltage = voltage[offset + antpos];
+            if (polarisation == 0) {
+                Ex[IDX3D_FIELDS(x,y,z)] = -terminal_voltage / dx;
+            }
+            else if (polarisation == 1) {
+                Ey[IDX3D_FIELDS(x,y,z)] = -terminal_voltage / dy;
+            }
+            else {
+                Ez[IDX3D_FIELDS(x,y,z)] = -terminal_voltage / dz;
+            }
+        }
+    }
+"""
+    ),
+}

--- a/gprMax/fields_outputs.py
+++ b/gprMax/fields_outputs.py
@@ -115,7 +115,9 @@ def write_hd5_data(basegrp, grid, is_subgrid=False):
         grid.voltagesources + grid.hertziandipoles + grid.magneticdipoles + grid.transmissionlines
     )
     basegrp.attrs["nsrc"] = nsrc
-    basegrp.attrs["nrx"] = len(grid.rxs)
+    public_rxs = [rx for rx in grid.rxs if not getattr(rx, "internal", False)]
+    basegrp.attrs["nrx"] = len(public_rxs)
+    basegrp.attrs["nports"] = len(getattr(grid, "port_monitors", ()))
 
     if is_subgrid:
         # Write additional meta data about subgrid
@@ -153,13 +155,18 @@ def write_hd5_data(basegrp, grid, is_subgrid=False):
         # Save total voltage and current
         basegrp["tls/tl" + str(tlindex + 1) + "/Vtotal"] = tl.Vtotal
         basegrp["tls/tl" + str(tlindex + 1) + "/Itotal"] = tl.Itotal
+        port_output = getattr(tl, "port_output", None)
+        if port_output is not None:
+            port_output.write_hdf5(grp)
 
-    # Ensure the order of receivers is always consistent (Needed for
-    # consistancy when using MPI with multiple receivers)
-    grid.rxs.sort(key=lambda rx: rx.ID)
+    # Ensure public receiver output order is consistent without mutating the
+    # solver's receiver order. Device transfer maps receiver pages by this
+    # original order and internal port monitors are intentionally omitted from
+    # the public /rxs namespace.
+    public_rxs.sort(key=lambda rx: rx.ID)
 
     # Create group, add positional data and write field component arrays for receivers
-    for rxindex, rx in enumerate(grid.rxs):
+    for rxindex, rx in enumerate(public_rxs):
         grp = basegrp.create_group("rxs/rx" + str(rxindex + 1))
         if rx.ID:
             grp.attrs["Name"] = rx.ID
@@ -180,6 +187,9 @@ def write_hd5_data(basegrp, grid, is_subgrid=False):
             write_ntff(basegrp)
     for writer in getattr(grid, "ntff_output_writers", ()):
         writer.write_hdf5(basegrp)
+
+    for port in getattr(grid, "port_monitors", ()):
+        port.write_hdf5(basegrp)
 
 
 def Ix(x, y, z, Hx, Hy, Hz, G):

--- a/gprMax/grid/fdtd_grid.py
+++ b/gprMax/grid/fdtd_grid.py
@@ -32,19 +32,10 @@ from typing_extensions import TypeVar
 
 from gprMax import config
 from gprMax.cython.pml_build import pml_average_er_mr
-from gprMax.cython.yee_cell_build import (
-    build_electric_components,
-    build_magnetic_components,
-)
+from gprMax.cython.yee_cell_build import build_electric_components, build_magnetic_components
 from gprMax.fractals.fractal_surface import FractalSurface
 from gprMax.fractals.fractal_volume import FractalVolume
-from gprMax.materials import (
-    ListMaterial,
-    Material,
-    PeplinskiSoil,
-    RangeMaterial,
-    process_materials,
-)
+from gprMax.materials import ListMaterial, Material, PeplinskiSoil, RangeMaterial, process_materials
 from gprMax.pml import CFS, PML, print_pml_info
 from gprMax.receivers import Rx
 from gprMax.sources import (
@@ -144,6 +135,7 @@ class FDTDGrid:
         self.transmissionlines: List[TransmissionLine] = []
         self.discreteplanewaves: List[DiscretePlaneWave] = []
         self.rxs: List[Rx] = []
+        self.port_monitors = []  # Source-bound S-parameter/impedance outputs
         self.snapshots = []  # List[Snapshot]
         self.ntff_monitors = []  # Time- and frequency-domain KSIR monitors
         # Reusable KSIR definitions are registered by user objects, then
@@ -694,7 +686,12 @@ class FDTDGrid:
                 outside of the grid.
         """
         try:
-            self._update_positions(self.rxs, self.rxsteps, step)
+            # Internal port receivers must remain on their fixed voltage
+            # source; #rx_steps applies only to public receiver commands.
+            public_receivers = (
+                rx for rx in self.rxs if not getattr(rx, "source_bound", False)
+            )
+            self._update_positions(public_receivers, self.rxsteps, step)
         except ValueError as e:
             logger.exception(
                 "Receiver(s) will be stepped to a position outside the domain."

--- a/gprMax/hash_cmds_file.py
+++ b/gprMax/hash_cmds_file.py
@@ -257,6 +257,7 @@ def check_cmd_names(processedlines, checkessential=True):
             "#excitation_file",
             "#rx",
             "#rx_array",
+            "#rx_port",
             "#snapshot",
             "#ksir_surface",
             "#ksir_frequency",

--- a/gprMax/hash_cmds_multiuse.py
+++ b/gprMax/hash_cmds_multiuse.py
@@ -54,6 +54,7 @@ from .user_objects.cmds_output import (
     KSIRTimeRx,
     KSIRTimeRxArray,
     KSIRTimeRxSpherical,
+    RxPort,
     Snapshot,
 )
 
@@ -412,6 +413,30 @@ def process_multicmds(multicmds):
 
             rx_array = RxArray(p1=p1, p2=p2, dl=dl)
             scene_objects.append(rx_array)
+
+    cmdname = "#rx_port"
+    if multicmds[cmdname] is not None:
+        for cmdinstance in multicmds[cmdname]:
+            tokens = cmdinstance.split()
+            if len(tokens) < 3 or len(tokens) > 5:
+                raise ValueError(
+                    f"'{cmdname}: {cmdinstance}' requires three coordinates, "
+                    "an optional ID, and one optional spectrum limit"
+                )
+            kwargs = {}
+            if len(tokens) >= 4:
+                kwargs["id"] = tokens[3]
+            if len(tokens) == 5:
+                try:
+                    kwargs["spectrum_limit"] = float(tokens[4])
+                except ValueError:
+                    kwargs["spectrum_limit"] = tokens[4].lower()
+            scene_objects.append(
+                RxPort(
+                    p1=tuple(float(value) for value in tokens[:3]),
+                    **kwargs,
+                )
+            )
 
     cmdname = "#snapshot"
     if multicmds[cmdname] is not None:

--- a/gprMax/model.py
+++ b/gprMax/model.py
@@ -32,8 +32,8 @@ from gprMax.geometry_outputs.geometry_view_lines import GeometryViewLines
 from gprMax.geometry_outputs.geometry_view_voxels import GeometryViewVoxels
 from gprMax.geometry_outputs.geometry_views import GeometryView, save_geometry_views
 from gprMax.grid.cuda_grid import CUDAGrid
-from gprMax.grid.opencl_grid import OpenCLGrid
 from gprMax.grid.metal_grid import MetalGrid
+from gprMax.grid.opencl_grid import OpenCLGrid
 from gprMax.subgrids.grid import SubGridBaseGrid
 
 init()
@@ -364,6 +364,24 @@ class Model:
 
         self.G.update_sources_and_recievers()
 
+        # Voltage-source ports bind their receiver during scene processing,
+        # but their effective edge material and update coefficient only exist
+        # after grid.build() has completed.
+        for port in getattr(self.G, "port_monitors", ()):
+            port.prepare(self.G)
+
+        # Transmission lines already record incident and terminal voltage and
+        # current histories. Prepare their automatic S11/impedance outputs
+        # after materials and the native time/frequency axes are finalised.
+        from gprMax.ports import prepare_transmission_line_ports
+
+        # MPI transmission-line objects are gathered only after solving. Do
+        # not attach cached spectral arrays before that transfer; the
+        # coordinator prepares and finalises them after the gather instead.
+        if not hasattr(self.G, "comm"):
+            for grid in [self.G] + self.subgrids:
+                prepare_transmission_line_ports(grid)
+
         # Source stepping is applied immediately above, so enclosure is
         # checked against the positions actually used by this model run.
         if self.G.ntff_monitors:
@@ -553,6 +571,17 @@ class Model:
         file(s).
         """
 
+        # Device finalisation has already copied receiver histories to the
+        # host. Complete derived port spectra before opening the HDF5 file so
+        # a calculation error cannot leave a partially written port group.
+        for port in getattr(self.G, "port_monitors", ()):
+            port.finalise(self.G)
+
+        from gprMax.ports import finalise_transmission_line_ports
+
+        for grid in [self.G] + self.subgrids:
+            finalise_transmission_line_ports(grid)
+
         # Write output data to file if they are any receivers in any grids
         sg_rxs = [True for sg in self.subgrids if sg.rxs]
         sg_tls = [True for sg in self.subgrids if sg.transmissionlines]
@@ -568,6 +597,7 @@ class Model:
             or self.G.transmissionlines
             or sg_tls
             or ntff_outputs
+            or self.G.port_monitors
         ):
             write_hdf5_outputfile(config.get_model_config().output_file_path_ext, self.title, self)
 

--- a/gprMax/mpi_model.py
+++ b/gprMax/mpi_model.py
@@ -248,6 +248,12 @@ class MPIModel(Model):
         # Write output data to file if they are any receivers in any grids
         if self.is_coordinator() and (self.G.rxs or self.G.transmissionlines):
             self.G.size = self.G.global_size
+            # Transmission-line objects and their complete histories have now
+            # been gathered onto the coordinator. Derived terminal quantities
+            # must be calculated here, before the HDF5 file is opened.
+            from gprMax.ports import finalise_transmission_line_ports
+
+            finalise_transmission_line_ports(self.G)
             write_hdf5_outputfile(config.get_model_config().output_file_path_ext, self.title, self)
 
     def _create_grid(self) -> MPIGrid:

--- a/gprMax/ports.py
+++ b/gprMax/ports.py
@@ -1,0 +1,1010 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+
+"""Source-bound port outputs.
+
+Voltage-source ports use the known Thevenin generator voltage and the electric
+field sampled on one electric Yee edge. Transmission-line sources already
+carry incident and terminal voltage/current histories, so their S11 and input
+impedance are calculated automatically without an additional receiver.
+"""
+
+import logging
+import numbers
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, Optional, Union
+
+import numpy as np
+import numpy.typing as npt
+
+import gprMax.config as config
+from gprMax.ntff.conventions import FORWARD_TRANSFORM_KERNEL, PHASOR_TIME_DEPENDENCE
+
+if TYPE_CHECKING:
+    from gprMax.grid.fdtd_grid import FDTDGrid
+    from gprMax.receivers import Rx
+    from gprMax.sources import TransmissionLine, VoltageSource
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MINIMUM_WAVELENGTH_CELLS = 10.0
+MINIMUM_PHYSICAL_WAVELENGTH_CELLS = 3.0
+DEFAULT_INCIDENT_FLOOR_DB = -40.0
+
+SpectrumLimit = Union[float, Literal["nyquist"]]
+
+
+def validate_spectrum_limit(value) -> SpectrumLimit:
+    """Validate the public spectrum-limit tagged value.
+
+    A finite numeric value is interpreted as cells per shortest material
+    wavelength. The string ``"nyquist"`` is the explicit research override.
+    """
+
+    if isinstance(value, str):
+        if value.lower() == "nyquist":
+            return "nyquist"
+        raise ValueError("spectrum_limit must be a finite number or 'nyquist'")
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, numbers.Real):
+        raise ValueError("spectrum_limit must be a finite number or 'nyquist'")
+    value = float(value)
+    if not np.isfinite(value):
+        raise ValueError("spectrum_limit must be a finite number or 'nyquist'")
+    if value < MINIMUM_PHYSICAL_WAVELENGTH_CELLS:
+        raise ValueError(
+            "numeric spectrum_limit must be at least "
+            f"{MINIMUM_PHYSICAL_WAVELENGTH_CELLS:g} cells per wavelength"
+        )
+    return value
+
+
+def engineering_rfft(
+    samples: npt.ArrayLike,
+    dt: float,
+    *,
+    time_offset: float = 0.0,
+) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.complexfloating]]:
+    """Return native rFFT bins using gprMax's engineering convention."""
+
+    real_dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
+    complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
+    values = np.asarray(samples, dtype=real_dtype)
+    if values.ndim != 1 or values.size == 0:
+        raise ValueError("port time samples must be a non-empty one-dimensional array")
+    if not np.all(np.isfinite(values)):
+        raise ValueError("port time samples must be finite")
+    if not np.isfinite(dt) or dt <= 0:
+        raise ValueError("port sample interval must be finite and positive")
+    if not np.isfinite(time_offset):
+        raise ValueError("port time offset must be finite")
+
+    frequencies64 = np.fft.rfftfreq(values.size, d=dt)
+    transformed = np.fft.rfft(values)
+    phase = np.exp(-2j * np.pi * frequencies64 * time_offset)
+    spectrum = np.asarray(dt * phase * transformed, dtype=complex_dtype)
+    return np.asarray(frequencies64, dtype=real_dtype), spectrum
+
+
+def _complex_relative_permittivity(material, frequencies):
+    """Return material relative permittivity including conductivity."""
+
+    values = np.empty(frequencies.shape, dtype=np.complex128)
+    zero = frequencies == 0
+    values[zero] = complex(material.er)
+    positive = ~zero
+    if not np.any(positive):
+        return values
+    if hasattr(material, "poles"):
+        values[positive] = np.asarray(
+            material.calculate_er(frequencies[positive]), dtype=np.complex128
+        )
+    else:
+        omega = 2 * np.pi * frequencies[positive]
+        values[positive] = material.er + material.se / (
+            1j * omega * config.sim_config.em_consts["e0"]
+        )
+    return values
+
+
+def _complex_relative_permeability(material, frequencies):
+    """Return material relative permeability including magnetic loss."""
+
+    values = np.empty(frequencies.shape, dtype=np.complex128)
+    zero = frequencies == 0
+    values[zero] = complex(material.mr)
+    positive = ~zero
+    if np.any(positive):
+        omega = 2 * np.pi * frequencies[positive]
+        values[positive] = material.mr + material.sm / (
+            1j * omega * config.sim_config.em_consts["m0"]
+        )
+    return values
+
+
+def minimum_wavelength_sampling(
+    grid: "FDTDGrid",
+    frequencies: npt.ArrayLike,
+) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.str_]]:
+    """Calculate cells per shortest material wavelength at every frequency.
+
+    PEC, PMC, and voltage-source-generated materials are excluded. For the
+    ordinary nonmagnetic/nondispersive case this reduces exactly to using the
+    largest relative permittivity in the model. The complex refractive-index
+    magnitude gives a conservative spatial-scale estimate for lossy and
+    dispersive media.
+    """
+
+    real_dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
+    frequencies64 = np.asarray(frequencies, dtype=np.float64)
+    if frequencies64.ndim != 1 or frequencies64.size == 0:
+        raise ValueError("frequencies must be a non-empty one-dimensional array")
+    if np.any(frequencies64 < 0) or not np.all(np.isfinite(frequencies64)):
+        raise ValueError("frequencies must be finite and non-negative")
+
+    delta = float(max(grid.dx, grid.dy, grid.dz))
+    cells = np.full(frequencies64.shape, np.inf, dtype=np.float64)
+    limiting = np.full(frequencies64.shape, "", dtype=object)
+    materials_found = 0
+
+    for material in grid.materials:
+        material_type = str(getattr(material, "type", "")).lower()
+        if (
+            "voltage-source" in material_type
+            or getattr(material, "is_pec", False)
+            or material.ID == "pmc"
+            or not np.isfinite(material.se)
+            or not np.isfinite(material.sm)
+        ):
+            continue
+
+        epsilon_r = _complex_relative_permittivity(material, frequencies64)
+        mu_r = _complex_relative_permeability(material, frequencies64)
+        refractive_index = np.abs(np.sqrt(epsilon_r * mu_r))
+        material_cells = np.full(frequencies64.shape, np.inf, dtype=np.float64)
+        positive = frequencies64 > 0
+        finite = positive & np.isfinite(refractive_index) & (refractive_index > 0)
+        material_cells[finite] = config.sim_config.em_consts["c"] / (
+            frequencies64[finite] * refractive_index[finite] * delta
+        )
+        update = material_cells < cells
+        cells[update] = material_cells[update]
+        limiting[update] = material.ID
+        materials_found += 1
+
+    if materials_found == 0:
+        raise ValueError("no propagating material is available for port frequency validation")
+    return np.asarray(cells, dtype=real_dtype), np.asarray(limiting, dtype=str)
+
+
+def _safe_complex_divide(numerator, denominator, complex_dtype):
+    """Divide where the denominator is algebraically resolvable.
+
+    The threshold is deliberately much lower than the source-band validity
+    floor. Finite but unreliable research values are retained and separately
+    identified by validity masks.
+    """
+
+    numerator = np.asarray(numerator, dtype=complex_dtype)
+    denominator = np.asarray(denominator, dtype=complex_dtype)
+    magnitude = np.abs(denominator)
+    finite_denominator = np.isfinite(denominator)
+    scale = float(np.max(magnitude[finite_denominator], initial=0.0))
+    threshold = np.finfo(np.empty((), dtype=complex_dtype).real.dtype).eps * scale
+    defined = finite_denominator & (magnitude > threshold)
+    result = np.full(numerator.shape, np.nan + 1j * np.nan, dtype=complex_dtype)
+    np.divide(numerator, denominator, out=result, where=defined)
+    defined &= np.isfinite(result)
+    return result, defined
+
+
+def correct_s11_for_parallel_gap(s11_source, gap_correction, complex_dtype=None):
+    """Remove a dimensionless parallel gap admittance from source-plane S11."""
+
+    if complex_dtype is None:
+        complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
+    else:
+        complex_dtype = np.dtype(complex_dtype)
+    s11_source = np.asarray(s11_source, dtype=complex_dtype)
+    gap_correction = np.asarray(gap_correction, dtype=complex_dtype)
+    numerator = 2 * s11_source + gap_correction * (1 + s11_source)
+    denominator = 2 - gap_correction * (1 + s11_source)
+    return _safe_complex_divide(numerator, denominator, complex_dtype)
+
+
+def impedance_from_s11(s11, reference_impedance, complex_dtype=None):
+    """Calculate input impedance from S11 with a separate validity mask."""
+
+    if complex_dtype is None:
+        complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
+    else:
+        complex_dtype = np.dtype(complex_dtype)
+    s11 = np.asarray(s11, dtype=complex_dtype)
+    return _safe_complex_divide(reference_impedance * (1 + s11), 1 - s11, complex_dtype)
+
+
+def admittance_from_s11(s11, reference_impedance, complex_dtype=None):
+    """Calculate input admittance from S11 with a separate validity mask."""
+
+    if complex_dtype is None:
+        complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
+    else:
+        complex_dtype = np.dtype(complex_dtype)
+    s11 = np.asarray(s11, dtype=complex_dtype)
+    return _safe_complex_divide(1 - s11, reference_impedance * (1 + s11), complex_dtype)
+
+
+@dataclass(frozen=True)
+class VoltageSourcePortResult:
+    """Final time- and frequency-domain result for one voltage-source port."""
+
+    time: npt.NDArray[np.floating]
+    generator_voltage: npt.NDArray[np.floating]
+    total_voltage: npt.NDArray[np.floating]
+    frequency: npt.NDArray[np.floating]
+    incident_spectrum: npt.NDArray[np.complexfloating]
+    reflected_source_spectrum: npt.NDArray[np.complexfloating]
+    total_spectrum: npt.NDArray[np.complexfloating]
+    gap_correction: npt.NDArray[np.complexfloating]
+    s11_source: npt.NDArray[np.complexfloating]
+    zin_source: npt.NDArray[np.complexfloating]
+    s11: npt.NDArray[np.complexfloating]
+    zin: npt.NDArray[np.complexfloating]
+    yin: npt.NDArray[np.complexfloating]
+    source_valid: npt.NDArray[np.bool_]
+    mesh_valid: npt.NDArray[np.bool_]
+    gap_correction_valid: npt.NDArray[np.bool_]
+    valid_s11: npt.NDArray[np.bool_]
+    valid_zin: npt.NDArray[np.bool_]
+    valid_yin: npt.NDArray[np.bool_]
+    incident_relative_db: npt.NDArray[np.floating]
+    cells_per_minimum_wavelength: npt.NDArray[np.floating]
+    tail_relative_db: float
+
+
+class VoltageSourcePortMonitor:
+    """Bind one internal electric-field receiver to one voltage source."""
+
+    def __init__(
+        self,
+        output_id: str,
+        source: "VoltageSource",
+        receiver: "Rx",
+        spectrum_limit: SpectrumLimit,
+        owner=None,
+    ):
+        self.output_id = output_id
+        self.source = source
+        self.receiver = receiver
+        self.spectrum_limit = spectrum_limit
+        self.owner = owner
+        self.result: Optional[VoltageSourcePortResult] = None
+        self.prepared = False
+
+        self.minimum_wavelength_cells = (
+            DEFAULT_MINIMUM_WAVELENGTH_CELLS
+            if spectrum_limit == "nyquist"
+            else float(spectrum_limit)
+        )
+        self.spectrum_limit_mode = (
+            "nyquist" if spectrum_limit == "nyquist" else "minimum_wavelength_cells"
+        )
+        self.incident_floor_db = DEFAULT_INCIDENT_FLOOR_DB
+
+    @property
+    def component(self):
+        return f"E{self.source.polarisation}"
+
+    def _edge_geometry(self, grid):
+        if self.source.polarisation == "x":
+            return float(grid.dx), float(grid.dy * grid.dz)
+        if self.source.polarisation == "y":
+            return float(grid.dy), float(grid.dx * grid.dz)
+        return float(grid.dz), float(grid.dx * grid.dy)
+
+    def prepare(self, grid: "FDTDGrid") -> None:
+        """Validate the built Yee edge and calculate fixed port parameters."""
+
+        if grid.iterations < 2:
+            raise ValueError(f"RxPort {self.output_id!r} requires at least two iterations")
+        if not np.array_equal(self.receiver.coord, self.source.coord):
+            raise ValueError(f"RxPort {self.output_id!r} receiver is no longer source-bound")
+        if getattr(self.source, "background_material_numID", None) is None:
+            raise ValueError(f"RxPort {self.output_id!r} source material was not constructed")
+        if getattr(self.source, "background_is_dispersive", False):
+            raise ValueError(
+                f"RxPort {self.output_id!r} does not yet support a dispersive material "
+                "on the voltage-source edge"
+            )
+
+        self.dl, self.area = self._edge_geometry(grid)
+        self.reference_impedance = float(self.source.resistance)
+        self.background_relative_permittivity = float(self.source.background_er)
+        self.background_conductivity = float(self.source.background_se)
+        if not np.isfinite(self.background_conductivity):
+            raise ValueError(f"RxPort {self.output_id!r} cannot use a voltage source on a PEC edge")
+        self.gap_capacitance = (
+            config.sim_config.em_consts["e0"]
+            * self.background_relative_permittivity
+            * self.area
+            / self.dl
+        )
+        self.background_conductance = self.background_conductivity * self.area / self.dl
+
+        source_material_id = int(self.source.source_material_numID)
+        source_material = grid.materials[source_material_id]
+        added_conductance = (
+            (float(source_material.se) - self.background_conductivity) * self.area / self.dl
+        )
+        dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
+        tolerance = 64 * np.finfo(dtype).eps
+        if not np.isclose(
+            added_conductance,
+            1 / self.reference_impedance,
+            rtol=tolerance,
+            atol=tolerance / self.reference_impedance,
+        ):
+            raise ValueError(
+                f"RxPort {self.output_id!r} source-edge conductance is inconsistent "
+                "with its source resistance"
+            )
+        if not np.isfinite(grid.updatecoeffsE[source_material_id, 4]) or np.isclose(
+            grid.updatecoeffsE[source_material_id, 4], 0
+        ):
+            raise ValueError(f"RxPort {self.output_id!r} source is on an inactive electric edge")
+
+        nsamples = grid.iterations - 1
+        self.aligned_samples = nsamples
+        full_frequency = np.fft.rfftfreq(nsamples, d=grid.dt)
+        cells, limiting_material = minimum_wavelength_sampling(grid, full_frequency)
+        mesh_valid_full = cells >= self.minimum_wavelength_cells
+        positive_invalid = np.flatnonzero((full_frequency > 0) & ~mesh_valid_full)
+        if positive_invalid.size:
+            first_invalid = int(positive_invalid[0])
+            last_mesh_index = max(0, first_invalid - 1)
+            limiting_index = first_invalid
+        else:
+            last_mesh_index = full_frequency.size - 1
+            limiting_index = last_mesh_index
+
+        self.nyquist_frequency = float(1 / (2 * grid.dt))
+        self.mesh_frequency_limit = float(full_frequency[last_mesh_index])
+        self.limiting_material = str(limiting_material[limiting_index])
+        self.independent_frequency_resolution = float(1 / (nsamples * grid.dt))
+        self._full_cells_per_wavelength = cells
+        self._full_mesh_valid = mesh_valid_full
+        if self.spectrum_limit_mode == "nyquist":
+            self._frequency_slice = slice(None)
+            log = logger.warning
+            message = (
+                f"RxPort {self.output_id!r}: full native spectrum 0--"
+                f"{full_frequency[-1]:g} Hz requested (Nyquist research override); "
+                f"advisory lambda/{self.minimum_wavelength_cells:g} limit "
+                f"{self.mesh_frequency_limit:g} Hz in material "
+                f"{self.limiting_material!r}."
+            )
+        else:
+            self._frequency_slice = slice(0, last_mesh_index + 1)
+            log = logger.info
+            message = (
+                f"RxPort {self.output_id!r}: spectrum 0--"
+                f"{self.mesh_frequency_limit:g} Hz, lambda/"
+                f"{self.minimum_wavelength_cells:g} mesh limit in material "
+                f"{self.limiting_material!r}; native df "
+                f"{self.independent_frequency_resolution:g} Hz; Nyquist "
+                f"{self.nyquist_frequency:g} Hz."
+            )
+        log(message)
+        self.set_output_context(grid)
+        self.prepared = True
+
+    def finalise(self, grid: "FDTDGrid") -> VoltageSourcePortResult:
+        """Calculate voltage waves, corrected S11, Zin, and Yin."""
+
+        if not self.prepared:
+            self.prepare(grid)
+        if not np.array_equal(self.receiver.coord, self.source.coord):
+            raise RuntimeError(f"RxPort {self.output_id!r} receiver moved away from its source")
+
+        real_dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
+        complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
+        electric = np.asarray(self.receiver.outputs[self.component], dtype=real_dtype)
+        if electric.size != grid.iterations:
+            raise RuntimeError(f"RxPort {self.output_id!r} receiver history has the wrong length")
+
+        integer_voltage = np.asarray(-self.dl * electric, dtype=real_dtype)
+        total_voltage = np.asarray(
+            0.5 * (integer_voltage[:-1] + integer_voltage[1:]), dtype=real_dtype
+        )
+        generator_voltage = np.asarray(
+            self.source.waveformvalues_halfdt[: total_voltage.size], dtype=real_dtype
+        )
+        time = np.asarray(
+            (np.arange(total_voltage.size, dtype=real_dtype) + real_dtype.type(0.5)) * grid.dt,
+            dtype=real_dtype,
+        )
+
+        frequency_full, total_spectrum_full = engineering_rfft(
+            total_voltage, grid.dt, time_offset=0.5 * grid.dt
+        )
+        generator_frequency, generator_spectrum_full = engineering_rfft(
+            generator_voltage, grid.dt, time_offset=0.5 * grid.dt
+        )
+        if not np.array_equal(frequency_full, generator_frequency):
+            raise RuntimeError("port voltage transforms produced inconsistent frequencies")
+
+        selection = self._frequency_slice
+        frequency = frequency_full[selection]
+        total_spectrum = total_spectrum_full[selection]
+        generator_spectrum = generator_spectrum_full[selection]
+        incident_spectrum = np.asarray(0.5 * generator_spectrum, dtype=complex_dtype)
+        reflected_source = np.asarray(total_spectrum - incident_spectrum, dtype=complex_dtype)
+        s11_source, source_defined = _safe_complex_divide(
+            reflected_source, incident_spectrum, complex_dtype
+        )
+
+        incident_magnitude = np.abs(incident_spectrum)
+        incident_peak = float(np.max(incident_magnitude, initial=0.0))
+        incident_relative_db = np.full(frequency.shape, -np.inf, dtype=real_dtype)
+        if incident_peak > 0:
+            nonzero = incident_magnitude > 0
+            incident_relative_db[nonzero] = np.asarray(
+                20 * np.log10(incident_magnitude[nonzero] / incident_peak), dtype=real_dtype
+            )
+        source_valid = source_defined & (incident_relative_db >= self.incident_floor_db)
+
+        omega_discrete = (2 / grid.dt) * np.tan(np.pi * frequency * grid.dt)
+        gap_correction = np.asarray(
+            self.reference_impedance
+            * (self.background_conductance + 1j * omega_discrete * self.gap_capacitance),
+            dtype=complex_dtype,
+        )
+        s11, gap_correction_valid = correct_s11_for_parallel_gap(
+            s11_source, gap_correction, complex_dtype
+        )
+        exact_nyquist_included = (
+            self.aligned_samples % 2 == 0 and frequency.size == frequency_full.size
+        )
+        if self.gap_capacitance != 0 and exact_nyquist_included:
+            gap_correction_valid[-1] = False
+            s11[-1] = np.nan + 1j * np.nan
+
+        zin_source, _ = impedance_from_s11(s11_source, self.reference_impedance, complex_dtype)
+        zin, zin_defined = impedance_from_s11(s11, self.reference_impedance, complex_dtype)
+        yin, yin_defined = admittance_from_s11(s11, self.reference_impedance, complex_dtype)
+
+        mesh_valid = np.asarray(self._full_mesh_valid[selection], dtype=bool)
+        cells_per_wavelength = np.asarray(
+            self._full_cells_per_wavelength[selection], dtype=real_dtype
+        )
+        valid_s11 = mesh_valid & source_valid & gap_correction_valid
+        valid_zin = valid_s11 & zin_defined
+        valid_yin = valid_s11 & yin_defined
+
+        trace_peak = float(np.max(np.abs(total_voltage), initial=0.0))
+        tail_count = max(1, total_voltage.size // 20)
+        tail_peak = float(np.max(np.abs(total_voltage[-tail_count:]), initial=0.0))
+        if trace_peak > 0 and tail_peak > 0:
+            tail_relative_db = float(20 * np.log10(tail_peak / trace_peak))
+        elif tail_peak == 0:
+            tail_relative_db = float("-inf")
+        else:
+            tail_relative_db = float("nan")
+        if np.isfinite(tail_relative_db) and tail_relative_db > -40:
+            logger.warning(
+                f"RxPort {self.output_id!r}: the final 5% of the voltage trace "
+                f"reaches {tail_relative_db:.1f} dB relative to its peak; spectral "
+                "leakage may be significant."
+            )
+
+        self.result = VoltageSourcePortResult(
+            time=time,
+            generator_voltage=generator_voltage,
+            total_voltage=total_voltage,
+            frequency=np.asarray(frequency, dtype=real_dtype),
+            incident_spectrum=incident_spectrum,
+            reflected_source_spectrum=reflected_source,
+            total_spectrum=np.asarray(total_spectrum, dtype=complex_dtype),
+            gap_correction=gap_correction,
+            s11_source=s11_source,
+            zin_source=zin_source,
+            s11=s11,
+            zin=zin,
+            yin=yin,
+            source_valid=np.asarray(source_valid, dtype=bool),
+            mesh_valid=mesh_valid,
+            gap_correction_valid=np.asarray(gap_correction_valid, dtype=bool),
+            valid_s11=np.asarray(valid_s11, dtype=bool),
+            valid_zin=np.asarray(valid_zin, dtype=bool),
+            valid_yin=np.asarray(valid_yin, dtype=bool),
+            incident_relative_db=incident_relative_db,
+            cells_per_minimum_wavelength=cells_per_wavelength,
+            tail_relative_db=tail_relative_db,
+        )
+        return self.result
+
+    def write_hdf5(self, base_group) -> None:
+        """Write the finalised port result beneath ``/ports/<ID>``."""
+
+        if self.result is None:
+            raise RuntimeError(f"RxPort {self.output_id!r} has not been finalised")
+        result = self.result
+        ports_group = base_group.require_group("ports")
+        group = ports_group.create_group(self.output_id)
+        real_dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
+        complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
+
+        group.attrs["Name"] = self.output_id
+        group.attrs["Position"] = np.asarray(self.source.coord * self.grid_dl, dtype=real_dtype)
+        group.attrs["GridPosition"] = np.asarray(self.source.coord, dtype=np.int32)
+        group.attrs["SourceType"] = type(self.source).__name__
+        group.attrs["SourceIndex"] = self.source_index
+        group.attrs["Polarisation"] = self.source.polarisation
+        group.attrs["CellLength"] = self.dl
+        group.attrs["ReferenceImpedance"] = self.reference_impedance
+        group.attrs["WaveformID"] = self.source.waveformID
+        group.attrs["BackgroundMaterial"] = self.source.background_material_ID
+        group.attrs["BackgroundRelativePermittivity"] = self.background_relative_permittivity
+        group.attrs["BackgroundConductivity"] = self.background_conductivity
+        group.attrs["GapCapacitance"] = self.gap_capacitance
+        group.attrs["BackgroundConductance"] = self.background_conductance
+        group.attrs["GapCorrection"] = "discrete_parallel_admittance"
+        group.attrs["TimeSampleOffset"] = 0.5 * self.dt
+        group.attrs["Window"] = "rectangular"
+        group.attrs["IncidentFloorDB"] = self.incident_floor_db
+        group.attrs["SpectrumLimitMode"] = self.spectrum_limit_mode
+        group.attrs["NyquistFrequency"] = self.nyquist_frequency
+        group.attrs["MinimumWavelengthCells"] = self.minimum_wavelength_cells
+        group.attrs["MeshFrequencyLimit"] = self.mesh_frequency_limit
+        group.attrs["LimitingMaterial"] = self.limiting_material
+        group.attrs["IndependentFrequencyResolution"] = self.independent_frequency_resolution
+        group.attrs["FrequencyRange"] = np.asarray(
+            (result.frequency[0], result.frequency[-1]), dtype=real_dtype
+        )
+        valid_indices = np.flatnonzero(result.valid_s11)
+        valid_range = (
+            (result.frequency[valid_indices[0]], result.frequency[valid_indices[-1]])
+            if valid_indices.size
+            else (np.nan, np.nan)
+        )
+        group.attrs["ValidFrequencyRange"] = np.asarray(valid_range, dtype=real_dtype)
+        group.attrs["TailRelativeLevelDB"] = result.tail_relative_db
+        group.attrs["phasor_time_sign"] = PHASOR_TIME_DEPENDENCE
+        group.attrs["forward_transform_sign"] = FORWARD_TRANSFORM_KERNEL
+        group.attrs["real_dtype"] = real_dtype.name
+        group.attrs["complex_dtype"] = complex_dtype.name
+
+        datasets = {
+            "time": result.time,
+            "Vgenerator": result.generator_voltage,
+            "Vtotal": result.total_voltage,
+            "frequency": result.frequency,
+            "Vincident_spectrum": result.incident_spectrum,
+            "Vreflected_source_spectrum": result.reflected_source_spectrum,
+            "Vtotal_spectrum": result.total_spectrum,
+            "gap_correction_c": result.gap_correction,
+            "S11_source": result.s11_source,
+            "Zin_source": result.zin_source,
+            "S11": result.s11,
+            "Zin": result.zin,
+            "Yin": result.yin,
+            "valid_S11": result.valid_s11.astype(np.uint8),
+            "valid_Zin": result.valid_zin.astype(np.uint8),
+            "valid_Yin": result.valid_yin.astype(np.uint8),
+            "source_valid": result.source_valid.astype(np.uint8),
+            "mesh_valid": result.mesh_valid.astype(np.uint8),
+            "gap_correction_valid": result.gap_correction_valid.astype(np.uint8),
+            "incident_relative_dB": result.incident_relative_db,
+            "cells_per_minimum_wavelength": result.cells_per_minimum_wavelength,
+        }
+        for name, values in datasets.items():
+            group.create_dataset(name, data=values)
+
+    def set_output_context(self, grid: "FDTDGrid") -> None:
+        """Cache immutable HDF5 context after the grid is fully built."""
+
+        self.grid_dl = np.asarray((grid.dx, grid.dy, grid.dz), dtype=np.float64)
+        self.dt = float(grid.dt)
+        self.source_index = grid.voltagesources.index(self.source) + 1
+
+
+@dataclass(frozen=True)
+class TransmissionLinePortResult:
+    """Final time- and frequency-domain result for one transmission line."""
+
+    time_voltage: npt.NDArray[np.floating]
+    time_current: npt.NDArray[np.floating]
+    frequency: npt.NDArray[np.floating]
+    incident_voltage_spectrum: npt.NDArray[np.complexfloating]
+    reflected_voltage_spectrum: npt.NDArray[np.complexfloating]
+    total_voltage_spectrum: npt.NDArray[np.complexfloating]
+    incident_current_spectrum: npt.NDArray[np.complexfloating]
+    total_current_spectrum: npt.NDArray[np.complexfloating]
+    reflected_voltage_current_spectrum: npt.NDArray[np.complexfloating]
+    terminal_current_spectrum: npt.NDArray[np.complexfloating]
+    s11: npt.NDArray[np.complexfloating]
+    zin: npt.NDArray[np.complexfloating]
+    yin: npt.NDArray[np.complexfloating]
+    s11_current: npt.NDArray[np.complexfloating]
+    zin_current: npt.NDArray[np.complexfloating]
+    source_valid: npt.NDArray[np.bool_]
+    mesh_valid: npt.NDArray[np.bool_]
+    line_propagation_valid: npt.NDArray[np.bool_]
+    valid_s11: npt.NDArray[np.bool_]
+    valid_zin: npt.NDArray[np.bool_]
+    valid_yin: npt.NDArray[np.bool_]
+    valid_s11_current: npt.NDArray[np.bool_]
+    valid_zin_current: npt.NDArray[np.bool_]
+    incident_relative_db: npt.NDArray[np.floating]
+    cells_per_minimum_wavelength: npt.NDArray[np.floating]
+    tail_relative_db: float
+
+
+class TransmissionLinePortOutput:
+    """Calculate automatic terminal quantities from one transmission line.
+
+    The voltage-wave result is primary. The line current is staggered by half
+    a time step and half a line cell relative to the terminal voltage node.
+    ``S11_current`` and ``Zin_current`` therefore use the discrete 1D-line
+    dispersion relation to separate and de-embed the current waves before
+    they are compared at the voltage reference plane.
+    """
+
+    def __init__(
+        self,
+        source: "TransmissionLine",
+        source_index: int,
+        spectrum_limit: SpectrumLimit = DEFAULT_MINIMUM_WAVELENGTH_CELLS,
+    ):
+        self.source = source
+        self.source_index = int(source_index)
+        self.spectrum_limit = validate_spectrum_limit(spectrum_limit)
+        self.result: Optional[TransmissionLinePortResult] = None
+        self.prepared = False
+        self.minimum_wavelength_cells = (
+            DEFAULT_MINIMUM_WAVELENGTH_CELLS
+            if self.spectrum_limit == "nyquist"
+            else float(self.spectrum_limit)
+        )
+        self.spectrum_limit_mode = (
+            "nyquist" if self.spectrum_limit == "nyquist" else "minimum_wavelength_cells"
+        )
+        self.incident_floor_db = DEFAULT_INCIDENT_FLOOR_DB
+
+    @property
+    def output_id(self) -> str:
+        return f"tl{self.source_index}"
+
+    def prepare(self, grid: "FDTDGrid") -> None:
+        """Calculate the native frequency axis and mesh-valid output band."""
+
+        if grid.iterations < 2:
+            raise ValueError(
+                f"Transmission line {self.output_id!r} requires at least two iterations"
+            )
+        if not np.isfinite(self.source.resistance) or self.source.resistance <= 0:
+            raise ValueError(f"Transmission line {self.output_id!r} has an invalid resistance")
+        if not np.isfinite(self.source.dl) or self.source.dl <= 0:
+            raise ValueError(f"Transmission line {self.output_id!r} has an invalid spatial step")
+
+        nsamples = int(grid.iterations)
+        full_frequency = np.fft.rfftfreq(nsamples, d=grid.dt)
+        cells, limiting_material = minimum_wavelength_sampling(grid, full_frequency)
+        mesh_valid_full = cells >= self.minimum_wavelength_cells
+        positive_invalid = np.flatnonzero((full_frequency > 0) & ~mesh_valid_full)
+        if positive_invalid.size:
+            first_invalid = int(positive_invalid[0])
+            last_mesh_index = max(0, first_invalid - 1)
+            limiting_index = first_invalid
+        else:
+            last_mesh_index = full_frequency.size - 1
+            limiting_index = last_mesh_index
+
+        self.nsamples = nsamples
+        self.reference_impedance = float(self.source.resistance)
+        self.nyquist_frequency = float(1 / (2 * grid.dt))
+        self.mesh_frequency_limit = float(full_frequency[last_mesh_index])
+        self.limiting_material = str(limiting_material[limiting_index])
+        self.independent_frequency_resolution = float(1 / (nsamples * grid.dt))
+        self._full_cells_per_wavelength = cells
+        self._full_mesh_valid = mesh_valid_full
+        if self.spectrum_limit_mode == "nyquist":
+            self._frequency_slice = slice(None)
+            logger.warning(
+                f"Transmission line {self.output_id!r}: full native spectrum 0--"
+                f"{full_frequency[-1]:g} Hz requested (Nyquist research override); "
+                f"advisory lambda/{self.minimum_wavelength_cells:g} limit "
+                f"{self.mesh_frequency_limit:g} Hz in material "
+                f"{self.limiting_material!r}."
+            )
+        else:
+            self._frequency_slice = slice(0, last_mesh_index + 1)
+            logger.info(
+                f"Transmission line {self.output_id!r}: automatic S11/Zin spectrum "
+                f"0--{self.mesh_frequency_limit:g} Hz, lambda/"
+                f"{self.minimum_wavelength_cells:g} mesh limit in material "
+                f"{self.limiting_material!r}; native df "
+                f"{self.independent_frequency_resolution:g} Hz; Nyquist "
+                f"{self.nyquist_frequency:g} Hz."
+            )
+        self.dt = float(grid.dt)
+        self.prepared = True
+
+    def _line_half_cell_phase(self, frequency, grid):
+        """Return exp(j*k*dl/2) for the propagating discrete line modes."""
+
+        real_dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
+        complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
+        argument = (
+            float(self.source.dl)
+            / (config.sim_config.em_consts["c"] * float(grid.dt))
+            * np.sin(np.pi * np.asarray(frequency, dtype=np.float64) * grid.dt)
+        )
+        tolerance = 32 * np.finfo(real_dtype).eps
+        propagating = np.abs(argument) <= 1 + tolerance
+        clipped = np.clip(argument, -1, 1)
+        wavenumber_step = 2 * np.arcsin(clipped)
+        phase = np.asarray(np.exp(0.5j * wavenumber_step), dtype=complex_dtype)
+        return phase, np.asarray(propagating, dtype=bool)
+
+    def finalise(self, grid: "FDTDGrid") -> TransmissionLinePortResult:
+        """Calculate automatic S11, Zin, Yin, and current-based checks."""
+
+        if not self.prepared:
+            self.prepare(grid)
+
+        real_dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
+        complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
+        histories = {}
+        for name in ("Vinc", "Iinc", "Vtotal", "Itotal"):
+            values = np.asarray(getattr(self.source, name), dtype=real_dtype)
+            if values.ndim != 1 or values.size < self.nsamples:
+                raise RuntimeError(
+                    f"Transmission line {self.output_id!r} {name} history has " "the wrong length"
+                )
+            values = values[: self.nsamples]
+            if not np.all(np.isfinite(values)):
+                raise RuntimeError(
+                    f"Transmission line {self.output_id!r} {name} history is not finite"
+                )
+            histories[name] = values
+
+        frequency_full, incident_voltage_full = engineering_rfft(histories["Vinc"], grid.dt)
+        _, total_voltage_full = engineering_rfft(histories["Vtotal"], grid.dt)
+        # Index n stores I at (n - 1/2) dt. Applying the physical sample-time
+        # offset here preserves all N samples and the voltage FFT grid.
+        _, incident_current_full = engineering_rfft(
+            histories["Iinc"], grid.dt, time_offset=-0.5 * grid.dt
+        )
+        _, total_current_full = engineering_rfft(
+            histories["Itotal"], grid.dt, time_offset=-0.5 * grid.dt
+        )
+
+        selection = self._frequency_slice
+        frequency = frequency_full[selection]
+        incident_voltage = incident_voltage_full[selection]
+        total_voltage = total_voltage_full[selection]
+        incident_current = incident_current_full[selection]
+        total_current = total_current_full[selection]
+        reflected_voltage = np.asarray(total_voltage - incident_voltage, dtype=complex_dtype)
+        s11, source_defined = _safe_complex_divide(
+            reflected_voltage, incident_voltage, complex_dtype
+        )
+
+        incident_magnitude = np.abs(incident_voltage)
+        incident_peak = float(np.max(incident_magnitude, initial=0.0))
+        incident_relative_db = np.full(frequency.shape, -np.inf, dtype=real_dtype)
+        if incident_peak > 0:
+            nonzero = incident_magnitude > 0
+            incident_relative_db[nonzero] = np.asarray(
+                20 * np.log10(incident_magnitude[nonzero] / incident_peak),
+                dtype=real_dtype,
+            )
+        source_valid = source_defined & (incident_relative_db >= self.incident_floor_db)
+
+        zin, zin_defined = impedance_from_s11(s11, self.reference_impedance, complex_dtype)
+        yin, yin_defined = admittance_from_s11(s11, self.reference_impedance, complex_dtype)
+
+        # The stored current lies half a line cell beyond the voltage node.
+        # Forward and reflected currents therefore need opposite spatial
+        # phase corrections; a single V/I phase multiplier is not sufficient.
+        # For the discrete line phase step K,
+        #   Z0 Iseg = Vinc exp(-jK/2) - Vref exp(+jK/2),
+        # which gives the current-derived reflected voltage used below.
+        half_cell_phase, line_propagation_valid = self._line_half_cell_phase(frequency, grid)
+        reflected_from_current = np.full(frequency.shape, np.nan + 1j * np.nan, dtype=complex_dtype)
+        inverse_half_cell_phase = np.conj(half_cell_phase)
+        reflected_from_current[line_propagation_valid] = (
+            incident_voltage[line_propagation_valid]
+            * inverse_half_cell_phase[line_propagation_valid]
+            - self.reference_impedance * total_current[line_propagation_valid]
+        ) * inverse_half_cell_phase[line_propagation_valid]
+        s11_current, s11_current_defined = _safe_complex_divide(
+            reflected_from_current, incident_voltage, complex_dtype
+        )
+        terminal_current = np.asarray(
+            (incident_voltage - reflected_from_current) / self.reference_impedance,
+            dtype=complex_dtype,
+        )
+        terminal_voltage_current = np.asarray(
+            incident_voltage + reflected_from_current, dtype=complex_dtype
+        )
+        zin_current, zin_current_defined = _safe_complex_divide(
+            terminal_voltage_current, terminal_current, complex_dtype
+        )
+
+        mesh_valid = np.asarray(self._full_mesh_valid[selection], dtype=bool)
+        cells_per_wavelength = np.asarray(
+            self._full_cells_per_wavelength[selection], dtype=real_dtype
+        )
+        valid_s11 = mesh_valid & source_valid
+        valid_zin = valid_s11 & zin_defined
+        valid_yin = valid_s11 & yin_defined
+        valid_s11_current = valid_s11 & line_propagation_valid & s11_current_defined
+        valid_zin_current = valid_s11_current & zin_current_defined
+
+        trace_peak = float(np.max(np.abs(histories["Vtotal"]), initial=0.0))
+        tail_count = max(1, self.nsamples // 20)
+        tail_peak = float(np.max(np.abs(histories["Vtotal"][-tail_count:]), initial=0.0))
+        if trace_peak > 0 and tail_peak > 0:
+            tail_relative_db = float(20 * np.log10(tail_peak / trace_peak))
+        elif tail_peak == 0:
+            tail_relative_db = float("-inf")
+        else:
+            tail_relative_db = float("nan")
+        if np.isfinite(tail_relative_db) and tail_relative_db > -40:
+            logger.warning(
+                f"Transmission line {self.output_id!r}: the final 5% of the "
+                f"terminal-voltage trace reaches {tail_relative_db:.1f} dB "
+                "relative to its peak; spectral leakage may be significant."
+            )
+
+        time_voltage = np.asarray(
+            np.arange(self.nsamples, dtype=real_dtype) * grid.dt,
+            dtype=real_dtype,
+        )
+        time_current = np.asarray(
+            (np.arange(self.nsamples, dtype=real_dtype) - real_dtype.type(0.5)) * grid.dt,
+            dtype=real_dtype,
+        )
+        self.result = TransmissionLinePortResult(
+            time_voltage=time_voltage,
+            time_current=time_current,
+            frequency=np.asarray(frequency, dtype=real_dtype),
+            incident_voltage_spectrum=np.asarray(incident_voltage, dtype=complex_dtype),
+            reflected_voltage_spectrum=reflected_voltage,
+            total_voltage_spectrum=np.asarray(total_voltage, dtype=complex_dtype),
+            incident_current_spectrum=np.asarray(incident_current, dtype=complex_dtype),
+            total_current_spectrum=np.asarray(total_current, dtype=complex_dtype),
+            reflected_voltage_current_spectrum=reflected_from_current,
+            terminal_current_spectrum=terminal_current,
+            s11=s11,
+            zin=zin,
+            yin=yin,
+            s11_current=s11_current,
+            zin_current=zin_current,
+            source_valid=np.asarray(source_valid, dtype=bool),
+            mesh_valid=mesh_valid,
+            line_propagation_valid=line_propagation_valid,
+            valid_s11=np.asarray(valid_s11, dtype=bool),
+            valid_zin=np.asarray(valid_zin, dtype=bool),
+            valid_yin=np.asarray(valid_yin, dtype=bool),
+            valid_s11_current=np.asarray(valid_s11_current, dtype=bool),
+            valid_zin_current=np.asarray(valid_zin_current, dtype=bool),
+            incident_relative_db=incident_relative_db,
+            cells_per_minimum_wavelength=cells_per_wavelength,
+            tail_relative_db=tail_relative_db,
+        )
+        return self.result
+
+    def write_hdf5(self, group) -> None:
+        """Add derived terminal quantities to an existing ``/tls/tlN`` group."""
+
+        if self.result is None:
+            raise RuntimeError(f"Transmission line {self.output_id!r} has not been finalised")
+        result = self.result
+        real_dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
+        complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
+
+        group.attrs["Polarisation"] = self.source.polarisation
+        group.attrs["WaveformID"] = self.source.waveformID
+        group.attrs["ReferenceImpedance"] = self.reference_impedance
+        group.attrs["ZinPrimaryMethod"] = "voltage_wave_S11"
+        group.attrs["CurrentCheckMethod"] = "discrete_line_wave_deembedding"
+        group.attrs["TimeVoltageOffset"] = 0.0
+        group.attrs["TimeCurrentOffset"] = -0.5 * self.dt
+        group.attrs["Window"] = "rectangular"
+        group.attrs["IncidentFloorDB"] = self.incident_floor_db
+        group.attrs["SpectrumLimitMode"] = self.spectrum_limit_mode
+        group.attrs["NyquistFrequency"] = self.nyquist_frequency
+        group.attrs["MinimumWavelengthCells"] = self.minimum_wavelength_cells
+        group.attrs["MeshFrequencyLimit"] = self.mesh_frequency_limit
+        group.attrs["LimitingMaterial"] = self.limiting_material
+        group.attrs["IndependentFrequencyResolution"] = self.independent_frequency_resolution
+        group.attrs["FrequencyRange"] = np.asarray(
+            (result.frequency[0], result.frequency[-1]), dtype=real_dtype
+        )
+        valid_indices = np.flatnonzero(result.valid_s11)
+        valid_range = (
+            (result.frequency[valid_indices[0]], result.frequency[valid_indices[-1]])
+            if valid_indices.size
+            else (np.nan, np.nan)
+        )
+        group.attrs["ValidFrequencyRange"] = np.asarray(valid_range, dtype=real_dtype)
+        group.attrs["TailRelativeLevelDB"] = result.tail_relative_db
+        group.attrs["phasor_time_sign"] = PHASOR_TIME_DEPENDENCE
+        group.attrs["forward_transform_sign"] = FORWARD_TRANSFORM_KERNEL
+        group.attrs["real_dtype"] = real_dtype.name
+        group.attrs["complex_dtype"] = complex_dtype.name
+
+        datasets = {
+            "time_voltage": result.time_voltage,
+            "time_current": result.time_current,
+            "frequency": result.frequency,
+            "Vincident_spectrum": result.incident_voltage_spectrum,
+            "Vreflected_spectrum": result.reflected_voltage_spectrum,
+            "Vtotal_spectrum": result.total_voltage_spectrum,
+            "Iincident_spectrum": result.incident_current_spectrum,
+            "Itotal_spectrum": result.total_current_spectrum,
+            "Vreflected_current_spectrum": (result.reflected_voltage_current_spectrum),
+            "Iterminal_current_spectrum": result.terminal_current_spectrum,
+            "S11": result.s11,
+            "Zin": result.zin,
+            "Yin": result.yin,
+            "S11_current": result.s11_current,
+            "Zin_current": result.zin_current,
+            "valid_S11": result.valid_s11.astype(np.uint8),
+            "valid_Zin": result.valid_zin.astype(np.uint8),
+            "valid_Yin": result.valid_yin.astype(np.uint8),
+            "valid_S11_current": result.valid_s11_current.astype(np.uint8),
+            "valid_Zin_current": result.valid_zin_current.astype(np.uint8),
+            "source_valid": result.source_valid.astype(np.uint8),
+            "mesh_valid": result.mesh_valid.astype(np.uint8),
+            "line_propagation_valid": result.line_propagation_valid.astype(np.uint8),
+            "incident_relative_dB": result.incident_relative_db,
+            "cells_per_minimum_wavelength": result.cells_per_minimum_wavelength,
+        }
+        for name, values in datasets.items():
+            group.create_dataset(name, data=values)
+
+
+def prepare_transmission_line_ports(grid: "FDTDGrid") -> None:
+    """Create and prepare the automatic port output for every line source."""
+
+    for index, source in enumerate(grid.transmissionlines, start=1):
+        output = getattr(source, "port_output", None)
+        if output is None:
+            output = TransmissionLinePortOutput(source, index)
+            source.port_output = output
+        else:
+            output.source_index = index
+        output.prepare(grid)
+
+
+def finalise_transmission_line_ports(grid: "FDTDGrid") -> None:
+    """Finalise all automatic transmission-line port outputs."""
+
+    for index, source in enumerate(grid.transmissionlines, start=1):
+        output = getattr(source, "port_output", None)
+        if output is None:
+            output = TransmissionLinePortOutput(source, index)
+            source.port_output = output
+        else:
+            output.source_index = index
+        output.finalise(grid)

--- a/gprMax/receivers.py
+++ b/gprMax/receivers.py
@@ -18,6 +18,7 @@
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+
 import numpy as np
 
 import gprMax.config as config
@@ -202,14 +203,15 @@ def dtoh_rx_array(rxs_dev, rxcoords_dev, G):
     # for Metal, the branch above has just produced the host numpy
     # equivalents. Either way, this assignment must run for every backend -
     # it is the only place rx.outputs actually gets populated.
-    for rx in G.rxs:
-        for rxd in range(len(G.rxs)):
-            if (
-                rx.xcoord == rxcoords_dev[rxd, 0]
-                and rx.ycoord == rxcoords_dev[rxd, 1]
-                and rx.zcoord == rxcoords_dev[rxd, 2]
-                ):
-                for output in rx.outputs.keys():
-                    rx.outputs[output] = rxs_dev[
-                        Rx.allowableoutputs_dev.index(output), :, rxd
-                        ]
+    if rxcoords_dev.shape != (len(G.rxs), 3) or rxs_dev.shape[2] != len(G.rxs):
+        raise RuntimeError("device receiver arrays do not match the grid receiver count")
+    for rxd, rx in enumerate(G.rxs):
+        expected = np.asarray((rx.xcoord, rx.ycoord, rx.zcoord), dtype=np.int32)
+        if not np.array_equal(expected, rxcoords_dev[rxd]):
+            raise RuntimeError(
+                "device receiver order/coordinates do not match the grid receiver list"
+            )
+        for output in rx.outputs:
+            rx.outputs[output] = rxs_dev[
+                Rx.allowableoutputs_dev.index(output), :, rxd
+            ]

--- a/gprMax/sources.py
+++ b/gprMax/sources.py
@@ -17,12 +17,12 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
+import math
 from copy import deepcopy
 
 import numpy as np
 import numpy.typing as npt
-import math
-import logging
 
 import gprMax.config as config
 from gprMax.waveforms import Waveform
@@ -30,12 +30,12 @@ from gprMax.waveforms import Waveform
 from .cython.plane_wave import (
     calculate1DWaveformValues,
     getSource,
-    updatePlaneWave_magnetic,
-    updatePlaneWave_magnetic_axial,
     updatePlaneWave_electric,
     updatePlaneWave_electric_axial,
     updatePlaneWave_electric_dispersive,
     updatePlaneWave_electric_dispersive_axial,
+    updatePlaneWave_magnetic,
+    updatePlaneWave_magnetic_axial,
 )
 from .utilities.utilities import round_value
 
@@ -117,6 +117,19 @@ class VoltageSource(Source):
     def __init__(self):
         super().__init__()
         self.resistance = None
+        # Preserved when create_material() replaces the selected electric-edge
+        # material with a copy carrying the source resistance. Port outputs
+        # need the pre-source values to remove the numerical Yee-gap
+        # capacitance/conductance without accidentally including 1/R.
+        self.background_material_numID = None
+        self.background_material_ID = None
+        self.background_material_type = None
+        self.background_er = None
+        self.background_se = None
+        self.background_mr = None
+        self.background_sm = None
+        self.background_is_dispersive = False
+        self.source_material_numID = None
 
     def calculate_waveform_values(self, G):
         """Calculates all waveform values for source for duration of simulation.
@@ -223,6 +236,14 @@ class VoltageSource(Source):
         componentID = f"E{self.polarisation}"
         requirednumID = G.ID[G.IDlookup[componentID], i, j, k]
         material = next(x for x in G.materials if x.numID == requirednumID)
+        self.background_material_numID = int(material.numID)
+        self.background_material_ID = str(material.ID)
+        self.background_material_type = str(material.type)
+        self.background_er = float(material.er)
+        self.background_se = float(material.se)
+        self.background_mr = float(material.mr)
+        self.background_sm = float(material.sm)
+        self.background_is_dispersive = hasattr(material, "poles")
         newmaterial = deepcopy(material)
         newmaterial.ID = f"{material.ID}+{self.ID}"
         newmaterial.numID = len(G.materials)
@@ -239,6 +260,7 @@ class VoltageSource(Source):
 
         G.ID[G.IDlookup[componentID], i, j, k] = newmaterial.numID
         G.materials.append(newmaterial)
+        self.source_material_numID = int(newmaterial.numID)
 
 
 class HertzianDipole(Source):
@@ -471,6 +493,156 @@ def htod_src_arrays(sources, G, queue=None):
     return srcinfo1_dev, srcinfo2_dev, srcwaves_dev
 
 
+def transmission_line_host_arrays(transmissionlines, G):
+    """Pack transmission-line state into backend-neutral contiguous arrays.
+
+    The coupled part of every transmission line is normally very short, but
+    each line owns mutable voltage, current, and ABC state. Keeping this state
+    in flat arrays lets one device work-item advance one complete line without
+    any host interaction during the FDTD time loop.
+
+    Args:
+        transmissionlines: transmission-line sources attached to a grid.
+        G: FDTDGrid containing the sources.
+
+    Returns:
+        Dictionary of NumPy arrays ready to copy to a compute device.
+    """
+
+    real = config.sim_config.dtypes["float_or_double"]
+    ntl = len(transmissionlines)
+    niterations = G.iterations + 1
+    int32_max = np.iinfo(np.int32).max
+
+    # Columns are x, y, z, polarisation, state offset, number of active line
+    # cells, source position, antenna position, first active iteration, and
+    # last active iteration. Keep this layout in sync with knl_transmission_line.py.
+    info = np.zeros((ntl, 10), dtype=np.int32)
+    resistance = np.zeros(ntl, dtype=real)
+    abcv0 = np.zeros(ntl, dtype=real)
+    abcv1 = np.zeros(ntl, dtype=real)
+    waveform_whole = np.zeros((ntl, niterations), dtype=real)
+    waveform_half = np.zeros((ntl, niterations), dtype=real)
+    Vtotal = np.zeros((ntl, niterations), dtype=real)
+    Itotal = np.zeros((ntl, niterations), dtype=real)
+
+    nstate = sum(int(tl.nl) for tl in transmissionlines)
+    if nstate > int32_max or ntl * niterations > int32_max:
+        raise ValueError(
+            "Transmission-line device arrays exceed the signed 32-bit index range."
+        )
+
+    voltage = np.zeros(nstate, dtype=real)
+    current = np.zeros(nstate, dtype=real)
+    times = G.dt * np.arange(G.iterations, dtype=np.float64)
+    used_ports = set()
+    offset = 0
+
+    for i, tl in enumerate(transmissionlines):
+        port = (int(tl.xcoord), int(tl.ycoord), int(tl.zcoord), tl.polarisation)
+        if port in used_ports:
+            raise ValueError(
+                "More than one transmission line is attached to the same Yee "
+                f"electric-field edge at {port[:3]} with {port[3]} polarisation."
+            )
+        used_ports.add(port)
+
+        if tl.nl <= tl.antpos or tl.srcpos <= 0 or tl.srcpos >= tl.nl:
+            raise ValueError(f"Invalid internal transmission-line layout for {tl.ID}.")
+
+        if tl.polarisation == "x":
+            polarisation = 0
+        elif tl.polarisation == "y":
+            polarisation = 1
+        elif tl.polarisation == "z":
+            polarisation = 2
+        else:
+            raise ValueError(f"Invalid transmission-line polarisation {tl.polarisation!r}.")
+
+        active = np.flatnonzero((times >= tl.start) & (times <= tl.stop))
+        if active.size:
+            first_active = int(active[0])
+            last_active = int(active[-1])
+        else:
+            first_active = 1
+            last_active = 0
+
+        info[i, :] = (
+            tl.xcoord,
+            tl.ycoord,
+            tl.zcoord,
+            polarisation,
+            offset,
+            tl.nl,
+            tl.srcpos,
+            tl.antpos,
+            first_active,
+            last_active,
+        )
+        resistance[i] = tl.resistance
+        abcv0[i] = tl.abcv0
+        abcv1[i] = tl.abcv1
+        voltage[offset : offset + tl.nl] = tl.voltage[: tl.nl]
+        current[offset : offset + tl.nl] = tl.current[: tl.nl]
+        waveform_whole[i, :] = tl.waveformvalues_wholedt
+        waveform_half[i, :] = tl.waveformvalues_halfdt
+        Vtotal[i, :] = tl.Vtotal
+        Itotal[i, :] = tl.Itotal
+        offset += tl.nl
+
+    return {
+        "info": info,
+        "resistance": resistance,
+        "abcv0": abcv0,
+        "abcv1": abcv1,
+        "voltage": voltage,
+        "current": current,
+        "waveform_whole": waveform_whole,
+        "waveform_half": waveform_half,
+        "Vtotal": Vtotal,
+        "Itotal": Itotal,
+    }
+
+
+def htod_transmission_line_arrays(transmissionlines, G, queue=None):
+    """Copy packed transmission-line arrays to the active compute device."""
+
+    arrays = transmission_line_host_arrays(transmissionlines, G)
+    solver = config.sim_config.general["solver"]
+
+    if solver == "cuda":
+        import pycuda.gpuarray as gpuarray
+
+        return {name: gpuarray.to_gpu(array) for name, array in arrays.items()}
+    if solver == "opencl":
+        import pyopencl.array as clarray
+
+        return {name: clarray.to_device(queue, array) for name, array in arrays.items()}
+    if solver == "metal":
+        dev = config.get_model_config().device["dev"]
+        return {
+            name: dev.newBufferWithBytes_length_options_(array.tobytes(), array.nbytes, 0)
+            for name, array in arrays.items()
+        }
+
+    raise ValueError(f"Unknown device solver {solver!r} for transmission-line arrays.")
+
+
+def dtoh_transmission_line_outputs(Vtotal, Itotal, G):
+    """Copy device terminal histories into their transmission-line objects."""
+
+    expected = (len(G.transmissionlines), G.iterations + 1)
+    if Vtotal.shape != expected or Itotal.shape != expected:
+        raise ValueError(
+            "Transmission-line device output shape does not match the grid: "
+            f"expected {expected}, got {Vtotal.shape} and {Itotal.shape}."
+        )
+
+    for i, tl in enumerate(G.transmissionlines):
+        np.copyto(tl.Vtotal, Vtotal[i, :], casting="same_kind")
+        np.copyto(tl.Itotal, Itotal[i, :], casting="same_kind")
+
+
 class TransmissionLine(Source):
     """A transmission line source is a one-dimensional transmission line
     which is attached virtually to a grid cell.
@@ -511,6 +683,10 @@ class TransmissionLine(Source):
         self.Iinc = np.zeros(self.iterations + 1, dtype=config.sim_config.dtypes["float_or_double"])
         self.Vtotal = np.zeros(self.iterations + 1, dtype=config.sim_config.dtypes["float_or_double"])
         self.Itotal = np.zeros(self.iterations + 1, dtype=config.sim_config.dtypes["float_or_double"])
+        # Bound after the grid materials and time axis have been finalised.
+        # Kept here rather than in the update loop because all spectral port
+        # processing is post-solve.
+        self.port_output = None
 
     def calculate_waveform_values(self, G):
         """Calculates all waveform values for source for duration of simulation.
@@ -560,6 +736,14 @@ class TransmissionLine(Source):
             G: FDTDGrid class describing a grid in a model.
         """
 
+        # The preliminary incident-wave calculation and the coupled FDTD run
+        # use separate output histories, but they advance the same internal
+        # line voltage/current vectors and ABC memories. Always start the
+        # preliminary line from rest and clear any old incident histories.
+        self._reset_update_state()
+        self.Vinc.fill(0)
+        self.Iinc.fill(0)
+
         for iteration in range(self.iterations):
             self.Iinc[iteration] = self.current[self.antpos]
             self.Vinc[iteration] = self.voltage[self.antpos]
@@ -568,6 +752,18 @@ class TransmissionLine(Source):
 
         # Shorten number of cells in the transmission line before use with main grid
         self.nl = self.antpos + 1
+
+        # Vinc/Iinc retain the completed incident histories, but the actual
+        # coupled source must begin with zero line fields and zero ABC memory.
+        self._reset_update_state()
+
+    def _reset_update_state(self):
+        """Reset mutable line and absorbing-boundary state to rest."""
+
+        self.voltage.fill(0)
+        self.current.fill(0)
+        self.abcv0 = 0
+        self.abcv1 = 0
 
     def update_abc(self, G):
         """Updates absorbing boundary condition at end of the transmission line.

--- a/gprMax/updates/cuda_updates.py
+++ b/gprMax/updates/cuda_updates.py
@@ -31,6 +31,7 @@ from gprMax.cuda_opencl import (
     knl_source_updates,
     knl_store_outputs,
     knl_symmetry_boundaries,
+    knl_transmission_line,
 )
 from gprMax.grid.cuda_grid import CUDAGrid
 from gprMax.ntff.device import CUDACombinedKSIRCollector
@@ -42,7 +43,11 @@ from gprMax.snapshots import (
     htod_snapshot_array,
     update_snapshot_max_dims,
 )
-from gprMax.sources import htod_src_arrays
+from gprMax.sources import (
+    dtoh_transmission_line_outputs,
+    htod_src_arrays,
+    htod_transmission_line_arrays,
+)
 from gprMax.updates.updates import Updates
 from gprMax.utilities.utilities import round32
 
@@ -106,6 +111,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
             self._set_rx_knl()
         if self.grid.voltagesources + self.grid.hertziandipoles + self.grid.magneticdipoles:
             self._set_src_knls()
+        if self.grid.transmissionlines:
+            self._set_transmission_line_knls()
         if self.grid.snapshots:
             self._set_snapshot_knl()
         self.ntff_collector = None
@@ -348,6 +355,55 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
         self._copy_mat_coeffs(knl, knl)
 
+    def _set_transmission_line_knls(self):
+        """Initialise device-resident transmission lines and their kernels."""
+
+        arrays = htod_transmission_line_arrays(self.grid.transmissionlines, self.grid)
+        for name, array in arrays.items():
+            setattr(self, f"tl_{name}_dev", array)
+
+        real = config.sim_config.dtypes["float_or_double"]
+        line = self.grid.transmissionlines[0]
+        self.tl_line_coefficient = real(config.c * self.grid.dt / line.dl)
+        self.tl_abc_coefficient = real(
+            (config.c * self.grid.dt - line.dl) / (config.c * self.grid.dt + line.dl)
+        )
+        self.tl_tpb = (32, 1, 1)
+        self.tl_bpg = (
+            int(np.ceil(len(self.grid.transmissionlines) / self.tl_tpb[0])),
+            1,
+            1,
+        )
+
+        substitutions = dict(self.subs_func)
+        substitutions.update(
+            {
+                "NY_TLINFO": 10,
+                "NY_TLWAVES": self.grid.iterations + 1,
+                "NY_TLOUTPUTS": self.grid.iterations + 1,
+            }
+        )
+
+        source = self._build_knl(
+            knl_transmission_line.update_transmission_line_magnetic,
+            self.subs_name_args,
+            substitutions,
+        )
+        module = self.source_module(source, options=config.sim_config.devices["nvcc_opts"])
+        self.update_transmission_line_magnetic_dev = module.get_function(
+            "update_transmission_line_magnetic"
+        )
+
+        source = self._build_knl(
+            knl_transmission_line.update_transmission_line_electric,
+            self.subs_name_args,
+            substitutions,
+        )
+        module = self.source_module(source, options=config.sim_config.devices["nvcc_opts"])
+        self.update_transmission_line_electric_dev = module.get_function(
+            "update_transmission_line_electric"
+        )
+
     def _set_snapshot_knl(self):
         """Snapshots - initialises arrays on GPU, prepares kernel and gets kernel
         function.
@@ -509,6 +565,28 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
     def update_magnetic_sources(self, iteration):
         """Updates magnetic field components from sources."""
+        if self.grid.transmissionlines:
+            self.update_transmission_line_magnetic_dev(
+                np.int32(len(self.grid.transmissionlines)),
+                np.int32(iteration),
+                config.sim_config.dtypes["float_or_double"](self.grid.dx),
+                config.sim_config.dtypes["float_or_double"](self.grid.dy),
+                config.sim_config.dtypes["float_or_double"](self.grid.dz),
+                self.tl_line_coefficient,
+                self.tl_info_dev.gpudata,
+                self.tl_resistance_dev.gpudata,
+                self.tl_waveform_half_dev.gpudata,
+                self.tl_voltage_dev.gpudata,
+                self.tl_current_dev.gpudata,
+                self.tl_Vtotal_dev.gpudata,
+                self.tl_Itotal_dev.gpudata,
+                self.grid.Hx_dev.gpudata,
+                self.grid.Hy_dev.gpudata,
+                self.grid.Hz_dev.gpudata,
+                block=self.tl_tpb,
+                grid=self.tl_bpg,
+            )
+
         if self.grid.magneticdipoles:
             self.update_magnetic_dipole_dev(
                 np.int32(len(self.grid.magneticdipoles)),
@@ -617,6 +695,29 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 grid=(round32(len(self.grid.voltagesources)), 1, 1),
             )
 
+        if self.grid.transmissionlines:
+            self.update_transmission_line_electric_dev(
+                np.int32(len(self.grid.transmissionlines)),
+                np.int32(iteration),
+                config.sim_config.dtypes["float_or_double"](self.grid.dx),
+                config.sim_config.dtypes["float_or_double"](self.grid.dy),
+                config.sim_config.dtypes["float_or_double"](self.grid.dz),
+                self.tl_line_coefficient,
+                self.tl_abc_coefficient,
+                self.tl_info_dev.gpudata,
+                self.tl_resistance_dev.gpudata,
+                self.tl_waveform_whole_dev.gpudata,
+                self.tl_voltage_dev.gpudata,
+                self.tl_current_dev.gpudata,
+                self.tl_abcv0_dev.gpudata,
+                self.tl_abcv1_dev.gpudata,
+                self.grid.Ex_dev.gpudata,
+                self.grid.Ey_dev.gpudata,
+                self.grid.Ez_dev.gpudata,
+                block=self.tl_tpb,
+                grid=self.tl_bpg,
+            )
+
         if self.grid.hertziandipoles:
             self.update_hertzian_dipole_dev(
                 np.int32(len(self.grid.hertziandipoles)),
@@ -696,6 +797,11 @@ class CUDAUpdates(Updates[CUDAGrid]):
         # Copy output from receivers array back to correct receiver objects
         if self.grid.rxs:
             dtoh_rx_array(self.rxs_dev.get(), self.rxcoords_dev.get(), self.grid)
+
+        if self.grid.transmissionlines:
+            dtoh_transmission_line_outputs(
+                self.tl_Vtotal_dev.get(), self.tl_Itotal_dev.get(), self.grid
+            )
 
         # Copy data from any snapshots back to correct snapshot objects
         if self.grid.snapshots and not config.get_model_config().device["snapsgpu2cpu"]:

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -889,7 +889,7 @@ class MagneticDipole(RotatableMixin, GridUserObject):
 
 class TransmissionLine(RotatableMixin, GridUserObject):
     """Specifies a one-dimensional transmission line model at an electric
-        field location.
+        field location. The source is supported by the CPU and CUDA solvers.
 
     Attributes:
         polarisation: string required for polarisation of the source x, y, z.
@@ -959,11 +959,13 @@ class TransmissionLine(RotatableMixin, GridUserObject):
             self._log(grid, transmission_line, *position)
 
     def _validate_parameters(self, grid: FDTDGrid):
-        # Warn about using a transmission line on GPU
-        if config.sim_config.general["solver"] in ["cuda", "opencl", "metal"]:
+        # CUDA has a device-resident transmission-line update. OpenCL and
+        # Metal use the same kernel template but do not yet have their host
+        # buffer/launch lifecycle enabled and verified.
+        if config.sim_config.general["solver"] in ["opencl", "metal"]:
             raise ValueError(
                 f"{self.params_str()} cannot currently be used "
-                "with the CUDA, OpenCL, or Metal-based solver. Consider "
+                "with the OpenCL or Metal-based solver. Consider "
                 "using a #voltage_source instead."
             )
 

--- a/gprMax/user_objects/cmds_output.py
+++ b/gprMax/user_objects/cmds_output.py
@@ -43,12 +43,157 @@ from gprMax.ntff.interface import (
     surface_reference_origin,
     validate_identifier,
 )
+from gprMax.ports import (
+    DEFAULT_MINIMUM_WAVELENGTH_CELLS,
+    VoltageSourcePortMonitor,
+    validate_spectrum_limit,
+)
+from gprMax.receivers import Rx as RxUser
 from gprMax.snapshots import Snapshot as SnapshotUser
 from gprMax.subgrids.grid import SubGridBaseGrid
 from gprMax.user_objects.user_objects import OutputUserObject
 from gprMax.utilities.utilities import round_int
 
 logger = logging.getLogger(__name__)
+
+
+class RxPort(OutputUserObject):
+    """Calculate S11 and input impedance at a one-edge voltage source.
+
+    Attributes:
+        p1: Position of the voltage source in metres.
+        id: Optional HDF5 port identifier.
+        spectrum_limit: Minimum cells per shortest material wavelength
+            (default 10), or ``"nyquist"`` for the full research spectrum.
+    """
+
+    @property
+    def order(self):
+        return 16
+
+    @property
+    def hash(self):
+        return "#rx_port"
+
+    def __init__(
+        self,
+        p1: Tuple[float, float, float],
+        id: Optional[str] = None,
+        spectrum_limit=DEFAULT_MINIMUM_WAVELENGTH_CELLS,
+    ):
+        spectrum_limit = validate_spectrum_limit(spectrum_limit)
+        if id is None and spectrum_limit != DEFAULT_MINIMUM_WAVELENGTH_CELLS:
+            raise ValueError(
+                "RxPort requires an ID before a non-default spectrum_limit so "
+                "the object has an unambiguous positional hash representation"
+            )
+        kwargs = dict(p1=p1, id=id)
+        if spectrum_limit != DEFAULT_MINIMUM_WAVELENGTH_CELLS:
+            kwargs["spectrum_limit"] = spectrum_limit
+        super().__init__(**kwargs)
+        self.point = p1
+        self.ID = id
+        self.spectrum_limit = spectrum_limit
+        self._monitor = None
+
+    @property
+    def result(self):
+        if self._monitor is None or self._monitor.result is None:
+            raise RuntimeError("RxPort result is not available until the model has solved")
+        return self._monitor.result
+
+    def _validate_context(self, grid):
+        if isinstance(grid, SubGridBaseGrid) or config.sim_config.general["subgrid"]:
+            raise ValueError(f"{self.params_str()} does not support subgrids.")
+        if config.sim_config.mpi:
+            raise ValueError(f"{self.params_str()} does not yet support MPI.")
+        if config.sim_config.args.geometry_fixed:
+            raise ValueError(f"{self.params_str()} does not support geometry-fixed runs.")
+        if config.get_model_config().mode != "3D":
+            raise ValueError(f"{self.params_str()} currently supports only 3-D models.")
+        if config.sim_config.general["solver"] not in ("cpu", "cuda", "opencl", "metal"):
+            raise ValueError(
+                f"{self.params_str()} supports CPU, CUDA, OpenCL, and Metal solvers."
+            )
+
+    def build(self, model: Model, grid: FDTDGrid):
+        self._validate_context(grid)
+        uip = self._create_uip(grid)
+        self.point = uip.resolve_inf_point(self.point)
+        point_within_grid, coord = uip.check_src_rx_point(self.point, self.params_str())
+        if not point_within_grid:
+            return
+
+        candidates = [
+            source
+            for source in grid.voltagesources
+            if np.array_equal(source.coord, coord)
+        ]
+        if len(candidates) != 1:
+            raise ValueError(
+                f"{self.params_str()} requires exactly one voltage source at "
+                f"grid position {tuple(int(value) for value in coord)}; found "
+                f"{len(candidates)}"
+            )
+        source = candidates[0]
+        if not np.isfinite(source.resistance) or source.resistance <= 0:
+            raise ValueError(
+                f"{self.params_str()} requires a finite, non-zero voltage-source resistance"
+            )
+        if grid.within_pml(coord):
+            raise ValueError(f"{self.params_str()} cannot be placed inside a PML.")
+        if any(monitor.source is source for monitor in grid.port_monitors):
+            raise ValueError(f"{self.params_str()} source already has an RxPort output.")
+
+        if self.ID is None:
+            used = {monitor.output_id for monitor in grid.port_monitors}
+            index = 1
+            while f"port{index}" in used:
+                index += 1
+            output_id = f"port{index}"
+        else:
+            validate_identifier("RxPort ID", self.ID)
+            output_id = self.ID
+        if any(monitor.output_id == output_id for monitor in grid.port_monitors):
+            raise ValueError(f"{self.params_str()} output ID is already in use.")
+
+        if (
+            self.spectrum_limit != "nyquist"
+            and self.spectrum_limit < DEFAULT_MINIMUM_WAVELENGTH_CELLS
+        ):
+            logger.warning(
+                f"{self.params_str()} requests only {self.spectrum_limit:g} cells "
+                "per shortest material wavelength; values below 10 may have "
+                "significant spatial-dispersion error."
+            )
+
+        receiver = RxUser()
+        receiver.ID = f"_rx_port_{output_id}"
+        receiver.coord = np.asarray(coord, dtype=np.int32).copy()
+        receiver.coordorigin = receiver.coord.copy()
+        receiver.outputs[f"E{source.polarisation}"] = np.zeros(
+            grid.iterations, dtype=config.sim_config.dtypes["float_or_double"]
+        )
+        receiver.internal = True
+        receiver.source_bound = True
+        receiver.port_id = output_id
+        grid.add_receiver(receiver)
+
+        monitor = VoltageSourcePortMonitor(
+            output_id,
+            source,
+            receiver,
+            self.spectrum_limit,
+            owner=self,
+        )
+        grid.port_monitors.append(monitor)
+        self._monitor = monitor
+        position = uip.round_to_grid_static_point(self.point)
+        logger.info(
+            f"RxPort {output_id!r} bound to the "
+            f"{source.polarisation}-polarised voltage source at "
+            f"{position[0]:g}m, {position[1]:g}m, {position[2]:g}m."
+        )
 
 
 class Snapshot(OutputUserObject):

--- a/tests/cmds_multiuse/test_metal_gpu_restriction_gaps.py
+++ b/tests/cmds_multiuse/test_metal_gpu_restriction_gaps.py
@@ -4,11 +4,8 @@ gprMax/user_objects/cmds_multiuse.py listed "cuda"/"opencl" but omitted
 feature they gate:
 
 1. TransmissionLine._validate_parameters() rejects transmission lines on
-   CUDA/OpenCL (no update path exists for them there), but Metal - which
-   also has zero transmission-line handling in
-   gprMax/updates/metal_updates.py - fell through and was silently
-   accepted. A Metal transmission-line model would run with no excitation
-   at all, and meaningless Vtotal/Itotal outputs.
+   OpenCL and Metal until their host-side lifecycle is enabled. CUDA has a
+   device-resident implementation.
 2. Rx.build()'s allowable-outputs check restricts CUDA/OpenCL receivers to
    the 6 field components the shared GPU kernel
    (gprMax/cuda_opencl/knl_store_outputs.py) actually writes, but Metal
@@ -23,6 +20,8 @@ Follows the established pattern (see tests/test_receivers_dtoh.py) of
 replacing config.sim_config wholesale to fake a non-CPU solver without
 needing real GPU/Metal hardware present.
 """
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 
@@ -34,10 +33,11 @@ def _set_solver(monkeypatch, solver):
     monkeypatch.setattr(config, "sim_config", type("_SC", (), {})())
     config.sim_config.general = {"solver": solver}
     config.sim_config.dtypes = {"float_or_double": np.float64}
+    config.sim_config.em_consts = {"z0": 376.730313668}
 
 
-@pytest.mark.parametrize("solver", ["cuda", "opencl", "metal"])
-def test_transmission_line_rejected_on_every_gpu_solver(monkeypatch, solver):
+@pytest.mark.parametrize("solver", ["opencl", "metal"])
+def test_transmission_line_rejected_on_unimplemented_gpu_solvers(monkeypatch, solver):
     _set_solver(monkeypatch, solver)
 
     tl = TransmissionLine(
@@ -46,6 +46,21 @@ def test_transmission_line_rejected_on_every_gpu_solver(monkeypatch, solver):
 
     with pytest.raises(ValueError, match="cannot currently be used"):
         tl._validate_parameters(grid=None)
+
+
+def test_transmission_line_is_allowed_on_cuda(monkeypatch):
+    _set_solver(monkeypatch, "cuda")
+    monkeypatch.setattr(
+        config,
+        "get_model_config",
+        lambda: SimpleNamespace(mode="3D"),
+    )
+    grid = SimpleNamespace(waveforms=[SimpleNamespace(ID="w")])
+    tl = TransmissionLine(
+        p1=(0.01, 0.01, 0.01), polarisation="x", resistance=50, waveform_id="w"
+    )
+
+    tl._validate_parameters(grid)
 
 
 @pytest.mark.parametrize("solver", ["cuda", "opencl", "metal"])

--- a/tests/ports/test_integration.py
+++ b/tests/ports/test_integration.py
@@ -1,0 +1,216 @@
+"""Small CPU integration tests for RxPort HDF5 output."""
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+
+
+def _scene(
+    spectrum_limit=10,
+    background=None,
+    dispersive_elsewhere=False,
+    polarisation="z",
+):
+    dl = 0.002
+    scene = gprMax.Scene()
+    scene.add(gprMax.Domain(p1=(0.02, 0.02, 0.02)))
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.TimeWindow(time=4e-10))
+    scene.add(gprMax.PMLThickness(thickness=2))
+    scene.add(gprMax.OMPThreads(1))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
+    if background is not None:
+        er, conductivity = background
+        scene.add(
+            gprMax.Material(
+                er=er,
+                se=conductivity,
+                mr=1,
+                sm=0,
+                id="background",
+            )
+        )
+        scene.add(
+            gprMax.Box(
+                p1=(0, 0, 0),
+                p2=(0.02, 0.02, 0.02),
+                material_id="background",
+            )
+        )
+    if dispersive_elsewhere:
+        scene.add(gprMax.Material(er=4, se=0, mr=1, sm=0, id="remote_debye"))
+        scene.add(
+            gprMax.AddDebyeDispersion(
+                poles=1,
+                er_delta=(3,),
+                tau=(1e-11,),
+                material_ids=("remote_debye",),
+            )
+        )
+        scene.add(
+            gprMax.Box(
+                p1=(0.014, 0.004, 0.004),
+                p2=(0.018, 0.016, 0.016),
+                material_id="remote_debye",
+            )
+        )
+    scene.add(
+        gprMax.VoltageSource(
+            p1=(0.01, 0.01, 0.01),
+            polarisation=polarisation,
+            resistance=50,
+            waveform_id="pulse",
+        )
+    )
+    port = gprMax.RxPort(
+        p1=(0.01, 0.01, 0.01),
+        id="feed",
+        spectrum_limit=spectrum_limit,
+    )
+    scene.add(port)
+    return scene, port
+
+
+def _run(
+    tmp_path,
+    name,
+    spectrum_limit=10,
+    background=None,
+    cpu_precision="single",
+    dispersive_elsewhere=False,
+    polarisation="z",
+):
+    output = tmp_path / name
+    scene, port = _scene(
+        spectrum_limit,
+        background,
+        dispersive_elsewhere,
+        polarisation,
+    )
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        outputfile=output,
+        hide_progress_bars=True,
+        cpu_precision=cpu_precision,
+    )
+    return str(output) + ".h5", port
+
+
+def test_default_port_writes_corrected_s11_impedance_and_frequency_axis(tmp_path):
+    filename, api_port = _run(tmp_path, "default_port")
+
+    assert api_port.result.s11.size > 0
+
+    with h5py.File(filename, "r") as output:
+        assert output.attrs["nrx"] == 0
+        assert output.attrs["nports"] == 1
+        assert "rxs" not in output
+        port = output["ports/feed"]
+        frequency = port["frequency"][...]
+        s11 = port["S11"][...]
+        zin = port["Zin"][...]
+        source_valid = port["source_valid"][...].astype(bool)
+        valid_s11 = port["valid_S11"][...].astype(bool)
+        valid_zin = port["valid_Zin"][...].astype(bool)
+
+        assert frequency.dtype == np.float32
+        assert s11.dtype == np.complex64
+        assert port.attrs["SpectrumLimitMode"] == "minimum_wavelength_cells"
+        assert port.attrs["MinimumWavelengthCells"] == 10
+        assert frequency[-1] <= port.attrs["MeshFrequencyLimit"]
+        np.testing.assert_allclose(port.attrs["FrequencyRange"], (frequency[0], frequency[-1]))
+        assert port.attrs["BackgroundMaterial"] == "free_space"
+        assert port.attrs["BackgroundConductivity"] == 0
+        assert source_valid.any()
+        assert valid_s11.any()
+        assert valid_zin.any()
+        assert port.attrs["GapCapacitance"] == pytest.approx(8.8541878128e-12 * 0.002, rel=2e-6)
+        np.testing.assert_allclose(
+            zin[valid_zin],
+            50 * (1 + s11[valid_zin]) / (1 - s11[valid_zin]),
+            rtol=2e-5,
+            atol=2e-5,
+        )
+
+
+def test_nyquist_research_mode_retains_full_native_axis_and_validity_masks(tmp_path):
+    filename, _ = _run(tmp_path, "full_port", "nyquist")
+
+    with h5py.File(filename, "r") as output:
+        port = output["ports/feed"]
+        frequency = port["frequency"][...]
+        iterations = int(output.attrs["Iterations"])
+        expected_bins = (iterations - 1) // 2 + 1
+
+        assert port.attrs["SpectrumLimitMode"] == "nyquist"
+        assert frequency.size == expected_bins
+        assert frequency[-1] > port.attrs["MeshFrequencyLimit"]
+        assert not port["mesh_valid"][...].astype(bool)[-1]
+        if (iterations - 1) % 2 == 0:
+            assert not port["gap_correction_valid"][...].astype(bool)[-1]
+            assert np.isnan(port["S11"][...][-1])
+        np.testing.assert_allclose(port.attrs["FrequencyRange"], (frequency[0], frequency[-1]))
+        for dataset in (
+            "S11",
+            "Zin",
+            "Yin",
+            "valid_S11",
+            "source_valid",
+            "mesh_valid",
+            "cells_per_minimum_wavelength",
+        ):
+            assert port[dataset].shape == frequency.shape
+
+
+def test_gap_properties_come_from_lossy_background_before_source_material(tmp_path):
+    filename, _ = _run(tmp_path, "lossy_port", background=(4, 0.02))
+
+    with h5py.File(filename, "r") as output:
+        port = output["ports/feed"]
+
+        assert port.attrs["BackgroundMaterial"] == "background"
+        assert port.attrs["BackgroundRelativePermittivity"] == 4
+        assert port.attrs["BackgroundConductivity"] == pytest.approx(0.02)
+        assert port.attrs["GapCapacitance"] == pytest.approx(8.8541878128e-12 * 4 * 0.002, rel=2e-6)
+        assert port.attrs["BackgroundConductance"] == pytest.approx(0.02 * 0.002)
+
+
+def test_port_arrays_follow_configured_double_precision(tmp_path):
+    filename, _ = _run(tmp_path, "double_port", cpu_precision="double")
+
+    with h5py.File(filename, "r") as output:
+        port = output["ports/feed"]
+
+        assert port["frequency"].dtype == np.float64
+        assert port["S11"].dtype == np.complex128
+        assert port.attrs["real_dtype"] == "float64"
+        assert port.attrs["complex_dtype"] == "complex128"
+
+
+def test_dispersive_material_away_from_source_is_supported_and_limits_mesh(tmp_path):
+    filename, _ = _run(tmp_path, "remote_debye", dispersive_elsewhere=True)
+
+    with h5py.File(filename, "r") as output:
+        port = output["ports/feed"]
+
+        assert port.attrs["BackgroundMaterial"] == "free_space"
+        assert port.attrs["LimitingMaterial"] == "remote_debye"
+        assert port["valid_S11"][...].astype(bool).any()
+
+
+@pytest.mark.parametrize("polarisation", ("x", "y"))
+def test_other_voltage_source_polarisations_produce_valid_ports(tmp_path, polarisation):
+    filename, _ = _run(
+        tmp_path,
+        f"{polarisation}_port",
+        polarisation=polarisation,
+    )
+
+    with h5py.File(filename, "r") as output:
+        port = output["ports/feed"]
+
+        assert port.attrs["Polarisation"] == polarisation
+        assert port["valid_S11"][...].astype(bool).any()

--- a/tests/ports/test_port_hash_command.py
+++ b/tests/ports/test_port_hash_command.py
@@ -1,0 +1,48 @@
+"""Hash-command coverage for the positional RxPort interface."""
+
+import pytest
+
+from gprMax.hash_cmds_file import get_user_objects
+from gprMax.user_objects.cmds_output import RxPort
+
+
+def _parse(command):
+    return get_user_objects([f"{command}\n"], checkessential=False)
+
+
+@pytest.mark.parametrize(
+    "command, output_id, spectrum_limit",
+    [
+        ("#rx_port: 0.1 0.2 0.3", None, 10),
+        ("#rx_port: 0.1 0.2 0.3 feed", "feed", 10),
+        ("#rx_port: 0.1 0.2 0.3 feed 15", "feed", 15),
+        ("#rx_port: 0.1 0.2 0.3 feed nyquist", "feed", "nyquist"),
+    ],
+)
+def test_rx_port_positional_forms(command, output_id, spectrum_limit):
+    objects = _parse(command)
+
+    assert len(objects) == 1
+    assert isinstance(objects[0], RxPort)
+    assert objects[0].ID == output_id
+    assert objects[0].spectrum_limit == spectrum_limit
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "#rx_port: 0.1 0.2",
+        "#rx_port: 0.1 0.2 0.3 feed 10 extra",
+        "#rx_port: 0.1 0.2 0.3 feed full",
+        "#rx_port: 0.1 0.2 0.3 feed 2",
+        "#rx_port: 0.1 0.2 0.3 feed nan",
+    ],
+)
+def test_rx_port_rejects_malformed_spectrum_limit(command):
+    with pytest.raises(ValueError):
+        _parse(command)
+
+
+def test_nondefault_api_limit_requires_id_for_positional_round_trip():
+    with pytest.raises(ValueError, match="requires an ID"):
+        RxPort((0.1, 0.2, 0.3), spectrum_limit="nyquist")

--- a/tests/ports/test_transmission_line_port.py
+++ b/tests/ports/test_transmission_line_port.py
@@ -1,0 +1,158 @@
+"""Automatic S11 and impedance output for transmission-line sources."""
+
+from types import SimpleNamespace
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+import gprMax.config as config
+from gprMax.materials import Material
+from gprMax.ports import TransmissionLinePortOutput
+
+
+@pytest.fixture
+def port_config(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "sim_config",
+        SimpleNamespace(
+            dtypes={"float_or_double": np.float64, "complex": np.complex128},
+            em_consts={
+                "c": 299792458.0,
+                "e0": 8.8541878128e-12,
+                "m0": 1.25663706212e-6,
+            },
+        ),
+    )
+
+
+def test_discrete_line_current_deembedding_recovers_known_reflection(port_config):
+    """The current check must correct both Yee time and line-space offsets."""
+
+    nsamples = 256
+    dt = 1e-12
+    frequency_bin = 8
+    omega_step = 2 * np.pi * frequency_bin / nsamples
+    line_dl = np.sqrt(3) * config.sim_config.em_consts["c"] * dt
+    line_k_step = 2 * np.arcsin(np.sqrt(3) * np.sin(omega_step / 2))
+    reference_impedance = 50.0
+    reflection = 0.25
+    sample = np.arange(nsamples)
+
+    incident_voltage = np.cos(omega_step * sample)
+    reflected_voltage = reflection * np.cos(omega_step * sample)
+    incident_current = np.cos(omega_step * (sample - 0.5) - line_k_step / 2) / reference_impedance
+    reflected_current = (
+        -reflection * np.cos(omega_step * (sample - 0.5) + line_k_step / 2) / reference_impedance
+    )
+
+    def legacy_history(values):
+        return np.concatenate((values, np.zeros(1)))
+
+    source = SimpleNamespace(
+        resistance=reference_impedance,
+        dl=line_dl,
+        polarisation="z",
+        waveformID="wave",
+        Vinc=legacy_history(incident_voltage),
+        Iinc=legacy_history(incident_current),
+        Vtotal=legacy_history(incident_voltage + reflected_voltage),
+        Itotal=legacy_history(incident_current + reflected_current),
+    )
+    free_space = Material(0, "free_space")
+    grid = SimpleNamespace(
+        iterations=nsamples,
+        dt=dt,
+        dx=1e-4,
+        dy=1e-4,
+        dz=1e-4,
+        materials=[free_space],
+    )
+
+    result = TransmissionLinePortOutput(source, 1).finalise(grid)
+    index = np.flatnonzero(
+        np.isclose(
+            result.frequency,
+            frequency_bin / (nsamples * dt),
+            rtol=1e-12,
+        )
+    )[0]
+
+    assert result.valid_s11[index]
+    assert result.valid_s11_current[index]
+    assert result.s11[index] == pytest.approx(reflection, abs=1e-12)
+    assert result.s11_current[index] == pytest.approx(reflection, abs=1e-12)
+    expected_impedance = reference_impedance * (1 + reflection) / (1 - reflection)
+    assert result.zin[index] == pytest.approx(expected_impedance, abs=1e-10)
+    assert result.zin_current[index] == pytest.approx(expected_impedance, abs=1e-10)
+
+
+def _scene():
+    dl = 1e-3
+    scene = gprMax.Scene()
+    scene.add(gprMax.Domain(p1=(0.012, 0.012, 0.012)))
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.TimeWindow(time=2e-10))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.OMPThreads(1))
+    scene.add(gprMax.Waveform(wave_type="gaussian", amp=1, freq=2e10, id="w"))
+    scene.add(
+        gprMax.TransmissionLine(
+            polarisation="z",
+            p1=(0.006, 0.006, 0.006),
+            resistance=50,
+            waveform_id="w",
+        )
+    )
+    return scene
+
+
+def test_cpu_line_writes_automatic_s11_and_impedance(tmp_path):
+    output_path = tmp_path / "tl_port"
+    gprMax.run(
+        scenes=[_scene()],
+        n=1,
+        outputfile=output_path,
+        hide_progress_bars=True,
+        cpu_precision="single",
+    )
+
+    with h5py.File(str(output_path) + ".h5", "r") as output:
+        line = output["tls/tl1"]
+        frequency = line["frequency"][...]
+        s11 = line["S11"][...]
+        zin = line["Zin"][...]
+        valid = line["valid_Zin"][...].astype(bool)
+        valid_current = valid & line["valid_Zin_current"][...].astype(bool)
+
+        assert frequency.dtype == np.float32
+        assert s11.dtype == np.complex64
+        assert line.attrs["ZinPrimaryMethod"] == "voltage_wave_S11"
+        assert line.attrs["CurrentCheckMethod"] == "discrete_line_wave_deembedding"
+        assert line.attrs["MinimumWavelengthCells"] == 10
+        assert valid.any()
+        np.testing.assert_allclose(
+            zin[valid],
+            50 * (1 + s11[valid]) / (1 - s11[valid]),
+            rtol=2e-5,
+            atol=2e-5,
+        )
+        assert valid_current.any()
+        assert (
+            np.linalg.norm(line["S11_current"][...][valid_current] - s11[valid_current])
+            / np.linalg.norm(s11[valid_current])
+            < 0.05
+        )
+        for name in (
+            "Yin",
+            "S11_current",
+            "Zin_current",
+            "valid_S11_current",
+            "valid_Zin_current",
+            "source_valid",
+            "mesh_valid",
+            "line_propagation_valid",
+        ):
+            assert line[name].shape == frequency.shape

--- a/tests/ports/test_validation.py
+++ b/tests/ports/test_validation.py
@@ -1,0 +1,113 @@
+"""Build-time validation for the initial single-edge RxPort interface."""
+
+import pytest
+
+import gprMax
+
+
+def _base_scene():
+    scene = gprMax.Scene()
+    scene.add(gprMax.Domain(p1=(0.02, 0.02, 0.02)))
+    scene.add(gprMax.Discretisation(p1=(0.002, 0.002, 0.002)))
+    scene.add(gprMax.TimeWindow(time=2e-11))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
+    return scene
+
+
+def _run_geometry(scene, tmp_path, name, **kwargs):
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        outputfile=tmp_path / name,
+        geometry_only=True,
+        hide_progress_bars=True,
+        **kwargs,
+    )
+
+
+def test_port_requires_exactly_one_colocated_voltage_source(tmp_path):
+    scene = _base_scene()
+    scene.add(gprMax.RxPort((0.01, 0.01, 0.01), id="feed"))
+
+    with pytest.raises(ValueError, match="exactly one voltage source.*found 0"):
+        _run_geometry(scene, tmp_path, "no_source")
+
+
+def test_port_rejects_hard_voltage_source(tmp_path):
+    scene = _base_scene()
+    scene.add(gprMax.VoltageSource((0.01, 0.01, 0.01), "z", 0, "pulse"))
+    scene.add(gprMax.RxPort((0.01, 0.01, 0.01), id="feed"))
+
+    with pytest.raises(ValueError, match="non-zero voltage-source resistance"):
+        _run_geometry(scene, tmp_path, "hard_source")
+
+
+def test_port_rejects_ambiguous_colocated_sources(tmp_path):
+    scene = _base_scene()
+    scene.add(gprMax.VoltageSource((0.01, 0.01, 0.01), "z", 50, "pulse"))
+    scene.add(gprMax.VoltageSource((0.01, 0.01, 0.01), "x", 50, "pulse"))
+    scene.add(gprMax.RxPort((0.01, 0.01, 0.01), id="feed"))
+
+    with pytest.raises(ValueError, match="exactly one voltage source.*found 2"):
+        _run_geometry(scene, tmp_path, "ambiguous_source")
+
+
+def test_port_rejects_geometry_fixed_even_for_first_run(tmp_path):
+    scene = _base_scene()
+    scene.add(gprMax.VoltageSource((0.01, 0.01, 0.01), "z", 50, "pulse"))
+    scene.add(gprMax.RxPort((0.01, 0.01, 0.01), id="feed"))
+
+    with pytest.raises(ValueError, match="does not support geometry-fixed"):
+        _run_geometry(scene, tmp_path, "geometry_fixed", geometry_fixed=True)
+
+
+def test_port_rejects_voltage_source_on_pec_edge(tmp_path):
+    scene = _base_scene()
+    scene.add(
+        gprMax.Box(
+            p1=(0.008, 0.008, 0.008),
+            p2=(0.012, 0.012, 0.012),
+            material_id="pec",
+        )
+    )
+    scene.add(gprMax.VoltageSource((0.01, 0.01, 0.01), "z", 50, "pulse"))
+    scene.add(gprMax.RxPort((0.01, 0.01, 0.01), id="feed"))
+
+    with pytest.raises(ValueError, match="voltage source on a PEC edge"):
+        _run_geometry(scene, tmp_path, "pec_source")
+
+
+def test_port_rejects_second_monitor_on_same_source(tmp_path):
+    scene = _base_scene()
+    scene.add(gprMax.VoltageSource((0.01, 0.01, 0.01), "z", 50, "pulse"))
+    scene.add(gprMax.RxPort((0.01, 0.01, 0.01), id="feed1"))
+    scene.add(gprMax.RxPort((0.01, 0.01, 0.01), id="feed2"))
+
+    with pytest.raises(ValueError, match="source already has an RxPort output"):
+        _run_geometry(scene, tmp_path, "duplicate_source")
+
+
+def test_port_rejects_dispersive_material_on_source_edge(tmp_path):
+    scene = _base_scene()
+    scene.add(gprMax.Material(er=4, se=0, mr=1, sm=0, id="dispersive"))
+    scene.add(
+        gprMax.AddDebyeDispersion(
+            poles=1,
+            er_delta=(3,),
+            tau=(1e-11,),
+            material_ids=("dispersive",),
+        )
+    )
+    scene.add(
+        gprMax.Box(
+            p1=(0.008, 0.008, 0.008),
+            p2=(0.012, 0.012, 0.012),
+            material_id="dispersive",
+        )
+    )
+    scene.add(gprMax.VoltageSource((0.01, 0.01, 0.01), "z", 50, "pulse"))
+    scene.add(gprMax.RxPort((0.01, 0.01, 0.01), id="feed"))
+
+    with pytest.raises(ValueError, match="dispersive material"):
+        _run_geometry(scene, tmp_path, "dispersive_source")

--- a/tests/ports/test_voltage_source_port.py
+++ b/tests/ports/test_voltage_source_port.py
@@ -1,0 +1,120 @@
+"""Unit tests for voltage-source S11 and impedance calculations."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import gprMax.config as config
+from gprMax.materials import Material
+from gprMax.ntff.conventions import engineering_dft
+from gprMax.ports import (
+    admittance_from_s11,
+    correct_s11_for_parallel_gap,
+    engineering_rfft,
+    impedance_from_s11,
+    minimum_wavelength_sampling,
+    validate_spectrum_limit,
+)
+
+
+@pytest.fixture
+def port_config(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "sim_config",
+        SimpleNamespace(
+            dtypes={"float_or_double": np.float64, "complex": np.complex128},
+            em_consts={
+                "c": 299792458.0,
+                "e0": 8.8541878128e-12,
+                "m0": 1.25663706212e-6,
+            },
+        ),
+    )
+
+
+@pytest.mark.parametrize("value, expected", [(10, 10.0), (12.5, 12.5), ("nyquist", "nyquist")])
+def test_spectrum_limit_accepts_numeric_or_explicit_nyquist(value, expected):
+    assert validate_spectrum_limit(value) == expected
+
+
+@pytest.mark.parametrize("value", [2.9, 0, -1, np.inf, np.nan, True, "full"])
+def test_spectrum_limit_rejects_ambiguous_or_nonphysical_values(value):
+    with pytest.raises(ValueError):
+        validate_spectrum_limit(value)
+
+
+def test_engineering_rfft_matches_reference_dft(port_config):
+    dt = 2.5e-11
+    time_offset = 0.5 * dt
+    samples = np.linspace(-0.8, 1.2, 17)
+
+    frequencies, spectrum = engineering_rfft(samples, dt, time_offset=time_offset)
+    reference = engineering_dft(
+        samples,
+        frequencies,
+        dt,
+        time_offset=time_offset,
+    )
+
+    np.testing.assert_allclose(spectrum, reference, rtol=1e-13, atol=1e-24)
+
+
+def test_gap_deembedding_recovers_known_load_and_impedance(port_config):
+    reference_impedance = 50.0
+    antenna_impedance = np.asarray([75 + 20j, 32 - 8j], dtype=np.complex128)
+    background_admittance = np.asarray([0.002 + 0.003j, 0.005 + 0.001j])
+    total_admittance = 1 / antenna_impedance + background_admittance
+    source_impedance = 1 / total_admittance
+    source_s11 = (source_impedance - reference_impedance) / (source_impedance + reference_impedance)
+
+    corrected_s11, correction_valid = correct_s11_for_parallel_gap(
+        source_s11,
+        reference_impedance * background_admittance,
+    )
+    corrected_impedance, impedance_valid = impedance_from_s11(corrected_s11, reference_impedance)
+    corrected_admittance, admittance_valid = admittance_from_s11(corrected_s11, reference_impedance)
+
+    assert correction_valid.all()
+    assert impedance_valid.all()
+    assert admittance_valid.all()
+    np.testing.assert_allclose(corrected_impedance, antenna_impedance, rtol=1e-13)
+    np.testing.assert_allclose(corrected_admittance, 1 / antenna_impedance, rtol=1e-13)
+
+
+def test_open_and_short_keep_s11_valid_but_mask_singular_secondary_quantity(port_config):
+    s11 = np.asarray([1 + 0j, -1 + 0j])
+
+    impedance, impedance_valid = impedance_from_s11(s11, 50.0)
+    admittance, admittance_valid = admittance_from_s11(s11, 50.0)
+
+    assert not impedance_valid[0]
+    assert np.isnan(impedance[0])
+    assert impedance_valid[1]
+    assert impedance[1] == 0
+    assert admittance_valid[0]
+    assert admittance[0] == 0
+    assert not admittance_valid[1]
+    assert np.isnan(admittance[1])
+
+
+def test_default_material_limit_uses_shortest_wavelength(port_config):
+    free_space = Material(0, "free_space")
+    high_er = Material(1, "high_er")
+    high_er.er = 9
+    generated_source = Material(2, "generated_source")
+    generated_source.er = 1000
+    generated_source.type = "voltage-source"
+    grid = SimpleNamespace(
+        dx=0.01,
+        dy=0.005,
+        dz=0.002,
+        materials=[free_space, high_er, generated_source],
+    )
+
+    cells, limiting = minimum_wavelength_sampling(grid, np.asarray([0.0, 1e9]))
+
+    assert np.isinf(cells[0])
+    assert limiting[1] == "high_er"
+    assert cells[1] == pytest.approx(299792458.0 / (1e9 * 3 * 0.01))

--- a/tests/test_receivers_dtoh.py
+++ b/tests/test_receivers_dtoh.py
@@ -68,3 +68,32 @@ def test_metal_dtoh_rx_array_populates_rx_outputs(monkeypatch):
     ex_index = Rx.allowableoutputs_dev.index("Ex")
     assert np.array_equal(rx.outputs["Ex"], known[ex_index, :, 0])
     assert not np.all(rx.outputs["Ex"] == 0), "Ex must not be left zero-filled"
+
+
+def test_device_receiver_copy_uses_order_for_colocated_receivers(monkeypatch):
+    """A hidden port receiver may share a coordinate with a public receiver."""
+
+    monkeypatch.setattr(config, "sim_config", type("_SC", (), {})())
+    config.sim_config.general = {"solver": "cuda"}
+    config.sim_config.dtypes = {"float_or_double": np.float64}
+
+    first = Rx()
+    second = Rx()
+    for rx in (first, second):
+        rx.xcoord, rx.ycoord, rx.zcoord = 1, 2, 3
+        rx.outputs["Ez"] = np.zeros(3)
+
+    class _DummyGrid:
+        rxs = [first, second]
+        iterations = 3
+
+    coordinates = np.asarray(((1, 2, 3), (1, 2, 3)), dtype=np.int32)
+    values = np.zeros((len(Rx.allowableoutputs_dev), 3, 2), dtype=np.float64)
+    ez = Rx.allowableoutputs_dev.index("Ez")
+    values[ez, :, 0] = (1, 2, 3)
+    values[ez, :, 1] = (10, 20, 30)
+
+    dtoh_rx_array(values, coordinates, _DummyGrid())
+
+    np.testing.assert_array_equal(first.outputs["Ez"], (1, 2, 3))
+    np.testing.assert_array_equal(second.outputs["Ez"], (10, 20, 30))

--- a/tests/test_transmission_line_device.py
+++ b/tests/test_transmission_line_device.py
@@ -1,0 +1,134 @@
+"""Device-data and shared-template tests for transmission-line sources."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import gprMax.config as config
+from gprMax.cuda_opencl import knl_transmission_line
+from gprMax.sources import (
+    TransmissionLine,
+    dtoh_transmission_line_outputs,
+    transmission_line_host_arrays,
+)
+
+
+def _line(polarisation="z", coord=(2, 3, 4)):
+    iterations = 4
+    return SimpleNamespace(
+        ID="tl",
+        xcoord=coord[0],
+        ycoord=coord[1],
+        zcoord=coord[2],
+        polarisation=polarisation,
+        nl=3,
+        srcpos=1,
+        antpos=2,
+        start=0.15,
+        stop=0.30,
+        resistance=50.0,
+        abcv0=0.25,
+        abcv1=-0.5,
+        voltage=np.array([1.0, 2.0, 3.0]),
+        current=np.array([4.0, 5.0, 6.0]),
+        waveformvalues_wholedt=np.arange(iterations + 1, dtype=np.float64),
+        waveformvalues_halfdt=np.arange(iterations + 1, dtype=np.float64) + 0.5,
+        Vtotal=np.zeros(iterations + 1, dtype=np.float64),
+        Itotal=np.zeros(iterations + 1, dtype=np.float64),
+    )
+
+
+@pytest.fixture
+def float64_config(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "sim_config",
+        SimpleNamespace(dtypes={"float_or_double": np.float64}),
+    )
+
+
+def test_transmission_line_host_arrays_pack_state_and_activity(float64_config):
+    line = _line()
+    grid = SimpleNamespace(iterations=4, dt=0.1)
+
+    arrays = transmission_line_host_arrays([line], grid)
+
+    # The host reproduces the CPU source's direct iteration*dt comparison;
+    # 3*0.1 is slightly greater than the requested stop time 0.3.
+    assert arrays["info"].tolist() == [[2, 3, 4, 2, 0, 3, 1, 2, 2, 2]]
+    np.testing.assert_array_equal(arrays["voltage"], line.voltage)
+    np.testing.assert_array_equal(arrays["current"], line.current)
+    np.testing.assert_array_equal(arrays["waveform_whole"][0], line.waveformvalues_wholedt)
+    np.testing.assert_array_equal(arrays["waveform_half"][0], line.waveformvalues_halfdt)
+    assert arrays["resistance"].dtype == np.float64
+
+
+def test_transmission_line_host_arrays_reject_duplicate_port(float64_config):
+    grid = SimpleNamespace(iterations=4, dt=0.1)
+
+    with pytest.raises(ValueError, match="same Yee electric-field edge"):
+        transmission_line_host_arrays([_line(), _line()], grid)
+
+
+def test_dtoh_transmission_line_outputs(float64_config):
+    line = _line()
+    grid = SimpleNamespace(iterations=4, transmissionlines=[line])
+    voltage = np.arange(5, dtype=np.float64).reshape(1, 5)
+    current = -voltage
+
+    dtoh_transmission_line_outputs(voltage, current, grid)
+
+    np.testing.assert_array_equal(line.Vtotal, voltage[0])
+    np.testing.assert_array_equal(line.Itotal, current[0])
+
+
+def test_incident_calculation_preserves_histories_but_resets_update_state(float64_config):
+    iterations = 80
+    dt = 1e-12
+    line = TransmissionLine(iterations, dt)
+    line.resistance = 50.0
+    line.waveformvalues_wholedt = np.ones(iterations + 1, dtype=np.float64)
+    line.waveformvalues_halfdt = np.ones(iterations + 1, dtype=np.float64)
+
+    # A repeated setup must not inherit any previous internal line state.
+    line.voltage.fill(3.0)
+    line.current.fill(-2.0)
+    line.abcv0 = 4.0
+    line.abcv1 = -5.0
+
+    line.calculate_incident_V_I(SimpleNamespace(dt=dt))
+
+    assert line.Vinc[0] == 0
+    assert line.Iinc[0] == 0
+    assert np.any(line.Vinc != 0)
+    assert np.any(line.Iinc != 0)
+    assert line.nl == line.antpos + 1
+    np.testing.assert_array_equal(line.voltage, 0)
+    np.testing.assert_array_equal(line.current, 0)
+    assert line.abcv0 == 0
+    assert line.abcv1 == 0
+
+
+@pytest.mark.parametrize("backend", ["cuda", "opencl", "metal"])
+@pytest.mark.parametrize(
+    "kernel",
+    [
+        knl_transmission_line.update_transmission_line_magnetic,
+        knl_transmission_line.update_transmission_line_electric,
+    ],
+)
+def test_transmission_line_template_substitutions_are_complete(backend, kernel):
+    arguments = kernel[f"args_{backend}"].substitute({"REAL": "double"})
+    body = kernel["func"].substitute(
+        {
+            "CUDA_IDX": "int i = 0;" if backend == "cuda" else "",
+            "REAL": "double",
+            "NY_TLINFO": 10,
+            "NY_TLWAVES": 5,
+            "NY_TLOUTPUTS": 5,
+        }
+    )
+
+    assert "$" not in arguments
+    assert "$" not in body

--- a/tests/updates/test_cuda_transmission_line_solve.py
+++ b/tests/updates/test_cuda_transmission_line_solve.py
@@ -1,0 +1,97 @@
+"""End-to-end CUDA/CPU parity for a device-resident transmission line."""
+
+import h5py
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import gprMax
+
+try:
+    import pycuda.driver as _cuda_driver
+
+    _cuda_driver.init()
+    HAS_CUDA = _cuda_driver.Device.count() > 0
+except Exception:
+    HAS_CUDA = False
+
+
+def _scene():
+    dl = 1e-3
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(0.012, 0.012, 0.012)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=1e-10))
+    scene.add(gprMax.Waveform(wave_type="gaussian", amp=1, freq=2e10, id="w"))
+    scene.add(
+        gprMax.TransmissionLine(
+            polarisation="z",
+            p1=(0.006, 0.006, 0.006),
+            resistance=50,
+            waveform_id="w",
+        )
+    )
+    scene.add(gprMax.Rx(p1=(0.006, 0.006, 0.006), id="rx"))
+    return scene
+
+
+@pytest.mark.skipif(not HAS_CUDA, reason="No CUDA device/pycuda available")
+@pytest.mark.parametrize("precision", ["single", "double"])
+def test_cuda_transmission_line_matches_cpu(tmp_path, precision):
+    cpu_path = tmp_path / f"cpu_tl_{precision}"
+    cuda_path = tmp_path / f"cuda_tl_{precision}"
+    gprMax.run(
+        scenes=[_scene()],
+        n=1,
+        outputfile=cpu_path,
+        hide_progress_bars=True,
+        cpu_precision=precision,
+    )
+    gprMax.run(
+        scenes=[_scene()],
+        n=1,
+        outputfile=cuda_path,
+        hide_progress_bars=True,
+        gpu=[0],
+        gpu_precision=precision,
+    )
+
+    with h5py.File(str(cpu_path) + ".h5", "r") as output:
+        cpu = {name: output[f"tls/tl1/{name}"][:] for name in ("Vinc", "Iinc", "Vtotal", "Itotal")}
+        cpu["frequency"] = output["tls/tl1/frequency"][:]
+        cpu["S11"] = output["tls/tl1/S11"][:]
+        cpu["Zin"] = output["tls/tl1/Zin"][:]
+        cpu["valid"] = output["tls/tl1/valid_Zin"][:].astype(bool)
+        cpu["Ez"] = output["rxs/rx1/Ez"][:]
+    with h5py.File(str(cuda_path) + ".h5", "r") as output:
+        cuda = {name: output[f"tls/tl1/{name}"][:] for name in ("Vinc", "Iinc", "Vtotal", "Itotal")}
+        cuda["frequency"] = output["tls/tl1/frequency"][:]
+        cuda["S11"] = output["tls/tl1/S11"][:]
+        cuda["Zin"] = output["tls/tl1/Zin"][:]
+        cuda["valid"] = output["tls/tl1/valid_Zin"][:].astype(bool)
+        cuda["Ez"] = output["rxs/rx1/Ez"][:]
+
+    assert np.max(np.abs(cpu["Vtotal"])) > 1e-3
+    for name in ("Vinc", "Iinc", "Vtotal", "Itotal", "Ez"):
+        scale = max(float(np.max(np.abs(cpu[name]))), 1e-12)
+        assert np.isfinite(cuda[name]).all()
+        tolerance = 2e-5 if precision == "single" else 2e-12
+        assert_allclose(cuda[name], cpu[name], rtol=tolerance, atol=tolerance * scale)
+
+    assert_allclose(cuda["frequency"], cpu["frequency"], rtol=0, atol=0)
+    valid = cpu["valid"] & cuda["valid"]
+    assert valid.any()
+    tolerance = 4e-5 if precision == "single" else 4e-12
+    assert_allclose(cuda["S11"][valid], cpu["S11"][valid], rtol=tolerance, atol=tolerance)
+    impedance_scale = max(float(np.max(np.abs(cpu["Zin"][valid]))), 1.0)
+    # Near an open circuit, Zin = Z0(1 + S11)/(1 - S11) amplifies a small
+    # single-precision S11 difference. Keep the tighter comparison on S11
+    # above and allow the corresponding conditioning in this secondary value.
+    impedance_tolerance = 2e-4 if precision == "single" else 4e-12
+    assert_allclose(
+        cuda["Zin"][valid],
+        cpu["Zin"][valid],
+        rtol=impedance_tolerance,
+        atol=impedance_tolerance * impedance_scale,
+    )


### PR DESCRIPTION
## Summary

This PR adds source-port output calculations and CUDA support for transmission-line sources.

### Source-port outputs

- Adds the `#rx_port` command and Python API `RxPort` object.
- Supports a single-cell resistive voltage source.
- Calculates and stores:
  - complex S11
  - input impedance `Zin`
  - input admittance `Yin`
  - frequency and validity information
- Corrects S11 for the Yee-edge parasitic capacitance and background conductance.
- Uses a default lambda/10 frequency limit, with an optional `nyquist` research mode.
- Stores results under `/ports/<port ID>` in the HDF5 output.

### Transmission-line outputs

- Automatically calculates S11, Zin and Yin for every transmission-line source.
- Stores voltage- and current-based diagnostic results under `/tls/tlN`.
- Accounts for the temporal and spatial staggering of the transmission-line current.
- Correctly resets the transmission-line fields and ABC storage before and after the preliminary incident-wave calculation.

### GPU support

- Adds a device-resident CUDA transmission-line update.
- Uses the shared CUDA/OpenCL kernel-template convention under `cuda_opencl`.
- OpenCL and Metal transmission-line execution remain explicitly unsupported until their host integration is implemented.

### Documentation and tests

- Documents the hash command, Python API and HDF5 output structure.
- Adds focused unit and integration tests for port processing, transmission-line output and CUDA execution.
- Research validation scripts, generated plots/results and `docs/design` are deliberately excluded from this PR.

## 🛠️ Related Issue (Number)

No associated issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update.

## Testing

- 61 focused tests passed, including CUDA transmission-line tests.
- Sphinx HTML documentation build completed successfully.
- Black 23.12.1 and isort 5.13.2 checks passed.

## Checklist

- [ ] Did pre-commit pass all checks?
- [x] I have performed a self-review of my code.
- [x] I have added comments for my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.

The complete pre-commit run was not marked as passed because its whitespace hook rewrites legacy CRLF files, creating a large unrelated line-ending diff.