### PR TITLE
Add antenna metrics and hard-source port outputs

### DIFF
--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -642,10 +642,11 @@ Voltage-source S11 and input impedance
 --------------------------------------
 .. autoclass:: gprMax.user_objects.cmds_output.RxPort
 
-``RxPort`` binds to one resistive, single-Yee-edge ``VoltageSource`` at the
-same discretised coordinate. It creates its electric-field monitor
-automatically and calculates corrected complex ``S11``, ``Zin``, and ``Yin``
-after the solve:
+``RxPort`` binds to one single-Yee-edge ``VoltageSource`` at the same
+discretised coordinate. It creates the necessary field monitors automatically
+and calculates corrected complex ``S11``, ``Zin``, and ``Yin`` after the
+solve. A finite-resistance source uses its resistance as the reference
+impedance:
 
 .. code-block:: python
 
@@ -670,10 +671,30 @@ non-negative FFT bins while retaining the normal validity metadata:
         spectrum_limit='nyquist',
     ))
 
+A hard voltage source can instead emulate an ideal MoM delta-gap excitation.
+Set the source resistance to zero. Its travelling-wave reference impedance
+defaults to 50 Ohms and can be changed on the source:
+
+.. code-block:: python
+
+    scene.add(gprMax.VoltageSource(
+        p1=(0.050, 0.050, 0.020),
+        polarisation='z',
+        resistance=0,
+        waveform_id='source_wave',
+        reference_impedance=50,
+    ))
+    hard_port = gprMax.RxPort(
+        p1=(0.050, 0.050, 0.020),
+        id='ideal_feed',
+    )
+    scene.add(hard_port)
+
 After ``gprMax.run`` completes, ``port.result`` provides the same numerical
-arrays that are stored under ``/ports/feed`` in the model HDF5 file. No current
-receiver is required; input impedance is calculated from the corrected S11
-and the voltage-source resistance.
+arrays that are stored under ``/ports/feed`` in the model HDF5 file. For a
+hard source, gprMax obtains terminal current from the surrounding magnetic-
+field loop and accounts explicitly for the half-step phase difference from
+the integer-time voltage during transformation.
 
 Source Steps
 ------------
@@ -725,6 +746,8 @@ hash commands:
       - ``#ksir_surface``
     * - ``KSIRFrequencyTransform``
       - ``#ksir_frequency``
+    * - ``KSIRAntennaPorts``
+      - ``#ksir_antenna_ports``
     * - ``KSIRTimeRx``
       - ``#ksir_time_rx``
     * - ``KSIRTimeRxSpherical``
@@ -788,6 +811,53 @@ positional optional parameters used by the equivalent hash commands.
 KSIR frequency transform
 ------------------------
 .. autoclass:: gprMax.user_objects.cmds_output.KSIRFrequencyTransform
+
+KSIR antenna-port association
+-----------------------------
+.. autoclass:: gprMax.user_objects.cmds_output.KSIRAntennaPorts
+
+The association is needed only for gain and efficiency. It must name every
+physical port, including a zero-amplitude source that acts as a termination.
+For voltage sources, use the ID of the coincident :class:`RxPort`; automatic
+transmission-line and magnetic-frill IDs are ``tl1``, ... and ``frill1``, ...
+respectively. For example:
+
+.. code-block:: python
+
+    scene.add(gprMax.KSIRFrequencyTransform(
+        surface_id='radiation_surface',
+        id='antenna_band',
+        frequencies=(0.8e9, 1.0e9, 1.2e9),
+        window='rectangular',
+    ))
+    scene.add(gprMax.KSIRAntennaPorts(
+        transform_id='antenna_band',
+        port_ids=('element1', 'element2'),
+    ))
+    scene.add(gprMax.KSIRFarFieldArray(
+        theta_start=0,
+        theta_stop=180,
+        theta_step=2,
+        phi_start=0,
+        phi_stop=360,
+        phi_step=2,
+        transform_id='antenna_band',
+        id='array_pattern',
+        outputs=(
+            'directivity_dbi',
+            'gain_dbi',
+            'realized_gain_dbi',
+            'radiation_efficiency',
+            'total_efficiency',
+        ),
+    ))
+
+The full sphere needed to normalise directivity and efficiency is generated
+internally. The directions stored for ``array_pattern`` remain exactly those
+requested above. Gain uses the coherent net accepted power of the complete
+port set, so amplitudes and delays applied to the source waveforms can model
+array steering. For broadband pulses, a time delay represents true-time-delay
+steering; a fixed phase shift is frequency-specific.
 
 KSIR exact time-domain receivers
 --------------------------------

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1050,12 +1050,13 @@ Allows you to introduce a voltage source at an electric field location. It can b
 
 .. code-block:: none
 
-    #voltage_source: c1 f1 f2 f3 f4 str1 [f5 f6]
+    #voltage_source: c1 f1 f2 f3 f4 str1 [f5 f6 [f7]]
 
 * ``c1`` is the polarisation of the source and can be ``x``, ``y``, or ``z``.
 * ``f1 f2 f3`` are the coordinates (x,y,z) of the source in the model.
 * ``f4`` is the internal resistance of the voltage source in Ohms. If ``f4`` is set to zero then the voltage source is a hard source. That means it prescribes the value of the electric field component. If the waveform becomes zero then the source is perfectly reflecting.
 * ``f5 f6`` are optional parameters. ``f5`` is a time delay in starting the source. ``f6`` is a time to remove the source. If the time window is longer than the source removal time then the source will stop after the source removal time. If the source removal time is longer than the time window then the source will be active for the entire time window. If ``f5 f6`` are omitted the source will start at the beginning of time window and stop at the end of the time window.
+* ``f7`` is the optional positive wave-reference impedance in Ohms used by a coincident ``#rx_port``. A hard source defaults to 50 Ohms. For a finite-resistance source, ``f7`` must equal ``f4``. In the positional hash syntax, ``f5`` and ``f6`` must be supplied before ``f7``; the Python API does not have this restriction.
 * ``str1`` is the identifier of the waveform that should be used with the source.
 
 For example, to specify a y directed voltage source with an internal resistance of 50 Ohms, an amplitude of five, and a 1.2 GHz centre frequency Gaussian waveform use: ``#waveform: gaussian 5 1.2e9 my_gauss_pulse`` and ``#voltage_source: y 0.05 0.05 0.05 50 my_gauss_pulse``.
@@ -1428,6 +1429,9 @@ Allows you to introduce output points into the model. These are locations where 
 .. note::
 
     * When the optional parameters ``str1`` and ``str2`` are not given all the electric and magnetic field components will be output with the receiver point.
+    * On CUDA, OpenCL, and Metal, ``Ix``, ``Iy``, and ``Iz`` use the same
+      single-cell Ampere loops as the CPU solver. Their device histories are
+      allocated only for explicitly requested current components.
 
 #rx_array:
 ----------
@@ -1445,7 +1449,7 @@ Provides a simple method of defining multiple output points in the model. The sy
 ---------
 
 Calculates the complex reflection coefficient and input impedance of a
-single-cell resistive voltage-source port. The output point must coincide
+single-cell voltage-source port. The output point must coincide
 exactly with one ``#voltage_source`` after both positions have been resolved to
 the Yee grid. A separate ``#rx`` command is not required. The syntax is:
 
@@ -1461,27 +1465,32 @@ the Yee grid. A separate ``#rx`` command is not required. The syntax is:
   ``nyquist`` requests every native non-negative FFT bin for research and
   diagnostic use.
 
-Because optional hash-command arguments are positional, ``str1`` must be
-given before ``str2``. For example:
+The voltage source supplies the reference impedance :math:`Z_0`. For example:
 
 .. code-block:: none
 
     #voltage_source: z 0.050 0.050 0.020 50 source_wave
     #rx_port: 0.050 0.050 0.020 feed
     #rx_port: 0.050 0.050 0.020 feed nyquist
+    #voltage_source: z 0.060 0.050 0.020 0 source_wave
+    #rx_port: 0.060 0.050 0.020 ideal_feed
+    # Custom 75 Ohm hard-source reference; start/stop precede it positionally
+    #voltage_source: z 0.070 0.050 0.020 0 source_wave 0 10e-9 75
+    #rx_port: 0.070 0.050 0.020 ideal_feed_75
 
-The voltage-source resistance is the reference impedance :math:`Z_0`. At the
-source plane, the known generator spectrum :math:`V_g` and sampled total gap
-voltage :math:`V` give
+For a finite-resistance source, the voltage-source resistance is the
+reference impedance :math:`Z_0`; a hard source defaults to 50 Ohms unless
+``f7`` is supplied. At the source plane, the known generator
+spectrum :math:`V_g` and sampled total gap voltage :math:`V` give
 
 .. math::
 
     S_{11,\mathrm{source}} = \frac{2V-V_g}{V_g}.
 
-No current calculation is required. gprMax removes the parallel capacitance
-and background conductance of the source Yee edge before reporting the
-antenna-terminal result. With :math:`c=Z_0Y_\mathrm{gap}`, this correction and
-the input impedance are
+No current calculation is required in this finite-resistance case. gprMax
+removes the parallel capacitance and background conductance of the source Yee
+edge before reporting the antenna-terminal result. With
+:math:`c=Z_0Y_\mathrm{gap}`, this correction and the input impedance are
 
 .. math::
 
@@ -1491,10 +1500,51 @@ the input impedance are
     \qquad
     Z_\mathrm{in}=Z_0\frac{1+S_{11}}{1-S_{11}}.
 
+For a zero-resistance source, the gap voltage is prescribed at integer
+electric-field times. gprMax calculates the Ampere-loop current from the four
+surrounding magnetic components. The voltage and current samples retain their
+exact Yee times,
+
+.. math::
+
+    V=V^{n+1}, \qquad I_\mathrm{loop}=I_\mathrm{loop}^{n+1/2},
+
+and the engineering-convention transforms apply the corresponding
+:math:`\Delta t` and :math:`\Delta t/2` time offsets. This corrects their
+relative phase without attenuating current by interpolation. The terminal
+current is then
+
+.. math::
+
+    I_\mathrm{terminal}=I_\mathrm{loop}-Y_\mathrm{gap}V.
+
+For this integer-voltage/half-step-current pairing, the discrete parallel-gap
+admittance is
+
+.. math::
+
+    Y_\mathrm{gap} = G_\mathrm{bg}\cos\left(\frac{\omega\Delta t}{2}\right)
+    +j\frac{2C_\mathrm{gap}}{\Delta t}
+    \sin\left(\frac{\omega\Delta t}{2}\right).
+
+This is the FDTD analogue of an ideal delta-gap MoM excitation: voltage is
+imposed and the antenna current is a solved response. The user-supplied
+:math:`Z_0` (or its 50 Ohm default) defines the travelling-wave normalisation
+only. The reported
+quantities are calculated directly as
+
+.. math::
+
+    Z_\mathrm{in}=\frac{V}{I_\mathrm{terminal}},
+    \qquad
+    V^\pm=\frac{V\pm Z_0 I_\mathrm{terminal}}{2},
+    \qquad
+    S_{11}=\frac{V^-}{V^+}.
+
 The gap capacitance and conductance use the effective electric-edge material
-before the artificial source resistance is added. The discrete capacitive
-admittance is used so the correction is consistent with the trapezoidal Yee
-update.
+before any artificial source resistance is added. The appropriate discrete
+admittance is used in each source mode so the correction is consistent with
+the trapezoidal Yee update and the mode's voltage/current sampling times.
 
 By default, output stops at the first native FFT bin that does not have at
 least 10 cells per shortest wavelength in the model. For nonmagnetic,
@@ -1508,12 +1558,15 @@ material are reported when the model is built.
 
 .. note::
 
-    * The initial implementation supports one finite, non-zero-resistance
+    * The implementation supports one finite-resistance or zero-resistance
       voltage source on the main 3D grid with the CPU, CUDA, OpenCL, or Metal
-      solver.
+      solver. A hard-source port uses a 50 Ohm default :math:`Z_0`, which can
+      be overridden on ``#voltage_source``.
     * MPI, subgrids, 2D modes, geometry-fixed runs, grouped sources, sources
       inside a PML, and dispersive material on the source edge are currently
       rejected. Dispersive materials elsewhere in the model are supported.
+      A hard-source current loop cannot lie on a domain-minimum transverse
+      boundary.
     * ``S11`` remains the primary result. ``Zin`` is singular near an open
       circuit (:math:`S_{11}=1`), so gprMax also stores ``Yin`` and separate
       validity masks.
@@ -1583,7 +1636,8 @@ The following conventions apply to every KSIR command:
 * a spherical coordinate is relative to the centre of its integration
   surface. The Python API can instead give a custom surface origin;
 * Cartesian outputs are ``Ex Ey Ez Hx Hy Hz``. Spherical outputs are
-  ``Er Etheta Ephi Hr Htheta Hphi``;
+  ``Er Etheta Ephi Hr Htheta Hphi``. Far-field derived outputs are described
+  under ``#ksir_far_field`` below;
 * every exact time- or frequency-domain point must be strictly outside the
   completed integration surface. A point may be outside the FDTD model domain;
 * the sampled surface and exterior must be one homogeneous, lossless,
@@ -1602,6 +1656,12 @@ The following conventions apply to every KSIR command:
   hardware-qualified on the development server. OpenCL and Metal have source-
   generation and dispatch coverage, but still require execution tests on
   suitable hardware.
+
+Directivity, gain, efficiency, and port normalisation are post-processing
+operations after the FDTD solve. The angular KSIR evaluation uses a
+Cython/OpenMP kernel on the host for CPU and accelerator simulations alike;
+it does not add a new per-iteration GPU operation or transfer fields back to
+the CPU during time stepping.
 
 A minimal dipole workflow can reuse one surface for an exact time-domain point
 and a frequency-domain radiation pattern:
@@ -1670,6 +1730,58 @@ the outgoing Green function contains ``exp(-j*k*R)``.
 .. code-block:: none
 
     #ksir_frequency: radiation_surface antenna_band 0.8e9 1.0e9 1.2e9 hann
+
+#ksir_antenna_ports:
+--------------------
+
+Associates a complete set of physical antenna ports with a frequency
+transform so that accepted power, gain, realized gain, and efficiency can be
+calculated:
+
+.. code-block:: none
+
+    #ksir_antenna_ports: transform_id port_id1 [port_id2 ...]
+
+For a voltage source, ``port_id`` is the ID of the coincident ``#rx_port``.
+Transmission-line and magnetic-frill sources provide automatic port IDs
+``tl1``, ``tl2``, ... and ``frill1``, ``frill2``, ... respectively, in source
+creation order. The association is not required for electric or magnetic
+far fields, radiation intensity, RCS, or directivity. It is required when a
+far-field command asks for gain or efficiency.
+
+The listed set must include **every** physical voltage, transmission-line,
+and magnetic-frill port in the model. Every voltage source must therefore
+have a coincident ``#rx_port``. This requirement makes the net accepted power
+unambiguous in coupled multiport antennas. A source whose waveform amplitude
+is zero is still a terminated physical port: list it normally. It has zero
+incident power, but coupling from driven ports can make its accepted power
+negative because it delivers coupled energy into its termination. gprMax
+sums that signed terminal power when normalising antenna gain.
+
+Gain normalisation currently requires the transform to use the
+``rectangular`` window. Active Hertzian electric or magnetic dipoles and
+plane-wave sources cannot be mixed with a port-normalised antenna result,
+because their input power is not represented by this port set.
+The normal per-port wavelength-sampling limit also applies to gain validity.
+For a voltage-source port, an explicit ``nyquist`` research override on its
+``#rx_port`` retains the full temporal band, including spatially
+under-resolved values, as it does for S11 and impedance. A coincident
+``#rx_port`` can apply the same override to a magnetic-frill output.
+
+For example, a two-element array with one driven and one terminated element
+uses:
+
+.. code-block:: none
+
+    #waveform: ricker 1 1e9 driven
+    #waveform: ricker 0 1e9 terminated
+    #voltage_source: z 0.045 0.050 0.050 50 driven
+    #voltage_source: z 0.055 0.050 0.050 50 terminated
+    #rx_port: 0.045 0.050 0.050 element1
+    #rx_port: 0.055 0.050 0.050 element2
+    #ksir_frequency: radiation_surface antenna_band 0.8e9 1.0e9 1.2e9 rectangular
+    #ksir_antenna_ports: antenna_band element1 element2
+    #ksir_far_field_array: 0 180 2 0 360 2 antenna_band pattern gain realized_gain
 
 #ksir_time_rx: and #ksir_time_rx_spherical:
 --------------------------------------------
@@ -1761,20 +1873,120 @@ Requests a range-normalized far field in one spherical direction:
     #ksir_far_field: theta phi transform_id [output_id [output1 output2 ...]]
 
 The default outputs are ``Etheta Ephi``. Cartesian and spherical electric or
-magnetic components may be requested. ``radiation_intensity`` may also be
-requested. ``rcs`` requests bistatic radar cross section and requires the
-surface to enclose exactly one existing TFSF plane-wave source; that plane
-wave is associated automatically.
+magnetic components may be requested. The derived outputs are
+``radiation_intensity``, ``directivity``, ``directivity_dbi``, ``gain``,
+``gain_dbi``, ``realized_gain``, ``realized_gain_dbi``,
+``radiation_efficiency``, ``total_efficiency``, and ``rcs``. Linear and dBi
+forms are separate outputs; gprMax does not silently convert one into the
+other.
+
+For the range-normalized electric field, radiation intensity is
+
+.. math::
+
+    U(\theta,\phi,f)
+    = \frac{|F_\theta|^2+|F_\phi|^2}{2\eta},
+
+where :math:`\eta` is the wave impedance of the homogeneous material around
+the KSIR surface. When directivity or either efficiency is requested, gprMax
+also evaluates a temporary full sphere using Gauss--Legendre quadrature in
+:math:`\cos\theta` and periodic quadrature in :math:`\phi`:
+
+.. math::
+
+    P_\mathrm{rad}(f) = \int_{4\pi}U(\theta,\phi,f)\,\mathrm{d}\Omega,
+    \qquad
+    D(\theta,\phi,f) = \frac{4\pi U(\theta,\phi,f)}{P_\mathrm{rad}(f)}.
+
+The quadrature order is selected from the largest requested value of
+:math:`ka`, where :math:`a` is the bounding radius of the completed
+integration surface. The temporary
+full-sphere fields are processed in blocks and are not stored; only the
+radiated power, estimated pattern maximum and its direction, and quadrature
+metadata are retained. The maximum estimate is additionally refined with the
+directions explicitly requested for that output, so a fine user grid cannot
+report a larger directivity than the stored maximum. Therefore a user may request only a principal-plane
+cut and still obtain correctly full-sphere-normalised directivity.
+
+For an associated antenna port set, the exact-frequency terminal spectra give
+
+.. math::
+
+    P_\mathrm{acc}(f)
+    = \sum_p \frac{1}{2}\Re\{V_p I_p^*\},
+    \qquad
+    P_\mathrm{inc}(f)
+    = \sum_p \frac{|V_p^+|^2}{2Z_{0p}}.
+
+The requested gain quantities are
+
+.. math::
+
+    G = \frac{4\pi U}{P_\mathrm{acc}}, \qquad
+    G_\mathrm{realized} = \frac{4\pi U}{P_\mathrm{inc}},
+
+and the scalar efficiencies stored for each frequency are
+
+.. math::
+
+    \eta_\mathrm{rad}=\frac{P_\mathrm{rad}}{P_\mathrm{acc}}, \qquad
+    \eta_\mathrm{total}=\frac{P_\mathrm{rad}}{P_\mathrm{inc}}.
+
+All surface and terminal spectra use the same engineering DFT and transform
+scale, which cancels in these dimensionless ratios. Frequencies below
+``-40 dB`` of the peak total incident spectrum, invalid terminal samples, or
+non-positive normalising powers are written as ``NaN`` and marked invalid in
+the HDF5 port metadata. A radiation efficiency materially above unity emits a
+warning and normally indicates an insufficient time window, mesh error,
+integration-surface error, or inconsistent port definition.
+
+``rcs`` requests bistatic radar cross section and requires a TFSF plane-wave
+source. The KSIR surface must strictly enclose the TFSF box and be clear of
+its field-correction stencil. With hash commands, exactly one plane wave must
+be present and it is associated automatically. Use one plane wave per
+simulation for an unambiguous RCS result. RCS and port-normalised gain belong
+to different excitation workflows and cannot be combined in one result.
 
 Unlike the exact spherical receiver commands, ``#ksir_far_field`` has no
 radius. Each field component is the range-normalized quantity
 
 .. math::
 
-    F(\theta,\phi,f) = r\,\exp(+jkr)\,E(r,\theta,\phi,f),
+    F_\mathrm{s}(\theta,\phi,f)
+    = r\,\exp(+jkr)\,E_\mathrm{s}(r,\theta,\phi,f),
 
-in the far-zone limit. The normalization and engineering phase convention are
-also written as HDF5 attributes.
+in the far-zone limit, where the subscript ``s`` denotes the scattered field.
+The RCS is
+
+.. math::
+
+    \sigma(\theta,\phi,f)
+    = 4\pi
+      \frac{|F_{\mathrm{s},\theta}|^2+|F_{\mathrm{s},\phi}|^2}
+      {|E_{\mathrm{inc},x}|^2+|E_{\mathrm{inc},y}|^2
+       +|E_{\mathrm{inc},z}|^2}.
+
+The incident spectrum is not inferred from the nominal waveform amplitude.
+gprMax samples the actual numerically propagated field of the associated
+discrete plane wave and transforms it using the same frequencies and time
+window as the KSIR surface data. Plane-wave start and stop times are therefore
+included automatically. Frequencies at which the incident spectrum is zero
+produce ``NaN``; results where it is very small can be poorly conditioned and
+should not be used.
+
+``rcs`` is stored as a real, linear quantity in square metres, not in dBsm. It
+can be converted using
+
+.. math::
+
+    \sigma_\mathrm{dBsm}
+    = 10\log_{10}\!\left(\frac{\sigma}{1\,\mathrm{m}^2}\right).
+
+The requested :math:`(\theta,\phi)` specifies the observation direction. For
+monostatic RCS it must be opposite to the incident propagation direction. For
+example, a plane wave propagating along ``+x`` is observed in backscatter at
+``theta=90`` and ``phi=180`` degrees. The far-field normalization and
+engineering phase convention are also written as HDF5 attributes.
 
 .. code-block:: none
 

--- a/docs/source/output.rst
+++ b/docs/source/output.rst
@@ -299,12 +299,16 @@ output.
 Voltage-source S11 and impedance output
 ---------------------------------------
 
-The ``#rx_port`` command and ``RxPort`` Python object write one group per port at
-``/ports/<port ID>``. The source resistance is the reference impedance
-:math:`Z_0`. The source-plane reflection coefficient is calculated directly
-from the known generator voltage and sampled total gap voltage; the reported
-``S11`` then removes the effective Yee-edge background capacitance and
-conductance. ``Zin`` and ``Yin`` are derived from that corrected result:
+The ``#rx_port`` command and ``RxPort`` Python object write one group per port
+at ``/ports/<port ID>``. For a finite-resistance source, its resistance is the
+reference impedance :math:`Z_0`; the source-plane reflection coefficient is
+calculated from the known generator voltage and sampled total gap voltage.
+For a zero-resistance hard source, :math:`Z_0` is supplied by the voltage
+source (50 Ohms by default) and
+the terminal quantities are calculated from the prescribed voltage and
+time-centred Ampere-loop current. Both paths remove the effective Yee-edge
+background capacitance and conductance before reporting ``S11``, ``Zin``, and
+``Yin``:
 
 .. math::
 
@@ -314,7 +318,8 @@ conductance. ``Zin`` and ``Yin`` are derived from that corrected result:
 
 Important attributes include:
 
-* ``ReferenceImpedance``, ``Polarisation``, ``Position``, and ``GridPosition``;
+* ``PortMode``, ``ReferenceImpedance``, ``ReferenceImpedanceSource``,
+  ``Polarisation``, ``Position``, and ``GridPosition``;
 * ``BackgroundMaterial``, ``GapCapacitance``, and
   ``BackgroundConductance``;
 * ``SpectrumLimitMode``, ``MinimumWavelengthCells``,
@@ -332,8 +337,11 @@ The principal datasets are:
 * ``S11_source`` and ``Zin_source``: uncorrected source-plane quantities;
 * ``Vincident_spectrum``, ``Vreflected_source_spectrum``, and
   ``Vtotal_spectrum``: complex voltage spectra;
-* ``time``, ``Vgenerator``, and ``Vtotal``: half-time-step-aligned audit
-  histories;
+* ``time``, ``Vgenerator``, and ``Vtotal``: aligned voltage audit histories;
+* ``time_current``, ``Iloop``, ``Iloop_spectrum``, and
+  ``Iterminal_spectrum``: additional hard-source current data. ``Iloop`` is
+  sampled at magnetic half-step times; its spectrum includes the Yee-gap
+  admittance, while the terminal spectrum has that admittance removed;
 * ``valid_S11``, ``valid_Zin``, ``valid_Yin``, ``source_valid``,
   ``mesh_valid``, and ``gap_correction_valid``: per-bin integer masks;
 * ``incident_relative_dB`` and ``cells_per_minimum_wavelength``: diagnostics
@@ -396,6 +404,28 @@ and transform IDs:
                 theta
                 phi
                 directions
+                radiated_power [directivity/efficiency requests]
+                maximum_directivity
+                maximum_directivity_dbi
+                maximum_directivity_theta
+                maximum_directivity_phi
+                port_power/ [gain/efficiency requests]
+                    port_ids
+                    source_types
+                    reference_impedances
+                    incident_voltage_per_port
+                    terminal_voltage_per_port
+                    terminal_current_per_port
+                    incident_power_per_port
+                    accepted_power_per_port
+                    incident_power
+                    accepted_power
+                    reflected_power
+                    incident_relative_db
+                    mesh_valid
+                    terminal_valid
+                    gain_valid
+                    realized_gain_valid
                 fields/<output>
 
 The surface group records logical bounds, physical reference origin, closure
@@ -411,6 +441,106 @@ Far-field groups have ``range_normalized=True`` and a ``normalization``
 attribute specifying ``r * exp(+j*k*r) * field``. Their radius is intentionally
 absent. Complex datasets use the complex type paired with the configured
 gprMax real precision.
+
+Far-field derived antenna quantities
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``radiation_intensity`` has shape ``(nfrequencies, ndirections)``. If
+``directivity`` or an efficiency is requested, the five full-sphere summary
+datasets shown above have shape ``(nfrequencies,)``. The far-field group also
+records the Gauss--Legendre/periodic quadrature orders and the completed
+surface's bounding radius in metres. These summaries come from an internal
+full-sphere calculation even if the stored user directions form only a cut;
+the internal directional fields are not written to the output file. The
+maximum is refined using the directions in that particular output whenever
+they sample a larger value than the internal quadrature.
+
+The linear definitions are
+
+.. math::
+
+    U=\frac{|F_\theta|^2+|F_\phi|^2}{2\eta},\qquad
+    D=\frac{4\pi U}{P_\mathrm{rad}},\qquad
+    P_\mathrm{rad}=\int_{4\pi}U\,\mathrm{d}\Omega.
+
+``directivity_dbi``, ``gain_dbi``, and ``realized_gain_dbi`` are
+``10*log10`` of their corresponding linear datasets. The linear gain and
+efficiency definitions are
+
+.. math::
+
+    G=\frac{4\pi U}{P_\mathrm{acc}},\qquad
+    G_\mathrm{realized}=\frac{4\pi U}{P_\mathrm{inc}},\qquad
+    \eta_\mathrm{rad}=\frac{P_\mathrm{rad}}{P_\mathrm{acc}},\qquad
+    \eta_\mathrm{total}=\frac{P_\mathrm{rad}}{P_\mathrm{inc}}.
+
+The two efficiencies are frequency-only quantities and therefore have shape
+``(nfrequencies,)`` even though they are stored in ``fields`` with the other
+requested outputs.
+
+For a ``#ksir_antenna_ports`` association, complex port spectra and per-port
+powers have shape ``(nports, nfrequencies)``. Total powers and all validity
+masks have shape ``(nfrequencies,)``. They use
+
+.. math::
+
+    P_\mathrm{acc}=\sum_p\frac{1}{2}\Re\{V_p I_p^*\},\qquad
+    P_\mathrm{inc}=\sum_p\frac{|V_p^+|^2}{2Z_{0p}},\qquad
+    P_\mathrm{refl}=P_\mathrm{inc}-P_\mathrm{acc}.
+
+These are spectral power-normalisation quantities: the voltage and field
+Fourier transforms carry a common time scale, which cancels in gain and
+efficiency. Their HDF5 attributes consequently give voltage spectra in
+``V s``, current spectra in ``A s``, and spectral powers in ``W s**2``. The
+exact complex terminal and incident spectra are retained so that every
+derived power can be checked independently. A zero-amplitude source remains
+a terminated port with zero incident voltage; its terminal voltage/current
+and signed accepted power can still be non-zero through mutual coupling.
+
+The validity datasets should always be applied before plotting. The default
+gain bandwidth includes frequencies whose total incident spectrum is within
+``40 dB`` of its peak and for which the mesh and port reconstruction are
+valid. Invalid derived results are stored as ``NaN`` rather than a plausible
+but ill-conditioned value.
+
+When requested, ``far_field/<output_id>/fields/rcs`` contains real, linear
+bistatic radar cross section in square metres. It is not stored in dBsm. For
+the range-normalized scattered electric field
+:math:`F_\mathrm{s}=r\exp(+jkr)E_\mathrm{s}`, gprMax calculates
+
+.. math::
+
+    \sigma(\theta,\phi,f)
+    = 4\pi
+      \frac{|F_{\mathrm{s},\theta}|^2+|F_{\mathrm{s},\phi}|^2}
+      {|E_{\mathrm{inc},x}|^2+|E_{\mathrm{inc},y}|^2
+       +|E_{\mathrm{inc},z}|^2}.
+
+The denominator is obtained from the actual field history in the associated
+discrete-plane-wave grid, accumulated at the transform frequencies with the
+same time window as the surface data. It therefore includes the numerical
+plane-wave amplitude and its configured start and stop times. A zero incident
+spectrum produces ``NaN`` RCS. Very small incident values are mathematically
+non-zero but can give unreliable results, so the requested frequencies should
+remain within the useful excitation bandwidth.
+
+For plotting in dBsm, convert the stored values explicitly:
+
+.. code-block:: python
+
+    import h5py
+    import numpy as np
+
+    with h5py.File('model.h5', 'r') as output:
+        far = output['ntff/surface/frequency/transform/far_field/backscatter']
+        rcs = far['fields/rcs'][...]  # linear RCS in m**2
+        rcs_dbsm = 10 * np.log10(rcs)
+
+Here ``theta`` and ``phi`` in the same group define the observation direction.
+Monostatic RCS is the value in the direction opposite to plane-wave
+propagation; all other directions are bistatic RCS. Use separate simulations
+for different incident plane waves because selecting an association does not
+separate simultaneously accumulated scattered fields.
 
 Time-domain fields have shape ``(npoints, max(valid_lengths))``. For point
 ``q``, the physical time vector and valid trace are:
@@ -432,8 +562,9 @@ transmission lines.
 
 KSIR surfaces must strictly enclose every impressed source. For plane-wave
 scattering models, the associated total-field/scattered-field box must be
-strictly enclosed by the KSIR surface so that incident-field subtraction can
-be applied consistently.
+strictly enclosed by the KSIR surface. The integration surface then samples
+the scattered-field region outside the TFSF box, while the associated
+numerical plane wave supplies the incident-field normalization used for RCS.
 
 
 .. _outputs-snaps:

--- a/gprMax/__init__.py
+++ b/gprMax/__init__.py
@@ -62,6 +62,7 @@ from .user_objects.cmds_multiuse import (
 from .user_objects.cmds_output import (
     GeometryObjectsWrite,
     GeometryView,
+    KSIRAntennaPorts,
     KSIRFarField,
     KSIRFarFieldArray,
     KSIRFrequencyRx,

--- a/gprMax/cuda_opencl/knl_store_outputs.py
+++ b/gprMax/cuda_opencl/knl_store_outputs.py
@@ -89,3 +89,80 @@ store_outputs = {
 """
     ),
 }
+
+
+store_current_outputs = {
+    "args_cuda": Template(
+        """
+                                __global__ void store_current_outputs(int NCURRENT,
+                                                    int iteration,
+                                                    const int* __restrict__ rxcurrentinfo,
+                                                    $REAL *rxcurrents,
+                                                    $REAL dx,
+                                                    $REAL dy,
+                                                    $REAL dz,
+                                                    const $REAL* __restrict__ Hx,
+                                                    const $REAL* __restrict__ Hy,
+                                                    const $REAL* __restrict__ Hz)
+                                """
+    ),
+    "args_opencl": Template(
+        """
+                                    int NCURRENT,
+                                    int iteration,
+                                    __global const int* restrict rxcurrentinfo,
+                                    __global $REAL *rxcurrents,
+                                    $REAL dx,
+                                    $REAL dy,
+                                    $REAL dz,
+                                    __global const $REAL* restrict Hx,
+                                    __global const $REAL* restrict Hy,
+                                    __global const $REAL* restrict Hz
+                                    """
+    ),
+    "args_metal": Template(
+        """
+                               kernel void store_current_outputs(device const int& NCURRENT,
+                                                    device const int& iteration,
+                                                    device const int* rxcurrentinfo,
+                                                    device $REAL* rxcurrents,
+                                                    device const $REAL& dx,
+                                                    device const $REAL& dy,
+                                                    device const $REAL& dz,
+                                                    device const $REAL* Hx,
+                                                    device const $REAL* Hy,
+                                                    device const $REAL* Hz,
+                                                    uint i [[thread_position_in_grid]])
+                                """
+    ),
+    "func": Template(
+        """
+    // Stores only explicitly requested Ampere-loop current components. Each
+    // row of rxcurrentinfo is x, y, z, component (0=Ix, 1=Iy, 2=Iz).
+
+    $CUDA_IDX
+
+    if (i < NCURRENT) {
+        int x = rxcurrentinfo[4 * i];
+        int y = rxcurrentinfo[4 * i + 1];
+        int z = rxcurrentinfo[4 * i + 2];
+        int component = rxcurrentinfo[4 * i + 3];
+        $REAL current = 0;
+
+        if (component == 0 && y != 0 && z != 0) {
+            current = dy * (Hy[IDX3D_FIELDS(x,y,z-1)] - Hy[IDX3D_FIELDS(x,y,z)])
+                    + dz * (Hz[IDX3D_FIELDS(x,y,z)] - Hz[IDX3D_FIELDS(x,y-1,z)]);
+        }
+        else if (component == 1 && x != 0 && z != 0) {
+            current = dx * (Hx[IDX3D_FIELDS(x,y,z)] - Hx[IDX3D_FIELDS(x,y,z-1)])
+                    + dz * (Hz[IDX3D_FIELDS(x-1,y,z)] - Hz[IDX3D_FIELDS(x,y,z)]);
+        }
+        else if (component == 2 && x != 0 && y != 0) {
+            current = dx * (Hx[IDX3D_FIELDS(x,y-1,z)] - Hx[IDX3D_FIELDS(x,y,z)])
+                    + dy * (Hy[IDX3D_FIELDS(x,y,z)] - Hy[IDX3D_FIELDS(x-1,y,z)]);
+        }
+        rxcurrents[iteration * NCURRENT + i] = current;
+    }
+"""
+    ),
+}

--- a/gprMax/cython/ntff.pyx
+++ b/gprMax/cython/ntff.pyx
@@ -23,8 +23,80 @@ import numpy as np
 
 cimport numpy as np
 from cython.parallel import prange
+from libc.math cimport cos, sin
 
 from gprMax.config cimport float_or_double, float_or_double_complex
+
+
+cpdef void evaluate_far_zone_patches(
+    int nthreads,
+    const float_or_double[:, ::1] patch_positions,
+    const float_or_double[:, ::1] patch_normals,
+    const float_or_double[::1] area_weights,
+    const float_or_double[::1] wavenumbers,
+    const float_or_double[:, ::1] directions,
+    const float_or_double_complex[:, ::1] surface_field,
+    const float_or_double_complex[:, ::1] normal_derivative,
+    float_or_double_complex[:, ::1] output,
+):
+    """Evaluate the frequency-domain far-zone KSIR surface integral.
+
+    OpenMP distributes complete frequency/direction pairs. Each worker
+    therefore owns one output element and can accumulate without atomics. The
+    combined loop also uses all threads when either the number of frequencies
+    or the number of directions is small. Position and normal projections are
+    intentionally calculated inside the patch loop so the kernel does not
+    allocate a potentially very large ``ndirections x npatches`` temporary
+    array.
+
+    Geometry is relative to the requested phase origin and all arrays are
+    validated and made contiguous by :mod:`gprMax.ntff.evaluator` before this
+    low-level kernel is called.
+    """
+
+    cdef Py_ssize_t task, direction, frequency, patch
+    cdef Py_ssize_t ndirections = directions.shape[0]
+    cdef Py_ssize_t nfrequencies = wavenumbers.shape[0]
+    cdef Py_ssize_t npatches = patch_positions.shape[0]
+    cdef Py_ssize_t ntasks = ndirections * nfrequencies
+    cdef float_or_double k, position_projection, normal_projection, angle
+    cdef float_or_double_complex phase, integrand
+    cdef float_or_double four_pi = 12.566370614359172953850573533118
+
+    for task in prange(
+        ntasks,
+        nogil=True,
+        schedule="static",
+        num_threads=nthreads,
+    ):
+        frequency = task // ndirections
+        direction = task - frequency * ndirections
+        k = wavenumbers[frequency]
+        output[frequency, direction] = 0
+        for patch in range(npatches):
+            position_projection = (
+                directions[direction, 0] * patch_positions[patch, 0]
+                + directions[direction, 1] * patch_positions[patch, 1]
+                + directions[direction, 2] * patch_positions[patch, 2]
+            )
+            normal_projection = (
+                directions[direction, 0] * patch_normals[patch, 0]
+                + directions[direction, 1] * patch_normals[patch, 1]
+                + directions[direction, 2] * patch_normals[patch, 2]
+            )
+            angle = k * position_projection
+            phase = cos(angle) + 1j * sin(angle)
+            integrand = -normal_derivative[frequency, patch] + (
+                1j
+                * k
+                * normal_projection
+                * surface_field[frequency, patch]
+            )
+            output[frequency, direction] = (
+                output[frequency, direction]
+                + integrand * phase * area_weights[patch]
+            )
+        output[frequency, direction] = output[frequency, direction] / four_pi
 
 
 cpdef void accumulate_surface_dft(

--- a/gprMax/grid/fdtd_grid.py
+++ b/gprMax/grid/fdtd_grid.py
@@ -161,6 +161,7 @@ class FDTDGrid:
         self.ksir_time_requests = []
         self.ksir_frequency_requests = []
         self.ksir_far_field_requests = []
+        self.ksir_antenna_port_specs = {}
         self.ksir_request_owners = {}
         self.ksir_transform_owners = {}
         self.ntff_output_writers = []

--- a/gprMax/hash_cmds_file.py
+++ b/gprMax/hash_cmds_file.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
 #                          and Nathan Mannall
 #
 # This file is part of gprMax.
@@ -270,6 +270,7 @@ def check_cmd_names(processedlines, checkessential=True):
             "#ksir_frequency_rx_array",
             "#ksir_far_field",
             "#ksir_far_field_array",
+            "#ksir_antenna_ports",
             "#pml_cfs",
             "#symmetry_boundary",
             "#include_file",

--- a/gprMax/hash_cmds_multiuse.py
+++ b/gprMax/hash_cmds_multiuse.py
@@ -47,6 +47,7 @@ from .user_objects.cmds_multiuse import (
 from .user_objects.cmds_output import (
     GeometryObjectsWrite,
     GeometryView,
+    KSIRAntennaPorts,
     KSIRFarField,
     KSIRFarFieldArray,
     KSIRFrequencyRx,
@@ -101,7 +102,7 @@ def process_multicmds(multicmds):
                     resistance=float(tmp[4]),
                     waveform_id=tmp[5],
                 )
-            elif len(tmp) == 8:
+            elif len(tmp) in (8, 9):
                 voltage_source = VoltageSource(
                     polarisation=tmp[0].lower(),
                     p1=(float(tmp[1]), float(tmp[2]), float(tmp[3])),
@@ -109,10 +110,16 @@ def process_multicmds(multicmds):
                     waveform_id=tmp[5],
                     start=float(tmp[6]),
                     stop=float(tmp[7]),
+                    reference_impedance=float(tmp[8]) if len(tmp) == 9 else None,
                 )
             else:
                 logger.exception(
-                    "'" + cmdname + ": " + " ".join(tmp) + "'" + " requires at least six parameters"
+                    "'"
+                    + cmdname
+                    + ": "
+                    + " ".join(tmp)
+                    + "'"
+                    + " requires six, eight, or nine parameters"
                 )
                 raise ValueError
 
@@ -488,12 +495,12 @@ def process_multicmds(multicmds):
             if len(tokens) < 3 or len(tokens) > 5:
                 raise ValueError(
                     f"'{cmdname}: {cmdinstance}' requires three coordinates, "
-                    "an optional ID, and one optional spectrum limit"
+                    "an optional ID and spectrum limit"
                 )
             kwargs = {}
             if len(tokens) >= 4:
                 kwargs["id"] = tokens[3]
-            if len(tokens) == 5:
+            if len(tokens) >= 5:
                 try:
                     kwargs["spectrum_limit"] = float(tokens[4])
                 except ValueError:
@@ -578,6 +585,21 @@ def process_multicmds(multicmds):
                     id=tokens[1],
                     frequencies=tuple(float(value) for value in tokens[2:]),
                     window=window,
+                )
+            )
+
+    cmdname = "#ksir_antenna_ports"
+    if multicmds[cmdname] is not None:
+        for cmdinstance in multicmds[cmdname]:
+            tokens = cmdinstance.split()
+            if len(tokens) < 2:
+                raise ValueError(
+                    f"'{cmdname}: {cmdinstance}' requires a transform ID and one or more port IDs"
+                )
+            scene_objects.append(
+                KSIRAntennaPorts(
+                    transform_id=tokens[0],
+                    port_ids=tuple(tokens[1:]),
                 )
             )
 

--- a/gprMax/ntff/antenna.py
+++ b/gprMax/ntff/antenna.py
@@ -1,0 +1,141 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+
+"""Antenna-pattern quadrature and dimensionless radiation metrics."""
+
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.typing as npt
+
+
+@dataclass(frozen=True)
+class SphericalQuadrature:
+    """Gauss--Legendre/punctured-periodic quadrature over a unit sphere."""
+
+    theta: npt.NDArray[np.floating]
+    phi: npt.NDArray[np.floating]
+    weights: npt.NDArray[np.floating]
+    theta_order: int
+    phi_order: int
+    enclosure_radius: float
+
+
+def spherical_quadrature(
+    enclosure_radius: float,
+    maximum_wavenumber: float,
+    dtype: npt.DTypeLike,
+) -> SphericalQuadrature:
+    """Build an angular grid capable of resolving a bounded radiator.
+
+    A source enclosed by radius ``a`` has an angular field bandwidth of
+    approximately ``ka``. Radiation intensity is quadratic in field, so the
+    conservative order below resolves approximately ``2ka`` plus a fixed
+    margin. Gauss--Legendre weights integrate in ``mu = cos(theta)`` directly;
+    periodic phi samples deliberately omit the duplicate 360-degree endpoint.
+    """
+
+    if not np.isfinite(enclosure_radius) or enclosure_radius <= 0:
+        raise ValueError("enclosure_radius must be finite and positive")
+    if not np.isfinite(maximum_wavenumber) or maximum_wavenumber < 0:
+        raise ValueError("maximum_wavenumber must be finite and non-negative")
+
+    real_dtype = np.dtype(dtype)
+    if real_dtype.kind != "f":
+        raise ValueError("spherical quadrature requires a real floating dtype")
+    angular_bandlimit = max(
+        4,
+        int(np.ceil(2 * maximum_wavenumber * enclosure_radius)) + 6,
+    )
+    theta_order = max(12, angular_bandlimit + 1)
+    # An odd Gauss--Legendre order includes mu=0 (theta=90 degrees). This
+    # avoids a systematic underestimate of the common broadside maximum while
+    # retaining the exact Gauss--Legendre integration rule.
+    if theta_order % 2 == 0:
+        theta_order += 1
+    phi_order = max(24, 2 * angular_bandlimit + 1)
+
+    mu64, mu_weights64 = np.polynomial.legendre.leggauss(theta_order)
+    # leggauss returns ascending mu, hence descending theta. Reverse it so
+    # public metadata follows the conventional north-to-south ordering.
+    mu64 = mu64[::-1]
+    mu_weights64 = mu_weights64[::-1]
+    theta_axis = np.arccos(mu64)
+    phi_axis = 2 * np.pi * np.arange(phi_order, dtype=np.float64) / phi_order
+    theta_grid, phi_grid = np.meshgrid(theta_axis, phi_axis, indexing="ij")
+    weights = mu_weights64[:, np.newaxis] * (2 * np.pi / phi_order)
+    weights = np.broadcast_to(weights, theta_grid.shape)
+
+    theta = np.ascontiguousarray(np.rad2deg(theta_grid).ravel(), dtype=real_dtype)
+    phi = np.ascontiguousarray(np.rad2deg(phi_grid).ravel(), dtype=real_dtype)
+    quadrature_weights = np.ascontiguousarray(weights.ravel(), dtype=real_dtype)
+    for values in (theta, phi, quadrature_weights):
+        values.setflags(write=False)
+    return SphericalQuadrature(
+        theta=theta,
+        phi=phi,
+        weights=quadrature_weights,
+        theta_order=theta_order,
+        phi_order=phi_order,
+        enclosure_radius=float(enclosure_radius),
+    )
+
+
+def radiation_intensity(
+    electric_cartesian: npt.ArrayLike,
+    theta: npt.ArrayLike,
+    phi: npt.ArrayLike,
+    impedance: float,
+) -> npt.NDArray[np.floating]:
+    """Return range-normalized radiation intensity from Cartesian fields."""
+
+    from gprMax.ntff.evaluator import project_cartesian_to_spherical
+
+    electric = np.asarray(electric_cartesian)
+    if electric.ndim != 3 or electric.shape[2] != 3 or electric.dtype.kind != "c":
+        raise ValueError("electric_cartesian must have shape (nf, nd, 3) and be complex")
+    if not np.isfinite(impedance) or impedance <= 0:
+        raise ValueError("impedance must be finite and positive")
+    spherical = project_cartesian_to_spherical(
+        electric,
+        theta,
+        phi,
+        degrees=True,
+    )
+    tangential_squared = np.abs(spherical[:, :, 1]) ** 2 + np.abs(spherical[:, :, 2]) ** 2
+    real_dtype = np.empty((), dtype=electric.dtype).real.dtype
+    return np.asarray(0.5 * tangential_squared / impedance, dtype=real_dtype)
+
+
+def directivity_from_intensity(
+    intensity: npt.ArrayLike,
+    radiated_power: npt.ArrayLike,
+) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]:
+    """Calculate linear directivity and dBi with explicit invalid masks."""
+
+    values = np.asarray(intensity)
+    power = np.asarray(radiated_power, dtype=values.dtype)
+    if values.ndim != 2 or power.shape != (values.shape[0],):
+        raise ValueError("intensity and radiated_power shapes are inconsistent")
+    directivity = np.full(values.shape, np.nan, dtype=values.dtype)
+    finite_power = np.isfinite(power) & (power > 0)
+    directivity[finite_power] = 4 * np.pi * values[finite_power] / power[finite_power, np.newaxis]
+    with np.errstate(divide="ignore", invalid="ignore"):
+        directivity_dbi = 10 * np.log10(directivity)
+    return directivity, np.asarray(directivity_dbi, dtype=values.dtype)

--- a/gprMax/ntff/evaluator.py
+++ b/gprMax/ntff/evaluator.py
@@ -25,6 +25,11 @@ from scipy.constants import c
 
 from .surfaces import KSIRComponentSurface
 
+try:
+    from gprMax.cython.ntff import evaluate_far_zone_patches as _evaluate_far_zone_patches_cython
+except ImportError:  # pragma: no cover - source-tree fallback before compilation
+    _evaluate_far_zone_patches_cython = None
+
 
 def _floating_input_dtype(*values) -> np.dtype:
     dtype = np.result_type(*(np.asarray(value).dtype for value in values))
@@ -128,8 +133,15 @@ def evaluate_far_zone_patches(
     origin: npt.ArrayLike = (0.0, 0.0, 0.0),
     direction_block_size: int = 256,
     patch_block_size: int = 8192,
+    nthreads: int = 1,
 ) -> npt.NDArray[np.complexfloating]:
-    """Evaluate KSIR from explicit patch geometry and phasors."""
+    """Evaluate KSIR from explicit patch geometry and phasors.
+
+    A Cython/OpenMP implementation is used when the extension is available.
+    The blocked NumPy implementation remains the source-tree fallback and
+    executable reference. ``direction_block_size`` and ``patch_block_size``
+    control only that fallback.
+    """
 
     raw_field = np.asarray(surface_field)
     raw_derivative = np.asarray(normal_derivative)
@@ -157,6 +169,8 @@ def evaluate_far_zone_patches(
         or patch_block_size <= 0
     ):
         raise ValueError("patch_block_size must be a positive integer")
+    if not isinstance(nthreads, (int, np.integer)) or nthreads <= 0:
+        raise ValueError("nthreads must be a positive integer")
 
     direction_vectors = np.asarray(directions, dtype=real_dtype)
     if direction_vectors.ndim != 2 or direction_vectors.shape[1] != 3:
@@ -196,11 +210,30 @@ def evaluate_far_zone_patches(
     derivative = _phasors(
         "normal_derivative", raw_derivative, freqs.size, npatches
     ).astype(complex_dtype, copy=False)
-    positions = positions - reference_origin
-    wavenumbers = 2 * np.pi * freqs / wave_speed
+    positions = np.ascontiguousarray(positions - reference_origin, dtype=real_dtype)
+    normals = np.ascontiguousarray(normals, dtype=real_dtype)
+    areas = np.ascontiguousarray(areas, dtype=real_dtype)
+    direction_vectors = np.ascontiguousarray(direction_vectors, dtype=real_dtype)
+    field = np.ascontiguousarray(field, dtype=complex_dtype)
+    derivative = np.ascontiguousarray(derivative, dtype=complex_dtype)
+    wavenumbers = np.ascontiguousarray(2 * np.pi * freqs / wave_speed, dtype=real_dtype)
     result = np.zeros(
         (freqs.size, direction_vectors.shape[0]), dtype=complex_dtype
     )
+
+    if _evaluate_far_zone_patches_cython is not None:
+        _evaluate_far_zone_patches_cython(
+            int(nthreads),
+            positions,
+            normals,
+            areas,
+            wavenumbers,
+            direction_vectors,
+            field,
+            derivative,
+            result,
+        )
+        return result
 
     for direction_start in range(0, direction_vectors.shape[0], direction_block_size):
         direction_stop = min(
@@ -377,6 +410,7 @@ def evaluate_far_zone(
     origin: npt.ArrayLike = (0.0, 0.0, 0.0),
     direction_block_size: int = 256,
     patch_block_size: int = 8192,
+    nthreads: int = 1,
 ) -> npt.NDArray[np.complexfloating]:
     """Evaluate the range-normalized scalar far-zone KSIR integral.
 
@@ -394,90 +428,26 @@ def evaluate_far_zone(
         origin: Phase-reference origin in metres.
         direction_block_size: Maximum directions in one temporary block.
         patch_block_size: Maximum patches in one temporary block.
+        nthreads: OpenMP threads used by the compiled evaluator.
 
     Returns:
         Range-normalized component phasors with shape ``(nf, nd)``.
     """
 
-    raw_field = np.asarray(surface_field)
-    raw_derivative = np.asarray(normal_derivative)
-    complex_dtype = np.result_type(raw_field.dtype, raw_derivative.dtype)
-    if complex_dtype.kind != "c":
-        raise ValueError("surface phasors must use a complex dtype")
-    real_dtype = np.empty((), dtype=complex_dtype).real.dtype
-    freqs = np.asarray(frequencies, dtype=real_dtype)
-    if freqs.ndim != 1 or freqs.size == 0:
-        raise ValueError("frequencies must be a non-empty one-dimensional array")
-    if not np.all(np.isfinite(freqs)) or np.any(freqs < 0):
-        raise ValueError("frequencies must contain finite, non-negative values")
-    if not np.isfinite(wave_speed) or wave_speed <= 0:
-        raise ValueError("wave_speed must be finite and greater than zero")
-    reference_origin = np.asarray(origin, dtype=real_dtype)
-    if reference_origin.shape != (3,) or not np.all(np.isfinite(reference_origin)):
-        raise ValueError("origin must contain exactly three finite values")
-    if not isinstance(direction_block_size, (int, np.integer)) or direction_block_size <= 0:
-        raise ValueError("direction_block_size must be a positive integer")
-    if not isinstance(patch_block_size, (int, np.integer)) or patch_block_size <= 0:
-        raise ValueError("patch_block_size must be a positive integer")
-
-    direction_vectors = np.asarray(directions, dtype=real_dtype)
-    if direction_vectors.ndim != 2 or direction_vectors.shape[1] != 3:
-        raise ValueError("directions must have shape (ndirections, 3)")
-    if direction_vectors.shape[0] == 0 or not np.all(np.isfinite(direction_vectors)):
-        raise ValueError("directions must contain finite unit vectors")
-    direction_norms = np.linalg.norm(direction_vectors, axis=1)
-    unit_tolerance = max(1e-12, 64 * np.finfo(real_dtype).eps)
-    if not np.allclose(
-        direction_norms, 1.0, rtol=unit_tolerance, atol=unit_tolerance
-    ):
-        raise ValueError("directions must be unit vectors")
-
-    npatches = surface.npatches
-    field = _phasors("surface_field", raw_field, freqs.size, npatches).astype(
-        complex_dtype, copy=False
+    return evaluate_far_zone_patches(
+        surface.patch_positions,
+        surface.normals,
+        surface.area_weights,
+        frequencies,
+        directions,
+        surface_field,
+        normal_derivative,
+        wave_speed=wave_speed,
+        origin=origin,
+        direction_block_size=direction_block_size,
+        patch_block_size=patch_block_size,
+        nthreads=nthreads,
     )
-    derivative = _phasors(
-        "normal_derivative", raw_derivative, freqs.size, npatches
-    ).astype(complex_dtype, copy=False)
-
-    positions = np.asarray(surface.patch_positions, dtype=real_dtype) - reference_origin
-    normals = np.asarray(surface.normals, dtype=real_dtype)
-    areas = np.asarray(surface.area_weights, dtype=real_dtype)
-    wavenumbers = 2 * np.pi * freqs / wave_speed
-    result = np.zeros(
-        (freqs.size, direction_vectors.shape[0]), dtype=complex_dtype
-    )
-
-    for direction_start in range(0, direction_vectors.shape[0], direction_block_size):
-        direction_stop = min(
-            direction_start + direction_block_size, direction_vectors.shape[0]
-        )
-        direction_block = direction_vectors[direction_start:direction_stop]
-        block_result = result[:, direction_start:direction_stop]
-
-        for patch_start in range(0, npatches, patch_block_size):
-            patch_stop = min(patch_start + patch_block_size, npatches)
-            direction_dot_position = direction_block @ positions[patch_start:patch_stop].T
-            normal_dot_direction = direction_block @ normals[patch_start:patch_stop].T
-            phase = np.exp(
-                1j
-                * wavenumbers[:, np.newaxis, np.newaxis]
-                * direction_dot_position[np.newaxis, :, :]
-            ).astype(complex_dtype, copy=False)
-            integrand = -derivative[:, np.newaxis, patch_start:patch_stop] + (
-                1j
-                * wavenumbers[:, np.newaxis, np.newaxis]
-                * normal_dot_direction[np.newaxis, :, :]
-                * field[:, np.newaxis, patch_start:patch_stop]
-            )
-            block_result += np.sum(
-                integrand
-                * phase
-                * areas[np.newaxis, np.newaxis, patch_start:patch_stop],
-                axis=2,
-            )
-
-    return result / np.asarray(4 * np.pi, dtype=real_dtype)
 
 
 def spherical_basis(

--- a/gprMax/ntff/frequency_domain.py
+++ b/gprMax/ntff/frequency_domain.py
@@ -255,7 +255,12 @@ def _evaluate_component_with_closure(
     directions: npt.ArrayLike,
     wave_speed: float,
     origin: npt.ArrayLike,
-) -> tuple[npt.NDArray[np.complexfloating], npt.NDArray[np.complexfloating]]:
+    nthreads: int = 1,
+    retain_face_contributions: bool = True,
+) -> tuple[
+    npt.NDArray[np.complexfloating],
+    Optional[npt.NDArray[np.complexfloating]],
+]:
     """Evaluate one component and retain contributions by physical face."""
 
     field_values = np.asarray(field)
@@ -268,9 +273,13 @@ def _evaluate_component_with_closure(
     total = np.zeros(
         (frequency_values.size, direction_values.shape[0]), dtype=result_dtype
     )
-    face_contributions = np.zeros(
-        (frequency_values.size, direction_values.shape[0], len(FACES)),
-        dtype=result_dtype,
+    face_contributions = (
+        np.zeros(
+            (frequency_values.size, direction_values.shape[0], len(FACES)),
+            dtype=result_dtype,
+        )
+        if retain_face_contributions
+        else None
     )
     for (
         face_id,
@@ -294,10 +303,14 @@ def _evaluate_component_with_closure(
             image_derivative,
             wave_speed=wave_speed,
             origin=origin,
+            nthreads=nthreads,
         )
         total += contribution
-        face_contributions[:, :, FACES.index(face_id)] += contribution
-    return _readonly(total), _readonly(face_contributions)
+        if face_contributions is not None:
+            face_contributions[:, :, FACES.index(face_id)] += contribution
+    return _readonly(total), (
+        None if face_contributions is None else _readonly(face_contributions)
+    )
 
 
 class _ComponentDFTAccumulator:
@@ -1071,6 +1084,7 @@ class KSIRFrequencyDomainMonitor:
                 self.directions,
                 self.wave_speed,
                 self.origin,
+                self.nthreads,
             )
             fields[component] = values
             face_contributions[component] = contributions

--- a/gprMax/ntff/interface.py
+++ b/gprMax/ntff/interface.py
@@ -19,7 +19,8 @@
 
 """Compiled reusable-surface interface for KSIR field transformations."""
 
-from dataclasses import dataclass
+import logging
+from dataclasses import dataclass, replace
 from types import MappingProxyType
 from typing import Mapping, Optional, Sequence
 
@@ -28,6 +29,11 @@ import numpy.typing as npt
 from scipy.constants import c, epsilon_0, mu_0
 
 import gprMax.config as config
+from gprMax.ntff.antenna import (
+    directivity_from_intensity,
+    radiation_intensity,
+    spherical_quadrature,
+)
 from gprMax.ntff.closures import SymmetryCompletion, resolve_closure
 from gprMax.ntff.conventions import (
     FORWARD_TRANSFORM_KERNEL,
@@ -46,6 +52,9 @@ from gprMax.ntff.frequency_domain import (
 )
 from gprMax.ntff.surfaces import COMPONENT_OFFSETS, COMPONENTS, build_component_surface
 from gprMax.ntff.time_domain import KSIRTimeDomainMonitor
+from gprMax.ports import evaluate_port_power_spectrum, port_output_registry
+
+logger = logging.getLogger(__name__)
 
 ELECTRIC_COMPONENTS = ("Ex", "Ey", "Ez")
 MAGNETIC_COMPONENTS = ("Hx", "Hy", "Hz")
@@ -58,9 +67,19 @@ SPHERICAL_OUTPUTS = (
     "Htheta",
     "Hphi",
 )
-FAR_METRICS = ("radiation_intensity", "rcs")
+DIRECTIVITY_OUTPUTS = ("directivity", "directivity_dbi")
+GAIN_OUTPUTS = ("gain", "gain_dbi", "realized_gain", "realized_gain_dbi")
+EFFICIENCY_OUTPUTS = ("radiation_efficiency", "total_efficiency")
+PORT_METRICS = GAIN_OUTPUTS + EFFICIENCY_OUTPUTS
+FAR_METRICS = (
+    ("radiation_intensity", "rcs") + DIRECTIVITY_OUTPUTS + GAIN_OUTPUTS + EFFICIENCY_OUTPUTS
+)
 TIME_ORIGINS = ("simulation", "first_arrival")
 WINDOWS = ("rectangular", "hann")
+# Post-processing block sizes are derived per transform from this cache-sized
+# working-set target. It is a performance bound, not a model-size limit.
+FAR_ZONE_TARGET_WORKING_SET_BYTES = 32 * 1024 * 1024
+MAX_FAR_ZONE_DIRECTION_BLOCK = 1024
 
 
 def _readonly(values: npt.ArrayLike, dtype=None) -> npt.NDArray:
@@ -118,6 +137,12 @@ class KSIRFrequencyTransformSpec:
     window: str = "rectangular"
     save_surface_dft: bool = True
     plane_wave_index: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class KSIRAntennaPortsSpec:
+    transform_id: str
+    port_ids: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -200,7 +225,84 @@ class KSIRFarFieldResult:
     directions: npt.NDArray[np.floating]
     fields: Mapping[str, npt.NDArray]
     origin: npt.NDArray[np.floating]
+    radiation_metrics: Optional["KSIRRadiationMetrics"]
+    port_metrics: Optional["KSIRPortMetrics"]
     range_normalized: bool = True
+
+
+@dataclass(frozen=True)
+class KSIRRadiationMetrics:
+    """Full-sphere quantities shared by far-field cuts and points."""
+
+    radiated_power: npt.NDArray[np.floating]
+    maximum_directivity: npt.NDArray[np.floating]
+    maximum_directivity_dbi: npt.NDArray[np.floating]
+    maximum_theta: npt.NDArray[np.floating]
+    maximum_phi: npt.NDArray[np.floating]
+    theta_order: int
+    phi_order: int
+    enclosure_radius: float
+
+
+def _refine_radiation_maximum(
+    metrics: KSIRRadiationMetrics,
+    intensity: npt.NDArray[np.floating],
+    theta: npt.NDArray[np.floating],
+    phi: npt.NDArray[np.floating],
+) -> KSIRRadiationMetrics:
+    """Include any more accurately sampled requested peak in the summary."""
+
+    local_index = np.argmax(intensity, axis=1)
+    local_intensity = intensity[np.arange(intensity.shape[0]), local_index]
+    local_directivity, local_directivity_dbi = directivity_from_intensity(
+        local_intensity[:, np.newaxis],
+        metrics.radiated_power,
+    )
+    local_directivity = local_directivity[:, 0]
+    local_directivity_dbi = local_directivity_dbi[:, 0]
+    update = np.isfinite(local_directivity) & (
+        local_directivity > metrics.maximum_directivity
+    )
+    if not np.any(update):
+        return metrics
+
+    maximum_directivity = np.array(metrics.maximum_directivity, copy=True)
+    maximum_directivity_dbi = np.array(metrics.maximum_directivity_dbi, copy=True)
+    maximum_theta = np.array(metrics.maximum_theta, copy=True)
+    maximum_phi = np.array(metrics.maximum_phi, copy=True)
+    maximum_directivity[update] = local_directivity[update]
+    maximum_directivity_dbi[update] = local_directivity_dbi[update]
+    maximum_theta[update] = theta[local_index[update]]
+    maximum_phi[update] = phi[local_index[update]]
+    return replace(
+        metrics,
+        maximum_directivity=_readonly(maximum_directivity),
+        maximum_directivity_dbi=_readonly(maximum_directivity_dbi),
+        maximum_theta=_readonly(maximum_theta),
+        maximum_phi=_readonly(maximum_phi),
+    )
+
+
+@dataclass(frozen=True)
+class KSIRPortMetrics:
+    """Exact-frequency powers for one coherently excited antenna port set."""
+
+    port_ids: tuple[str, ...]
+    source_types: tuple[str, ...]
+    reference_impedances: npt.NDArray[np.floating]
+    incident_voltage_per_port: npt.NDArray[np.complexfloating]
+    terminal_voltage_per_port: npt.NDArray[np.complexfloating]
+    terminal_current_per_port: npt.NDArray[np.complexfloating]
+    incident_power_per_port: npt.NDArray[np.floating]
+    accepted_power_per_port: npt.NDArray[np.floating]
+    incident_power: npt.NDArray[np.floating]
+    accepted_power: npt.NDArray[np.floating]
+    reflected_power: npt.NDArray[np.floating]
+    incident_relative_db: npt.NDArray[np.floating]
+    mesh_valid: npt.NDArray[np.bool_]
+    terminal_valid: npt.NDArray[np.bool_]
+    gain_valid: npt.NDArray[np.bool_]
+    realized_gain_valid: npt.NDArray[np.bool_]
 
 
 @dataclass(frozen=True)
@@ -389,6 +491,7 @@ def validate_ksir_source_enclosure(grid) -> None:
         ("hertziandipoles", "E"),
         ("magneticdipoles", "H"),
         ("transmissionlines", "E"),
+        ("magneticfrillsources", "E"),
     )
     for monitor in grid.ntff_monitors:
         if getattr(monitor, "allow_external_sources", False):
@@ -480,16 +583,28 @@ def _project_frequency_fields(
 class KSIRCompiledOutputs:
     """Own grouped monitors and expose per-command results/HDF5 output."""
 
-    def __init__(self, grid, surfaces, transforms, time_requests, frequency_requests, far_requests):
+    def __init__(
+        self,
+        grid,
+        surfaces,
+        transforms,
+        time_requests,
+        frequency_requests,
+        far_requests,
+        antenna_port_specs,
+    ):
         self.grid = grid
         self.surfaces = surfaces
         self.transforms = transforms
         self.time_requests = {item.key: item for item in time_requests}
         self.frequency_requests = {item.key: item for item in frequency_requests}
         self.far_requests = {item.key: item for item in far_requests}
+        self.antenna_port_specs = dict(antenna_port_specs)
         self.time_bindings = {}
         self.frequency_monitors = {}
         self._results = {}
+        self._radiation_cache = {}
+        self._port_cache = {}
 
     def result_for(self, key: str):
         if key not in self._results:
@@ -505,6 +620,211 @@ class KSIRCompiledOutputs:
 
     def transform_monitor(self, transform_id: str):
         return self.frequency_monitors[transform_id]
+
+    @staticmethod
+    def _enclosure_radius(compiled: _CompiledSurface) -> float:
+        radius = 0.0
+        for component, surface in compiled.surfaces.items():
+            for image in compiled.closure.component_images(component):
+                positions, _ = image.transform(
+                    surface.patch_positions,
+                    surface.normals,
+                )
+                radius = max(
+                    radius,
+                    float(
+                        np.max(
+                            np.linalg.norm(
+                                positions - compiled.origin[np.newaxis, :],
+                                axis=1,
+                            )
+                        )
+                    ),
+                )
+        if radius <= 0:
+            raise RuntimeError("KSIR surface has no finite angular extent")
+        return radius
+
+    def _radiation_metrics(self, transform_id: str) -> KSIRRadiationMetrics:
+        """Integrate a temporary full sphere without retaining its fields."""
+
+        if transform_id in self._radiation_cache:
+            return self._radiation_cache[transform_id]
+        monitor = self.frequency_monitors[transform_id]
+        transform = self.transforms[transform_id]
+        compiled = self.surfaces[transform.surface_id]
+        radius = self._enclosure_radius(compiled)
+        maximum_wavenumber = (
+            2 * np.pi * float(np.max(monitor.frequencies, initial=0)) / monitor.wave_speed
+        )
+        quadrature = spherical_quadrature(
+            radius,
+            maximum_wavenumber,
+            monitor.real_dtype,
+        )
+        logger.info(
+            f"KSIR transform {transform_id!r}: evaluating {quadrature.theta.size} "
+            f"temporary full-sphere directions ({quadrature.theta_order} x "
+            f"{quadrature.phi_order}) for radiation normalisation"
+        )
+        nfrequencies = monitor.frequencies.size
+        radiated_power = np.zeros(nfrequencies, dtype=monitor.real_dtype)
+        maximum_intensity = np.full(nfrequencies, -np.inf, dtype=monitor.real_dtype)
+        maximum_theta = np.full(nfrequencies, np.nan, dtype=monitor.real_dtype)
+        maximum_phi = np.full(nfrequencies, np.nan, dtype=monitor.real_dtype)
+
+        complex_bytes = np.dtype(monitor.complex_dtype).itemsize
+        real_bytes = np.dtype(monitor.real_dtype).itemsize
+        bytes_per_direction = max(1, nfrequencies) * (8 * complex_bytes + 2 * real_bytes)
+        direction_block_size = max(
+            1,
+            min(
+                MAX_FAR_ZONE_DIRECTION_BLOCK,
+                FAR_ZONE_TARGET_WORKING_SET_BYTES // bytes_per_direction,
+            ),
+        )
+        for start in range(0, quadrature.theta.size, direction_block_size):
+            stop = min(start + direction_block_size, quadrature.theta.size)
+            theta = quadrature.theta[start:stop]
+            phi = quadrature.phi[start:stop]
+            directions = spherical_directions(theta, phi, degrees=True)
+            cartesian = []
+            for component in ELECTRIC_COMPONENTS:
+                data = monitor.surface_data[component]
+                values, _ = _evaluate_component_with_closure(
+                    data.surface,
+                    data.field,
+                    data.normal_derivative,
+                    compiled.closure,
+                    monitor.frequencies,
+                    directions,
+                    monitor.wave_speed,
+                    compiled.origin,
+                    monitor.nthreads,
+                    retain_face_contributions=False,
+                )
+                cartesian.append(values)
+            intensity = radiation_intensity(
+                np.stack(cartesian, axis=-1),
+                theta,
+                phi,
+                monitor.impedance,
+            )
+            radiated_power += np.sum(
+                intensity * quadrature.weights[np.newaxis, start:stop],
+                axis=1,
+            )
+            local_index = np.argmax(intensity, axis=1)
+            local_maximum = intensity[np.arange(nfrequencies), local_index]
+            update = local_maximum > maximum_intensity
+            maximum_intensity[update] = local_maximum[update]
+            maximum_theta[update] = theta[local_index[update]]
+            maximum_phi[update] = phi[local_index[update]]
+
+        maximum_directivity, maximum_directivity_dbi = directivity_from_intensity(
+            maximum_intensity[:, np.newaxis],
+            radiated_power,
+        )
+        valid_pattern = np.isfinite(radiated_power) & (radiated_power > 0)
+        maximum_theta[~valid_pattern] = np.nan
+        maximum_phi[~valid_pattern] = np.nan
+        result = KSIRRadiationMetrics(
+            radiated_power=_readonly(radiated_power),
+            maximum_directivity=_readonly(maximum_directivity[:, 0]),
+            maximum_directivity_dbi=_readonly(maximum_directivity_dbi[:, 0]),
+            maximum_theta=_readonly(maximum_theta),
+            maximum_phi=_readonly(maximum_phi),
+            theta_order=quadrature.theta_order,
+            phi_order=quadrature.phi_order,
+            enclosure_radius=quadrature.enclosure_radius,
+        )
+        self._radiation_cache[transform_id] = result
+        return result
+
+    def _port_metrics(self, transform_id: str) -> KSIRPortMetrics:
+        if transform_id in self._port_cache:
+            return self._port_cache[transform_id]
+        if transform_id not in self.antenna_port_specs:
+            raise RuntimeError(f"KSIR transform {transform_id!r} has no antenna-port association")
+        spec = self.antenna_port_specs[transform_id]
+        monitor = self.frequency_monitors[transform_id]
+        registry = port_output_registry(self.grid)
+        spectra = [
+            evaluate_port_power_spectrum(
+                registry[port_id],
+                self.grid,
+                monitor.frequencies,
+                window=self.transforms[transform_id].window,
+            )
+            for port_id in spec.port_ids
+        ]
+        incident_voltage_per_port = np.stack([item.incident_voltage for item in spectra])
+        terminal_voltage_per_port = np.stack([item.terminal_voltage for item in spectra])
+        terminal_current_per_port = np.stack([item.terminal_current for item in spectra])
+        incident_per_port = np.stack([item.incident_power for item in spectra])
+        accepted_per_port = np.stack([item.accepted_power for item in spectra])
+        incident_power = np.sum(incident_per_port, axis=0, dtype=monitor.real_dtype)
+        accepted_power = np.sum(accepted_per_port, axis=0, dtype=monitor.real_dtype)
+        reflected_power = np.asarray(
+            incident_power - accepted_power,
+            dtype=monitor.real_dtype,
+        )
+        mesh_valid = np.logical_and.reduce([item.mesh_valid for item in spectra])
+        terminal_valid = np.logical_and.reduce([item.terminal_valid for item in spectra])
+
+        incident_relative_db = np.full(
+            incident_power.shape,
+            -np.inf,
+            dtype=monitor.real_dtype,
+        )
+        incident_peak = float(np.max(incident_power, initial=0.0))
+        if incident_peak > 0:
+            nonzero = incident_power > 0
+            incident_relative_db[nonzero] = np.asarray(
+                10 * np.log10(incident_power[nonzero] / incident_peak),
+                dtype=monitor.real_dtype,
+            )
+        source_valid = incident_relative_db >= -40
+        scale = max(
+            incident_peak,
+            float(np.max(np.abs(accepted_power), initial=0.0)),
+        )
+        threshold = 64 * np.finfo(monitor.real_dtype).eps * scale
+        common_valid = mesh_valid & terminal_valid & source_valid
+        gain_valid = common_valid & (accepted_power > threshold)
+        realized_gain_valid = common_valid & (incident_power > threshold)
+        result = KSIRPortMetrics(
+            port_ids=spec.port_ids,
+            source_types=tuple(item.source_type for item in spectra),
+            reference_impedances=_readonly(
+                [item.reference_impedance for item in spectra],
+                monitor.real_dtype,
+            ),
+            incident_voltage_per_port=_readonly(
+                incident_voltage_per_port,
+                monitor.complex_dtype,
+            ),
+            terminal_voltage_per_port=_readonly(
+                terminal_voltage_per_port,
+                monitor.complex_dtype,
+            ),
+            terminal_current_per_port=_readonly(
+                terminal_current_per_port,
+                monitor.complex_dtype,
+            ),
+            incident_power_per_port=_readonly(incident_per_port, monitor.real_dtype),
+            accepted_power_per_port=_readonly(accepted_per_port, monitor.real_dtype),
+            incident_power=_readonly(incident_power, monitor.real_dtype),
+            accepted_power=_readonly(accepted_power, monitor.real_dtype),
+            reflected_power=_readonly(reflected_power, monitor.real_dtype),
+            incident_relative_db=_readonly(incident_relative_db, monitor.real_dtype),
+            mesh_valid=_readonly(mesh_valid, bool),
+            terminal_valid=_readonly(terminal_valid, bool),
+            gain_valid=_readonly(gain_valid, bool),
+            realized_gain_valid=_readonly(realized_gain_valid, bool),
+        )
+        self._port_cache[transform_id] = result
+        return result
 
     def _time_result(self, spec: KSIRTimeRequestSpec) -> KSIRTimeReceiverResult:
         monitor, point_slice = self.time_bindings[spec.key]
@@ -615,18 +935,100 @@ class KSIRCompiledOutputs:
                 directions,
                 monitor.wave_speed,
                 compiled_surface.origin,
+                monitor.nthreads,
             )
             cartesian[component] = values
         ordinary_outputs = [item for item in spec.outputs if item not in FAR_METRICS]
         fields = _project_frequency_fields(cartesian, ordinary_outputs, spec.theta, spec.phi)
+        radiation_metrics = None
+        port_metrics = None
         if any(item in spec.outputs for item in FAR_METRICS):
             electric = np.stack([cartesian[item] for item in ELECTRIC_COMPONENTS], axis=-1)
-            spherical = project_cartesian_to_spherical(electric, spec.theta, spec.phi, degrees=True)
-            tangential_squared = np.abs(spherical[:, :, 1]) ** 2 + np.abs(spherical[:, :, 2]) ** 2
+            intensity = radiation_intensity(
+                electric,
+                spec.theta,
+                spec.phi,
+                monitor.impedance,
+            )
             if "radiation_intensity" in spec.outputs:
-                fields["radiation_intensity"] = _readonly(
-                    0.5 * tangential_squared / monitor.impedance,
-                    monitor.real_dtype,
+                fields["radiation_intensity"] = _readonly(intensity, monitor.real_dtype)
+            if any(item in spec.outputs for item in DIRECTIVITY_OUTPUTS):
+                radiation_metrics = self._radiation_metrics(spec.transform_id)
+                directivity, directivity_dbi = directivity_from_intensity(
+                    intensity,
+                    radiation_metrics.radiated_power,
+                )
+                if "directivity" in spec.outputs:
+                    fields["directivity"] = _readonly(directivity, monitor.real_dtype)
+                if "directivity_dbi" in spec.outputs:
+                    fields["directivity_dbi"] = _readonly(
+                        directivity_dbi,
+                        monitor.real_dtype,
+                    )
+            if any(item in spec.outputs for item in PORT_METRICS):
+                port_metrics = self._port_metrics(spec.transform_id)
+                if any(item in spec.outputs for item in GAIN_OUTPUTS):
+                    gain, gain_dbi = directivity_from_intensity(
+                        intensity,
+                        port_metrics.accepted_power,
+                    )
+                    gain[~port_metrics.gain_valid] = np.nan
+                    gain_dbi[~port_metrics.gain_valid] = np.nan
+                    realized_gain, realized_gain_dbi = directivity_from_intensity(
+                        intensity,
+                        port_metrics.incident_power,
+                    )
+                    realized_gain[~port_metrics.realized_gain_valid] = np.nan
+                    realized_gain_dbi[~port_metrics.realized_gain_valid] = np.nan
+                    for name, values in (
+                        ("gain", gain),
+                        ("gain_dbi", gain_dbi),
+                        ("realized_gain", realized_gain),
+                        ("realized_gain_dbi", realized_gain_dbi),
+                    ):
+                        if name in spec.outputs:
+                            fields[name] = _readonly(values, monitor.real_dtype)
+                if any(item in spec.outputs for item in EFFICIENCY_OUTPUTS):
+                    if radiation_metrics is None:
+                        radiation_metrics = self._radiation_metrics(spec.transform_id)
+                    radiation_efficiency = np.full(
+                        monitor.frequencies.shape,
+                        np.nan,
+                        dtype=monitor.real_dtype,
+                    )
+                    total_efficiency = np.full_like(radiation_efficiency, np.nan)
+                    radiation_efficiency[port_metrics.gain_valid] = (
+                        radiation_metrics.radiated_power[port_metrics.gain_valid]
+                        / port_metrics.accepted_power[port_metrics.gain_valid]
+                    )
+                    total_efficiency[port_metrics.realized_gain_valid] = (
+                        radiation_metrics.radiated_power[port_metrics.realized_gain_valid]
+                        / port_metrics.incident_power[port_metrics.realized_gain_valid]
+                    )
+                    efficiency_tolerance = max(
+                        0.02,
+                        512 * np.finfo(monitor.real_dtype).eps,
+                    )
+                    if np.any(
+                        radiation_efficiency[np.isfinite(radiation_efficiency)]
+                        > 1 + efficiency_tolerance
+                    ):
+                        logger.warning(
+                            "KSIR radiation efficiency exceeds unity for output %s; "
+                            "check the integration surface, time window, mesh, and "
+                            "port definitions",
+                            spec.output_id,
+                        )
+                    if "radiation_efficiency" in spec.outputs:
+                        fields["radiation_efficiency"] = _readonly(radiation_efficiency)
+                    if "total_efficiency" in spec.outputs:
+                        fields["total_efficiency"] = _readonly(total_efficiency)
+            if radiation_metrics is not None:
+                radiation_metrics = _refine_radiation_maximum(
+                    radiation_metrics,
+                    intensity,
+                    spec.theta,
+                    spec.phi,
                 )
             if "rcs" in spec.outputs:
                 incident = monitor.result.incident_electric
@@ -635,6 +1037,7 @@ class KSIRCompiledOutputs:
                         "RCS output requires a KSIR surface enclosing one TFSF plane wave"
                     )
                 incident_power = np.sum(np.abs(incident) ** 2, axis=1)
+                tangential_squared = 2 * monitor.impedance * intensity
                 rcs = np.full(tangential_squared.shape, np.nan, dtype=monitor.real_dtype)
                 valid = incident_power > 0
                 rcs[valid] = (
@@ -649,6 +1052,8 @@ class KSIRCompiledOutputs:
             directions=directions,
             fields=MappingProxyType(fields),
             origin=compiled_surface.origin,
+            radiation_metrics=radiation_metrics,
+            port_metrics=port_metrics,
         )
 
     def _write_surface_metadata(self, group, compiled: _CompiledSurface):
@@ -765,6 +1170,49 @@ class KSIRCompiledOutputs:
             group["theta"] = result.theta
             group["phi"] = result.phi
             group["directions"] = result.directions
+            if result.radiation_metrics is not None:
+                metrics = result.radiation_metrics
+                group.attrs["radiation_quadrature"] = "Gauss-Legendre theta, periodic phi"
+                group.attrs["radiation_spectral_power_units"] = "W s^2"
+                group.attrs["radiation_quadrature_theta_order"] = metrics.theta_order
+                group.attrs["radiation_quadrature_phi_order"] = metrics.phi_order
+                group.attrs[
+                    "maximum_directivity_sampling"
+                ] = "full-sphere quadrature plus requested directions"
+                group.attrs["radiation_enclosure_radius"] = metrics.enclosure_radius
+                group.attrs["radiation_enclosure_radius_units"] = "m"
+                group["radiated_power"] = metrics.radiated_power
+                group["maximum_directivity"] = metrics.maximum_directivity
+                group["maximum_directivity_dbi"] = metrics.maximum_directivity_dbi
+                group["maximum_directivity_theta"] = metrics.maximum_theta
+                group["maximum_directivity_phi"] = metrics.maximum_phi
+            if result.port_metrics is not None:
+                metrics = result.port_metrics
+                power_group = group.create_group("port_power")
+                power_group.attrs[
+                    "accepted_power_definition"
+                ] = "sum(0.5*Re(Vterminal*conj(Iterminal)))"
+                power_group.attrs["incident_power_definition"] = "sum(abs(Vincident)**2/(2*Z0))"
+                power_group.attrs["incident_floor_db"] = -40.0
+                power_group.attrs["voltage_spectrum_units"] = "V s"
+                power_group.attrs["current_spectrum_units"] = "A s"
+                power_group.attrs["spectral_power_units"] = "W s^2"
+                power_group["port_ids"] = np.asarray(metrics.port_ids, dtype="S64")
+                power_group["source_types"] = np.asarray(metrics.source_types, dtype="S40")
+                power_group["reference_impedances"] = metrics.reference_impedances
+                power_group["incident_voltage_per_port"] = metrics.incident_voltage_per_port
+                power_group["terminal_voltage_per_port"] = metrics.terminal_voltage_per_port
+                power_group["terminal_current_per_port"] = metrics.terminal_current_per_port
+                power_group["incident_power_per_port"] = metrics.incident_power_per_port
+                power_group["accepted_power_per_port"] = metrics.accepted_power_per_port
+                power_group["incident_power"] = metrics.incident_power
+                power_group["accepted_power"] = metrics.accepted_power
+                power_group["reflected_power"] = metrics.reflected_power
+                power_group["incident_relative_db"] = metrics.incident_relative_db
+                power_group["mesh_valid"] = metrics.mesh_valid.astype(np.uint8)
+                power_group["terminal_valid"] = metrics.terminal_valid.astype(np.uint8)
+                power_group["gain_valid"] = metrics.gain_valid.astype(np.uint8)
+                power_group["realized_gain_valid"] = metrics.realized_gain_valid.astype(np.uint8)
             self._write_fields(group, result)
 
 
@@ -822,6 +1270,7 @@ def compile_ksir_outputs(model, grid) -> Optional[KSIRCompiledOutputs]:
     time_requests = list(getattr(grid, "ksir_time_requests", ()))
     frequency_requests = list(getattr(grid, "ksir_frequency_requests", ()))
     far_requests = list(getattr(grid, "ksir_far_field_requests", ()))
+    antenna_port_specs = dict(getattr(grid, "ksir_antenna_port_specs", {}))
     if not (
         surface_specs or transform_specs or time_requests or frequency_requests or far_requests
     ):
@@ -855,6 +1304,66 @@ def compile_ksir_outputs(model, grid) -> Optional[KSIRCompiledOutputs]:
             raise ValueError(
                 f"KSIR output {request.output_id!r} refers to unknown transform "
                 f"{request.transform_id!r}"
+            )
+
+    gain_transforms = {
+        request.transform_id
+        for request in far_requests
+        if any(output in PORT_METRICS for output in request.outputs)
+    }
+    for transform_id in gain_transforms:
+        if transform_id not in antenna_port_specs:
+            raise ValueError(
+                f"KSIR transform {transform_id!r} requests gain or efficiency "
+                "without a #ksir_antenna_ports association"
+            )
+        transform = transform_specs[transform_id]
+        if transform.window != "rectangular":
+            raise ValueError(
+                f"KSIR transform {transform_id!r} requests gain with window "
+                f"{transform.window!r}; antenna gain currently requires rectangular"
+            )
+
+        expected_ids = [monitor.output_id for monitor in grid.port_monitors]
+        expected_ids.extend(f"tl{index}" for index, _ in enumerate(grid.transmissionlines, start=1))
+        expected_ids.extend(
+            f"frill{index}" for index, _ in enumerate(grid.magneticfrillsources, start=1)
+        )
+        if len(set(expected_ids)) != len(expected_ids):
+            raise ValueError("antenna port IDs are ambiguous across source types")
+        requested_ids = set(antenna_port_specs[transform_id].port_ids)
+        missing = set(expected_ids) - requested_ids
+        if missing:
+            raise ValueError(
+                f"KSIR antenna-port group for transform {transform_id!r} must "
+                f"include every physical port; missing {sorted(missing)}"
+            )
+        monitored_voltage_sources = {
+            monitor.source for monitor in getattr(grid, "port_monitors", ())
+        }
+        unmonitored_voltage_sources = [
+            source for source in grid.voltagesources if source not in monitored_voltage_sources
+        ]
+        if unmonitored_voltage_sources:
+            raise ValueError(
+                "antenna gain requires an #rx_port for every voltage source; "
+                f"found {len(unmonitored_voltage_sources)} unmonitored source(s)"
+            )
+
+        def source_is_active(source):
+            for name in ("waveformvalues_wholedt", "waveformvalues_halfdt"):
+                values = getattr(source, name, None)
+                if values is not None and np.any(np.asarray(values) != 0):
+                    return True
+            return False
+
+        nonport_sources = list(grid.hertziandipoles) + list(grid.magneticdipoles)
+        nonport_sources.extend(getattr(grid, "discreteplanewaves", ()))
+        active_nonport = [source for source in nonport_sources if source_is_active(source)]
+        if active_nonport:
+            raise ValueError(
+                "antenna gain cannot be normalised while active non-port sources "
+                f"contribute to the field; found {len(active_nonport)} source(s)"
             )
 
     needed_surface_ids = {item.surface_id for item in transform_specs.values()}
@@ -899,6 +1408,7 @@ def compile_ksir_outputs(model, grid) -> Optional[KSIRCompiledOutputs]:
         time_requests,
         frequency_requests,
         far_requests,
+        antenna_port_specs,
     )
 
     groups = {}

--- a/gprMax/ports.py
+++ b/gprMax/ports.py
@@ -34,7 +34,11 @@ import numpy as np
 import numpy.typing as npt
 
 import gprMax.config as config
-from gprMax.ntff.conventions import FORWARD_TRANSFORM_KERNEL, PHASOR_TIME_DEPENDENCE
+from gprMax.ntff.conventions import (
+    FORWARD_TRANSFORM_KERNEL,
+    PHASOR_TIME_DEPENDENCE,
+    engineering_dft,
+)
 
 if TYPE_CHECKING:
     from gprMax.grid.fdtd_grid import FDTDGrid
@@ -49,6 +53,270 @@ MINIMUM_PHYSICAL_WAVELENGTH_CELLS = 3.0
 DEFAULT_INCIDENT_FLOOR_DB = -40.0
 
 SpectrumLimit = Union[float, Literal["nyquist"]]
+
+
+@dataclass(frozen=True)
+class PortPowerSpectrum:
+    """Terminal phasors and spectral powers at arbitrary frequencies.
+
+    The Fourier amplitudes carry the common pulse-transform scale used by
+    KSIR. Consequently the power-like quantities are intended for ratios;
+    their common transform scale cancels in gain and efficiency.
+    """
+
+    port_id: str
+    source_type: str
+    reference_impedance: float
+    frequency: npt.NDArray[np.floating]
+    incident_voltage: npt.NDArray[np.complexfloating]
+    terminal_voltage: npt.NDArray[np.complexfloating]
+    terminal_current: npt.NDArray[np.complexfloating]
+    incident_power: npt.NDArray[np.floating]
+    accepted_power: npt.NDArray[np.floating]
+    mesh_valid: npt.NDArray[np.bool_]
+    terminal_valid: npt.NDArray[np.bool_]
+
+
+def _port_mesh_valid(output, grid, frequencies):
+    if getattr(output, "spectrum_limit", None) == "nyquist" or getattr(
+        output, "spectrum_limit_mode", None
+    ) == "nyquist":
+        return np.ones(np.asarray(frequencies).shape, dtype=bool)
+    cells, _ = minimum_wavelength_sampling(grid, frequencies)
+    minimum = float(getattr(output, "minimum_wavelength_cells", DEFAULT_MINIMUM_WAVELENGTH_CELLS))
+    return np.asarray(cells >= minimum, dtype=bool)
+
+
+def _power_spectrum_result(
+    output,
+    grid,
+    frequencies,
+    incident_voltage,
+    terminal_voltage,
+    terminal_current,
+    terminal_valid,
+) -> PortPowerSpectrum:
+    real_dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
+    complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
+    frequency = np.asarray(frequencies, dtype=real_dtype)
+    incident_voltage = np.asarray(incident_voltage, dtype=complex_dtype)
+    terminal_voltage = np.asarray(terminal_voltage, dtype=complex_dtype)
+    terminal_current = np.asarray(terminal_current, dtype=complex_dtype)
+    reference_impedance = float(output.reference_impedance)
+    incident_power = np.asarray(
+        np.abs(incident_voltage) ** 2 / (2 * reference_impedance),
+        dtype=real_dtype,
+    )
+    accepted_power = np.asarray(
+        0.5 * np.real(terminal_voltage * np.conj(terminal_current)),
+        dtype=real_dtype,
+    )
+    finite = (
+        np.isfinite(incident_voltage)
+        & np.isfinite(terminal_voltage)
+        & np.isfinite(terminal_current)
+        & np.isfinite(incident_power)
+        & np.isfinite(accepted_power)
+    )
+    return PortPowerSpectrum(
+        port_id=output.output_id,
+        source_type=type(output.source).__name__,
+        reference_impedance=reference_impedance,
+        frequency=frequency,
+        incident_voltage=incident_voltage,
+        terminal_voltage=terminal_voltage,
+        terminal_current=terminal_current,
+        incident_power=incident_power,
+        accepted_power=accepted_power,
+        mesh_valid=_port_mesh_valid(output, grid, frequency),
+        terminal_valid=np.asarray(terminal_valid, dtype=bool) & finite,
+    )
+
+
+def _hard_source_gap_admittance(output, frequency, dt, complex_dtype):
+    """Return the Yee-gap admittance at magnetic half-step times.
+
+    The hard-source voltage is an integer-time quantity. The Ampere-loop
+    current is sampled half a step earlier, and its DFT carries that physical
+    time offset. The trapezoidal conductive term therefore contributes
+    ``G*cos(omega*dt/2)`` and the centred displacement difference contributes
+    ``j*2*C*sin(omega*dt/2)/dt``.
+    """
+
+    half_phase = np.pi * np.asarray(frequency) * dt
+    return np.asarray(
+        output.background_conductance * np.cos(half_phase)
+        + 1j * (2 * output.gap_capacitance / dt) * np.sin(half_phase),
+        dtype=complex_dtype,
+    )
+
+
+def evaluate_port_power_spectrum(
+    output,
+    grid: "FDTDGrid",
+    frequencies: npt.ArrayLike,
+    *,
+    window: str = "rectangular",
+) -> PortPowerSpectrum:
+    """Evaluate one supported port at the exact KSIR frequencies.
+
+    This path deliberately uses terminal voltage/current rather than S11, so
+    an unexcited but coupled port remains measurable. Only a rectangular
+    transform is currently accepted because delayed radiated and terminal
+    pulse histories would otherwise receive different window weights.
+    """
+
+    if window != "rectangular":
+        raise ValueError("antenna gain currently requires a rectangular KSIR window")
+    real_dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
+    complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
+    frequency = np.asarray(frequencies, dtype=real_dtype)
+    if frequency.ndim != 1 or frequency.size == 0:
+        raise ValueError("port-power frequencies must be one-dimensional and non-empty")
+    if not np.all(np.isfinite(frequency)) or np.any(frequency < 0):
+        raise ValueError("port-power frequencies must be finite and non-negative")
+    if output.result is None:
+        raise RuntimeError(f"port {output.output_id!r} has not been finalised")
+
+    if isinstance(output, VoltageSourcePortMonitor):
+        result = output.result
+        if output.hard_source:
+            terminal_voltage = engineering_dft(
+                result.total_voltage,
+                frequency,
+                grid.dt,
+                time_offset=output.hard_voltage_time_offset,
+            )
+            loop_current = engineering_dft(
+                output._hard_loop_current,
+                frequency,
+                grid.dt,
+                time_offset=output.hard_current_time_offset,
+            )
+            gap_admittance = _hard_source_gap_admittance(
+                output,
+                frequency,
+                grid.dt,
+                complex_dtype,
+            )
+            terminal_current = np.asarray(
+                loop_current - gap_admittance * terminal_voltage,
+                dtype=complex_dtype,
+            )
+            incident_voltage = np.asarray(
+                0.5
+                * (
+                    terminal_voltage
+                    + output.reference_impedance * terminal_current
+                ),
+                dtype=complex_dtype,
+            )
+            return _power_spectrum_result(
+                output,
+                grid,
+                frequency,
+                incident_voltage,
+                terminal_voltage,
+                terminal_current,
+                np.ones(frequency.shape, dtype=bool),
+            )
+
+        terminal_voltage = engineering_dft(
+            result.total_voltage,
+            frequency,
+            grid.dt,
+            time_offset=0.5 * grid.dt,
+        )
+        generator_voltage = engineering_dft(
+            result.generator_voltage,
+            frequency,
+            grid.dt,
+            time_offset=0.5 * grid.dt,
+        )
+        incident_voltage = np.asarray(0.5 * generator_voltage, dtype=complex_dtype)
+        omega_discrete = (2 / grid.dt) * np.tan(np.pi * frequency * grid.dt)
+        gap_admittance = np.asarray(
+            output.background_conductance + 1j * omega_discrete * output.gap_capacitance,
+            dtype=complex_dtype,
+        )
+        source_current = (generator_voltage - terminal_voltage) / output.reference_impedance
+        terminal_current = np.asarray(
+            source_current - gap_admittance * terminal_voltage,
+            dtype=complex_dtype,
+        )
+        nyquist = np.isclose(
+            frequency,
+            1 / (2 * grid.dt),
+            rtol=64 * np.finfo(real_dtype).eps,
+            atol=0,
+        )
+        terminal_valid = ~(nyquist & (output.gap_capacitance != 0))
+        return _power_spectrum_result(
+            output,
+            grid,
+            frequency,
+            incident_voltage,
+            terminal_voltage,
+            terminal_current,
+            terminal_valid,
+        )
+
+    if isinstance(output, TransmissionLinePortOutput):
+        source = output.source
+        incident_voltage = engineering_dft(source.Vinc, frequency, grid.dt)
+        terminal_voltage = engineering_dft(source.Vtotal, frequency, grid.dt)
+        terminal_current = np.asarray(
+            (2 * incident_voltage - terminal_voltage) / output.reference_impedance,
+            dtype=complex_dtype,
+        )
+        return _power_spectrum_result(
+            output,
+            grid,
+            frequency,
+            incident_voltage,
+            terminal_voltage,
+            terminal_current,
+            np.ones(frequency.shape, dtype=bool),
+        )
+
+    if isinstance(output, MagneticFrillPortOutput):
+        source = output.source
+        incident_voltage = engineering_dft(source.Vinc, frequency, grid.dt)
+        terminal_voltage = engineering_dft(source.Vtotal, frequency, grid.dt)
+        terminal_current = engineering_dft(source.Itot, frequency, grid.dt)
+        return _power_spectrum_result(
+            output,
+            grid,
+            frequency,
+            incident_voltage,
+            terminal_voltage,
+            terminal_current,
+            np.ones(frequency.shape, dtype=bool),
+        )
+
+    raise TypeError(f"unsupported antenna port output type {type(output).__name__}")
+
+
+def port_output_registry(grid: "FDTDGrid") -> dict[str, object]:
+    """Return every finalised port output using one unambiguous ID namespace."""
+
+    outputs = list(getattr(grid, "port_monitors", ()))
+    outputs.extend(
+        source.port_output
+        for source in getattr(grid, "transmissionlines", ())
+        if getattr(source, "port_output", None) is not None
+    )
+    outputs.extend(
+        source.port_output
+        for source in getattr(grid, "magneticfrillsources", ())
+        if getattr(source, "port_output", None) is not None
+    )
+    registry = {}
+    for output in outputs:
+        if output.output_id in registry:
+            raise ValueError(f"antenna port ID {output.output_id!r} is ambiguous")
+        registry[output.output_id] = output
+    return registry
 
 
 def validate_spectrum_limit(value) -> SpectrumLimit:
@@ -279,7 +547,13 @@ class VoltageSourcePortResult:
 
 
 class VoltageSourcePortMonitor:
-    """Bind one internal electric-field receiver to one voltage source."""
+    """Bind terminal field receivers to one voltage source.
+
+    Finite-resistance sources use their Thevenin voltage-wave separation.
+    Zero-resistance hard sources instead use the surrounding Ampere contour,
+    with explicit transform offsets for the magnetic half-step current and
+    integer-time gap voltage.
+    """
 
     def __init__(
         self,
@@ -325,7 +599,28 @@ class VoltageSourcePortMonitor:
             raise ValueError(f"RxPort {self.output_id!r} requires at least two iterations")
         if not np.array_equal(self.receiver.coord, self.source.coord):
             raise ValueError(f"RxPort {self.output_id!r} receiver is no longer source-bound")
-        if getattr(self.source, "background_material_numID", None) is None:
+        self.hard_source = self.source.resistance == 0
+        if self.hard_source:
+            component_id = f"E{self.source.polarisation}"
+            material_num_id = int(
+                grid.ID[
+                    grid.IDlookup[component_id],
+                    self.source.xcoord,
+                    self.source.ycoord,
+                    self.source.zcoord,
+                ]
+            )
+            material = next(item for item in grid.materials if item.numID == material_num_id)
+            self.source.background_material_numID = material_num_id
+            self.source.background_material_ID = str(material.ID)
+            self.source.background_material_type = str(material.type)
+            self.source.background_er = float(material.er)
+            self.source.background_se = float(material.se)
+            self.source.background_mr = float(material.mr)
+            self.source.background_sm = float(material.sm)
+            self.source.background_is_dispersive = hasattr(material, "poles")
+            self.source.source_material_numID = material_num_id
+        elif getattr(self.source, "background_material_numID", None) is None:
             raise ValueError(f"RxPort {self.output_id!r} source material was not constructed")
         if getattr(self.source, "background_is_dispersive", False):
             raise ValueError(
@@ -334,7 +629,12 @@ class VoltageSourcePortMonitor:
             )
 
         self.dl, self.area = self._edge_geometry(grid)
-        self.reference_impedance = float(self.source.resistance)
+        self.reference_impedance = float(self.source.reference_impedance)
+        if not np.isfinite(self.reference_impedance) or self.reference_impedance <= 0:
+            raise ValueError(
+                f"RxPort {self.output_id!r} requires a finite, positive "
+                "reference impedance"
+            )
         self.background_relative_permittivity = float(self.source.background_er)
         self.background_conductivity = float(self.source.background_se)
         if not np.isfinite(self.background_conductivity):
@@ -349,25 +649,34 @@ class VoltageSourcePortMonitor:
 
         source_material_id = int(self.source.source_material_numID)
         source_material = grid.materials[source_material_id]
-        added_conductance = (
-            (float(source_material.se) - self.background_conductivity) * self.area / self.dl
-        )
         dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
-        tolerance = 64 * np.finfo(dtype).eps
-        if not np.isclose(
-            added_conductance,
-            1 / self.reference_impedance,
-            rtol=tolerance,
-            atol=tolerance / self.reference_impedance,
-        ):
-            raise ValueError(
-                f"RxPort {self.output_id!r} source-edge conductance is inconsistent "
-                "with its source resistance"
+        if not self.hard_source:
+            added_conductance = (
+                (float(source_material.se) - self.background_conductivity)
+                * self.area
+                / self.dl
             )
-        if not np.isfinite(grid.updatecoeffsE[source_material_id, 4]) or np.isclose(
-            grid.updatecoeffsE[source_material_id, 4], 0
-        ):
-            raise ValueError(f"RxPort {self.output_id!r} source is on an inactive electric edge")
+            tolerance = 64 * np.finfo(dtype).eps
+            if not np.isclose(
+                added_conductance,
+                1 / self.reference_impedance,
+                rtol=tolerance,
+                atol=tolerance / self.reference_impedance,
+            ):
+                raise ValueError(
+                    f"RxPort {self.output_id!r} source-edge conductance is inconsistent "
+                    "with its source resistance"
+                )
+            if not np.isfinite(grid.updatecoeffsE[source_material_id, 4]) or np.isclose(
+                grid.updatecoeffsE[source_material_id, 4], 0
+            ):
+                raise ValueError(
+                    f"RxPort {self.output_id!r} source is on an inactive electric edge"
+                )
+        elif f"I{self.source.polarisation}" not in self.receiver.outputs:
+            raise ValueError(
+                f"RxPort {self.output_id!r} hard source has no terminal-current samples"
+            )
 
         nsamples = grid.iterations - 1
         self.aligned_samples = nsamples
@@ -419,6 +728,8 @@ class VoltageSourcePortMonitor:
 
         if not self.prepared:
             self.prepare(grid)
+        if self.hard_source:
+            return self._finalise_hard_source(grid)
         if not np.array_equal(self.receiver.coord, self.source.coord):
             raise RuntimeError(f"RxPort {self.output_id!r} receiver moved away from its source")
 
@@ -512,6 +823,12 @@ class VoltageSourcePortMonitor:
                 f"reaches {tail_relative_db:.1f} dB relative to its peak; spectral "
                 "leakage may be significant."
             )
+        if np.isfinite(tail_relative_db) and tail_relative_db > -40:
+            logger.warning(
+                f"RxPort {self.output_id!r}: the final 5% of the voltage trace "
+                f"reaches {tail_relative_db:.1f} dB relative to its peak; spectral "
+                "leakage may be significant."
+            )
 
         self.result = VoltageSourcePortResult(
             time=time,
@@ -539,6 +856,168 @@ class VoltageSourcePortMonitor:
         )
         return self.result
 
+    def _hard_loop_current_history(self, real_dtype):
+        """Return the Ampere-loop current at stored magnetic half steps."""
+
+        current_component = f"I{self.source.polarisation}"
+        return np.asarray(self.receiver.outputs[current_component], dtype=real_dtype)
+
+    def _finalise_hard_source(self, grid: "FDTDGrid") -> VoltageSourcePortResult:
+        """Derive a delta-gap port from prescribed voltage and loop current."""
+
+        if not np.array_equal(self.receiver.coord, self.source.coord):
+            raise RuntimeError(f"RxPort {self.output_id!r} receiver moved away from its source")
+
+        real_dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
+        complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
+        electric = np.asarray(self.receiver.outputs[self.component], dtype=real_dtype)
+        loop_half = self._hard_loop_current_history(real_dtype)
+        if electric.size != grid.iterations or loop_half.size != grid.iterations:
+            raise RuntimeError(f"RxPort {self.output_id!r} receiver history has the wrong length")
+
+        # At receiver-storage index m, E is at m*dt and H is at
+        # (m-1/2)*dt. Drop the unexcited initial fields so each retained pair
+        # is exactly V^(n+1), I_loop^(n+1/2). Their separate transform offsets
+        # remove the half-step phase difference without the cosine attenuation
+        # introduced by time-domain averaging.
+        total_voltage = np.asarray(-self.dl * electric[1:], dtype=real_dtype)
+        loop_current = np.asarray(loop_half[1:], dtype=real_dtype)
+        generator_voltage = total_voltage.copy()
+        self.hard_voltage_time_offset = float(grid.dt)
+        self.hard_current_time_offset = float(0.5 * grid.dt)
+        time = np.asarray(
+            (np.arange(total_voltage.size, dtype=real_dtype) + 1) * grid.dt,
+            dtype=real_dtype,
+        )
+        self._hard_current_time = np.asarray(
+            (np.arange(loop_current.size, dtype=real_dtype) + 0.5) * grid.dt,
+            dtype=real_dtype,
+        )
+
+        frequency_full, total_spectrum_full = engineering_rfft(
+            total_voltage,
+            grid.dt,
+            time_offset=self.hard_voltage_time_offset,
+        )
+        _, loop_spectrum_full = engineering_rfft(
+            loop_current,
+            grid.dt,
+            time_offset=self.hard_current_time_offset,
+        )
+        selection = self._frequency_slice
+        frequency = frequency_full[selection]
+        total_spectrum = np.asarray(total_spectrum_full[selection], dtype=complex_dtype)
+        loop_spectrum = np.asarray(loop_spectrum_full[selection], dtype=complex_dtype)
+
+        gap_admittance = _hard_source_gap_admittance(
+            self,
+            frequency,
+            grid.dt,
+            complex_dtype,
+        )
+        terminal_current = np.asarray(
+            loop_spectrum - gap_admittance * total_spectrum, dtype=complex_dtype
+        )
+
+        incident_source = np.asarray(
+            0.5 * (total_spectrum + self.reference_impedance * loop_spectrum),
+            dtype=complex_dtype,
+        )
+        reflected_source = np.asarray(
+            0.5 * (total_spectrum - self.reference_impedance * loop_spectrum),
+            dtype=complex_dtype,
+        )
+        incident_spectrum = np.asarray(
+            0.5 * (total_spectrum + self.reference_impedance * terminal_current),
+            dtype=complex_dtype,
+        )
+        reflected_terminal = np.asarray(
+            0.5 * (total_spectrum - self.reference_impedance * terminal_current),
+            dtype=complex_dtype,
+        )
+        s11_source, source_plane_defined = _safe_complex_divide(
+            reflected_source, incident_source, complex_dtype
+        )
+        s11, terminal_wave_defined = _safe_complex_divide(
+            reflected_terminal, incident_spectrum, complex_dtype
+        )
+        zin_source, zin_source_defined = _safe_complex_divide(
+            total_spectrum, loop_spectrum, complex_dtype
+        )
+        zin, zin_defined = _safe_complex_divide(
+            total_spectrum, terminal_current, complex_dtype
+        )
+        yin, yin_defined = _safe_complex_divide(
+            terminal_current, total_spectrum, complex_dtype
+        )
+
+        incident_magnitude = np.abs(incident_spectrum)
+        incident_peak = float(np.max(incident_magnitude, initial=0.0))
+        incident_relative_db = np.full(frequency.shape, -np.inf, dtype=real_dtype)
+        if incident_peak > 0:
+            nonzero = incident_magnitude > 0
+            incident_relative_db[nonzero] = np.asarray(
+                20 * np.log10(incident_magnitude[nonzero] / incident_peak),
+                dtype=real_dtype,
+            )
+        source_valid = terminal_wave_defined & (
+            incident_relative_db >= self.incident_floor_db
+        )
+
+        gap_correction = np.asarray(
+            self.reference_impedance * gap_admittance, dtype=complex_dtype
+        )
+        gap_correction_valid = np.ones(frequency.shape, dtype=bool)
+
+        mesh_valid = np.asarray(self._full_mesh_valid[selection], dtype=bool)
+        cells_per_wavelength = np.asarray(
+            self._full_cells_per_wavelength[selection], dtype=real_dtype
+        )
+        source_plane_valid = source_plane_defined & zin_source_defined
+        valid_s11 = mesh_valid & source_valid & gap_correction_valid
+        valid_zin = valid_s11 & zin_defined
+        valid_yin = valid_s11 & yin_defined
+
+        trace_peak = float(np.max(np.abs(total_voltage), initial=0.0))
+        tail_count = max(1, total_voltage.size // 20)
+        tail_peak = float(np.max(np.abs(total_voltage[-tail_count:]), initial=0.0))
+        if trace_peak > 0 and tail_peak > 0:
+            tail_relative_db = float(20 * np.log10(tail_peak / trace_peak))
+        elif tail_peak == 0:
+            tail_relative_db = float("-inf")
+        else:
+            tail_relative_db = float("nan")
+
+        self._hard_loop_current = loop_current
+        self._hard_loop_current_spectrum = loop_spectrum
+        self._hard_terminal_current_spectrum = terminal_current
+        self._hard_source_plane_valid = source_plane_valid
+        self.result = VoltageSourcePortResult(
+            time=time,
+            generator_voltage=generator_voltage,
+            total_voltage=total_voltage,
+            frequency=np.asarray(frequency, dtype=real_dtype),
+            incident_spectrum=incident_spectrum,
+            reflected_source_spectrum=reflected_source,
+            total_spectrum=total_spectrum,
+            gap_correction=gap_correction,
+            s11_source=s11_source,
+            zin_source=zin_source,
+            s11=s11,
+            zin=zin,
+            yin=yin,
+            source_valid=np.asarray(source_valid, dtype=bool),
+            mesh_valid=mesh_valid,
+            gap_correction_valid=gap_correction_valid,
+            valid_s11=np.asarray(valid_s11, dtype=bool),
+            valid_zin=np.asarray(valid_zin, dtype=bool),
+            valid_yin=np.asarray(valid_yin, dtype=bool),
+            incident_relative_db=incident_relative_db,
+            cells_per_minimum_wavelength=cells_per_wavelength,
+            tail_relative_db=tail_relative_db,
+        )
+        return self.result
+
     def write_hdf5(self, base_group) -> None:
         """Write the finalised port result beneath ``/ports/<ID>``."""
 
@@ -554,10 +1033,14 @@ class VoltageSourcePortMonitor:
         group.attrs["Position"] = np.asarray(self.source.coord * self.grid_dl, dtype=real_dtype)
         group.attrs["GridPosition"] = np.asarray(self.source.coord, dtype=np.int32)
         group.attrs["SourceType"] = type(self.source).__name__
+        group.attrs["PortMode"] = (
+            "hard_delta_gap" if self.hard_source else "resistive_thevenin"
+        )
         group.attrs["SourceIndex"] = self.source_index
         group.attrs["Polarisation"] = self.source.polarisation
         group.attrs["CellLength"] = self.dl
         group.attrs["ReferenceImpedance"] = self.reference_impedance
+        group.attrs["ReferenceImpedanceSource"] = "voltage_source"
         group.attrs["WaveformID"] = self.source.waveformID
         group.attrs["BackgroundMaterial"] = self.source.background_material_ID
         group.attrs["BackgroundRelativePermittivity"] = self.background_relative_permittivity
@@ -565,7 +1048,12 @@ class VoltageSourcePortMonitor:
         group.attrs["GapCapacitance"] = self.gap_capacitance
         group.attrs["BackgroundConductance"] = self.background_conductance
         group.attrs["GapCorrection"] = "discrete_parallel_admittance"
-        group.attrs["TimeSampleOffset"] = 0.5 * self.dt
+        group.attrs["TimeSampleOffset"] = (
+            self.hard_voltage_time_offset if self.hard_source else 0.5 * self.dt
+        )
+        if self.hard_source:
+            group.attrs["CurrentTimeSampleOffset"] = self.hard_current_time_offset
+            group.attrs["CurrentTimeAlignment"] = "explicit_fft_half_step_phase"
         group.attrs["Window"] = "rectangular"
         group.attrs["IncidentFloorDB"] = self.incident_floor_db
         group.attrs["SpectrumLimitMode"] = self.spectrum_limit_mode
@@ -613,6 +1101,18 @@ class VoltageSourcePortMonitor:
             "incident_relative_dB": result.incident_relative_db,
             "cells_per_minimum_wavelength": result.cells_per_minimum_wavelength,
         }
+        if self.hard_source:
+            datasets.update(
+                {
+                    "time_current": self._hard_current_time,
+                    "Iloop": self._hard_loop_current,
+                    "Iloop_spectrum": self._hard_loop_current_spectrum,
+                    "Iterminal_spectrum": self._hard_terminal_current_spectrum,
+                    "Vreflected_spectrum": (
+                        result.total_spectrum - result.incident_spectrum
+                    ),
+                }
+            )
         for name, values in datasets.items():
             group.create_dataset(name, data=values)
 

--- a/gprMax/receivers.py
+++ b/gprMax/receivers.py
@@ -31,7 +31,7 @@ class Rx:
 
     allowableoutputs = ["Ex", "Ey", "Ez", "Hx", "Hy", "Hz", "Ix", "Iy", "Iz"]
     defaultoutputs = allowableoutputs[:-3]
-    allowableoutputs_dev = allowableoutputs[:-3]
+    allowableoutputs_dev = allowableoutputs
 
     def __init__(self):
         self.ID: str
@@ -88,6 +88,18 @@ class Rx:
         self.coordorigin[2] = value
 
 
+def requested_current_outputs(G):
+    """Return requested device-current channels in a stable packed order."""
+
+    components = ("Ix", "Iy", "Iz")
+    return [
+        (receiver_index, component)
+        for receiver_index, rx in enumerate(G.rxs)
+        for component in components
+        if component in rx.outputs
+    ]
+
+
 def htod_rx_arrays(G, queue=None, dev=None):
     """Initialise arrays on compute device for receiver coordinates and to store field
         components for receivers.
@@ -99,7 +111,10 @@ def htod_rx_arrays(G, queue=None, dev=None):
 
     Returns:
         rxcoords_dev: MTLBuffer for receiver coordinates on compute device.
-        rxs_dev: MTLBuffer for receiver data on compute device.
+        rxs_dev: MTLBuffer for receiver field data on compute device.
+        rxcurrentinfo_dev: MTLBuffer containing packed current-channel metadata,
+            or ``None`` if no current outputs were requested.
+        rxcurrents_dev: MTLBuffer for packed current data, or ``None``.
     """
 
     # Array to store receiver coordinates on compute device
@@ -112,7 +127,26 @@ def htod_rx_arrays(G, queue=None, dev=None):
     # Array to store field components for receivers on compute device -
     #   rows are field components; columns are iterations; pages are receivers
     rxs = np.zeros(
-        (len(Rx.allowableoutputs_dev), G.iterations, len(G.rxs)),
+        (len(Rx.defaultoutputs), G.iterations, len(G.rxs)),
+        dtype=config.sim_config.dtypes["float_or_double"],
+    )
+
+    # Current channels are relatively uncommon and each requires an Ampere
+    # contour rather than one field lookup. Pack only explicitly requested
+    # channels so adding Ix/Iy/Iz support does not increase every receiver's
+    # device storage from six histories to nine.
+    current_outputs = requested_current_outputs(G)
+    rxcurrentinfo = np.zeros((len(current_outputs), 4), dtype=np.int32)
+    for channel, (receiver_index, component) in enumerate(current_outputs):
+        rx = G.rxs[receiver_index]
+        rxcurrentinfo[channel] = (
+            rx.xcoord,
+            rx.ycoord,
+            rx.zcoord,
+            ("Ix", "Iy", "Iz").index(component),
+        )
+    rxcurrents = np.zeros(
+        (G.iterations, len(current_outputs)),
         dtype=config.sim_config.dtypes["float_or_double"],
     )
 
@@ -122,12 +156,18 @@ def htod_rx_arrays(G, queue=None, dev=None):
 
         rxcoords_dev = gpuarray.to_gpu(rxcoords)
         rxs_dev = gpuarray.to_gpu(rxs)
+        rxcurrentinfo_dev = gpuarray.to_gpu(rxcurrentinfo) if current_outputs else None
+        rxcurrents_dev = gpuarray.to_gpu(rxcurrents) if current_outputs else None
 
     elif config.sim_config.general["solver"] == "opencl":
         import pyopencl.array as clarray
 
         rxcoords_dev = clarray.to_device(queue, rxcoords)
         rxs_dev = clarray.to_device(queue, rxs)
+        rxcurrentinfo_dev = (
+            clarray.to_device(queue, rxcurrentinfo) if current_outputs else None
+        )
+        rxcurrents_dev = clarray.to_device(queue, rxcurrents) if current_outputs else None
 
     elif config.sim_config.general["solver"] == "metal":
         # Create Metal buffers for receiver coordinates and field components
@@ -137,24 +177,36 @@ def htod_rx_arrays(G, queue=None, dev=None):
         rxs_dev = dev.newBufferWithBytes_length_options_(
             rxs, rxs.nbytes, 0
         )  # 0 for default options
+        if current_outputs:
+            rxcurrentinfo_dev = dev.newBufferWithBytes_length_options_(
+                rxcurrentinfo, rxcurrentinfo.nbytes, 0
+            )
+            rxcurrents_dev = dev.newBufferWithBytes_length_options_(
+                rxcurrents, rxcurrents.nbytes, 0
+            )
+        else:
+            rxcurrentinfo_dev = None
+            rxcurrents_dev = None
 
-    return rxcoords_dev, rxs_dev
+    return rxcoords_dev, rxs_dev, rxcurrentinfo_dev, rxcurrents_dev
 
 
-def dtoh_rx_array(rxs_dev, rxcoords_dev, G):
+def dtoh_rx_array(rxs_dev, rxcoords_dev, G, rxcurrents_dev=None):
     """Copy output from receivers array used on compute device back to receiver objects.
 
     Args:
         rxs_dev: MTLBuffer for receiver data on compute device.
         rxcoords_dev: MTLBuffer for receiver coordinates on compute device.
         G: FDTDGrid class describing a grid in a model.
+        rxcurrents_dev: Packed current histories. For CUDA/OpenCL this is
+            already a NumPy array; for Metal it is an MTLBuffer.
     """
 
     if config.sim_config.general["solver"] == "metal":
         # For Metal, we need to read the data back from the GPU buffers
         # Create NumPy arrays to hold the data
         rxcoords_shape = (len(G.rxs), 3)
-        rxs_shape = (len(Rx.allowableoutputs_dev), G.iterations, len(G.rxs))
+        rxs_shape = (len(Rx.defaultoutputs), G.iterations, len(G.rxs))
 
         # Initialize arrays
         rxcoords_np = np.zeros(rxcoords_shape, dtype=np.int32)
@@ -198,6 +250,32 @@ def dtoh_rx_array(rxs_dev, rxcoords_dev, G):
         rxcoords_dev = rxcoords_np
         rxs_dev = rxs_np
 
+        current_outputs = requested_current_outputs(G)
+        if current_outputs:
+            current_shape = (G.iterations, len(current_outputs))
+            current_np = np.zeros(
+                current_shape, dtype=config.sim_config.dtypes["float_or_double"]
+            )
+            try:
+                expected_bytes = current_np.nbytes
+                if rxcurrents_dev is not None and rxcurrents_dev.length() == expected_bytes:
+                    buffer = rxcurrents_dev.contents().as_buffer(expected_bytes)
+                    current_np = (
+                        np.frombuffer(
+                            buffer, dtype=config.sim_config.dtypes["float_or_double"]
+                        )
+                        .reshape(current_shape)
+                        .copy()
+                    )
+                else:
+                    raise RuntimeError("Metal current-output buffer size mismatch")
+            except Exception as e:
+                logger.exception(
+                    f"Error copying Metal current-output data: {e}, "
+                    "using zero-filled arrays as fallback"
+                )
+            rxcurrents_dev = current_np
+
     # For CUDA/OpenCL, rxs_dev/rxcoords_dev are already host numpy arrays by
     # the time this function is called (the caller does .get() beforehand);
     # for Metal, the branch above has just produced the host numpy
@@ -212,6 +290,13 @@ def dtoh_rx_array(rxs_dev, rxcoords_dev, G):
                 "device receiver order/coordinates do not match the grid receiver list"
             )
         for output in rx.outputs:
-            rx.outputs[output] = rxs_dev[
-                Rx.allowableoutputs_dev.index(output), :, rxd
-            ]
+            if output in Rx.defaultoutputs:
+                rx.outputs[output] = rxs_dev[Rx.defaultoutputs.index(output), :, rxd]
+
+    current_outputs = requested_current_outputs(G)
+    if current_outputs:
+        expected_shape = (G.iterations, len(current_outputs))
+        if rxcurrents_dev is None or rxcurrents_dev.shape != expected_shape:
+            raise RuntimeError("device current-output array does not match requested channels")
+        for channel, (receiver_index, component) in enumerate(current_outputs):
+            G.rxs[receiver_index].outputs[component] = rxcurrents_dev[:, channel]

--- a/gprMax/sources.py
+++ b/gprMax/sources.py
@@ -1359,6 +1359,10 @@ class VoltageSource(Source):
     def __init__(self):
         super().__init__()
         self.resistance = None
+        # Wave-reference impedance used by a coincident RxPort. For a
+        # finite-resistance source it is the Thevenin resistance; for a hard
+        # source it defaults to 50 Ohms unless explicitly overridden.
+        self.reference_impedance = None
         # Preserved when create_material() replaces the selected electric-edge
         # material with a copy carrying the source resistance. Port outputs
         # need the pre-source values to remove the numerical Yee-gap

--- a/gprMax/updates/cuda_updates.py
+++ b/gprMax/updates/cuda_updates.py
@@ -38,7 +38,7 @@ from gprMax.cuda_opencl import (
 )
 from gprMax.grid.cuda_grid import CUDAGrid
 from gprMax.ntff.device import CUDACombinedKSIRCollector
-from gprMax.receivers import dtoh_rx_array, htod_rx_arrays
+from gprMax.receivers import dtoh_rx_array, htod_rx_arrays, requested_current_outputs
 from gprMax.snapshots import (
     Snapshot,
     _snapshot_axis_strides,
@@ -307,7 +307,13 @@ class CUDAUpdates(Updates[CUDAGrid]):
         """Receivers - initialises arrays on GPU, prepares kernel and gets kernel
         function.
         """
-        self.rxcoords_dev, self.rxs_dev = htod_rx_arrays(self.grid)
+        (
+            self.rxcoords_dev,
+            self.rxs_dev,
+            self.rxcurrentinfo_dev,
+            self.rxcurrents_dev,
+        ) = htod_rx_arrays(self.grid)
+        self.nrxcurrent = len(requested_current_outputs(self.grid))
 
         self.subs_func.update(
             {
@@ -322,6 +328,14 @@ class CUDAUpdates(Updates[CUDAGrid]):
         bld = self._build_knl(knl_store_outputs.store_outputs, self.subs_name_args, self.subs_func)
         knl = self.source_module(bld, options=config.sim_config.devices["nvcc_opts"])
         self.store_outputs_dev = knl.get_function("store_outputs")
+        if self.nrxcurrent:
+            bld = self._build_knl(
+                knl_store_outputs.store_current_outputs,
+                self.subs_name_args,
+                self.subs_func,
+            )
+            knl = self.source_module(bld, options=config.sim_config.devices["nvcc_opts"])
+            self.store_current_outputs_dev = knl.get_function("store_current_outputs")
 
     def _set_src_knls(self):
         """Sources - initialises arrays on GPU, prepares kernel and gets kernel
@@ -1062,6 +1076,21 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 block=(1, 1, 1),
                 grid=(round32(len(self.grid.rxs)), 1, 1),
             )
+            if self.nrxcurrent:
+                self.store_current_outputs_dev(
+                    np.int32(self.nrxcurrent),
+                    np.int32(iteration),
+                    self.rxcurrentinfo_dev.gpudata,
+                    self.rxcurrents_dev.gpudata,
+                    config.sim_config.dtypes["float_or_double"](self.grid.dx),
+                    config.sim_config.dtypes["float_or_double"](self.grid.dy),
+                    config.sim_config.dtypes["float_or_double"](self.grid.dz),
+                    self.grid.Hx_dev.gpudata,
+                    self.grid.Hy_dev.gpudata,
+                    self.grid.Hz_dev.gpudata,
+                    block=(1, 1, 1),
+                    grid=(round32(self.nrxcurrent), 1, 1),
+                )
 
     def store_snapshots(self, iteration):
         """Stores any snapshots.
@@ -2139,7 +2168,10 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
         # Copy output from receivers array back to correct receiver objects
         if self.grid.rxs:
-            dtoh_rx_array(self.rxs_dev.get(), self.rxcoords_dev.get(), self.grid)
+            currents = self.rxcurrents_dev.get() if self.nrxcurrent else None
+            dtoh_rx_array(
+                self.rxs_dev.get(), self.rxcoords_dev.get(), self.grid, currents
+            )
 
         if self.grid.transmissionlines:
             dtoh_transmission_line_outputs(

--- a/gprMax/updates/metal_updates.py
+++ b/gprMax/updates/metal_updates.py
@@ -33,7 +33,7 @@ from gprMax.cuda_opencl import (
     knl_symmetry_boundaries,
 )
 from gprMax.ntff.device import MetalCombinedKSIRCollector
-from gprMax.receivers import dtoh_rx_array, htod_rx_arrays
+from gprMax.receivers import dtoh_rx_array, htod_rx_arrays, requested_current_outputs
 from gprMax.snapshots import (
     Snapshot,
     _snapshot_axis_strides,
@@ -367,7 +367,13 @@ class MetalUpdates:
         """Receivers - initialises arrays on compute device, prepares kernel and
         gets kernel function.
         """
-        self.rxcoords_dev, self.rxs_dev = htod_rx_arrays(self.grid, None, self.dev)
+        (
+            self.rxcoords_dev,
+            self.rxs_dev,
+            self.rxcurrentinfo_dev,
+            self.rxcurrents_dev,
+        ) = htod_rx_arrays(self.grid, None, self.dev)
+        self.nrxcurrent = len(requested_current_outputs(self.grid))
 
         self.subs_func.update(
             {
@@ -387,6 +393,21 @@ class MetalUpdates:
         self.pso_store_outputs = self.dev.newComputePipelineStateWithFunction_error_(
             self.store_outputs_dev, None
         )[0]
+        if self.nrxcurrent:
+            bld = self._build_knl(
+                knl_store_outputs.store_current_outputs,
+                self.subs_name_args,
+                self.subs_func,
+            )
+            lib, _ = self.dev.newLibraryWithSource_options_error_(bld, self.opts, None)
+            self.store_current_outputs_dev = lib.newFunctionWithName_(
+                "store_current_outputs"
+            )
+            self.pso_store_current_outputs = (
+                self.dev.newComputePipelineStateWithFunction_error_(
+                    self.store_current_outputs_dev, None
+                )[0]
+            )
 
         # No self.grid.set_thread_group_size() call here - store_outputs()'s
         # own dispatch always computes its thread-group size directly from
@@ -628,6 +649,46 @@ class MetalUpdates:
                 ),
             )
             self.cmpencoder_store_outputs.endEncoding()
+            if self.nrxcurrent:
+                encoder = self.cmdbuffer_store_outputs.computeCommandEncoder()
+                encoder.setComputePipelineState_(self.pso_store_current_outputs)
+                ncurrent_buffer = self.dev.newBufferWithBytes_length_options_(
+                    np.int32(self.nrxcurrent).tobytes(), 4, 0
+                )
+                real_dtype = config.sim_config.dtypes["float_or_double"]
+                dx_buffer = self.dev.newBufferWithBytes_length_options_(
+                    real_dtype(self.grid.dx).tobytes(), np.dtype(real_dtype).itemsize, 0
+                )
+                dy_buffer = self.dev.newBufferWithBytes_length_options_(
+                    real_dtype(self.grid.dy).tobytes(), np.dtype(real_dtype).itemsize, 0
+                )
+                dz_buffer = self.dev.newBufferWithBytes_length_options_(
+                    real_dtype(self.grid.dz).tobytes(), np.dtype(real_dtype).itemsize, 0
+                )
+                for index, buffer in enumerate(
+                    (
+                        ncurrent_buffer,
+                        iteration_buffer,
+                        self.rxcurrentinfo_dev,
+                        self.rxcurrents_dev,
+                        dx_buffer,
+                        dy_buffer,
+                        dz_buffer,
+                        self.grid.Hx_dev,
+                        self.grid.Hy_dev,
+                        self.grid.Hz_dev,
+                    )
+                ):
+                    encoder.setBuffer_offset_atIndex_(buffer, 0, index)
+                encoder.dispatchThreads_threadsPerThreadgroup_(
+                    self.metal.MTLSizeMake(round32(self.nrxcurrent), 1, 1),
+                    self.metal.MTLSizeMake(
+                        self.pso_store_current_outputs.maxTotalThreadsPerThreadgroup(),
+                        1,
+                        1,
+                    ),
+                )
+                encoder.endEncoding()
             self.cmdbuffer_store_outputs.commit()
             self.cmdbuffer_store_outputs.waitUntilCompleted()
 
@@ -1242,7 +1303,12 @@ class MetalUpdates:
 
         # Copy output from receivers array back to correct receiver objects
         if self.grid.rxs:
-            dtoh_rx_array(self.rxs_dev, self.rxcoords_dev, self.grid)
+            dtoh_rx_array(
+                self.rxs_dev,
+                self.rxcoords_dev,
+                self.grid,
+                self.rxcurrents_dev if self.nrxcurrent else None,
+            )
 
         if self.grid.magneticfrillsources:
             dtoh_magnetic_frill_source_outputs(

--- a/gprMax/updates/opencl_updates.py
+++ b/gprMax/updates/opencl_updates.py
@@ -34,7 +34,7 @@ from gprMax.cuda_opencl import (
 )
 from gprMax.grid.opencl_grid import OpenCLGrid
 from gprMax.ntff.device import OpenCLCombinedKSIRCollector
-from gprMax.receivers import dtoh_rx_array, htod_rx_arrays
+from gprMax.receivers import dtoh_rx_array, htod_rx_arrays, requested_current_outputs
 from gprMax.snapshots import (
     Snapshot,
     _snapshot_axis_strides,
@@ -325,7 +325,13 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
         """Receivers - initialises arrays on compute device, prepares kernel and
         gets kernel function.
         """
-        self.rxcoords_dev, self.rxs_dev = htod_rx_arrays(self.grid, self.queue)
+        (
+            self.rxcoords_dev,
+            self.rxs_dev,
+            self.rxcurrentinfo_dev,
+            self.rxcurrents_dev,
+        ) = htod_rx_arrays(self.grid, self.queue)
+        self.nrxcurrent = len(requested_current_outputs(self.grid))
         self.store_outputs_dev = self.elwiseknl(
             self.ctx,
             knl_store_outputs.store_outputs["args_opencl"].substitute(
@@ -427,6 +433,19 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
             preamble=self.knl_common,
             options=config.sim_config.devices["compiler_opts"],
         )
+        if self.nrxcurrent:
+            self.store_current_outputs_dev = self.elwiseknl(
+                self.ctx,
+                knl_store_outputs.store_current_outputs["args_opencl"].substitute(
+                    {"REAL": config.sim_config.dtypes["C_float_or_double"]}
+                ),
+                knl_store_outputs.store_current_outputs["func"].substitute(
+                    {"CUDA_IDX": "", "REAL": config.sim_config.dtypes["C_float_or_double"]}
+                ),
+                "store_current_outputs",
+                preamble=self.knl_common,
+                options=config.sim_config.devices["compiler_opts"],
+            )
 
     def _set_snapshot_knl(self):
         """Snapshots - initialises arrays on compute device, prepares kernel and
@@ -594,6 +613,19 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
                 self.grid.Hy_dev,
                 self.grid.Hz_dev,
             )
+            if self.nrxcurrent:
+                self.store_current_outputs_dev(
+                    np.int32(self.nrxcurrent),
+                    np.int32(iteration),
+                    self.rxcurrentinfo_dev,
+                    self.rxcurrents_dev,
+                    config.sim_config.dtypes["float_or_double"](self.grid.dx),
+                    config.sim_config.dtypes["float_or_double"](self.grid.dy),
+                    config.sim_config.dtypes["float_or_double"](self.grid.dz),
+                    self.grid.Hx_dev,
+                    self.grid.Hy_dev,
+                    self.grid.Hz_dev,
+                )
 
     def update_electric_a(self):
         """Updates electric field components."""
@@ -748,7 +780,10 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
 
         # Copy output from receivers array back to correct receiver objects
         if self.grid.rxs:
-            dtoh_rx_array(self.rxs_dev.get(), self.rxcoords_dev.get(), self.grid)
+            currents = self.rxcurrents_dev.get() if self.nrxcurrent else None
+            dtoh_rx_array(
+                self.rxs_dev.get(), self.rxcoords_dev.get(), self.grid, currents
+            )
 
         if self.grid.magneticfrillsources:
             dtoh_magnetic_frill_source_outputs(

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -352,6 +352,9 @@ class VoltageSource(RotatableMixin, GridUserObject):
         waveform_id: string required for identifier of waveform used with source.
         start: float optional to delay start time (secs) of source.
         stop: float optional to time (secs) to remove source.
+        reference_impedance: float optional wave-reference impedance (Ohms)
+            for a hard source. The default is 50 Ohms. For a finite-
+            resistance source it must equal the source resistance.
     """
 
     @property
@@ -370,6 +373,7 @@ class VoltageSource(RotatableMixin, GridUserObject):
         waveform_id: str,
         start: Optional[float] = None,
         stop: Optional[float] = None,
+        reference_impedance: Optional[float] = None,
     ):
         super().__init__(
             polarisation=polarisation,
@@ -378,6 +382,7 @@ class VoltageSource(RotatableMixin, GridUserObject):
             waveform_id=waveform_id,
             start=start,
             stop=stop,
+            reference_impedance=reference_impedance,
         )
 
         self.point = p1
@@ -386,6 +391,7 @@ class VoltageSource(RotatableMixin, GridUserObject):
         self.waveform_id = waveform_id
         self.start = start
         self.stop = stop
+        self.reference_impedance = reference_impedance
 
     def _do_rotate(self, grid: FDTDGrid):
         """Performs rotation."""
@@ -455,6 +461,19 @@ class VoltageSource(RotatableMixin, GridUserObject):
             raise ValueError(
                 f"{self.params_str()} requires a source resistance of zero or greater."
             )
+        if self.reference_impedance is not None:
+            self.reference_impedance = float(self.reference_impedance)
+            if not np.isfinite(self.reference_impedance) or self.reference_impedance <= 0:
+                raise ValueError(
+                    f"{self.params_str()} reference impedance must be finite and positive."
+                )
+            if self.resistance > 0 and not np.isclose(
+                self.reference_impedance, self.resistance
+            ):
+                raise ValueError(
+                    f"{self.params_str()} reference impedance must equal the finite "
+                    "source resistance."
+                )
 
         # Check if there is a waveformID in the waveforms list
         if not any(x.ID == self.waveform_id for x in grid.waveforms):
@@ -488,6 +507,11 @@ class VoltageSource(RotatableMixin, GridUserObject):
         x, y, z = uip.discretise_static_point(self.point)
         voltage_source.ID = f"{voltage_source.__class__.__name__}({x},{y},{z})"
         voltage_source.resistance = self.resistance
+        voltage_source.reference_impedance = (
+            float(self.reference_impedance)
+            if self.reference_impedance is not None
+            else (50.0 if self.resistance == 0 else float(self.resistance))
+        )
         voltage_source.waveformID = self.waveform_id
 
         if self.start is None or self.stop is None:

--- a/gprMax/user_objects/cmds_output.py
+++ b/gprMax/user_objects/cmds_output.py
@@ -34,6 +34,7 @@ from gprMax.ntff.interface import (
     SPHERICAL_OUTPUTS,
     TIME_ORIGINS,
     WINDOWS,
+    KSIRAntennaPortsSpec,
     KSIRFarFieldRequestSpec,
     KSIRFrequencyRequestSpec,
     KSIRFrequencyTransformSpec,
@@ -50,8 +51,8 @@ from gprMax.ports import (
     validate_spectrum_limit,
 )
 from gprMax.receivers import Rx as RxUser
-from gprMax.sources import MagneticFrillSource
 from gprMax.snapshots import Snapshot as SnapshotUser
+from gprMax.sources import MagneticFrillSource
 from gprMax.subgrids.grid import SubGridBaseGrid
 from gprMax.user_objects.user_objects import OutputUserObject
 from gprMax.utilities.utilities import round_int
@@ -61,6 +62,10 @@ logger = logging.getLogger(__name__)
 
 class RxPort(OutputUserObject):
     """Calculate S11 and input impedance at a one-edge voltage source.
+
+    A finite-resistance source uses its Thevenin wave separation. A zero-
+    resistance hard source uses the sampled gap voltage and an Ampere-loop
+    terminal current. The voltage source owns the wave-reference impedance.
 
     Attributes:
         p1: Position of the voltage source in metres.
@@ -126,9 +131,7 @@ class RxPort(OutputUserObject):
         if config.get_model_config().mode != "3D":
             raise ValueError(f"{self.params_str()} currently supports only 3-D models.")
         if config.sim_config.general["solver"] not in ("cpu", "cuda", "opencl", "metal"):
-            raise ValueError(
-                f"{self.params_str()} supports CPU, CUDA, OpenCL, and Metal solvers."
-            )
+            raise ValueError(f"{self.params_str()} supports CPU, CUDA, OpenCL, and Metal solvers.")
 
     def build(self, model: Model, grid: FDTDGrid):
         self._validate_context(grid)
@@ -142,9 +145,7 @@ class RxPort(OutputUserObject):
             source for source in grid.voltagesources if np.array_equal(source.coord, coord)
         ]
         frill_candidates = [
-            source
-            for source in grid.magneticfrillsources
-            if np.array_equal(source.coord, coord)
+            source for source in grid.magneticfrillsources if np.array_equal(source.coord, coord)
         ]
         candidates = voltage_candidates + frill_candidates
         if len(candidates) != 1:
@@ -161,9 +162,9 @@ class RxPort(OutputUserObject):
             self._build_for_frill_source(grid, source, coord, uip)
             return
 
-        if not np.isfinite(source.resistance) or source.resistance <= 0:
+        if not np.isfinite(source.resistance) or source.resistance < 0:
             raise ValueError(
-                f"{self.params_str()} requires a finite, non-zero voltage-source resistance"
+                f"{self.params_str()} requires a finite, non-negative voltage-source resistance"
             )
         if any(monitor.source is source for monitor in grid.port_monitors):
             raise ValueError(f"{self.params_str()} source already has an RxPort output.")
@@ -194,13 +195,31 @@ class RxPort(OutputUserObject):
         receiver.ID = f"_rx_port_{output_id}"
         receiver.coord = np.asarray(coord, dtype=np.int32).copy()
         receiver.coordorigin = receiver.coord.copy()
+        real_dtype = config.sim_config.dtypes["float_or_double"]
         receiver.outputs[f"E{source.polarisation}"] = np.zeros(
-            grid.iterations, dtype=config.sim_config.dtypes["float_or_double"]
+            grid.iterations, dtype=real_dtype
         )
         receiver.internal = True
         receiver.source_bound = True
         receiver.port_id = output_id
         grid.add_receiver(receiver)
+
+        if source.resistance == 0:
+            transverse_axes = {
+                "x": (1, 2),
+                "y": (0, 2),
+                "z": (0, 1),
+            }[source.polarisation]
+            if any(coord[axis] == 0 for axis in transverse_axes):
+                raise ValueError(
+                    f"{self.params_str()} cannot calculate a hard-source current "
+                    "loop on a domain-minimum transverse boundary"
+                )
+            # CPU and device solvers store the identical requested-only
+            # Ampere-loop component at the magnetic half step.
+            receiver.outputs[f"I{source.polarisation}"] = np.zeros(
+                grid.iterations, dtype=real_dtype
+            )
 
         monitor = VoltageSourcePortMonitor(
             output_id,
@@ -215,7 +234,8 @@ class RxPort(OutputUserObject):
         logger.info(
             f"RxPort {output_id!r} bound to the "
             f"{source.polarisation}-polarised voltage source at "
-            f"{position[0]:g}m, {position[1]:g}m, {position[2]:g}m."
+            f"{position[0]:g}m, {position[1]:g}m, {position[2]:g}m, "
+            f"reference impedance {source.reference_impedance:g} Ohms."
         )
 
     def _build_for_frill_source(self, grid: FDTDGrid, source, coord, uip):
@@ -1019,7 +1039,14 @@ class KSIRFrequencyRxSpherical(KSIRFrequencyRx):
 
 
 class KSIRFarField(_KSIRRequest):
-    """Request range-normalized far fields in paired spherical directions."""
+    """Request range-normalized far fields in paired spherical directions.
+
+    In addition to Cartesian and spherical field components, ``outputs`` may
+    contain radiation intensity, directivity, gain, realized gain, radiation
+    or total efficiency, and RCS. Directivity and efficiency use an internal
+    full-sphere quadrature even when only a cut is requested. Gain and
+    efficiency require a :class:`KSIRAntennaPorts` association.
+    """
 
     @property
     def order(self):
@@ -1125,6 +1152,73 @@ class KSIRFarFieldArray(KSIRFarField):
         theta_grid, phi_grid = np.meshgrid(theta, phi, indexing="ij")
         self.theta, self.phi = theta_grid.ravel(), phi_grid.ravel()
         return super()._angles(dtype)
+
+
+class KSIRAntennaPorts(OutputUserObject):
+    """Associate all physical antenna ports with one KSIR transform.
+
+    Args:
+        transform_id: ID of a rectangular-window
+            :class:`KSIRFrequencyTransform`.
+        port_ids: IDs of every physical antenna port. Voltage-source IDs come
+            from coincident :class:`RxPort` objects. Transmission-line and
+            magnetic-frill sources use their automatic ``tlN`` and ``frillN``
+            IDs.
+
+    The complete set is required for an unambiguous coherent accepted-power
+    balance. A source with zero waveform amplitude is still a terminated port
+    and must be included.
+    """
+
+    @property
+    def order(self):
+        # RxPort objects use order 16. Building afterwards makes their public
+        # IDs available irrespective of input-file or Scene insertion order.
+        return 17
+
+    @property
+    def hash(self):
+        return "#ksir_antenna_ports"
+
+    def __init__(self, transform_id, port_ids):
+        super().__init__(transform_id=transform_id, port_ids=port_ids)
+        self.transform_id = transform_id
+        self.port_ids = tuple(port_ids)
+
+    def build(self, model: Model, grid: FDTDGrid):
+        _check_ksir_interface_context(self, grid)
+        if self.transform_id not in grid.ksir_transform_specs:
+            raise ValueError(
+                f"{self.params_str()} refers to unknown transform {self.transform_id!r}"
+            )
+        if not self.port_ids:
+            raise ValueError(f"{self.params_str()} requires at least one port ID")
+        for port_id in self.port_ids:
+            validate_identifier("antenna port ID", port_id)
+        if len(set(self.port_ids)) != len(self.port_ids):
+            raise ValueError(f"{self.params_str()} port IDs must not contain duplicates")
+        if self.transform_id in grid.ksir_antenna_port_specs:
+            raise ValueError(
+                f"KSIR transform {self.transform_id!r} already has an antenna-port group"
+            )
+
+        available = [monitor.output_id for monitor in grid.port_monitors]
+        available.extend(f"tl{index}" for index, _ in enumerate(grid.transmissionlines, start=1))
+        available.extend(
+            f"frill{index}" for index, _ in enumerate(grid.magneticfrillsources, start=1)
+        )
+        if len(set(available)) != len(available):
+            raise ValueError("antenna port IDs are ambiguous across source types")
+        unknown = set(self.port_ids) - set(available)
+        if unknown:
+            raise ValueError(
+                f"{self.params_str()} refers to unknown port IDs {sorted(unknown)}; "
+                f"available ports are {available}"
+            )
+        grid.ksir_antenna_port_specs[self.transform_id] = KSIRAntennaPortsSpec(
+            self.transform_id,
+            self.port_ids,
+        )
 
 
 class GeometryView(OutputUserObject):

--- a/tests/cmds_multiuse/test_metal_gpu_restriction_gaps.py
+++ b/tests/cmds_multiuse/test_metal_gpu_restriction_gaps.py
@@ -6,14 +6,10 @@ feature they gate:
 1. TransmissionLine._validate_parameters() rejects transmission lines on
    OpenCL and Metal until their host-side lifecycle is enabled. CUDA has a
    device-resident implementation.
-2. Rx.build()'s allowable-outputs check restricts CUDA/OpenCL receivers to
-   the 6 field components the shared GPU kernel
-   (gprMax/cuda_opencl/knl_store_outputs.py) actually writes, but Metal
-   (which uses that exact same shared kernel/args_metal template) fell
-   through to the full CPU list including Ix/Iy/Iz - accepted at parse
-   time, then raised a late, confusing ValueError from
-   Rx.allowableoutputs_dev.index() during output finalisation instead of
-   a clean upfront rejection.
+2. Rx.build() applies the same allowable-output list to CUDA, OpenCL, and
+   Metal. Device solvers now support packed, requested-only Ix/Iy/Iz output,
+   so the current components must be accepted consistently on all four
+   solvers.
 
 Both are fixed by adding "metal" to the respective solver-name lists.
 Follows the established pattern (see tests/test_receivers_dtoh.py) of
@@ -63,23 +59,15 @@ def test_transmission_line_is_allowed_on_cuda(monkeypatch):
     tl._validate_parameters(grid)
 
 
-@pytest.mark.parametrize("solver", ["cuda", "opencl", "metal"])
-def test_current_output_rejected_on_every_gpu_solver(monkeypatch, solver):
+@pytest.mark.parametrize("solver", ["cuda", "opencl", "metal", "cpu"])
+def test_current_output_allowed_on_every_solver(monkeypatch, solver):
     _set_solver(monkeypatch, solver)
 
     rx = Rx(p1=(0.01, 0.01, 0.01), id="r1", outputs=["Ix"])
 
-    with pytest.raises(ValueError, match="not allowable"):
-        rx._create_receiver(grid=None, coord=np.array([1, 1, 1], dtype=np.int32))
-
-
-def test_current_output_still_allowed_on_cpu(monkeypatch):
-    _set_solver(monkeypatch, "cpu")
-
     class _Grid:
         iterations = 5
 
-    rx = Rx(p1=(0.01, 0.01, 0.01), id="r1", outputs=["Ix"])
     r = rx._create_receiver(grid=_Grid(), coord=np.array([1, 1, 1], dtype=np.int32))
 
     assert "Ix" in r.outputs

--- a/tests/ntff/test_antenna_metrics.py
+++ b/tests/ntff/test_antenna_metrics.py
@@ -1,0 +1,84 @@
+"""Closed-form tests for antenna-pattern quadrature and directivity."""
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+from gprMax.ntff.antenna import directivity_from_intensity, spherical_quadrature
+from gprMax.ntff.interface import KSIRRadiationMetrics, _refine_radiation_maximum
+
+
+def test_spherical_quadrature_integrates_isotropic_pattern():
+    quadrature = spherical_quadrature(0.1, 20.0, np.float64)
+    intensity = np.ones((2, quadrature.weights.size))
+    radiated_power = np.sum(
+        intensity * quadrature.weights[np.newaxis, :],
+        axis=1,
+    )
+    directivity, directivity_dbi = directivity_from_intensity(
+        intensity,
+        radiated_power,
+    )
+
+    assert_allclose(np.sum(quadrature.weights), 4 * np.pi, rtol=2e-14)
+    assert_allclose(radiated_power, 4 * np.pi, rtol=2e-14)
+    assert_allclose(directivity, 1.0, rtol=2e-14)
+    assert_allclose(directivity_dbi, 0.0, atol=1e-13)
+    assert quadrature.theta_order % 2 == 1
+    assert np.any(np.isclose(quadrature.theta, 90.0))
+
+
+def test_hertzian_dipole_pattern_has_one_point_five_directivity():
+    quadrature = spherical_quadrature(0.01, 1.0, np.float64)
+    theta = np.deg2rad(quadrature.theta)
+    intensity = np.sin(theta)[np.newaxis, :] ** 2
+    radiated_power = np.sum(
+        intensity * quadrature.weights[np.newaxis, :],
+        axis=1,
+    )
+    maximum_intensity = np.asarray([[1.0]])
+    maximum, maximum_dbi = directivity_from_intensity(
+        maximum_intensity,
+        radiated_power,
+    )
+
+    assert_allclose(radiated_power, 8 * np.pi / 3, rtol=2e-14)
+    assert_allclose(maximum[0, 0], 1.5, rtol=2e-14)
+    assert_allclose(maximum_dbi[0, 0], 10 * np.log10(1.5), rtol=2e-14)
+
+
+def test_directivity_marks_zero_power_invalid_and_true_null_as_minus_infinity():
+    intensity = np.asarray([[0.0, 1.0], [1.0, 2.0]])
+    directivity, directivity_dbi = directivity_from_intensity(
+        intensity,
+        np.asarray([4 * np.pi, 0.0]),
+    )
+
+    assert directivity[0, 0] == 0
+    assert np.isneginf(directivity_dbi[0, 0])
+    assert np.isnan(directivity[1]).all()
+    assert np.isnan(directivity_dbi[1]).all()
+
+
+def test_requested_directions_refine_but_never_reduce_stored_maximum():
+    metrics = KSIRRadiationMetrics(
+        radiated_power=np.asarray((2 * np.pi, 2 * np.pi)),
+        maximum_directivity=np.asarray((1.5, 1.5)),
+        maximum_directivity_dbi=10 * np.log10(np.asarray((1.5, 1.5))),
+        maximum_theta=np.asarray((90.0, 90.0)),
+        maximum_phi=np.asarray((0.0, 0.0)),
+        theta_order=13,
+        phi_order=25,
+        enclosure_radius=0.1,
+    )
+    intensity = np.asarray(((0.5, 1.0), (0.5, 0.7)))
+    refined = _refine_radiation_maximum(
+        metrics,
+        intensity,
+        np.asarray((82.0, 87.0)),
+        np.asarray((20.0, 30.0)),
+    )
+
+    assert_allclose(refined.maximum_directivity, (2.0, 1.5))
+    assert_allclose(refined.maximum_directivity_dbi, 10 * np.log10((2.0, 1.5)))
+    assert_allclose(refined.maximum_theta, (87.0, 90.0))
+    assert_allclose(refined.maximum_phi, (30.0, 0.0))

--- a/tests/ntff/test_cuda_reusable_interface.py
+++ b/tests/ntff/test_cuda_reusable_interface.py
@@ -58,6 +58,49 @@ def _scene():
     return scene, transform, time_receiver, frequency_receiver, far_field
 
 
+def _antenna_scene():
+    dl = 0.004
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(0.08, 0.08, 0.08)))
+    scene.add(gprMax.TimeWindow(time=4e-10))
+    scene.add(gprMax.PMLThickness(thickness=3))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
+    scene.add(
+        gprMax.VoltageSource(
+            polarisation="z",
+            p1=(0.04, 0.04, 0.04),
+            resistance=50,
+            waveform_id="pulse",
+        )
+    )
+    scene.add(gprMax.RxPort(p1=(0.04, 0.04, 0.04), id="feed"))
+    scene.add(
+        gprMax.KSIRSurface(
+            p1=(0.028, 0.028, 0.028),
+            p2=(0.052, 0.052, 0.052),
+            id="surface",
+        )
+    )
+    scene.add(gprMax.KSIRFrequencyTransform("surface", "spectrum", (5e9,)))
+    scene.add(gprMax.KSIRAntennaPorts("spectrum", ("feed",)))
+    far_field = gprMax.KSIRFarField(
+        (30, 90, 150),
+        (0, 0, 0),
+        "spectrum",
+        id="far",
+        outputs=(
+            "directivity",
+            "gain",
+            "realized_gain",
+            "radiation_efficiency",
+            "total_efficiency",
+        ),
+    )
+    scene.add(far_field)
+    return scene, far_field
+
+
 @pytest.mark.skipif(not HAS_CUDA, reason="No CUDA device/pycuda available")
 @pytest.mark.parametrize(
     "precision,real_dtype,complex_dtype,rtol",
@@ -133,3 +176,52 @@ def test_cuda_reusable_outputs_match_cpu(tmp_path, precision, real_dtype, comple
         assert frequency_group.attrs["solver"] == "cuda"
         assert frequency_group.attrs["collection_backend"] == "cuda_device"
         assert frequency_group["surface_dft/Ez/field"].dtype == complex_dtype
+
+
+@pytest.mark.skipif(not HAS_CUDA, reason="No CUDA device/pycuda available")
+def test_cuda_antenna_metrics_match_cpu(tmp_path):
+    cpu_scene, cpu_far = _antenna_scene()
+    cuda_scene, cuda_far = _antenna_scene()
+    gprMax.run(
+        scenes=[cpu_scene],
+        n=1,
+        outputfile=tmp_path / "cpu_antenna",
+        hide_progress_bars=True,
+        cpu_precision="single",
+    )
+    gprMax.run(
+        scenes=[cuda_scene],
+        n=1,
+        outputfile=tmp_path / "cuda_antenna",
+        hide_progress_bars=True,
+        gpu=[0],
+        gpu_precision="single",
+    )
+
+    for output in cpu_far.result.fields:
+        assert_allclose(
+            cuda_far.result.fields[output],
+            cpu_far.result.fields[output],
+            rtol=2e-3,
+            atol=2e-3 * np.nanmax(np.abs(cpu_far.result.fields[output])),
+        )
+    assert_allclose(
+        cuda_far.result.radiation_metrics.radiated_power,
+        cpu_far.result.radiation_metrics.radiated_power,
+        rtol=2e-3,
+    )
+    assert_allclose(
+        cuda_far.result.port_metrics.accepted_power,
+        cpu_far.result.port_metrics.accepted_power,
+        rtol=2e-3,
+    )
+    assert_allclose(
+        cuda_far.result.port_metrics.incident_power,
+        cpu_far.result.port_metrics.incident_power,
+        rtol=2e-3,
+    )
+
+    with h5py.File(tmp_path / "cuda_antenna.h5", "r") as output:
+        group = output["ntff/surface/frequency/spectrum/far_field/far"]
+        assert group["port_power/port_ids"].asstr()[...].tolist() == ["feed"]
+        assert group["port_power/gain_valid"][0] == 1

--- a/tests/ntff/test_cython_far_zone.py
+++ b/tests/ntff/test_cython_far_zone.py
@@ -1,0 +1,117 @@
+"""Tests for the Cython/OpenMP far-zone KSIR evaluator."""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import gprMax.ntff.evaluator as evaluator
+
+
+@pytest.mark.parametrize(
+    "real_dtype,complex_dtype,rtol,atol",
+    [
+        (np.float32, np.complex64, 2e-5, 2e-5),
+        (np.float64, np.complex128, 2e-13, 2e-13),
+    ],
+)
+@pytest.mark.parametrize("nthreads", [1, 2])
+def test_cython_far_zone_matches_numpy_fallback(
+    monkeypatch,
+    real_dtype,
+    complex_dtype,
+    rtol,
+    atol,
+    nthreads,
+):
+    compiled = evaluator._evaluate_far_zone_patches_cython
+    if compiled is None:
+        pytest.skip("Cython NTFF extension is not built")
+    rng = np.random.default_rng(4815)
+    npatches = 137
+    nfrequencies = 3
+    ndirections = 17
+    positions = rng.uniform(-0.2, 0.2, (npatches, 3)).astype(real_dtype)
+    normals = rng.normal(size=(npatches, 3)).astype(real_dtype)
+    normals /= np.linalg.norm(normals, axis=1)[:, np.newaxis]
+    areas = rng.uniform(1e-5, 4e-4, npatches).astype(real_dtype)
+    frequencies = np.asarray((0.0, 3e8, 7e8), dtype=real_dtype)
+    directions = rng.normal(size=(ndirections, 3)).astype(real_dtype)
+    directions /= np.linalg.norm(directions, axis=1)[:, np.newaxis]
+    field = (
+        rng.normal(size=(nfrequencies, npatches)) + 1j * rng.normal(size=(nfrequencies, npatches))
+    ).astype(complex_dtype)
+    derivative = (
+        rng.normal(size=(nfrequencies, npatches)) + 1j * rng.normal(size=(nfrequencies, npatches))
+    ).astype(complex_dtype)
+
+    actual = evaluator.evaluate_far_zone_patches(
+        positions,
+        normals,
+        areas,
+        frequencies,
+        directions,
+        field,
+        derivative,
+        origin=(0.03, -0.02, 0.01),
+        nthreads=nthreads,
+    )
+    monkeypatch.setattr(evaluator, "_evaluate_far_zone_patches_cython", None)
+    expected = evaluator.evaluate_far_zone_patches(
+        positions,
+        normals,
+        areas,
+        frequencies,
+        directions,
+        field,
+        derivative,
+        origin=(0.03, -0.02, 0.01),
+        direction_block_size=5,
+        patch_block_size=31,
+    )
+
+    assert actual.dtype == np.dtype(complex_dtype)
+    assert_allclose(actual, expected, rtol=rtol, atol=atol)
+
+
+def test_cython_far_zone_supports_many_frequencies_and_few_directions(monkeypatch):
+    if evaluator._evaluate_far_zone_patches_cython is None:
+        pytest.skip("Cython NTFF extension is not built")
+    rng = np.random.default_rng(621)
+    npatches = 53
+    nfrequencies = 47
+    positions = rng.uniform(-0.1, 0.1, (npatches, 3))
+    normals = rng.normal(size=(npatches, 3))
+    normals /= np.linalg.norm(normals, axis=1)[:, np.newaxis]
+    areas = rng.uniform(1e-5, 2e-4, npatches)
+    frequencies = np.linspace(1e7, 2e9, nfrequencies)
+    directions = np.asarray(((1.0, 0.0, 0.0), (0.0, 0.0, 1.0)))
+    field = rng.normal(size=(nfrequencies, npatches)) + 1j * rng.normal(
+        size=(nfrequencies, npatches)
+    )
+    derivative = rng.normal(size=(nfrequencies, npatches)) + 1j * rng.normal(
+        size=(nfrequencies, npatches)
+    )
+
+    actual = evaluator.evaluate_far_zone_patches(
+        positions,
+        normals,
+        areas,
+        frequencies,
+        directions,
+        field,
+        derivative,
+        nthreads=4,
+    )
+    monkeypatch.setattr(evaluator, "_evaluate_far_zone_patches_cython", None)
+    expected = evaluator.evaluate_far_zone_patches(
+        positions,
+        normals,
+        areas,
+        frequencies,
+        directions,
+        field,
+        derivative,
+        patch_block_size=17,
+    )
+
+    assert_allclose(actual, expected, rtol=2e-13, atol=2e-13)

--- a/tests/ntff/test_hash_command.py
+++ b/tests/ntff/test_hash_command.py
@@ -8,6 +8,7 @@ import gprMax
 from gprMax.hash_cmds_file import get_user_objects
 from gprMax.ntff.interface import validate_identifier
 from gprMax.user_objects.cmds_output import (
+    KSIRAntennaPorts,
     KSIRFarField,
     KSIRFarFieldArray,
     KSIRFrequencyRx,
@@ -39,11 +40,13 @@ def test_positional_hash_commands_create_public_objects():
         "#ksir_frequency_rx_array: 0.12 0.05 0.05 0.14 0.05 0.05 0.01 0.01 0.01 spectrum1 freq3 Ez",
         "#ksir_far_field: 90 30 spectrum1 far1 Etheta Ephi radiation_intensity",
         "#ksir_far_field_array: 0 180 90 0 360 180 spectrum1 far2 Etheta Ephi",
+        "#ksir_antenna_ports: spectrum1 feed1 feed2",
     )
 
     assert [type(item) for item in objects] == [
         KSIRSurface,
         KSIRFrequencyTransform,
+        KSIRAntennaPorts,
         KSIRTimeRx,
         KSIRTimeRxSpherical,
         KSIRTimeRxArray,
@@ -56,7 +59,8 @@ def test_positional_hash_commands_create_public_objects():
     transform = objects[1]
     assert transform.frequencies == (1e8, 2e8)
     assert transform.window == "hann"
-    time_receiver = objects[2]
+    assert objects[2].port_ids == ("feed1", "feed2")
+    time_receiver = objects[3]
     assert time_receiver.ID == "time1"
     assert time_receiver.outputs == ("Ez", "Hy")
     assert time_receiver.time_origin == "first_arrival"
@@ -119,6 +123,7 @@ def test_hdf5_identifiers_reject_invalid_path_components(identifier):
         "#ksir_frequency_rx: 1 2 3",
         "#ksir_far_field: 90 0",
         "#ksir_far_field_array: 0 180 5 0 360 transform",
+        "#ksir_antenna_ports: transform",
         "#ksir_field_extension: 0 0 0 1 1 1 2 2 2 components=Ez",
         "#ksir_near_to_far: 0 0 0 1 1 1",
     ],
@@ -143,7 +148,8 @@ def test_reusable_commands_run_and_write_grouped_hdf5(tmp_path):
         "#ksir_time_rx_spherical: 0.03 90 0 surf1 time2 Etheta simulation\n"
         "#ksir_frequency_rx: 0.064 0.04 0.042 spec1 freq1 Ez\n"
         "#ksir_frequency_rx_spherical: 0.03 90 0 spec1 freq2 Etheta\n"
-        "#ksir_far_field: 90 0 spec1 far1 Etheta Ephi radiation_intensity\n"
+        "#ksir_far_field: 90 0 spec1 far1 Etheta Ephi radiation_intensity "
+        "directivity directivity_dbi\n"
     )
     outputfile = tmp_path / "reusable_ksir"
 
@@ -168,9 +174,142 @@ def test_reusable_commands_run_and_write_grouped_hdf5(tmp_path):
         assert np.isfinite(transform["receivers/freq2/fields/Etheta"][...]).all()
         assert np.isfinite(transform["far_field/far1/fields/Etheta"][...]).all()
         assert np.isfinite(transform["far_field/far1/fields/radiation_intensity"][...]).all()
+        assert np.isfinite(transform["far_field/far1/fields/directivity"][...]).all()
+        assert np.isfinite(transform["far_field/far1/radiated_power"][...]).all()
         assert surface["time/time1"].attrs["time_origin"] == "first_arrival"
         assert surface["time/time2"].attrs["coordinate_system"] == "spherical"
         assert surface["time/time1/fields/Ez"].dtype == np.float32
+
+
+def test_antenna_metrics_run_from_single_voltage_port(tmp_path):
+    inputfile = tmp_path / "antenna_metrics.in"
+    inputfile.write_text(
+        "#domain: 0.08 0.08 0.08\n"
+        "#dx_dy_dz: 0.004 0.004 0.004\n"
+        "#time_window: 4e-10\n"
+        "#pml_cells: 3\n"
+        "#waveform: ricker 1 5e9 pulse\n"
+        "#voltage_source: z 0.04 0.04 0.04 50 pulse\n"
+        "#rx_port: 0.04 0.04 0.04 feed\n"
+        "#ksir_surface: 0.028 0.028 0.028 0.052 0.052 0.052 surf\n"
+        "#ksir_frequency: surf band 5e9 rectangular\n"
+        "#ksir_antenna_ports: band feed\n"
+        "#ksir_far_field: 90 0 band broadside Etheta Ephi directivity "
+        "directivity_dbi gain gain_dbi realized_gain realized_gain_dbi "
+        "radiation_efficiency total_efficiency\n"
+    )
+    outputfile = tmp_path / "antenna_metrics"
+
+    gprMax.run(
+        inputfile=str(inputfile),
+        n=1,
+        outputfile=outputfile,
+        hide_progress_bars=True,
+        cpu_precision="double",
+    )
+
+    with h5py.File(str(outputfile) + ".h5", "r") as output:
+        group = output["ntff/surf/frequency/band/far_field/broadside"]
+        assert group.attrs["radiation_quadrature_theta_order"] >= 12
+        assert group.attrs["radiation_quadrature_phi_order"] >= 24
+        assert (
+            group.attrs["maximum_directivity_sampling"]
+            == "full-sphere quadrature plus requested directions"
+        )
+        assert group["port_power/port_ids"].asstr()[...].tolist() == ["feed"]
+        assert group["port_power/incident_voltage_per_port"].shape == (1, 1)
+        assert group["port_power/terminal_voltage_per_port"].shape == (1, 1)
+        assert group["port_power/terminal_current_per_port"].shape == (1, 1)
+        assert group["port_power"].attrs["spectral_power_units"] == "W s^2"
+        assert group["port_power/gain_valid"][0] == 1
+        assert group["port_power/realized_gain_valid"][0] == 1
+        for name in (
+            "directivity",
+            "directivity_dbi",
+            "gain",
+            "gain_dbi",
+            "realized_gain",
+            "realized_gain_dbi",
+            "radiation_efficiency",
+            "total_efficiency",
+        ):
+            assert np.isfinite(group[f"fields/{name}"][...]).all()
+
+
+def test_multiport_gain_keeps_zero_amplitude_port_in_power_balance(tmp_path):
+    inputfile = tmp_path / "multiport_metrics.in"
+    inputfile.write_text(
+        "#domain: 0.08 0.08 0.08\n"
+        "#dx_dy_dz: 0.004 0.004 0.004\n"
+        "#time_window: 4e-10\n"
+        "#pml_cells: 3\n"
+        "#waveform: ricker 1 5e9 driven\n"
+        "#waveform: ricker 0 5e9 terminated\n"
+        "#voltage_source: z 0.036 0.04 0.04 50 driven\n"
+        "#voltage_source: z 0.044 0.04 0.04 50 terminated\n"
+        "#rx_port: 0.036 0.04 0.04 element1\n"
+        "#rx_port: 0.044 0.04 0.04 element2\n"
+        "#ksir_surface: 0.024 0.028 0.028 0.056 0.052 0.052 surf\n"
+        "#ksir_frequency: surf band 5e9 rectangular\n"
+        "#ksir_antenna_ports: band element1 element2\n"
+        "#ksir_far_field: 90 0 band broadside gain realized_gain\n"
+    )
+    outputfile = tmp_path / "multiport_metrics"
+
+    gprMax.run(
+        inputfile=str(inputfile),
+        n=1,
+        outputfile=outputfile,
+        hide_progress_bars=True,
+        cpu_precision="double",
+    )
+
+    with h5py.File(str(outputfile) + ".h5", "r") as output:
+        group = output["ntff/surf/frequency/band/far_field/broadside"]
+        port_power = group["port_power"]
+        assert port_power["port_ids"].asstr()[...].tolist() == ["element1", "element2"]
+        assert port_power["incident_power_per_port"][0, 0] > 0
+        assert port_power["incident_power_per_port"][1, 0] == 0
+        assert port_power["incident_voltage_per_port"].shape == (2, 1)
+        assert port_power["terminal_voltage_per_port"].shape == (2, 1)
+        assert port_power["terminal_current_per_port"].shape == (2, 1)
+        assert port_power["terminal_valid"][0] == 1
+        assert np.isfinite(port_power["accepted_power_per_port"][:, 0]).all()
+        assert np.isfinite(group["fields/gain"][...]).all()
+        assert np.isfinite(group["fields/realized_gain"][...]).all()
+
+
+def test_automatic_transmission_line_port_can_normalise_gain(tmp_path):
+    inputfile = tmp_path / "transmission_line_gain.in"
+    inputfile.write_text(
+        "#domain: 0.08 0.08 0.08\n"
+        "#dx_dy_dz: 0.004 0.004 0.004\n"
+        "#time_window: 4e-10\n"
+        "#pml_cells: 3\n"
+        "#waveform: ricker 1 5e9 pulse\n"
+        "#transmission_line: z 0.04 0.04 0.04 50 pulse\n"
+        "#ksir_surface: 0.028 0.028 0.028 0.052 0.052 0.052 surf\n"
+        "#ksir_frequency: surf band 5e9 rectangular\n"
+        "#ksir_antenna_ports: band tl1\n"
+        "#ksir_far_field: 90 0 band broadside gain realized_gain\n"
+    )
+    outputfile = tmp_path / "transmission_line_gain"
+
+    gprMax.run(
+        inputfile=str(inputfile),
+        n=1,
+        outputfile=outputfile,
+        hide_progress_bars=True,
+        cpu_precision="double",
+    )
+
+    with h5py.File(str(outputfile) + ".h5", "r") as output:
+        group = output["ntff/surf/frequency/band/far_field/broadside"]
+        assert group["port_power/port_ids"].asstr()[...].tolist() == ["tl1"]
+        assert group["port_power/source_types"].asstr()[...].tolist() == ["TransmissionLine"]
+        assert group["port_power/gain_valid"][0] == 1
+        assert np.isfinite(group["fields/gain"][...]).all()
+        assert np.isfinite(group["fields/realized_gain"][...]).all()
 
 
 def test_surface_on_symmetry_plane_is_completed_automatically(tmp_path):

--- a/tests/ntff/test_port_power.py
+++ b/tests/ntff/test_port_power.py
@@ -1,0 +1,219 @@
+"""Exact-frequency antenna-port power tests."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import gprMax.config as config
+import gprMax.ports as ports
+from gprMax.ntff.conventions import engineering_dft
+from gprMax.ports import (
+    MagneticFrillPortOutput,
+    TransmissionLinePortOutput,
+    VoltageSourcePortMonitor,
+    evaluate_port_power_spectrum,
+)
+
+
+@pytest.fixture(autouse=True)
+def port_config(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "sim_config",
+        SimpleNamespace(
+            dtypes={"float_or_double": np.float64, "complex": np.complex128},
+        ),
+    )
+
+
+def _voltage_port(total_voltage, generator_voltage, *, dt, resistance=50.0, capacitance=0.0):
+    source = SimpleNamespace(polarisation="z")
+    receiver = SimpleNamespace()
+    output = VoltageSourcePortMonitor("feed", source, receiver, 10.0)
+    output.reference_impedance = resistance
+    output.hard_source = False
+    output.background_conductance = 0.0
+    output.gap_capacitance = capacitance
+    output.minimum_wavelength_cells = 10.0
+    output.result = SimpleNamespace(
+        total_voltage=np.asarray(total_voltage, dtype=np.float64),
+        generator_voltage=np.asarray(generator_voltage, dtype=np.float64),
+    )
+    grid = SimpleNamespace(dt=dt)
+    return output, grid
+
+
+def _hard_voltage_port(total_voltage, loop_current, *, dt, resistance=50.0):
+    output, grid = _voltage_port(
+        total_voltage,
+        total_voltage,
+        dt=dt,
+        resistance=resistance,
+    )
+    output.hard_source = True
+    output._hard_loop_current = np.asarray(loop_current, dtype=np.float64)
+    output.hard_voltage_time_offset = dt
+    output.hard_current_time_offset = 0.5 * dt
+    return output, grid
+
+
+def test_nyquist_research_override_retains_full_port_mesh_band(monkeypatch):
+    output = SimpleNamespace(
+        spectrum_limit="nyquist",
+        minimum_wavelength_cells=10.0,
+    )
+    monkeypatch.setattr(
+        ports,
+        "minimum_wavelength_sampling",
+        lambda grid, frequency: (
+            np.zeros(np.asarray(frequency).shape),
+            np.full(np.asarray(frequency).shape, "material"),
+        ),
+    )
+
+    assert ports._port_mesh_valid(output, SimpleNamespace(), [1.0, 2.0]).all()
+
+
+def test_zero_amplitude_voltage_port_retains_negative_coupled_power(monkeypatch):
+    dt = 1e-3
+    nsamples = 32
+    output, grid = _voltage_port(
+        np.full(nsamples, 2.0),
+        np.zeros(nsamples),
+        dt=dt,
+    )
+    monkeypatch.setattr(
+        ports,
+        "_port_mesh_valid",
+        lambda output, grid, frequency: np.ones(frequency.shape, dtype=bool),
+    )
+
+    result = evaluate_port_power_spectrum(output, grid, [0.0])
+    voltage_spectrum = 2 * nsamples * dt
+
+    assert result.incident_power[0] == 0
+    assert result.accepted_power[0] < 0
+    assert_allclose(
+        result.accepted_power[0],
+        -(voltage_spectrum**2) / (2 * output.reference_impedance),
+    )
+    assert result.terminal_valid[0]
+
+
+def test_voltage_port_terminal_current_reproduces_gap_corrected_s11(monkeypatch):
+    dt = 1e-3
+    nsamples = 64
+    frequency = 1 / (nsamples * dt)
+    time = (np.arange(nsamples) + 0.5) * dt
+    generator = 4.0 * np.cos(2 * np.pi * frequency * time)
+    total = 1.4 * np.cos(2 * np.pi * frequency * time + 0.35)
+    output, grid = _voltage_port(
+        total,
+        generator,
+        dt=dt,
+        capacitance=2e-3,
+    )
+    monkeypatch.setattr(
+        ports,
+        "_port_mesh_valid",
+        lambda output, grid, values: np.ones(values.shape, dtype=bool),
+    )
+
+    result = evaluate_port_power_spectrum(output, grid, [frequency])
+    generator_spectrum = engineering_dft(
+        generator,
+        [frequency],
+        dt,
+        time_offset=0.5 * dt,
+    )
+    total_spectrum = engineering_dft(
+        total,
+        [frequency],
+        dt,
+        time_offset=0.5 * dt,
+    )
+    source_s11 = (total_spectrum - 0.5 * generator_spectrum) / (0.5 * generator_spectrum)
+    omega_discrete = (2 / dt) * np.tan(np.pi * frequency * dt)
+    correction = output.reference_impedance * 1j * omega_discrete * output.gap_capacitance
+    expected_s11, _ = ports.correct_s11_for_parallel_gap(source_s11, correction)
+    terminal_s11 = (
+        result.terminal_voltage - output.reference_impedance * result.terminal_current
+    ) / (result.terminal_voltage + output.reference_impedance * result.terminal_current)
+
+    assert_allclose(terminal_s11, expected_s11, rtol=2e-13, atol=2e-13)
+
+
+def test_hard_voltage_port_uses_time_aligned_loop_current(monkeypatch):
+    dt = 1e-3
+    nsamples = 64
+    frequency = 1 / (nsamples * dt)
+    voltage_time = (np.arange(nsamples) + 1) * dt
+    current_time = (np.arange(nsamples) + 0.5) * dt
+    voltage = 2.0 * np.cos(2 * np.pi * frequency * voltage_time + 0.2)
+    current = 0.04 * np.cos(2 * np.pi * frequency * current_time - 0.1)
+    output, grid = _hard_voltage_port(voltage, current, dt=dt)
+    monkeypatch.setattr(
+        ports,
+        "_port_mesh_valid",
+        lambda output, grid, values: np.ones(values.shape, dtype=bool),
+    )
+
+    result = evaluate_port_power_spectrum(output, grid, [frequency])
+    expected_voltage = engineering_dft(voltage, [frequency], dt, time_offset=dt)
+    expected_current = engineering_dft(
+        current,
+        [frequency],
+        dt,
+        time_offset=0.5 * dt,
+    )
+    expected_incident = 0.5 * (
+        expected_voltage + output.reference_impedance * expected_current
+    )
+
+    assert_allclose(result.terminal_voltage, expected_voltage)
+    assert_allclose(result.terminal_current, expected_current)
+    assert_allclose(result.incident_voltage, expected_incident)
+    assert result.terminal_valid[0]
+
+
+@pytest.mark.parametrize("output_type", [TransmissionLinePortOutput, MagneticFrillPortOutput])
+def test_automatic_source_ports_use_their_terminal_wave_definitions(monkeypatch, output_type):
+    dt = 1e-3
+    nsamples = 32
+    frequency = 1 / (nsamples * dt)
+    time = np.arange(nsamples) * dt
+    incident = np.cos(2 * np.pi * frequency * time)
+    terminal = 1.4 * np.cos(2 * np.pi * frequency * time + 0.2)
+    current = 0.03 * np.cos(2 * np.pi * frequency * time - 0.1)
+    source = SimpleNamespace(
+        Vinc=incident,
+        Vtotal=terminal,
+        Itot=current,
+    )
+    output = output_type.__new__(output_type)
+    output.source = source
+    output.source_index = 1
+    output.result = SimpleNamespace()
+    output.reference_impedance = 50.0
+    output.minimum_wavelength_cells = 10.0
+    grid = SimpleNamespace(dt=dt)
+    monkeypatch.setattr(
+        ports,
+        "_port_mesh_valid",
+        lambda output, grid, values: np.ones(values.shape, dtype=bool),
+    )
+
+    result = evaluate_port_power_spectrum(output, grid, [frequency])
+    expected_incident = engineering_dft(incident, [frequency], dt)
+    expected_terminal = engineering_dft(terminal, [frequency], dt)
+    if output_type is TransmissionLinePortOutput:
+        expected_current = (2 * expected_incident - expected_terminal) / 50.0
+    else:
+        expected_current = engineering_dft(current, [frequency], dt)
+
+    assert_allclose(result.incident_voltage, expected_incident)
+    assert_allclose(result.terminal_voltage, expected_terminal)
+    assert_allclose(result.terminal_current, expected_current)
+    assert result.terminal_valid[0]

--- a/tests/ntff/test_reusable_interface.py
+++ b/tests/ntff/test_reusable_interface.py
@@ -85,7 +85,7 @@ def test_python_api_groups_requests_and_exposes_results(tmp_path):
         phi=(0, 0, 0),
         transform_id="spectrum",
         id="far_field",
-        outputs=("Etheta", "Ephi"),
+        outputs=("Etheta", "Ephi", "directivity", "directivity_dbi"),
     )
     for item in (time_cartesian, time_spherical, frequency_receiver, far_field):
         scene.add(item)
@@ -106,6 +106,8 @@ def test_python_api_groups_requests_and_exposes_results(tmp_path):
     assert far_field.result.range_normalized
     assert np.isfinite(frequency_receiver.result.fields["Ez"]).all()
     assert np.isfinite(far_field.result.fields["Etheta"]).all()
+    assert np.isfinite(far_field.result.fields["directivity"]).all()
+    assert far_field.result.radiation_metrics is not None
     assert transform.surface_data["Ez"].field.dtype == np.complex128
 
     writer = time_cartesian._compiled_outputs

--- a/tests/ntff/test_solver_integration.py
+++ b/tests/ntff/test_solver_integration.py
@@ -22,12 +22,14 @@ def test_solver_calls_ntff_observers_at_completed_e_and_h_time_levels():
         "update_magnetic",
         "update_magnetic_pml",
         "update_magnetic_sources",
+        "update_eigenmode_sources_magnetic",
         "update_plane_waves_magnetic",
         "observe_ntff_magnetic",
         "update_electric_a",
         "update_symmetry_boundaries_electric",
         "update_electric_pml",
         "update_electric_sources",
+        "update_eigenmode_sources_electric",
         "update_plane_waves_electric",
         "update_symmetry_boundaries_electric_b",
         "update_electric_b",
@@ -42,8 +44,20 @@ def test_solver_calls_ntff_observers_at_completed_e_and_h_time_levels():
 
     assert calls.index("observe_ntff_electric") > calls.index("store_snapshots")
     assert calls.index("observe_ntff_electric") < calls.index("update_magnetic")
+    assert calls.index("update_magnetic_sources") < calls.index(
+        "update_eigenmode_sources_magnetic"
+    )
+    assert calls.index("update_eigenmode_sources_magnetic") < calls.index(
+        "update_plane_waves_magnetic"
+    )
     assert calls.index("observe_ntff_magnetic") > calls.index("update_plane_waves_magnetic")
     assert calls.index("observe_ntff_magnetic") < calls.index("update_electric_a")
+    assert calls.index("update_electric_sources") < calls.index(
+        "update_eigenmode_sources_electric"
+    )
+    assert calls.index("update_eigenmode_sources_electric") < calls.index(
+        "update_plane_waves_electric"
+    )
     assert calls.index("finalise") > calls.index("update_electric_b")
 
 

--- a/tests/ntff/test_validation_guards.py
+++ b/tests/ntff/test_validation_guards.py
@@ -201,3 +201,65 @@ def test_exact_receiver_validation_uses_full_patch_support():
 
     with pytest.raises(ValueError, match="strictly outside"):
         _validate_external_points(np.asarray(((0.046, 0.1, 0.1),)), {"Ez": surface}, closure)
+
+
+def _antenna_gain_input(*, window="rectangular", association=None, extra_source=""):
+    association_command = (
+        "" if association is None else f"#ksir_antenna_ports: band {association}\n"
+    )
+    return (
+        "#domain: 0.04 0.04 0.04\n"
+        "#dx_dy_dz: 0.002 0.002 0.002\n"
+        "#time_window: 1e-10\n"
+        "#pml_cells: 2\n"
+        "#waveform: ricker 1 5e9 pulse\n"
+        "#voltage_source: z 0.018 0.02 0.02 50 pulse\n"
+        "#voltage_source: z 0.022 0.02 0.02 50 pulse\n"
+        "#rx_port: 0.018 0.02 0.02 feed1\n"
+        "#rx_port: 0.022 0.02 0.02 feed2\n"
+        f"{extra_source}"
+        "#ksir_surface: 0.012 0.012 0.012 0.028 0.028 0.028 surface\n"
+        f"#ksir_frequency: surface band 5e9 {window}\n"
+        f"{association_command}"
+        "#ksir_far_field: 90 0 band broadside gain\n"
+    )
+
+
+@pytest.mark.parametrize(
+    ("window", "association", "extra_source", "message"),
+    [
+        ("rectangular", None, "", "without a #ksir_antenna_ports"),
+        ("hann", "feed1 feed2", "", "requires rectangular"),
+        ("rectangular", "feed1", "", "include every physical port"),
+        (
+            "rectangular",
+            "feed1 feed2",
+            "#hertzian_dipole: z 0.02 0.02 0.02 pulse\n",
+            "active non-port sources",
+        ),
+    ],
+)
+def test_antenna_gain_rejects_ambiguous_normalisation(
+    tmp_path,
+    window,
+    association,
+    extra_source,
+    message,
+):
+    inputfile = tmp_path / "invalid_antenna_gain.in"
+    inputfile.write_text(
+        _antenna_gain_input(
+            window=window,
+            association=association,
+            extra_source=extra_source,
+        )
+    )
+
+    with pytest.raises(ValueError, match=message):
+        gprMax.run(
+            inputfile=str(inputfile),
+            n=1,
+            geometry_only=True,
+            outputfile=tmp_path / "invalid_antenna_gain",
+            hide_progress_bars=True,
+        )

--- a/tests/ports/test_integration.py
+++ b/tests/ports/test_integration.py
@@ -12,6 +12,8 @@ def _scene(
     background=None,
     dispersive_elsewhere=False,
     polarisation="z",
+    resistance=50,
+    reference_impedance=None,
 ):
     dl = 0.002
     scene = gprMax.Scene()
@@ -60,8 +62,9 @@ def _scene(
         gprMax.VoltageSource(
             p1=(0.01, 0.01, 0.01),
             polarisation=polarisation,
-            resistance=50,
+            resistance=resistance,
             waveform_id="pulse",
+            reference_impedance=reference_impedance,
         )
     )
     port = gprMax.RxPort(
@@ -81,6 +84,8 @@ def _run(
     cpu_precision="single",
     dispersive_elsewhere=False,
     polarisation="z",
+    resistance=50,
+    reference_impedance=None,
 ):
     output = tmp_path / name
     scene, port = _scene(
@@ -88,6 +93,8 @@ def _run(
         background,
         dispersive_elsewhere,
         polarisation,
+        resistance,
+        reference_impedance,
     )
     gprMax.run(
         scenes=[scene],
@@ -214,3 +221,76 @@ def test_other_voltage_source_polarisations_produce_valid_ports(tmp_path, polari
 
         assert port.attrs["Polarisation"] == polarisation
         assert port["valid_S11"][...].astype(bool).any()
+
+
+@pytest.mark.parametrize("polarisation", ("x", "y", "z"))
+def test_hard_source_port_uses_phase_aligned_ampere_current(tmp_path, polarisation):
+    filename, api_port = _run(
+        tmp_path,
+        f"hard_{polarisation}_port",
+        polarisation=polarisation,
+        resistance=0,
+        reference_impedance=50,
+    )
+
+    with h5py.File(filename, "r") as output:
+        port = output["ports/feed"]
+        frequency = port["frequency"][...]
+        valid = port["valid_Zin"][...].astype(bool)
+
+        assert port.attrs["PortMode"] == "hard_delta_gap"
+        assert port.attrs["ReferenceImpedance"] == 50
+        assert port.attrs["ReferenceImpedanceSource"] == "voltage_source"
+        assert port.attrs["TimeSampleOffset"] == pytest.approx(
+            output.attrs["dt"]
+        )
+        assert port.attrs["CurrentTimeSampleOffset"] == pytest.approx(
+            0.5 * output.attrs["dt"]
+        )
+        assert port.attrs["CurrentTimeAlignment"] == "explicit_fft_half_step_phase"
+        assert port["Iloop"].shape == port["time"].shape
+        assert port["time_current"].shape == port["time"].shape
+        assert port["Iloop_spectrum"].shape == frequency.shape
+        assert port["Iterminal_spectrum"].shape == frequency.shape
+        assert valid.any()
+        np.testing.assert_allclose(
+            port["Zin"][...][valid],
+            port["Vtotal_spectrum"][...][valid]
+            / port["Iterminal_spectrum"][...][valid],
+            rtol=2e-5,
+            atol=2e-5,
+        )
+        np.testing.assert_allclose(
+            api_port.result.total_voltage,
+            api_port.result.generator_voltage,
+        )
+
+
+def test_hard_source_port_defaults_to_50_ohm_reference(tmp_path):
+    filename, _ = _run(
+        tmp_path,
+        "hard_default_reference",
+        resistance=0,
+    )
+
+    with h5py.File(filename, "r") as output:
+        port = output["ports/feed"]
+        assert port.attrs["ReferenceImpedance"] == 50
+        assert port.attrs["ReferenceImpedanceSource"] == "voltage_source"
+
+
+def test_hard_source_nyquist_gap_admittance_remains_finite(tmp_path):
+    filename, _ = _run(
+        tmp_path,
+        "hard_nyquist_port",
+        spectrum_limit="nyquist",
+        resistance=0,
+        reference_impedance=50,
+    )
+
+    with h5py.File(filename, "r") as output:
+        port = output["ports/feed"]
+
+        assert port["gap_correction_valid"][...].astype(bool)[-1]
+        assert np.isfinite(port["gap_correction_c"][...][-1])
+        assert np.isfinite(port["Iterminal_spectrum"][...][-1])

--- a/tests/ports/test_port_hash_command.py
+++ b/tests/ports/test_port_hash_command.py
@@ -4,6 +4,7 @@ import pytest
 
 from gprMax.hash_cmds_file import get_user_objects
 from gprMax.user_objects.cmds_output import RxPort
+from gprMax.user_objects.cmds_multiuse import VoltageSource
 
 
 def _parse(command):
@@ -32,7 +33,7 @@ def test_rx_port_positional_forms(command, output_id, spectrum_limit):
     "command",
     [
         "#rx_port: 0.1 0.2",
-        "#rx_port: 0.1 0.2 0.3 feed 10 extra",
+        "#rx_port: 0.1 0.2 0.3 feed 10 50",
         "#rx_port: 0.1 0.2 0.3 feed full",
         "#rx_port: 0.1 0.2 0.3 feed 2",
         "#rx_port: 0.1 0.2 0.3 feed nan",
@@ -46,3 +47,13 @@ def test_rx_port_rejects_malformed_spectrum_limit(command):
 def test_nondefault_api_limit_requires_id_for_positional_round_trip():
     with pytest.raises(ValueError, match="requires an ID"):
         RxPort((0.1, 0.2, 0.3), spectrum_limit="nyquist")
+
+
+def test_voltage_source_hash_accepts_reference_impedance_after_start_stop():
+    objects = _parse(
+        "#voltage_source: z 0.1 0.2 0.3 0 pulse 0 1e-9 75"
+    )
+
+    assert len(objects) == 1
+    assert isinstance(objects[0], VoltageSource)
+    assert objects[0].reference_impedance == 75

--- a/tests/ports/test_validation.py
+++ b/tests/ports/test_validation.py
@@ -34,13 +34,29 @@ def test_port_requires_exactly_one_colocated_voltage_source(tmp_path):
         _run_geometry(scene, tmp_path, "no_source")
 
 
-def test_port_rejects_hard_voltage_source(tmp_path):
+def test_hard_voltage_source_defaults_to_50_ohm_reference_impedance(tmp_path):
     scene = _base_scene()
     scene.add(gprMax.VoltageSource((0.01, 0.01, 0.01), "z", 0, "pulse"))
     scene.add(gprMax.RxPort((0.01, 0.01, 0.01), id="feed"))
 
-    with pytest.raises(ValueError, match="non-zero voltage-source resistance"):
-        _run_geometry(scene, tmp_path, "hard_source")
+    _run_geometry(scene, tmp_path, "hard_source")
+
+
+def test_port_rejects_reference_impedance_different_from_finite_resistance(tmp_path):
+    scene = _base_scene()
+    scene.add(
+        gprMax.VoltageSource(
+            (0.01, 0.01, 0.01),
+            "z",
+            50,
+            "pulse",
+            reference_impedance=75,
+        )
+    )
+    scene.add(gprMax.RxPort((0.01, 0.01, 0.01), id="feed"))
+
+    with pytest.raises(ValueError, match="must equal the finite source resistance"):
+        _run_geometry(scene, tmp_path, "finite_reference_mismatch")
 
 
 def test_port_rejects_ambiguous_colocated_sources(tmp_path):

--- a/tests/test_receivers_dtoh.py
+++ b/tests/test_receivers_dtoh.py
@@ -46,7 +46,7 @@ def test_metal_dtoh_rx_array_populates_rx_outputs(monkeypatch):
     config.sim_config.dtypes = {"float_or_double": np.float64}
 
     iterations = 4
-    n_outputs = len(Rx.allowableoutputs_dev)
+    n_outputs = len(Rx.defaultoutputs)
 
     rx = Rx()
     rx.xcoord, rx.ycoord, rx.zcoord = 1, 2, 3
@@ -65,9 +65,36 @@ def test_metal_dtoh_rx_array_populates_rx_outputs(monkeypatch):
 
     dtoh_rx_array(fake_buffer, rxcoords_dev=None, G=_DummyGrid())
 
-    ex_index = Rx.allowableoutputs_dev.index("Ex")
+    ex_index = Rx.defaultoutputs.index("Ex")
     assert np.array_equal(rx.outputs["Ex"], known[ex_index, :, 0])
     assert not np.all(rx.outputs["Ex"] == 0), "Ex must not be left zero-filled"
+
+
+def test_metal_dtoh_rx_array_populates_packed_current_outputs(monkeypatch):
+    monkeypatch.setattr(config, "sim_config", type("_SC", (), {})())
+    config.sim_config.general = {"solver": "metal"}
+    config.sim_config.dtypes = {"float_or_double": np.float64}
+
+    iterations = 4
+    rx = Rx()
+    rx.xcoord, rx.ycoord, rx.zcoord = 1, 2, 3
+    rx.outputs["Iz"] = np.zeros(iterations)
+
+    class _DummyGrid:
+        rxs = [rx]
+        iterations = 4
+
+    fields = np.zeros((len(Rx.defaultoutputs), iterations, 1), dtype=np.float64)
+    current = np.asarray(((1,), (2,), (3,), (4,)), dtype=np.float64)
+
+    dtoh_rx_array(
+        _FakeMetalBuffer(fields),
+        rxcoords_dev=None,
+        G=_DummyGrid(),
+        rxcurrents_dev=_FakeMetalBuffer(current),
+    )
+
+    np.testing.assert_array_equal(rx.outputs["Iz"], (1, 2, 3, 4))
 
 
 def test_device_receiver_copy_uses_order_for_colocated_receivers(monkeypatch):
@@ -88,8 +115,8 @@ def test_device_receiver_copy_uses_order_for_colocated_receivers(monkeypatch):
         iterations = 3
 
     coordinates = np.asarray(((1, 2, 3), (1, 2, 3)), dtype=np.int32)
-    values = np.zeros((len(Rx.allowableoutputs_dev), 3, 2), dtype=np.float64)
-    ez = Rx.allowableoutputs_dev.index("Ez")
+    values = np.zeros((len(Rx.defaultoutputs), 3, 2), dtype=np.float64)
+    ez = Rx.defaultoutputs.index("Ez")
     values[ez, :, 0] = (1, 2, 3)
     values[ez, :, 1] = (10, 20, 30)
 
@@ -97,3 +124,29 @@ def test_device_receiver_copy_uses_order_for_colocated_receivers(monkeypatch):
 
     np.testing.assert_array_equal(first.outputs["Ez"], (1, 2, 3))
     np.testing.assert_array_equal(second.outputs["Ez"], (10, 20, 30))
+
+
+def test_device_receiver_copy_maps_only_requested_packed_currents(monkeypatch):
+    monkeypatch.setattr(config, "sim_config", type("_SC", (), {})())
+    config.sim_config.general = {"solver": "cuda"}
+    config.sim_config.dtypes = {"float_or_double": np.float64}
+
+    first = Rx()
+    first.xcoord, first.ycoord, first.zcoord = 1, 2, 3
+    first.outputs["Ix"] = np.zeros(3)
+    second = Rx()
+    second.xcoord, second.ycoord, second.zcoord = 4, 5, 6
+    second.outputs["Iz"] = np.zeros(3)
+
+    class _DummyGrid:
+        rxs = [first, second]
+        iterations = 3
+
+    coordinates = np.asarray(((1, 2, 3), (4, 5, 6)), dtype=np.int32)
+    fields = np.zeros((len(Rx.defaultoutputs), 3, 2), dtype=np.float64)
+    currents = np.asarray(((1, 10), (2, 20), (3, 30)), dtype=np.float64)
+
+    dtoh_rx_array(fields, coordinates, _DummyGrid(), currents)
+
+    np.testing.assert_array_equal(first.outputs["Ix"], (1, 2, 3))
+    np.testing.assert_array_equal(second.outputs["Iz"], (10, 20, 30))

--- a/tests/updates/test_metal_current_output_dispatch.py
+++ b/tests/updates/test_metal_current_output_dispatch.py
@@ -1,0 +1,137 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+
+"""Metal receiver-current dispatch contract without requiring Metal hardware."""
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from gprMax import config
+from gprMax.updates.metal_updates import MetalUpdates
+
+
+class _Buffer:
+    pass
+
+
+class _Device:
+    def newBufferWithBytes_length_options_(self, data, length, options):
+        return _Buffer()
+
+
+class _Encoder:
+    def __init__(self):
+        self.pso = None
+        self.buffers = {}
+        self.dispatched = False
+        self.ended = False
+
+    def setComputePipelineState_(self, pso):
+        self.pso = pso
+
+    def setBuffer_offset_atIndex_(self, buffer, offset, index):
+        self.buffers[index] = buffer
+
+    def dispatchThreads_threadsPerThreadgroup_(self, grid_size, group_size):
+        self.dispatched = True
+
+    def endEncoding(self):
+        self.ended = True
+
+
+class _CommandBuffer:
+    def __init__(self):
+        self.encoders = []
+        self.committed = False
+        self.waited = False
+
+    def computeCommandEncoder(self):
+        encoder = _Encoder()
+        self.encoders.append(encoder)
+        return encoder
+
+    def commit(self):
+        self.committed = True
+
+    def waitUntilCompleted(self):
+        self.waited = True
+
+
+class _Queue:
+    def __init__(self):
+        self.buffer = None
+
+    def commandBuffer(self):
+        self.buffer = _CommandBuffer()
+        return self.buffer
+
+
+class _PSO:
+    def maxTotalThreadsPerThreadgroup(self):
+        return 64
+
+
+class _Metal:
+    @staticmethod
+    def MTLSizeMake(x, y, z):
+        return (x, y, z)
+
+
+def test_current_output_uses_second_encoder_and_all_ten_kernel_arguments(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "sim_config",
+        SimpleNamespace(dtypes={"float_or_double": np.float32}),
+    )
+    updates = MetalUpdates.__new__(MetalUpdates)
+    updates.dev = _Device()
+    updates.cmdqueue = _Queue()
+    updates.metal = _Metal()
+    updates.pso_store_outputs = _PSO()
+    updates.pso_store_current_outputs = _PSO()
+    updates.nrxcurrent = 2
+    updates.rxcoords_dev = _Buffer()
+    updates.rxs_dev = _Buffer()
+    updates.rxcurrentinfo_dev = _Buffer()
+    updates.rxcurrents_dev = _Buffer()
+
+    fields = {name: _Buffer() for name in ("Ex", "Ey", "Ez", "Hx", "Hy", "Hz")}
+    updates.grid = SimpleNamespace(
+        rxs=(object(),),
+        dx=1e-3,
+        dy=2e-3,
+        dz=3e-3,
+        **{f"{name}_dev": value for name, value in fields.items()},
+    )
+
+    updates.store_outputs(iteration=3)
+
+    command = updates.cmdqueue.buffer
+    assert command.committed and command.waited
+    assert len(command.encoders) == 2
+    current = command.encoders[1]
+    assert current.pso is updates.pso_store_current_outputs
+    assert current.dispatched and current.ended
+    assert set(current.buffers) == set(range(10))
+    assert current.buffers[2] is updates.rxcurrentinfo_dev
+    assert current.buffers[3] is updates.rxcurrents_dev
+    assert current.buffers[7] is fields["Hx"]
+    assert current.buffers[8] is fields["Hy"]
+    assert current.buffers[9] is fields["Hz"]

--- a/tests/updates/test_metal_magnetic_dipole_dispatch.py
+++ b/tests/updates/test_metal_magnetic_dipole_dispatch.py
@@ -112,6 +112,7 @@ def _make_updates(magnetic_dipole_list):
 
     class _Grid:
         magneticdipoles = magnetic_dipole_list
+        magneticfrillsources = []
         dx = dy = dz = 1e-3
         ID_dev = _FakeBuffer(b"id")
         Hx_dev = _FakeBuffer(b"hx")

--- a/tests/updates/test_metal_snapshot_dispatch.py
+++ b/tests/updates/test_metal_snapshot_dispatch.py
@@ -147,6 +147,7 @@ def _make_updates(snapshots, snapsgpu2cpu, monkeypatch):
 
     grid = _Grid()
     grid.snapshots = snapshots
+    grid.magneticfrillsources = []
     grid.Ex_dev = _FakeBuffer()
     grid.Ey_dev = _FakeBuffer()
     grid.Ez_dev = _FakeBuffer()

--- a/tests/updates/test_metal_tgs_clobbering.py
+++ b/tests/updates/test_metal_tgs_clobbering.py
@@ -56,6 +56,7 @@ class _FakeDevice:
 
 class _FakeRx:
     xcoord = ycoord = zcoord = 0
+    outputs = {}
 
 
 class _FakeGrid:


### PR DESCRIPTION
# PR Description

## Summary

This PR:

- adds GPU receiver-current outputs (`Ix`, `Iy`, `Iz`) for CUDA, OpenCL, and Metal;
- supports S11, impedance, and admittance outputs from hard voltage-source ports;
- adds configurable port reference impedance;
- adds KSIR antenna-port associations and multiport support;
- calculates radiated power, directivity, gain, radiation efficiency, and total efficiency;
- stores the new results and validity information in HDF5;
- documents the hash-command and Python interfaces.

## Type of change

- [x] New feature
- [x] This change requires a documentation update

## Testing

- 315 affected regression tests passed.
- 105 combined FDFD/NTFF/port integration tests passed.
- Cython extensions built successfully.
- Sphinx documentation built successfully with only existing warnings.

## Checklist

- [ ] Did pre-commit pass all checks?
- [x] I have performed a self-review of my code.
- [x] I have added comments for hard-to-understand areas.
- [x] I have made corresponding documentation changes.
- [x] My changes generate no new warnings.
- [x] The PR title is a short description of the changes.