### PR TITLE
Fix fine geometry-view boundary edges and restore regression coverage

### DIFF
--- a/gprMax/cython/geometry_outputs.pyx
+++ b/gprMax/cython/geometry_outputs.pyx
@@ -31,6 +31,10 @@ cpdef get_line_properties(
 ):
     """Generate connectivity array and get material ID for each line.
 
+    Each edge direction spans the full point lattice on both perpendicular
+    axes. For example, x-directed edges exist for every j in ``0..ny`` and
+    k in ``0..nz``, including edges on the far boundary planes.
+
     Args:
         number_of_lines: Number of lines.
         nx: Number of points in the x dimension.
@@ -49,7 +53,7 @@ cpdef get_line_properties(
     cdef np.ndarray connectivity = np.zeros(2 * number_of_lines, dtype=np.int32)
     cdef int line_index = 0
     cdef int connectivity_index = 0
-    cdef int point_id = 0
+    cdef int point_id
 
     cdef int z_step = 1
     cdef int y_step = nz + 1
@@ -57,39 +61,38 @@ cpdef get_line_properties(
 
     cdef int i, j, k
 
+    # x-direction cell edges
     for i in range(nx):
-        for j in range(ny):
-            for k in range(nz):
-
-                # x-direction cell edge
+        for j in range(ny + 1):
+            for k in range(nz + 1):
+                point_id = i * x_step + j * y_step + k * z_step
                 material_data[line_index] = ID[0, i, j, k]
                 connectivity[connectivity_index] = point_id
                 connectivity[connectivity_index + 1] = point_id + x_step
                 line_index += 1
                 connectivity_index += 2
 
-                # y-direction cell edge
+    # y-direction cell edges
+    for i in range(nx + 1):
+        for j in range(ny):
+            for k in range(nz + 1):
+                point_id = i * x_step + j * y_step + k * z_step
                 material_data[line_index] = ID[1, i, j, k]
                 connectivity[connectivity_index] = point_id
                 connectivity[connectivity_index + 1] = point_id + y_step
                 line_index += 1
                 connectivity_index += 2
 
-                # z-direction cell edge
+    # z-direction cell edges
+    for i in range(nx + 1):
+        for j in range(ny + 1):
+            for k in range(nz):
+                point_id = i * x_step + j * y_step + k * z_step
                 material_data[line_index] = ID[2, i, j, k]
                 connectivity[connectivity_index] = point_id
                 connectivity[connectivity_index + 1] = point_id + z_step
                 line_index += 1
                 connectivity_index += 2
-
-                # Next point
-                point_id += 1
-
-            # Skip point at (i, j, nz)
-            point_id += 1
-
-        # Skip points in line (i, ny, t) where 0 <= t <= nz
-        point_id += nz + 1
 
     return connectivity, material_data
 

--- a/gprMax/geometry_outputs/geometry_view_lines.py
+++ b/gprMax/geometry_outputs/geometry_view_lines.py
@@ -70,10 +70,12 @@ class GeometryViewLines(GeometryView[GridType]):
             offset = [self.grid.i0, self.grid.j0, self.grid.k0]
             self.points += offset * self.grid.dl * self.grid.ratio
 
-        # Each point is the 'source' for 3 lines.
-        # NB: Excluding points at the far edge of the geometry as those
-        # are the 'source' for no lines
-        n_lines = 3 * np.prod(self.grid_view.size)
+        nx, ny, nz = self.grid_view.size
+        n_lines = (
+            nx * (ny + 1) * (nz + 1)
+            + ny * (nx + 1) * (nz + 1)
+            + nz * (nx + 1) * (ny + 1)
+        )
 
         self.cell_types = np.full(n_lines, VtkCellType.LINE)
         self.cell_offsets = np.arange(0, 2 * n_lines + 2, 2, dtype=np.intc)
@@ -139,10 +141,12 @@ class MPIGeometryViewLines(GeometryViewLines[MPIGrid]):
         self.points += self.grid_view.global_start + self.grid_view.offset
         self.points *= self.grid_view.step * self.grid.dl
 
-        # Each point is the 'source' for 3 lines.
-        # NB: Excluding points at the far edge of the geometry as those
-        # are the 'source' for no lines
-        n_lines = 3 * np.prod(self.grid_view.size)
+        nx, ny, nz = self.grid_view.size
+        n_lines = (
+            nx * (ny + 1) * (nz + 1)
+            + ny * (nx + 1) * (nz + 1)
+            + nz * (nx + 1) * (ny + 1)
+        )
 
         self.cell_types = np.full(n_lines, VtkCellType.LINE)
         self.cell_offsets = np.arange(0, 2 * n_lines + 2, 2, dtype=np.intc)

--- a/gprMax/user_objects/cmds_geometry/fractal_box.py
+++ b/gprMax/user_objects/cmds_geometry/fractal_box.py
@@ -133,7 +133,7 @@ class FractalBox(RotatableMixin, GeometryUserObject):
             raise ValueError(
                 f"{self.__str__()} requires a positive value for the fractal weighting in the z direction"
             )
-        if n_materials < 0:
+        if n_materials <= 0:
             raise ValueError(f"{self.__str__()} requires a positive value for the number of bins")
 
         # Find materials to use to build fractal volume, either from mixing

--- a/tests/cmds_geometry/test_fractal_box_n_materials.py
+++ b/tests/cmds_geometry/test_fractal_box_n_materials.py
@@ -1,0 +1,69 @@
+import pytest
+
+import gprMax
+
+
+def _base_scene():
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(1e-3, 1e-3, 1e-3)))
+    scene.add(gprMax.Domain(p1=(0.05, 0.05, 0.05)))
+    scene.add(gprMax.TimeWindow(time=1e-12))
+    return scene
+
+
+def test_zero_n_materials_rejected(tmp_path):
+    scene = _base_scene()
+    scene.add(
+        gprMax.FractalBox(
+            p1=(0.01, 0.01, 0.01),
+            p2=(0.02, 0.02, 0.02),
+            frac_dim=1.5,
+            weighting=(1, 1, 1),
+            n_materials=0,
+            mixing_model_id="pec",
+            id="fb1",
+        )
+    )
+
+    with pytest.raises(ValueError, match="positive value for the number of bins"):
+        gprMax.run(
+            scenes=[scene],
+            n=1,
+            geometry_only=True,
+            outputfile=tmp_path / "zero_n_materials",
+            hide_progress_bars=True,
+        )
+
+
+def test_positive_n_materials_still_works(tmp_path):
+    scene = _base_scene()
+    scene.add(
+        gprMax.SoilPeplinski(
+            sand_fraction=0.5,
+            clay_fraction=0.5,
+            bulk_density=2.0,
+            sand_density=2.66,
+            water_fraction_lower=0.001,
+            water_fraction_upper=0.25,
+            id="soil1",
+        )
+    )
+    scene.add(
+        gprMax.FractalBox(
+            p1=(0.01, 0.01, 0.01),
+            p2=(0.02, 0.02, 0.02),
+            frac_dim=1.5,
+            weighting=(1, 1, 1),
+            n_materials=2,
+            mixing_model_id="soil1",
+            id="fb1",
+        )
+    )
+
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        geometry_only=True,
+        outputfile=tmp_path / "positive_n_materials",
+        hide_progress_bars=True,
+    )

--- a/tests/outputs/test_geometry_view_fine_boundary_edges.py
+++ b/tests/outputs/test_geometry_view_fine_boundary_edges.py
@@ -1,0 +1,56 @@
+import h5py
+
+import gprMax
+
+
+def test_fine_geometry_view_includes_domain_boundary_edges(tmp_path):
+    dl = 1e-3
+    nx = ny = nz = 2
+
+    scene = gprMax.Scene()
+    scene.add(gprMax.Title(name="fine_view_boundary_edges"))
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(nx * dl, ny * dl, nz * dl)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=1e-12))
+    scene.add(gprMax.Material(er=4, se=0, mr=1, sm=0, id="uniform"))
+    scene.add(
+        gprMax.Box(
+            p1=(0, 0, 0),
+            p2=(nx * dl, ny * dl, nz * dl),
+            material_id="uniform",
+        )
+    )
+
+    outfile = tmp_path / "fine_view"
+    scene.add(
+        gprMax.GeometryView(
+            p1=(0, 0, 0),
+            p2=(nx * dl, ny * dl, nz * dl),
+            dl=(dl, dl, dl),
+            output_type="f",
+            filename=str(outfile),
+        )
+    )
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        geometry_only=True,
+        outputfile=tmp_path / "run",
+        hide_progress_bars=True,
+    )
+
+    expected_n_lines = (
+        nx * (ny + 1) * (nz + 1)
+        + ny * (nx + 1) * (nz + 1)
+        + nz * (nx + 1) * (ny + 1)
+    )
+    assert expected_n_lines == 54
+
+    with h5py.File(str(outfile) + ".vtkhdf") as h:
+        material = h["VTKHDF/CellData/Material"][:]
+        connectivity = h["VTKHDF/Connectivity"][:]
+
+        assert material.shape[0] == expected_n_lines
+        assert connectivity.shape[0] == 2 * expected_n_lines
+        assert (material == material[0]).all()

--- a/tests/outputs/test_snapshot_2d_invariant_axis_averaging.py
+++ b/tests/outputs/test_snapshot_2d_invariant_axis_averaging.py
@@ -1,0 +1,105 @@
+import numpy as np
+import pytest
+
+import gprMax.config as config
+import gprMax.snapshots as snapshots_mod
+from gprMax.cython.snapshots import calculate_snapshot_fields
+
+
+@pytest.mark.parametrize(
+    "mode, expected",
+    [
+        ("3D", (1, 1, 1)),
+        ("2D TMx", (1, 1, 1)),
+        ("2D TMy", (1, 1, 1)),
+        ("2D TMz", (1, 1, 1)),
+        ("2D TEx", (0, 1, 1)),
+        ("2D TEy", (1, 0, 1)),
+        ("2D TEz", (1, 1, 0)),
+    ],
+)
+def test_snapshot_axis_strides(monkeypatch, mode, expected):
+    monkeypatch.setattr(
+        config, "get_model_config", lambda: type("ModelConfig", (), {"mode": mode})()
+    )
+
+    assert snapshots_mod._snapshot_axis_strides() == expected
+
+
+def test_zero_z_stride_avoids_averaging_tez_ex_with_boundary_zero():
+    nx, ny, nz = 2, 2, 1
+    ex = np.arange(3 * 3 * 2, dtype=np.float64).reshape(3, 3, 2)
+    ex_snapshot = np.zeros((nx, ny, nz), dtype=np.float64)
+    unused = np.zeros((1, 1, 1), dtype=np.float64)
+
+    calculate_snapshot_fields(
+        nx,
+        ny,
+        nz,
+        1,
+        True,
+        False,
+        False,
+        False,
+        False,
+        False,
+        ex,
+        unused,
+        unused,
+        unused,
+        unused,
+        unused,
+        ex_snapshot,
+        unused,
+        unused,
+        unused,
+        unused,
+        unused,
+        1,
+        1,
+        0,
+    )
+
+    expected = np.zeros((nx, ny, nz))
+    for i in range(nx):
+        for j in range(ny):
+            expected[i, j, 0] = (ex[i, j, 0] + ex[i, j + 1, 0]) / 2
+
+    assert np.allclose(ex_snapshot, expected)
+
+
+def test_zero_z_stride_preserves_tez_hz_value():
+    nx, ny, nz = 2, 2, 1
+    hz = np.arange(3 * 3 * 2, dtype=np.float64).reshape(3, 3, 2)
+    hz_snapshot = np.zeros((nx, ny, nz), dtype=np.float64)
+    unused = np.zeros((1, 1, 1), dtype=np.float64)
+
+    calculate_snapshot_fields(
+        nx,
+        ny,
+        nz,
+        1,
+        False,
+        False,
+        False,
+        False,
+        False,
+        True,
+        unused,
+        unused,
+        unused,
+        unused,
+        unused,
+        hz,
+        unused,
+        unused,
+        unused,
+        unused,
+        unused,
+        hz_snapshot,
+        1,
+        1,
+        0,
+    )
+
+    assert np.allclose(hz_snapshot, hz[:nx, :ny, :1])


### PR DESCRIPTION
# PR Description

## Summary

This PR recovers two corrections and associated regression coverage that were identified during cleanup of the earlier 2D TE development work.

- Fix fine geometry views so Yee edges on the far boundary planes are included.
- Apply the corrected edge count and connectivity generation to standard and MPI geometry views.
- Reject `FractalBox` configurations with `n_materials=0` at validation time.
- Add regression coverage for fine geometry-view boundary edges, fractal material validation, and 2D TE snapshot averaging.

## Motivation

Fine geometry views previously omitted edges located on the far boundary planes because the line count and connectivity loops only covered the interior cell lattice.

A fractal box with zero materials was also accepted initially and then failed later during geometry construction with an unrelated internal error.

## 🛠️ Related Issue (Number)

No related issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update.

