### PR TITLE
Support NTFF and antenna ports with subgrids

### DIFF
--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -550,8 +550,37 @@ resulting aperture remains sub-cell. For example:
     ))
 
 The corrected formulation is supported by the CPU, CUDA, OpenCL, and Metal
-solvers. It writes its time-domain terminal histories and derived ``S11``,
-``Zin``, and ``Yin`` automatically beneath ``/frills/frillN``. See
+solvers. It is also supported inside a CPU ``SubGridHSG``. Add the waveform,
+PEC ground plane, thin wire, and magnetic frill to the same subgrid object,
+using the same global-coordinate convention as other subgrid sources when
+``autotranslate=True``:
+
+.. code-block:: python
+
+    subgrid.add(gprMax.Waveform(
+        wave_type='ricker', amp=1, freq=5e9, id='fine_feed_wave'
+    ))
+    subgrid.add(gprMax.Plate(
+        p1=(0.08, 0.06, 0.05), p2=(0.10, 0.08, 0.05),
+        material_id='pec',
+    ))
+    subgrid.add(gprMax.ThinWire(
+        p1=(0.09, 0.07, 0.05), p2=(0.09, 0.07, 0.06),
+        radius=0.0001,
+    ))
+    subgrid.add(gprMax.MagneticFrillSource(
+        p1=(0.09, 0.07, 0.05), polarisation='z', zcoax=50,
+        waveform_id='fine_feed_wave',
+    ))
+
+The complete frill stencil and attached wire should remain within the
+subgrid's working region; objects traversing its outer surface produce the
+usual advanced-use warning, while thin-wire or frill placement in its PML is
+rejected. Symmetry boundaries are not supported on a subgrid, so subgrid
+frills cannot use symmetry-plane completion. The source
+writes its time-domain terminal histories and derived ``S11``, ``Zin``, and
+``Yin`` automatically beneath ``/frills/frillN`` on the main grid or
+``/subgrids/<subgrid ID>/frills/frillN`` on a subgrid. See
 :ref:`Simulation Output <output>`.
 
 All local sources refer to the ID of a waveform that has already been added to
@@ -618,7 +647,11 @@ Here ``pulse`` must identify a built-in analytic waveform. Discrete plane waves
 currently use the CPU solver. Homogeneous angle/vector plane waves and layered
 axial plane waves support non-dispersive materials and multi-pole Debye,
 Lorentz, and Drude materials. Their auxiliary dispersive state uses the same
-real or complex precision selected for the main grid.
+real or complex precision selected for the main grid. A discrete plane wave
+must be added to the main scene, not to a subgrid. Its TFSF box may contain a
+complete subgrid; where the two regions overlap, the box must strictly enclose
+the subgrid's HSG outer coupling surface so that the TFSF correction stencil
+remains on the main grid.
 
 Excitation File
 ---------------
@@ -696,6 +729,32 @@ hard source, gprMax obtains terminal current from the surrounding magnetic-
 field loop and accounts explicitly for the half-step phase difference from
 the integer-time voltage during transformation.
 
+An ``RxPort`` may also be placed inside a ``SubGridHSG``. Add the waveform,
+voltage source, and port to the same subgrid object; the port is then sampled
+using that subgrid's finer spatial and temporal discretisation. With
+``autotranslate=True``, the port and source use the same global physical
+coordinate:
+
+.. code-block:: python
+
+    subgrid.add(gprMax.Waveform(
+        wave_type='ricker', amp=1, freq=5e9, id='feed_wave'
+    ))
+    subgrid.add(gprMax.VoltageSource(
+        p1=(0.090, 0.070, 0.060),
+        polarisation='z', resistance=50,
+        waveform_id='feed_wave',
+    ))
+    fine_port = gprMax.RxPort(
+        p1=(0.090, 0.070, 0.060), id='fine_feed'
+    )
+    subgrid.add(fine_port)
+
+The result is stored at
+``/subgrids/<subgrid ID>/ports/<port ID>``. The source and port must belong to
+the same grid object so that their discretised coordinates, material edge,
+``dl``, and ``dt`` are unambiguous.
+
 Source Steps
 ------------
 .. autoclass:: gprMax.user_objects.cmds_singleuse.SrcSteps
@@ -772,6 +831,13 @@ entered positionally in a hash command: ``KSIRSurface.origin``, and
 commands use the default surface centre, save the surface DFT, and associate
 an enclosed plane wave automatically.
 
+KSIR definitions are main-grid objects, but their notional closed integration
+surface may enclose complete HSG subgrids. A surface must not touch or cut an
+HSG outer coupling surface: overlapping regions require the KSIR surface to
+strictly enclose that outer surface. Sources and scatterers inside the subgrid
+then contribute through the normal HSG field exchange. A disjoint subgrid is
+permitted. KSIR surfaces cannot be defined inside a subgrid.
+
 The following example reuses one surface for an exact time-domain point and a
 frequency-domain radiation pattern. Python keyword arguments replace the
 positional optional parameters used by the equivalent hash commands.
@@ -818,6 +884,10 @@ KSIR antenna-port association
 
 The association is needed only for gain and efficiency. It must name every
 physical port, including a zero-amplitude source that acts as a termination.
+Main-grid port IDs are used directly. A subgrid port is qualified by its
+subgrid ID, for example ``fine_grid/feed``, ``fine_grid/tl1``, or
+``fine_grid/frill1``. Its voltage and current spectra are transformed with the
+owning subgrid's finer time step.
 For voltage sources, use the ID of the coincident :class:`RxPort`; automatic
 transmission-line and magnetic-frill IDs are ``tl1``, ... and ``frill1``, ...
 respectively. For example:

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1266,6 +1266,11 @@ ground plane at z = 0 by a 50 Ohm coax is:
     #thin_wire: 0.05 0.05 0 0.05 0.05 0.04 0.0001
     #magnetic_frill_source: z 0.05 0.05 0 50 my_pulse
 
+The hash command creates a main-grid source and remains valid in a model that
+also contains subgrids. To place the frill, its attached thin wire, and its
+ground plane inside a ``SubGridHSG``, use the Python API and add all four
+objects (including the waveform) to the same subgrid object.
+
 .. note::
 
     * This source can be placed at a symmetry-plane corner declared with
@@ -1307,6 +1312,7 @@ For example, to specify a discrete plane wave in a TFSF box (0.010, 0.010, 0.010
 .. note::
 
     * Plane waves support non-dispersive dielectric backgrounds and multi-pole Debye, Lorentz, and Drude media. They do not currently support ``user``-defined waveforms.
+    * The plane-wave command must be defined on the main grid. Its TFSF box may contain a complete subgrid, but must strictly enclose the subgrid's HSG outer coupling surface wherever the two regions overlap.
     * This plane wave implementation was based on an intitial implementation made possible by a `Google Summer of Code <https://summerofcode.withgoogle.com/>`_ (GSoC) project and `more details can be found in the original pull request <https://github.com/gprMax/gprMax/pull/373>`_.
     * Internally, theta and phi are approximated by an integer direction vector (Mx, My, Mz) found to within a maximum acceptable angular difference of 3 arc minutes (0.05 degrees) by default. This tolerance can be relaxed or tightened using the ``max_angle_diff`` parameter (in degrees) when using the Python API.
 
@@ -1331,6 +1337,7 @@ For example, to specify a discrete plane wave in a TFSF box (0.010, 0.010, 0.010
 .. note::
 
     * Plane waves support non-dispersive dielectric backgrounds and multi-pole Debye, Lorentz, and Drude media. They do not currently support ``user``-defined waveforms.
+    * The plane-wave command must be defined on the main grid. Its TFSF box may contain a complete subgrid, but must strictly enclose the subgrid's HSG outer coupling surface wherever the two regions overlap.
     * This plane wave implementation was based on an intitial implementation made possible by a `Google Summer of Code <https://summerofcode.withgoogle.com/>`_ (GSoC) project and `more details can be found in the original pull request <https://github.com/gprMax/gprMax/pull/373>`_.
 
 
@@ -1356,6 +1363,7 @@ For example, to specify a discrete plane wave in a TFSF box (0.010, 0.010, 0.010
 
     * For simulations that do not involve half-space setups it is recommended to use either the ``#plane_wave_angles`` or ``#plane_wave_vector`` commands instead as the formualtions are more efficient and faster if the background medium of propagation for the plane wave is homogeneous.
     * Plane waves support non-dispersive dielectric layers and multi-pole Debye, Lorentz, and Drude layers. They do not currently support ``user``-defined waveforms.
+    * The plane-wave command must be defined on the main grid. Its TFSF box may contain a complete subgrid, but must strictly enclose the subgrid's HSG outer coupling surface wherever the two regions overlap.
     * This plane wave implementation was based on an intitial implementation made possible by a `Google Summer of Code <https://summerofcode.withgoogle.com/>`_ (GSoC) project and `more details can be found in the original pull request <https://github.com/gprMax/gprMax/pull/373>`_.
 
 
@@ -1647,9 +1655,11 @@ The following conventions apply to every KSIR command:
   stencil. The surface must enclose the radiating source or the complete TFSF
   box and scatterer as appropriate;
 * the implementation currently requires a three-dimensional serial model and
-  does not support MPI, subgrids, or geometry-fixed reuse. Both time- and
-  frequency-domain KSIR collection are available with CPU, CUDA, OpenCL, and
-  Metal;
+  does not support MPI or geometry-fixed reuse. KSIR commands are main-grid
+  objects, but their closed surface may contain complete subgrids. A surface
+  that overlaps a subgrid must strictly enclose its HSG outer coupling surface;
+  it cannot touch or cut the coupling region. Both time- and frequency-domain
+  KSIR collection are available with CPU, CUDA, OpenCL, and Metal;
 * CPU collection uses the Cython/OpenMP implementation. Accelerator surface
   state and time-domain output storage remain on the device during FDTD
   iterations and are transferred to the host once, after the solve. CUDA is
@@ -1748,6 +1758,12 @@ Transmission-line and magnetic-frill sources provide automatic port IDs
 creation order. The association is not required for electric or magnetic
 far fields, radiation intensity, RCS, or directivity. It is required when a
 far-field command asks for gain or efficiency.
+
+A port on a subgrid is named as ``subgrid_id/port_id``. For example,
+``fine_grid/feed`` identifies an ``#rx_port`` called ``feed`` on subgrid
+``fine_grid``; automatic source ports use forms such as ``fine_grid/tl1`` and
+``fine_grid/frill1``. Main-grid IDs remain unqualified. Each subgrid port is
+post-processed using its owning grid's finer spatial and temporal steps.
 
 The listed set must include **every** physical voltage, transmission-line,
 and magnetic-frill port in the model. Every voltage source must therefore

--- a/docs/source/output.rst
+++ b/docs/source/output.rst
@@ -265,6 +265,11 @@ every ``#magnetic_frill_source``, exactly as for a transmission line; no
 ``#rx_port`` command or additional receiver is required (the electric field
 component along the polarisation axis is identically zero at the feed point
 by construction, so no field sample is possible there in the first place).
+Main-grid results are stored at ``/frills/frillN``. A Python API frill inside
+a subgrid is stored at ``/subgrids/<subgrid ID>/frills/frillN``; its
+``Position`` is reported in global physical coordinates, while its histories,
+frequency axis, and validity limits use the owning subgrid's finer ``dt`` and
+``dl``.
 With the frill's user-supplied characteristic impedance :math:`Z_0` as the
 reference impedance,
 
@@ -299,10 +304,13 @@ output.
 Voltage-source S11 and impedance output
 ---------------------------------------
 
-The ``#rx_port`` command and ``RxPort`` Python object write one group per port
-at ``/ports/<port ID>``. For a finite-resistance source, its resistance is the
-reference impedance :math:`Z_0`; the source-plane reflection coefficient is
-calculated from the known generator voltage and sampled total gap voltage.
+The ``#rx_port`` command and ``RxPort`` Python object write one group per
+main-grid port at ``/ports/<port ID>``. A port added to a Python API subgrid is
+stored at ``/subgrids/<subgrid ID>/ports/<port ID>`` and uses the owning
+subgrid's spatial step, time step, iteration count, material edge, and field
+histories. For a finite-resistance source, its resistance is the reference
+impedance :math:`Z_0`; the source-plane reflection coefficient is calculated
+from the known generator voltage and sampled total gap voltage.
 For a zero-resistance hard source, :math:`Z_0` is supplied by the voltage
 source (50 Ohms by default) and
 the terminal quantities are calculated from the prescribed voltage and
@@ -329,6 +337,11 @@ Important attributes include:
   ``IndependentFrequencyResolution``;
 * ``phasor_time_sign=exp(+j*omega*t)`` and
   ``forward_transform_sign=exp(-j*omega*t)``.
+
+``Position`` is always expressed in the global physical coordinate frame,
+including for a subgrid port, and therefore matches the associated source's
+``Position`` attribute. ``GridPosition`` is the integer index in the owning
+grid and can include the subgrid's internal boundary padding.
 
 The principal datasets are:
 
@@ -496,6 +509,10 @@ exact complex terminal and incident spectra are retained so that every
 derived power can be checked independently. A zero-amplitude source remains
 a terminated port with zero incident voltage; its terminal voltage/current
 and signed accepted power can still be non-zero through mutual coupling.
+The ``port_ids`` dataset stores main-grid IDs unchanged and qualifies subgrid
+ports as ``<subgrid ID>/<local port ID>``. Although the grouped antenna result
+is written below the main-grid NTFF group, each port spectrum is calculated
+with the spatial step, time step, and trace length of the grid that owns it.
 
 The validity datasets should always be applied before plotting. The default
 gain bandwidth includes frequencies whose total incident spectrum is within
@@ -565,6 +582,10 @@ scattering models, the associated total-field/scattered-field box must be
 strictly enclosed by the KSIR surface. The integration surface then samples
 the scattered-field region outside the TFSF box, while the associated
 numerical plane wave supplies the incident-field normalization used for RCS.
+Sources and scatterers may reside on an HSG subgrid enclosed by these
+main-grid surfaces. Neither a KSIR surface nor a TFSF correction surface may
+touch or cut the HSG outer coupling surface; an overlapping surface must
+strictly enclose the complete subgrid coupling region.
 
 
 .. _outputs-snaps:

--- a/gprMax/fields_outputs.py
+++ b/gprMax/fields_outputs.py
@@ -76,7 +76,9 @@ def write_hdf5_outputfile(outputfile: Path, title: str, model):
         # Write meta data and data for any subgrids
         sg_rxs = [True for sg in model.subgrids if sg.rxs]
         sg_tls = [True for sg in model.subgrids if sg.transmissionlines]
-        if sg_rxs or sg_tls:
+        sg_frills = [True for sg in model.subgrids if sg.magneticfrillsources]
+        sg_ports = [True for sg in model.subgrids if sg.port_monitors]
+        if sg_rxs or sg_tls or sg_frills or sg_ports:
             for sg in model.subgrids:
                 grp = f.create_group(f"/subgrids/{sg.name}")
                 write_hd5_data(grp, sg, is_subgrid=True)

--- a/gprMax/model.py
+++ b/gprMax/model.py
@@ -349,6 +349,14 @@ class Model:
         else:
             self.build_geometry()
 
+        # TFSF corrections are applied on the main grid. A box may contain a
+        # complete subgrid, but it must not cut through the HSG outer coupling
+        # surface where main- and fine-grid fields are exchanged.
+        if self.subgrids and self.G.discreteplanewaves:
+            from gprMax.ntff.interface import validate_tfsf_subgrid_enclosure
+
+            validate_tfsf_subgrid_enclosure(self)
+
         # KSIR definitions are registered while the scene is parsed, but the
         # component surfaces can only be compiled after grid.build() has
         # finalised the Yee material IDs.
@@ -362,22 +370,26 @@ class Model:
             f"Output directory: {config.get_model_config().output_file_path.parent.resolve()}\n"
         )
 
-        self.G.update_sources_and_recievers()
+        grids = [self.G] + self.subgrids
+        for grid in grids:
+            grid.update_sources_and_recievers()
 
         # Magnetic-frill sources bind the attached thin-wire radius, resolve
         # symmetry, validate the PEC ground plane, and precompute their
         # feed-cell recurrence here. This needs final material coefficients
         # and symmetry boundaries, which do not exist during scene parsing.
-        # MPI/subgrid use is rejected by the source builder.
-        for grid in [self.G] + self.subgrids:
+        # MPI use is rejected by the source builder; a frill can belong to a
+        # CPU subgrid and is then prepared against that fine grid.
+        for grid in grids:
             for frill in grid.magneticfrillsources:
                 frill.finalise_setup(grid)
 
         # Voltage-source ports bind their receiver during scene processing,
         # but their effective edge material and update coefficient only exist
         # after grid.build() has completed.
-        for port in getattr(self.G, "port_monitors", ()):
-            port.prepare(self.G)
+        for grid in grids:
+            for port in getattr(grid, "port_monitors", ()):
+                port.prepare(grid)
 
         # Transmission lines already record incident and terminal voltage and
         # current histories. Prepare their automatic S11/impedance outputs
@@ -388,7 +400,7 @@ class Model:
         # not attach cached spectral arrays before that transfer; the
         # coordinator prepares and finalises them after the gather instead.
         if not hasattr(self.G, "comm"):
-            for grid in [self.G] + self.subgrids:
+            for grid in grids:
                 prepare_transmission_line_ports(grid)
                 prepare_magnetic_frill_ports(grid)
 
@@ -397,7 +409,7 @@ class Model:
         if self.G.ntff_monitors:
             from gprMax.ntff.interface import validate_ksir_source_enclosure
 
-            validate_ksir_source_enclosure(self.G)
+            validate_ksir_source_enclosure(self, self.G)
 
         self._output_geometry()
 
@@ -595,8 +607,10 @@ class Model:
         # Device finalisation has already copied receiver histories to the
         # host. Complete derived port spectra before opening the HDF5 file so
         # a calculation error cannot leave a partially written port group.
-        for port in getattr(self.G, "port_monitors", ()):
-            port.finalise(self.G)
+        grids = [self.G] + self.subgrids
+        for grid in grids:
+            for port in getattr(grid, "port_monitors", ()):
+                port.finalise(grid)
 
         from gprMax.ports import finalise_magnetic_frill_ports, finalise_transmission_line_ports
 
@@ -608,6 +622,7 @@ class Model:
         sg_rxs = [True for sg in self.subgrids if sg.rxs]
         sg_tls = [True for sg in self.subgrids if sg.transmissionlines]
         sg_frills = [True for sg in self.subgrids if sg.magneticfrillsources]
+        sg_ports = [True for sg in self.subgrids if sg.port_monitors]
         ntff_outputs = [
             monitor
             for monitor in self.G.ntff_monitors
@@ -621,6 +636,7 @@ class Model:
             or sg_tls
             or self.G.magneticfrillsources
             or sg_frills
+            or sg_ports
             or ntff_outputs
             or self.G.port_monitors
         ):

--- a/gprMax/ntff/device.py
+++ b/gprMax/ntff/device.py
@@ -85,6 +85,7 @@ class _DeviceKSIRCollector:
             configure_ntff_monitors(self.grid)
         self.monitors = list(self.grid.ntff_monitors if monitors is None else monitors)
         self.records: List[_ComponentRecord] = []
+        self.incident_records = []
         limits = np.iinfo(np.int32)
         for monitor in self.monitors:
             if not _is_frequency_monitor(monitor):
@@ -123,6 +124,34 @@ class _DeviceKSIRCollector:
                 )
                 self._allocate(record)
                 self.records.append(record)
+            if getattr(monitor, "associated_plane_wave", None) is not None:
+                plane_wave = monitor.associated_plane_wave
+                if not hasattr(plane_wave, "E_fields_dev"):
+                    raise ValueError(
+                        "device KSIR RCS normalisation requires the associated "
+                        "plane wave to have device-resident electric fields"
+                    )
+                reference_index = int(monitor._incident_reference_index)
+                if reference_index < 0 or reference_index > limits.max:
+                    raise ValueError(
+                        "KSIR incident plane-wave reference index exceeds device " "int32 indexing"
+                    )
+                component_records = []
+                indices = np.asarray([reference_index], dtype=np.int32)
+                for axis, component in enumerate(ELECTRIC_COMPONENTS):
+                    record = _ComponentRecord(
+                        monitor=monitor,
+                        component=component,
+                        npatches=1,
+                        nfrequencies=int(monitor.frequencies.size),
+                        inside_index=indices,
+                        outside_index=indices,
+                        device={},
+                    )
+                    self._allocate(record)
+                    record.device["field"] = plane_wave.E_fields_dev[axis]
+                    component_records.append(record)
+                self.incident_records.append((monitor, component_records))
 
     def _allocate(self, record: _ComponentRecord) -> None:
         raise NotImplementedError
@@ -151,6 +180,10 @@ class _DeviceKSIRCollector:
 
     def observe_electric(self, iteration: int) -> None:
         self._observe(iteration, ELECTRIC_COMPONENTS)
+        for monitor, records in self.incident_records:
+            multiplier = monitor.device_incident_sampling_multiplier(iteration)
+            for record in records:
+                self._accumulate(record, record.device["field"], multiplier)
 
     def observe_magnetic(self, iteration: int) -> None:
         self._observe(iteration, MAGNETIC_COMPONENTS)
@@ -166,6 +199,16 @@ class _DeviceKSIRCollector:
             outside.real = np.asarray(outside_real).reshape(record.shape)
             outside.imag = np.asarray(outside_imag).reshape(record.shape)
             record.monitor.load_device_component_dfts(record.component, inside, outside)
+        for monitor, records in self.incident_records:
+            incident = np.empty(
+                (monitor.frequencies.size, len(ELECTRIC_COMPONENTS)),
+                dtype=monitor.complex_dtype,
+            )
+            for axis, record in enumerate(records):
+                inside_real, inside_imag, _, _ = self._download(record)
+                incident[:, axis].real = np.asarray(inside_real).reshape(record.shape)[:, 0]
+                incident[:, axis].imag = np.asarray(inside_imag).reshape(record.shape)[:, 0]
+            monitor.load_device_incident_electric(incident)
         for monitor in self.monitors:
             monitor.finalise()
 
@@ -197,6 +240,12 @@ class CUDAKSIRCollector(_DeviceKSIRCollector):
         imag = np.asarray(multiplier.imag, dtype=self.real_dtype)
         record.device["multiplier_real"].set(real)
         record.device["multiplier_imag"].set(imag)
+        field_pointer = field.gpudata
+        # A row view into the 2-D auxiliary plane-wave array exposes its
+        # offset pointer as an integer. Passing the GPUArray view lets PyCUDA
+        # obtain the correctly offset pointer from its CUDA array interface.
+        if isinstance(field_pointer, (int, np.integer)):
+            field_pointer = field
         self.kernel(
             np.int32(record.total),
             np.int32(record.npatches),
@@ -204,7 +253,7 @@ class CUDAKSIRCollector(_DeviceKSIRCollector):
             record.device["outside_index"].gpudata,
             record.device["multiplier_real"].gpudata,
             record.device["multiplier_imag"].gpudata,
-            field.gpudata,
+            field_pointer,
             record.device["inside_real"].gpudata,
             record.device["inside_imag"].gpudata,
             record.device["outside_real"].gpudata,

--- a/gprMax/ntff/frequency_domain.py
+++ b/gprMax/ntff/frequency_domain.py
@@ -873,16 +873,32 @@ class KSIRFrequencyDomainMonitor:
 
         if self.associated_plane_wave is None:
             return
+        multiplier = self.device_incident_sampling_multiplier(iteration)
+        incident = self.associated_plane_wave.E_fields[
+            :, self._incident_reference_index
+        ]
+        self._incident_electric += multiplier[:, np.newaxis] * incident[np.newaxis, :]
+
+    def device_incident_sampling_multiplier(
+        self, iteration: int
+    ) -> npt.NDArray[np.complexfloating]:
+        """Advance and return the incident-plane-wave DFT multiplier.
+
+        Device collectors use this independently of the surface-component
+        accumulators so the auxiliary one-dimensional plane wave remains on
+        the accelerator throughout timestepping.
+        """
+
+        if self.associated_plane_wave is None:
+            raise RuntimeError(
+                f"KSIR monitor {self.name!r} has no associated incident plane wave"
+            )
         if iteration != self._incident_next_iteration:
             raise ValueError(
                 f"expected incident iteration {self._incident_next_iteration}, "
                 f"received {iteration}"
             )
-        incident = self.associated_plane_wave.E_fields[
-            :, self._incident_reference_index
-        ]
         multiplier = self.dt * self.window_values[iteration] * self._incident_phase
-        self._incident_electric += multiplier[:, np.newaxis] * incident[np.newaxis, :]
         self._incident_next_iteration += 1
         if self._incident_next_iteration % DFT_PHASE_REANCHOR_INTERVAL == 0:
             physical_time = self._incident_next_iteration * self.dt
@@ -891,6 +907,22 @@ class KSIRFrequencyDomainMonitor:
             )
         else:
             self._incident_phase *= self._incident_step
+        return multiplier
+
+    def load_device_incident_electric(self, values: npt.ArrayLike) -> None:
+        """Load an incident electric-field DFT downloaded at finalisation."""
+
+        if self.associated_plane_wave is None or self._incident_electric is None:
+            raise RuntimeError(
+                f"KSIR monitor {self.name!r} has no associated incident plane wave"
+            )
+        incident = np.asarray(values, dtype=self.complex_dtype)
+        if incident.shape != self._incident_electric.shape:
+            raise ValueError(
+                f"incident electric DFT has shape {incident.shape}, expected "
+                f"{self._incident_electric.shape}"
+            )
+        self._incident_electric[...] = incident
 
     def observe_magnetic(
         self,

--- a/gprMax/ntff/interface.py
+++ b/gprMax/ntff/interface.py
@@ -52,7 +52,7 @@ from gprMax.ntff.frequency_domain import (
 )
 from gprMax.ntff.surfaces import COMPONENT_OFFSETS, COMPONENTS, build_component_surface
 from gprMax.ntff.time_domain import KSIRTimeDomainMonitor
-from gprMax.ports import evaluate_port_power_spectrum, port_output_registry
+from gprMax.ports import evaluate_port_power_spectrum, model_port_ids, model_port_output_registry
 
 logger = logging.getLogger(__name__)
 
@@ -260,9 +260,7 @@ def _refine_radiation_maximum(
     )
     local_directivity = local_directivity[:, 0]
     local_directivity_dbi = local_directivity_dbi[:, 0]
-    update = np.isfinite(local_directivity) & (
-        local_directivity > metrics.maximum_directivity
-    )
+    update = np.isfinite(local_directivity) & (local_directivity > metrics.maximum_directivity)
     if not np.any(update):
         return metrics
 
@@ -478,7 +476,68 @@ def _completed_logical_bounds(surface, closure):
     return _completed_bounds(lower, upper, closure)
 
 
-def validate_ksir_source_enclosure(grid) -> None:
+def _subgrid_outer_bounds(subgrid, main_grid, *, physical=False):
+    """Return the HSG outer-surface bounds in the main-grid frame."""
+
+    lower = np.asarray((subgrid.i0, subgrid.j0, subgrid.k0), dtype=np.float64)
+    upper = np.asarray((subgrid.i1, subgrid.j1, subgrid.k1), dtype=np.float64)
+    lower -= subgrid.is_os_sep
+    upper += subgrid.is_os_sep
+    if physical:
+        spacing = np.asarray(main_grid.dl, dtype=np.float64)
+        lower *= spacing
+        upper *= spacing
+    return lower, upper
+
+
+def _boxes_overlap(lower_a, upper_a, lower_b, upper_b):
+    """Return whether two closed axis-aligned boxes touch or overlap."""
+
+    return bool(np.all(lower_a <= upper_b) and np.all(upper_a >= lower_b))
+
+
+def validate_tfsf_subgrid_enclosure(model) -> None:
+    """Prevent a main-grid TFSF correction surface cutting an HSG region.
+
+    A subgrid may be wholly inside or wholly outside a TFSF box. If their
+    extents touch or overlap, the TFSF box must strictly enclose the HSG
+    outer surface, leaving its correction stencil on the main grid.
+    """
+
+    for index, plane_wave in enumerate(getattr(model.G, "discreteplanewaves", ())):
+        corners = np.asarray(plane_wave.corners, dtype=np.float64)
+        box_lower, box_upper = corners[:3], corners[3:]
+        for subgrid in model.subgrids:
+            outer_lower, outer_upper = _subgrid_outer_bounds(subgrid, model.G)
+            if not _boxes_overlap(box_lower, box_upper, outer_lower, outer_upper):
+                continue
+            if not (np.all(box_lower < outer_lower) and np.all(box_upper > outer_upper)):
+                raise ValueError(
+                    f"DiscretePlaneWave[{index}] TFSF box must strictly enclose "
+                    f"the complete outer coupling surface of subgrid {subgrid.name!r}, "
+                    "or be disjoint from it."
+                )
+
+
+def _validate_ksir_subgrid_enclosure(model, compiled_surfaces) -> None:
+    """Prevent a main-grid KSIR surface cutting an HSG coupling region."""
+
+    for surface_id, compiled in compiled_surfaces.items():
+        sample_surface = next(iter(compiled.surfaces.values()))
+        lower, upper = _completed_logical_bounds(sample_surface, compiled.closure)
+        for subgrid in model.subgrids:
+            outer_lower, outer_upper = _subgrid_outer_bounds(subgrid, model.G, physical=True)
+            if not _boxes_overlap(lower, upper, outer_lower, outer_upper):
+                continue
+            if not (np.all(lower < outer_lower) and np.all(upper > outer_upper)):
+                raise ValueError(
+                    f"KSIR surface {surface_id!r} must strictly enclose the "
+                    f"complete outer coupling surface of subgrid {subgrid.name!r}, "
+                    "or be disjoint from it."
+                )
+
+
+def validate_ksir_source_enclosure(model, grid) -> None:
     """Require every active KSIR monitor to enclose impressed sources.
 
     This is called after ``#src_steps`` has moved simple sources for the
@@ -503,30 +562,41 @@ def validate_ksir_source_enclosure(grid) -> None:
         closure = monitor.closure
         lower, upper = _completed_logical_bounds(surface, closure)
         offenders = []
-        for collection_name, field_prefix in source_groups:
-            for source in getattr(grid, collection_name, ()):
-                component = f"{field_prefix}{source.polarisation}"
-                position = (
-                    np.asarray(source.coord, dtype=np.float64)
-                    + np.asarray(COMPONENT_OFFSETS[component], dtype=np.float64)
-                ) * np.asarray(grid.dl, dtype=np.float64)
-                if not np.all((position > lower) & (position < upper)):
-                    source_id = getattr(source, "ID", source.__class__.__name__)
-                    offenders.append(
-                        f"{source.__class__.__name__} {source_id!r} at "
-                        f"({position[0]:g}, {position[1]:g}, {position[2]:g}) m"
+        for source_grid in (model.G, *model.subgrids):
+            grid_name = "main grid" if source_grid is model.G else f"subgrid {source_grid.name!r}"
+            for collection_name, field_prefix in source_groups:
+                for source in getattr(source_grid, collection_name, ()):
+                    component = f"{field_prefix}{source.polarisation}"
+                    local_position = np.asarray(source.coord, dtype=np.float64) + np.asarray(
+                        COMPONENT_OFFSETS[component], dtype=np.float64
                     )
+                    if source_grid is model.G:
+                        position = local_position * np.asarray(source_grid.dl, dtype=np.float64)
+                    else:
+                        position = np.asarray(
+                            source_grid.local_to_global(local_position), dtype=np.float64
+                        )
+                    if not np.all((position > lower) & (position < upper)):
+                        source_id = getattr(source, "ID", source.__class__.__name__)
+                        offenders.append(
+                            f"{source.__class__.__name__} {source_id!r} on {grid_name} at "
+                            f"({position[0]:g}, {position[1]:g}, {position[2]:g}) m"
+                        )
 
-        spacing = np.asarray(grid.dl, dtype=np.float64)
-        for index, plane_wave in enumerate(getattr(grid, "discreteplanewaves", ())):
-            corners = np.asarray(plane_wave.corners, dtype=np.float64)
-            box_lower = corners[:3] * spacing
-            box_upper = corners[3:] * spacing
-            if not (np.all(lower < box_lower) and np.all(upper > box_upper)):
-                offenders.append(
-                    f"DiscretePlaneWave[{index}] TFSF box from "
-                    f"{tuple(box_lower)} m to {tuple(box_upper)} m"
-                )
+            spacing = np.asarray(source_grid.dl, dtype=np.float64)
+            for index, plane_wave in enumerate(getattr(source_grid, "discreteplanewaves", ())):
+                corners = np.asarray(plane_wave.corners, dtype=np.float64)
+                if source_grid is model.G:
+                    box_lower = corners[:3] * spacing
+                    box_upper = corners[3:] * spacing
+                else:
+                    box_lower = source_grid.local_to_global(corners[:3])
+                    box_upper = source_grid.local_to_global(corners[3:])
+                if not (np.all(lower < box_lower) and np.all(upper > box_upper)):
+                    offenders.append(
+                        f"DiscretePlaneWave[{index}] on {grid_name} TFSF box from "
+                        f"{tuple(box_lower)} m to {tuple(box_upper)} m"
+                    )
 
         if offenders:
             details = "; ".join(offenders)
@@ -585,6 +655,7 @@ class KSIRCompiledOutputs:
 
     def __init__(
         self,
+        model,
         grid,
         surfaces,
         transforms,
@@ -593,6 +664,7 @@ class KSIRCompiledOutputs:
         far_requests,
         antenna_port_specs,
     ):
+        self.model = model
         self.grid = grid
         self.surfaces = surfaces
         self.transforms = transforms
@@ -748,16 +820,20 @@ class KSIRCompiledOutputs:
             raise RuntimeError(f"KSIR transform {transform_id!r} has no antenna-port association")
         spec = self.antenna_port_specs[transform_id]
         monitor = self.frequency_monitors[transform_id]
-        registry = port_output_registry(self.grid)
-        spectra = [
-            evaluate_port_power_spectrum(
-                registry[port_id],
-                self.grid,
+        registry = model_port_output_registry(self.model)
+        missing = set(spec.port_ids) - set(registry)
+        if missing:
+            raise RuntimeError(f"KSIR antenna ports were not finalised: {sorted(missing)}")
+        spectra = []
+        for port_id in spec.port_ids:
+            binding = registry[port_id]
+            spectrum = evaluate_port_power_spectrum(
+                binding.output,
+                binding.grid,
                 monitor.frequencies,
                 window=self.transforms[transform_id].window,
             )
-            for port_id in spec.port_ids
-        ]
+            spectra.append(replace(spectrum, port_id=port_id))
         incident_voltage_per_port = np.stack([item.incident_voltage for item in spectra])
         terminal_voltage_per_port = np.stack([item.terminal_voltage for item in spectra])
         terminal_current_per_port = np.stack([item.terminal_current for item in spectra])
@@ -1311,6 +1387,15 @@ def compile_ksir_outputs(model, grid) -> Optional[KSIRCompiledOutputs]:
         for request in far_requests
         if any(output in PORT_METRICS for output in request.outputs)
     }
+    available_port_ids = model_port_ids(model) if antenna_port_specs else ()
+    for transform_id, antenna_spec in antenna_port_specs.items():
+        unknown = set(antenna_spec.port_ids) - set(available_port_ids)
+        if unknown:
+            raise ValueError(
+                f"KSIR antenna-port group for transform {transform_id!r} refers "
+                f"to unknown port IDs {sorted(unknown)}; available ports are "
+                f"{list(available_port_ids)}"
+            )
     for transform_id in gain_transforms:
         if transform_id not in antenna_port_specs:
             raise ValueError(
@@ -1324,13 +1409,7 @@ def compile_ksir_outputs(model, grid) -> Optional[KSIRCompiledOutputs]:
                 f"{transform.window!r}; antenna gain currently requires rectangular"
             )
 
-        expected_ids = [monitor.output_id for monitor in grid.port_monitors]
-        expected_ids.extend(f"tl{index}" for index, _ in enumerate(grid.transmissionlines, start=1))
-        expected_ids.extend(
-            f"frill{index}" for index, _ in enumerate(grid.magneticfrillsources, start=1)
-        )
-        if len(set(expected_ids)) != len(expected_ids):
-            raise ValueError("antenna port IDs are ambiguous across source types")
+        expected_ids = available_port_ids
         requested_ids = set(antenna_port_specs[transform_id].port_ids)
         missing = set(expected_ids) - requested_ids
         if missing:
@@ -1338,11 +1417,19 @@ def compile_ksir_outputs(model, grid) -> Optional[KSIRCompiledOutputs]:
                 f"KSIR antenna-port group for transform {transform_id!r} must "
                 f"include every physical port; missing {sorted(missing)}"
             )
-        monitored_voltage_sources = {
-            monitor.source for monitor in getattr(grid, "port_monitors", ())
-        }
+        monitored_voltage_sources = set()
+        voltage_sources = []
+        nonport_sources = []
+        for source_grid in (model.G, *model.subgrids):
+            monitored_voltage_sources.update(
+                monitor.source for monitor in getattr(source_grid, "port_monitors", ())
+            )
+            voltage_sources.extend(getattr(source_grid, "voltagesources", ()))
+            nonport_sources.extend(getattr(source_grid, "hertziandipoles", ()))
+            nonport_sources.extend(getattr(source_grid, "magneticdipoles", ()))
+            nonport_sources.extend(getattr(source_grid, "discreteplanewaves", ()))
         unmonitored_voltage_sources = [
-            source for source in grid.voltagesources if source not in monitored_voltage_sources
+            source for source in voltage_sources if source not in monitored_voltage_sources
         ]
         if unmonitored_voltage_sources:
             raise ValueError(
@@ -1357,8 +1444,6 @@ def compile_ksir_outputs(model, grid) -> Optional[KSIRCompiledOutputs]:
                     return True
             return False
 
-        nonport_sources = list(grid.hertziandipoles) + list(grid.magneticdipoles)
-        nonport_sources.extend(getattr(grid, "discreteplanewaves", ()))
         active_nonport = [source for source in nonport_sources if source_is_active(source)]
         if active_nonport:
             raise ValueError(
@@ -1401,7 +1486,10 @@ def compile_ksir_outputs(model, grid) -> Optional[KSIRCompiledOutputs]:
             pml_limits=limits,
         )
 
+    _validate_ksir_subgrid_enclosure(model, compiled_surfaces)
+
     writer = KSIRCompiledOutputs(
+        model,
         grid,
         compiled_surfaces,
         transform_specs,

--- a/gprMax/ports.py
+++ b/gprMax/ports.py
@@ -42,6 +42,7 @@ from gprMax.ntff.conventions import (
 
 if TYPE_CHECKING:
     from gprMax.grid.fdtd_grid import FDTDGrid
+    from gprMax.model import Model
     from gprMax.receivers import Rx
     from gprMax.sources import MagneticFrillSource, TransmissionLine, VoltageSource
 
@@ -75,6 +76,14 @@ class PortPowerSpectrum:
     accepted_power: npt.NDArray[np.floating]
     mesh_valid: npt.NDArray[np.bool_]
     terminal_valid: npt.NDArray[np.bool_]
+
+
+@dataclass(frozen=True)
+class PortOutputBinding:
+    """A finalised port output together with the grid that sampled it."""
+
+    output: object
+    grid: "FDTDGrid"
 
 
 def _port_mesh_valid(output, grid, frequencies):
@@ -316,6 +325,49 @@ def port_output_registry(grid: "FDTDGrid") -> dict[str, object]:
         if output.output_id in registry:
             raise ValueError(f"antenna port ID {output.output_id!r} is ambiguous")
         registry[output.output_id] = output
+    return registry
+
+
+def model_port_ids(model: "Model") -> tuple[str, ...]:
+    """Return physical port references across the main grid and subgrids.
+
+    Main-grid IDs retain their public spelling. Subgrid IDs are qualified as
+    ``<subgrid ID>/<local port ID>`` so per-grid automatic IDs such as ``tl1``
+    and ``frill1`` remain unambiguous.
+    """
+
+    references = []
+    for grid in (model.G, *model.subgrids):
+        local_ids = [monitor.output_id for monitor in getattr(grid, "port_monitors", ())]
+        local_ids.extend(
+            f"tl{index}"
+            for index, _ in enumerate(getattr(grid, "transmissionlines", ()), start=1)
+        )
+        local_ids.extend(
+            f"frill{index}"
+            for index, _ in enumerate(getattr(grid, "magneticfrillsources", ()), start=1)
+        )
+        if len(set(local_ids)) != len(local_ids):
+            location = "main grid" if grid is model.G else f"subgrid {grid.name!r}"
+            raise ValueError(f"antenna port IDs are ambiguous on the {location}")
+        prefix = "" if grid is model.G else f"{grid.name}/"
+        references.extend(f"{prefix}{port_id}" for port_id in local_ids)
+    if len(set(references)) != len(references):
+        raise ValueError("antenna port references are ambiguous across model grids")
+    return tuple(references)
+
+
+def model_port_output_registry(model: "Model") -> dict[str, PortOutputBinding]:
+    """Return finalised, grid-aware port outputs for an entire model."""
+
+    registry = {}
+    for grid in (model.G, *model.subgrids):
+        prefix = "" if grid is model.G else f"{grid.name}/"
+        for local_id, output in port_output_registry(grid).items():
+            port_id = f"{prefix}{local_id}"
+            if port_id in registry:
+                raise ValueError(f"antenna port reference {port_id!r} is ambiguous")
+            registry[port_id] = PortOutputBinding(output=output, grid=grid)
     return registry
 
 
@@ -1030,7 +1082,7 @@ class VoltageSourcePortMonitor:
         complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
 
         group.attrs["Name"] = self.output_id
-        group.attrs["Position"] = np.asarray(self.source.coord * self.grid_dl, dtype=real_dtype)
+        group.attrs["Position"] = np.asarray(self.source_position, dtype=real_dtype)
         group.attrs["GridPosition"] = np.asarray(self.source.coord, dtype=np.int32)
         group.attrs["SourceType"] = type(self.source).__name__
         group.attrs["PortMode"] = (
@@ -1120,6 +1172,14 @@ class VoltageSourcePortMonitor:
         """Cache immutable HDF5 context after the grid is fully built."""
 
         self.grid_dl = np.asarray((grid.dx, grid.dy, grid.dz), dtype=np.float64)
+        if hasattr(grid, "local_to_global"):
+            self.source_position = np.asarray(
+                grid.local_to_global(self.source.coord), dtype=np.float64
+            )
+        else:
+            self.source_position = np.asarray(
+                self.source.coord * self.grid_dl, dtype=np.float64
+            )
         self.dt = float(grid.dt)
         self.source_index = grid.voltagesources.index(self.source) + 1
 

--- a/gprMax/updates/cuda_updates.py
+++ b/gprMax/updates/cuda_updates.py
@@ -1491,14 +1491,6 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 # Standard face corrections
                 self._launch_std_H_face_kernels(dpw)
 
-                if iteration == 500:
-                    hf = dpw.H_fields_dev.get()
-                    print("GPU 1D H_fields max per row:", abs(hf).max(axis=1))
-                    ef = dpw.E_fields_dev.get()
-                    print("GPU 1D E_fields max per row:", abs(ef).max(axis=1))
-                    print("Projections:", dpw.projections)
-                    print("waveformvalues_halfdt[500] max:", abs(dpw.waveformvalues_halfdt[500]).max())
-
             else:
                 # Axial magnetic 1D update (3 sequential launches)
 
@@ -1647,14 +1639,6 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                 # Axial face corrections
                 self._launch_axial_H_face_kernels(dpw)
-
-                if iteration == 500:
-                    hf = dpw.H_fields_s_dev.get()
-                    print("GPU 1D H_fields_s max per row:", abs(hf).max(axis=1))
-                    ef = dpw.E_fields_s_dev.get()
-                    print("GPU 1D E_fields_s max per row:", abs(ef).max(axis=1))
-                    print("Projections:", dpw.projections)
-                    print("waveformvalues_halfdt[500] max:", abs(dpw.waveformvalues_halfdt[500]).max())
 
     def update_plane_waves_electric(self, iteration):
         """Updates 1D DPW auxiliary grid E fields and applies TF/SF

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -1089,7 +1089,8 @@ class MagneticFrillSource(RotatableMixin, GridUserObject):
         coaxial line. Complements #transmission_line: a different,
         well-established formulation (not a variant of the two-wire line -
         no 1D line, no ABC, no magic timestep). The corrected Hyun feed-cell
-        formulation is supported by the CPU, CUDA, OpenCL, and Metal solvers.
+        formulation is supported by the CPU, CUDA, OpenCL, and Metal solvers,
+        and by the CPU subgrid updater.
 
     Attributes:
         polarisation: string required for polarisation of the source - x, y,
@@ -1165,14 +1166,12 @@ class MagneticFrillSource(RotatableMixin, GridUserObject):
             self._log(grid, frill_source, *position)
 
     def _validate_parameters(self, grid: FDTDGrid):
-        # MPI and subgrids rejected outright, more strictly than
-        # #transmission_line: a symmetry-plane-adjacent feed point's
-        # build-time resolution has no meaning split across an MPI domain
-        # boundary or a subgrid's own local indexing.
+        # MPI is rejected because a feed stencil cannot be split across rank
+        # boundaries. A subgrid is safe: the frill, attached thin wire,
+        # material rows, field stencil, and time histories all belong to the
+        # same fine grid and are advanced by its CPU updater.
         if config.sim_config.mpi:
             raise ValueError(f"{self.params_str()} does not support MPI.")
-        if isinstance(grid, SubGridBaseGrid) or config.sim_config.general["subgrid"]:
-            raise ValueError(f"{self.params_str()} does not support subgrids.")
 
         # 2D mode rejected outright - the feed point's four surrounding H
         # components have no meaningful reduction to a 2D TM/TE invariant-
@@ -1273,6 +1272,12 @@ def _dpw_tfsf_corners(uip, p1, p2, params_str):
     Returns:
         start, stop: discretised corner index arrays.
     """
+    if isinstance(uip.grid, SubGridBaseGrid):
+        raise ValueError(
+            f"{params_str} must be defined on the main grid; its TFSF box "
+            "may strictly enclose complete subgrids."
+        )
+
     mode = config.get_model_config().mode
     is_2d = mode.startswith("2D")
     if is_2d:

--- a/gprMax/user_objects/cmds_output.py
+++ b/gprMax/user_objects/cmds_output.py
@@ -122,8 +122,6 @@ class RxPort(OutputUserObject):
         raise RuntimeError("RxPort result is not available until the model has solved")
 
     def _validate_context(self, grid):
-        if isinstance(grid, SubGridBaseGrid) or config.sim_config.general["subgrid"]:
-            raise ValueError(f"{self.params_str()} does not support subgrids.")
         if config.sim_config.mpi:
             raise ValueError(f"{self.params_str()} does not yet support MPI.")
         if config.sim_config.args.geometry_fixed:
@@ -196,9 +194,7 @@ class RxPort(OutputUserObject):
         receiver.coord = np.asarray(coord, dtype=np.int32).copy()
         receiver.coordorigin = receiver.coord.copy()
         real_dtype = config.sim_config.dtypes["float_or_double"]
-        receiver.outputs[f"E{source.polarisation}"] = np.zeros(
-            grid.iterations, dtype=real_dtype
-        )
+        receiver.outputs[f"E{source.polarisation}"] = np.zeros(grid.iterations, dtype=real_dtype)
         receiver.internal = True
         receiver.source_bound = True
         receiver.port_id = output_id
@@ -500,8 +496,11 @@ class Snapshot(OutputUserObject):
 
 
 def _check_ksir_interface_context(user_object, grid):
-    if isinstance(grid, SubGridBaseGrid) or config.sim_config.general["subgrid"]:
-        raise ValueError(f"{user_object.params_str()} does not support subgrids.")
+    if isinstance(grid, SubGridBaseGrid):
+        raise ValueError(
+            f"{user_object.params_str()} must be defined on the main grid; "
+            "its closed surface may enclose complete subgrids."
+        )
     if config.sim_config.mpi:
         raise ValueError(f"{user_object.params_str()} does not yet support MPI.")
     if config.sim_config.general["solver"] not in ("cpu", "cuda", "opencl", "metal"):
@@ -1163,7 +1162,8 @@ class KSIRAntennaPorts(OutputUserObject):
         port_ids: IDs of every physical antenna port. Voltage-source IDs come
             from coincident :class:`RxPort` objects. Transmission-line and
             magnetic-frill sources use their automatic ``tlN`` and ``frillN``
-            IDs.
+            IDs. A port on a subgrid is referenced as
+            ``<subgrid ID>/<local port ID>``.
 
     The complete set is required for an unambiguous coherent accepted-power
     balance. A source with zero waveform amplitude is still a terminated port
@@ -1194,7 +1194,17 @@ class KSIRAntennaPorts(OutputUserObject):
         if not self.port_ids:
             raise ValueError(f"{self.params_str()} requires at least one port ID")
         for port_id in self.port_ids:
-            validate_identifier("antenna port ID", port_id)
+            if not isinstance(port_id, str):
+                validate_identifier("antenna port reference component", port_id)
+                continue
+            parts = port_id.split("/")
+            if len(parts) not in (1, 2):
+                raise ValueError(
+                    "antenna port reference must be a main-grid port ID or "
+                    "'<subgrid ID>/<local port ID>'"
+                )
+            for part in parts:
+                validate_identifier("antenna port reference component", part)
         if len(set(self.port_ids)) != len(self.port_ids):
             raise ValueError(f"{self.params_str()} port IDs must not contain duplicates")
         if self.transform_id in grid.ksir_antenna_port_specs:
@@ -1202,19 +1212,9 @@ class KSIRAntennaPorts(OutputUserObject):
                 f"KSIR transform {self.transform_id!r} already has an antenna-port group"
             )
 
-        available = [monitor.output_id for monitor in grid.port_monitors]
-        available.extend(f"tl{index}" for index, _ in enumerate(grid.transmissionlines, start=1))
-        available.extend(
-            f"frill{index}" for index, _ in enumerate(grid.magneticfrillsources, start=1)
-        )
-        if len(set(available)) != len(available):
-            raise ValueError("antenna port IDs are ambiguous across source types")
-        unknown = set(self.port_ids) - set(available)
-        if unknown:
-            raise ValueError(
-                f"{self.params_str()} refers to unknown port IDs {sorted(unknown)}; "
-                f"available ports are {available}"
-            )
+        # Subgrid objects are built after main-grid output commands. Resolve
+        # and validate the complete cross-grid namespace during KSIR
+        # compilation, after every subgrid child has been registered.
         grid.ksir_antenna_port_specs[self.transform_id] = KSIRAntennaPortsSpec(
             self.transform_id,
             self.port_ids,

--- a/tests/cmds_multiuse/test_magnetic_frill_source.py
+++ b/tests/cmds_multiuse/test_magnetic_frill_source.py
@@ -63,10 +63,9 @@ def test_rejected_with_mpi(monkeypatch):
         _frill()._validate_parameters(_fake_grid())
 
 
-def test_rejected_with_subgrid(monkeypatch):
+def test_main_grid_frill_is_accepted_when_model_contains_subgrid(monkeypatch):
     _set_solver(monkeypatch, "cpu", subgrid=True)
-    with pytest.raises(ValueError, match="subgrid"):
-        _frill()._validate_parameters(_fake_grid())
+    _frill()._validate_parameters(_fake_grid())
 
 
 def test_rejected_in_2d_mode(monkeypatch):

--- a/tests/ntff/test_cuda_reusable_interface.py
+++ b/tests/ntff/test_cuda_reusable_interface.py
@@ -101,6 +101,50 @@ def _antenna_scene():
     return scene, far_field
 
 
+def _plane_wave_rcs_scene():
+    dl = 0.004
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(0.08, 0.08, 0.08)))
+    scene.add(gprMax.TimeWindow(time=4e-10))
+    scene.add(gprMax.PMLThickness(thickness=3))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
+    scene.add(
+        gprMax.DiscretePlaneWaveAxial(
+            p1=(0.028, 0.028, 0.028),
+            p2=(0.052, 0.052, 0.052),
+            axis="x",
+            psi=90,
+            waveform_id="pulse",
+        )
+    )
+    scene.add(
+        gprMax.KSIRSurface(
+            p1=(0.02, 0.02, 0.02),
+            p2=(0.06, 0.06, 0.06),
+            id="surface",
+            origin=(0.04, 0.04, 0.04),
+        )
+    )
+    transform = gprMax.KSIRFrequencyTransform(
+        "surface",
+        "spectrum",
+        (5e9,),
+        save_surface_dft=False,
+        plane_wave_index=0,
+    )
+    far_field = gprMax.KSIRFarField(
+        (90,),
+        (180,),
+        "spectrum",
+        id="backscatter",
+        outputs=("rcs",),
+    )
+    scene.add(transform)
+    scene.add(far_field)
+    return scene, transform, far_field
+
+
 @pytest.mark.skipif(not HAS_CUDA, reason="No CUDA device/pycuda available")
 @pytest.mark.parametrize(
     "precision,real_dtype,complex_dtype,rtol",
@@ -225,3 +269,50 @@ def test_cuda_antenna_metrics_match_cpu(tmp_path):
         group = output["ntff/surface/frequency/spectrum/far_field/far"]
         assert group["port_power/port_ids"].asstr()[...].tolist() == ["feed"]
         assert group["port_power/gain_valid"][0] == 1
+
+
+@pytest.mark.skipif(not HAS_CUDA, reason="No CUDA device/pycuda available")
+@pytest.mark.parametrize(
+    "precision,complex_dtype,rtol",
+    [
+        ("single", np.dtype("complex64"), 2e-4),
+        ("double", np.dtype("complex128"), 2e-10),
+    ],
+)
+def test_cuda_plane_wave_rcs_incident_reference_matches_cpu(
+    tmp_path, precision, complex_dtype, rtol
+):
+    cpu_scene, cpu_transform, _ = _plane_wave_rcs_scene()
+    cuda_scene, cuda_transform, cuda_far = _plane_wave_rcs_scene()
+    gprMax.run(
+        scenes=[cpu_scene],
+        n=1,
+        outputfile=tmp_path / f"cpu_plane_wave_rcs_{precision}",
+        hide_progress_bars=True,
+        cpu_precision=precision,
+    )
+    gprMax.run(
+        scenes=[cuda_scene],
+        n=1,
+        outputfile=tmp_path / f"cuda_plane_wave_rcs_{precision}",
+        hide_progress_bars=True,
+        gpu=[0],
+        gpu_precision=precision,
+    )
+
+    cpu_monitor = cpu_transform._compiled_outputs.transform_monitor(cpu_transform.ID)
+    cuda_monitor = cuda_transform._compiled_outputs.transform_monitor(cuda_transform.ID)
+    assert cuda_monitor.result.incident_electric.dtype == complex_dtype
+    assert_allclose(
+        cuda_monitor.result.incident_electric,
+        cpu_monitor.result.incident_electric,
+        rtol=rtol,
+        atol=rtol * np.max(np.abs(cpu_monitor.result.incident_electric)),
+    )
+    assert np.all(np.isfinite(cuda_far.result.fields["rcs"]))
+
+    with h5py.File(tmp_path / f"cuda_plane_wave_rcs_{precision}.h5", "r") as output:
+        transform = output["ntff/surface/frequency/spectrum"]
+        assert transform.attrs["solver"] == "cuda"
+        assert transform.attrs["collection_backend"] == "cuda_device"
+        assert np.all(np.isfinite(transform["far_field/backscatter/fields/rcs"][:]))

--- a/tests/ntff/test_device_collection.py
+++ b/tests/ntff/test_device_collection.py
@@ -170,6 +170,81 @@ def test_device_contract_matches_cpu_flat_index_collection(real_dtype, complex_d
 
 
 @pytest.mark.parametrize(
+    "real_dtype,complex_dtype,rtol",
+    [(np.dtype("f4"), np.dtype("c8"), 2e-6), (np.dtype("f8"), np.dtype("c16"), 2e-13)],
+)
+def test_device_incident_plane_wave_dft_matches_cpu(real_dtype, complex_dtype, rtol):
+    shape = (8, 8, 8)
+    surface = build_component_surface("Ex", (2, 2, 2), (5, 5, 5), (0.01,) * 3, shape)
+    iterations = 16
+    dt = 1e-11
+    cpu = _monitor("cpu", {"Ex": surface}, real_dtype, complex_dtype, iterations, dt)
+    device = _monitor("device", {"Ex": surface}, real_dtype, complex_dtype, iterations, dt)
+
+    def plane_wave():
+        fields = np.zeros((3, 1), dtype=real_dtype)
+        return SimpleNamespace(
+            m=np.zeros(3, dtype=np.int32),
+            origin=np.zeros(3, dtype=np.int32),
+            axial=0,
+            E_fields=fields,
+            E_fields_dev=fields.copy(),
+            corners=np.asarray((1, 1, 1, 6, 6, 6), dtype=np.int32),
+            waveformID="pulse",
+            materialID="free_space",
+            actual_angles=np.asarray((90.0, 0.0), dtype=real_dtype),
+            psi=0.0,
+            start=0.0,
+            stop=1.0,
+        )
+
+    cpu_plane_wave = plane_wave()
+    device_plane_wave = plane_wave()
+    cpu.associate_plane_wave(cpu_plane_wave, (0.01,) * 3, 0)
+    device.associate_plane_wave(device_plane_wave, (0.01,) * 3, 0)
+
+    ids = np.ones((6,) + shape, dtype=np.uint32)
+    lookup = {"Ex": 0}
+    cpu.validate_materials(ids, lookup)
+    cpu.configure_background([_material()])
+    grid = SimpleNamespace(
+        ntff_monitors=[device],
+        ID=ids,
+        IDlookup=lookup,
+        materials=[_material()],
+        Ex_dev=np.zeros(shape, dtype=real_dtype),
+    )
+    collector = _HostEmulatedDeviceCollector(SimpleNamespace(grid=grid))
+    zeros = np.zeros(shape, dtype=real_dtype)
+
+    for iteration in range(iterations):
+        time = iteration * dt
+        sample = np.asarray(
+            (
+                np.sin(2 * np.pi * cpu.frequencies[0] * time),
+                0.25 * np.cos(2 * np.pi * cpu.frequencies[1] * time),
+                0.1 * (iteration + 1),
+            ),
+            dtype=real_dtype,
+        )
+        cpu_plane_wave.E_fields[:, 0] = sample
+        device_plane_wave.E_fields_dev[:, 0] = sample
+        cpu.observe_electric(iteration, zeros, zeros, zeros)
+        collector.observe_electric(iteration)
+
+    cpu.finalise()
+    collector.finalise()
+
+    assert device._incident_next_iteration == iterations
+    assert_allclose(
+        device.result.incident_electric,
+        cpu.result.incident_electric,
+        rtol=rtol,
+        atol=rtol * np.max(np.abs(cpu.result.incident_electric)),
+    )
+
+
+@pytest.mark.parametrize(
     "backend,c_real,marker",
     [
         ("cuda", "float", "blockIdx.x"),

--- a/tests/ntff/test_subgrid_ksir_tfsf_integration.py
+++ b/tests/ntff/test_subgrid_ksir_tfsf_integration.py
@@ -1,0 +1,226 @@
+"""End-to-end KSIR, antenna, TFSF, and RCS coverage with HSG subgrids."""
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+
+
+def _base_scene():
+    scene = gprMax.Scene()
+    scene.add(gprMax.Domain(p1=(0.09, 0.09, 0.09)))
+    scene.add(gprMax.Discretisation(p1=(0.003, 0.003, 0.003)))
+    scene.add(gprMax.TimeWindow(time=1e-9))
+    scene.add(gprMax.PMLThickness(thickness=2))
+    scene.add(gprMax.OMPThreads(1))
+    subgrid = gprMax.SubGridHSG(
+        p1=(0.03, 0.03, 0.03),
+        p2=(0.06, 0.06, 0.06),
+        ratio=3,
+        id="fine_grid",
+    )
+    scene.add(subgrid)
+    return scene, subgrid
+
+
+def test_antenna_metrics_use_subgrid_port_and_time_step(tmp_path):
+    scene, subgrid = _base_scene()
+    source_position = (0.045, 0.045, 0.045)
+    subgrid.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
+    subgrid.add(
+        gprMax.VoltageSource(
+            p1=source_position,
+            polarisation="z",
+            resistance=50,
+            waveform_id="pulse",
+        )
+    )
+    subgrid.add(
+        gprMax.RxPort(
+            p1=source_position,
+            id="feed",
+            spectrum_limit="nyquist",
+        )
+    )
+
+    scene.add(
+        gprMax.KSIRSurface(
+            p1=(0.015, 0.015, 0.015),
+            p2=(0.075, 0.075, 0.075),
+            id="surface",
+        )
+    )
+    scene.add(
+        gprMax.KSIRFrequencyTransform(
+            surface_id="surface",
+            id="band",
+            frequencies=(5e9,),
+        )
+    )
+    scene.add(gprMax.KSIRAntennaPorts("band", ("fine_grid/feed",)))
+    pattern = gprMax.KSIRFarField(
+        theta=(90,),
+        phi=(0,),
+        transform_id="band",
+        id="broadside",
+        outputs=("gain", "realized_gain", "radiation_efficiency"),
+    )
+    scene.add(pattern)
+
+    output = tmp_path / "subgrid_antenna"
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        outputfile=output,
+        subgrid=True,
+        autotranslate=True,
+        hide_progress_bars=True,
+        cpu_precision="double",
+    )
+
+    assert np.isfinite(pattern.result.fields["gain"]).all()
+    with h5py.File(output.with_suffix(".h5"), "r") as handle:
+        port_power = handle["ntff/surface/frequency/band/far_field/broadside/port_power"]
+        assert port_power["port_ids"].asstr()[...].tolist() == ["fine_grid/feed"]
+        assert port_power["source_types"].asstr()[...].tolist() == ["VoltageSource"]
+        assert port_power["gain_valid"][0] == 1
+
+
+def test_tfsf_and_rcs_include_scatterer_inside_subgrid(tmp_path):
+    scene, subgrid = _base_scene()
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
+    scene.add(
+        gprMax.DiscretePlaneWaveAxial(
+            axis="x",
+            psi=90,
+            p1=(0.018, 0.018, 0.018),
+            p2=(0.072, 0.072, 0.072),
+            waveform_id="pulse",
+        )
+    )
+    subgrid.add(
+        gprMax.Sphere(
+            p1=(0.045, 0.045, 0.045),
+            r=0.004,
+            material_id="pec",
+        )
+    )
+    scene.add(
+        gprMax.KSIRSurface(
+            p1=(0.012, 0.012, 0.012),
+            p2=(0.078, 0.078, 0.078),
+            id="surface",
+        )
+    )
+    scene.add(
+        gprMax.KSIRFrequencyTransform(
+            surface_id="surface",
+            id="scattering",
+            frequencies=(5e9,),
+        )
+    )
+    backscatter = gprMax.KSIRFarField(
+        theta=(90,),
+        phi=(180,),
+        transform_id="scattering",
+        id="backscatter",
+        outputs=("rcs",),
+    )
+    scene.add(backscatter)
+
+    output = tmp_path / "subgrid_rcs"
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        outputfile=output,
+        subgrid=True,
+        autotranslate=True,
+        hide_progress_bars=True,
+        cpu_precision="double",
+    )
+
+    rcs = backscatter.result.fields["rcs"]
+    assert rcs.shape == (1, 1)
+    assert np.isfinite(rcs).all()
+    assert np.all(rcs >= 0)
+    assert np.max(rcs) > 0
+
+
+def test_ksir_surface_cannot_cut_subgrid_coupling_region(tmp_path):
+    scene, _ = _base_scene()
+    scene.add(
+        gprMax.KSIRSurface(
+            p1=(0.024, 0.024, 0.024),
+            p2=(0.066, 0.066, 0.066),
+            id="cutting_surface",
+        )
+    )
+    scene.add(
+        gprMax.KSIRFrequencyTransform(
+            surface_id="cutting_surface",
+            id="band",
+            frequencies=(5e9,),
+        )
+    )
+
+    with pytest.raises(ValueError, match="outer coupling surface of subgrid 'fine_grid'"):
+        gprMax.run(
+            scenes=[scene],
+            n=1,
+            outputfile=tmp_path / "cutting_ksir",
+            subgrid=True,
+            autotranslate=True,
+            geometry_only=True,
+            hide_progress_bars=True,
+        )
+
+
+def test_tfsf_surface_cannot_cut_subgrid_coupling_region(tmp_path):
+    scene, _ = _base_scene()
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
+    scene.add(
+        gprMax.DiscretePlaneWaveAxial(
+            axis="x",
+            psi=90,
+            p1=(0.018, 0.018, 0.018),
+            p2=(0.060, 0.060, 0.060),
+            waveform_id="pulse",
+        )
+    )
+
+    with pytest.raises(ValueError, match="outer coupling surface of subgrid 'fine_grid'"):
+        gprMax.run(
+            scenes=[scene],
+            n=1,
+            outputfile=tmp_path / "cutting_tfsf",
+            subgrid=True,
+            autotranslate=True,
+            geometry_only=True,
+            hide_progress_bars=True,
+        )
+
+
+def test_tfsf_source_must_be_defined_on_main_grid(tmp_path):
+    scene, subgrid = _base_scene()
+    subgrid.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
+    subgrid.add(
+        gprMax.DiscretePlaneWaveAxial(
+            axis="x",
+            psi=90,
+            p1=(0.033, 0.033, 0.033),
+            p2=(0.057, 0.057, 0.057),
+            waveform_id="pulse",
+        )
+    )
+
+    with pytest.raises(ValueError, match="must be defined on the main grid"):
+        gprMax.run(
+            scenes=[scene],
+            n=1,
+            outputfile=tmp_path / "subgrid_tfsf_source",
+            subgrid=True,
+            autotranslate=True,
+            geometry_only=True,
+            hide_progress_bars=True,
+        )

--- a/tests/ports/test_subgrid_integration.py
+++ b/tests/ports/test_subgrid_integration.py
@@ -1,0 +1,97 @@
+"""End-to-end coverage for voltage-source ports inside a subgrid."""
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+
+
+@pytest.fixture(scope="module")
+def subgrid_port_result(tmp_path_factory):
+    """Run one hard-source port on a 1 mm grid nested in a 3 mm grid."""
+
+    output = tmp_path_factory.mktemp("subgrid_port") / "hard_source"
+    source_position = (0.045, 0.045, 0.045)
+
+    scene = gprMax.Scene()
+    scene.add(gprMax.Domain(p1=(0.09, 0.09, 0.09)))
+    scene.add(gprMax.Discretisation(p1=(0.003, 0.003, 0.003)))
+    scene.add(gprMax.TimeWindow(time=4e-10))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.OMPThreads(1))
+
+    subgrid = gprMax.SubGridHSG(
+        p1=(0.03, 0.03, 0.03),
+        p2=(0.06, 0.06, 0.06),
+        ratio=3,
+        id="fine_grid",
+    )
+    scene.add(subgrid)
+    subgrid.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
+    subgrid.add(
+        gprMax.VoltageSource(
+            p1=source_position,
+            polarisation="z",
+            resistance=0,
+            waveform_id="pulse",
+            reference_impedance=50,
+        )
+    )
+    port = gprMax.RxPort(
+        p1=source_position,
+        id="feed",
+        spectrum_limit="nyquist",
+    )
+    subgrid.add(port)
+
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        outputfile=output,
+        subgrid=True,
+        autotranslate=True,
+        hide_progress_bars=True,
+    )
+    return output.with_suffix(".h5"), port, source_position
+
+
+def test_subgrid_port_uses_owning_grid_and_returns_api_result(subgrid_port_result):
+    filename, api_port, _ = subgrid_port_result
+
+    assert api_port.result.frequency.size > 0
+    assert api_port.result.valid_zin.any()
+
+    with h5py.File(filename, "r") as output:
+        assert output.attrs["nports"] == 0
+        assert output.attrs["nrx"] == 0
+        assert "ports" not in output
+        assert "rxs" not in output
+
+        subgrid = output["subgrids/fine_grid"]
+        assert subgrid.attrs["nports"] == 1
+        assert subgrid.attrs["nrx"] == 0
+        assert subgrid.attrs["Iterations"] == 3 * output.attrs["Iterations"]
+        np.testing.assert_allclose(subgrid.attrs["dx_dy_dz"], (0.001, 0.001, 0.001))
+
+        port = subgrid["ports/feed"]
+        assert port.attrs["PortMode"] == "hard_delta_gap"
+        assert port.attrs["CellLength"] == pytest.approx(0.001)
+        assert port.attrs["NyquistFrequency"] == pytest.approx(1 / (2 * subgrid.attrs["dt"]))
+        assert port["time"].size == subgrid.attrs["Iterations"] - 1
+        assert port["Iloop"].shape == port["time"].shape
+        assert port["valid_Zin"][...].astype(bool).any()
+
+
+def test_subgrid_port_and_source_store_same_global_position(subgrid_port_result):
+    filename, _, source_position = subgrid_port_result
+
+    with h5py.File(filename, "r") as output:
+        subgrid = output["subgrids/fine_grid"]
+        source = subgrid["srcs/src1"]
+        port = subgrid["ports/feed"]
+
+        np.testing.assert_allclose(source.attrs["Position"], source_position)
+        np.testing.assert_allclose(port.attrs["Position"], source_position)
+        np.testing.assert_allclose(port.attrs["Position"], source.attrs["Position"])
+        np.testing.assert_array_equal(port.attrs["GridPosition"], (33, 33, 33))

--- a/tests/subgrids/test_subgrid_magnetic_frill.py
+++ b/tests/subgrids/test_subgrid_magnetic_frill.py
@@ -1,0 +1,101 @@
+"""End-to-end coverage for a magnetic-frill source inside a subgrid."""
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+
+
+@pytest.fixture(scope="module")
+def subgrid_frill_result(tmp_path_factory):
+    output = tmp_path_factory.mktemp("subgrid_frill") / "frill"
+    feed = (0.045, 0.045, 0.045)
+
+    scene = gprMax.Scene()
+    scene.add(gprMax.Domain(p1=(0.09, 0.09, 0.09)))
+    scene.add(gprMax.Discretisation(p1=(0.003, 0.003, 0.003)))
+    scene.add(gprMax.TimeWindow(time=4e-10))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.OMPThreads(1))
+
+    subgrid = gprMax.SubGridHSG(
+        p1=(0.03, 0.03, 0.03),
+        p2=(0.06, 0.06, 0.06),
+        ratio=3,
+        id="fine_grid",
+    )
+    scene.add(subgrid)
+    subgrid.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
+    subgrid.add(
+        gprMax.Plate(
+            p1=(0.035, 0.035, feed[2]),
+            p2=(0.055, 0.055, feed[2]),
+            material_id="pec",
+        )
+    )
+    subgrid.add(
+        gprMax.ThinWire(
+            p1=feed,
+            p2=(feed[0], feed[1], 0.055),
+            radius=0.1e-3,
+        )
+    )
+    subgrid.add(
+        gprMax.MagneticFrillSource(
+            p1=feed,
+            polarisation="z",
+            zcoax=50,
+            waveform_id="pulse",
+        )
+    )
+
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        outputfile=output,
+        subgrid=True,
+        autotranslate=True,
+        hide_progress_bars=True,
+    )
+    return output.with_suffix(".h5"), feed
+
+
+def test_subgrid_frill_uses_fine_grid_and_writes_automatic_port(subgrid_frill_result):
+    filename, _ = subgrid_frill_result
+
+    with h5py.File(filename, "r") as output:
+        assert output.attrs["nsrc"] == 0
+        assert "frills" not in output
+
+        subgrid = output["subgrids/fine_grid"]
+        assert subgrid.attrs["nsrc"] == 1
+        assert subgrid.attrs["Iterations"] == 3 * output.attrs["Iterations"]
+        np.testing.assert_allclose(subgrid.attrs["dx_dy_dz"], (0.001, 0.001, 0.001))
+
+        frill = subgrid["frills/frill1"]
+        assert frill.attrs["Polarisation"] == "z"
+        assert frill.attrs["Z0"] == pytest.approx(50)
+        assert frill.attrs["InnerConductorRadius"] == pytest.approx(0.1e-3)
+        assert frill.attrs["NyquistFrequency"] == pytest.approx(1 / (2 * subgrid.attrs["dt"]))
+        assert frill["time"].size == subgrid.attrs["Iterations"]
+        assert frill["Vinc"].size == subgrid.attrs["Iterations"] + 1
+        for name in ("Vtotal", "Itot", "S11", "Zin", "Yin"):
+            assert np.all(np.isfinite(frill[name][...]))
+        assert np.max(np.abs(frill["Vtotal"][...])) > 0
+
+
+def test_subgrid_frill_position_is_global_and_terminal_identity_holds(
+    subgrid_frill_result,
+):
+    filename, feed = subgrid_frill_result
+
+    with h5py.File(filename, "r") as output:
+        frill = output["subgrids/fine_grid/frills/frill1"]
+        np.testing.assert_allclose(frill.attrs["Position"], feed)
+        np.testing.assert_allclose(
+            frill["Vtotal"][...],
+            2 * frill["Vinc"][...] - frill.attrs["Z0"] * frill["Itot"][...],
+            rtol=2e-5,
+            atol=5e-8,
+        )


### PR DESCRIPTION
## Summary

- Allow `RxPort` and magnetic-frill sources to operate inside CPU HSG subgrids.
- Store subgrid port and frill results in their owning subgrid HDF5 groups while retaining global physical positions.
- Allow main-grid KSIR/NTFF and TFSF surfaces to enclose complete subgrids, with guards that reject surfaces touching or cutting an HSG coupling region.
- Include subgrid sources and qualified subgrid port IDs in KSIR source validation and antenna gain/efficiency calculations.
- Keep plane-wave incident-reference DFT accumulation on accelerator devices for RCS normalisation, eliminating per-iteration host access and removing temporary CUDA debug transfers.
- Document the input, output, enclosure, naming, and backend restrictions.

## Motivation

Subgrids are used to resolve fine feed and scatterer geometry. Ports, magnetic-frill feeds, TFSF excitation, RCS, and antenna metrics therefore need to work when the relevant source or object lies inside a finer HSG region. The KSIR and TFSF collection surfaces remain on the main grid and must strictly enclose any overlapping subgrid coupling surface.

This also corrects accelerator RCS normalisation so the associated one-dimensional plane-wave reference remains device-resident throughout timestepping.

## Restrictions

- HSG subgrids remain CPU-only.
- Discrete plane waves and KSIR surfaces remain main-grid objects.
- An overlapping TFSF or KSIR surface must strictly enclose the complete HSG outer coupling surface; disjoint surfaces remain valid.
- MPI support is unchanged.
- CUDA was hardware-tested. OpenCL and Metal use the shared device-collector path but were not hardware-tested on this server.

## Validation

- `356 passed` across `tests/ports`, `tests/subgrids`, `tests/ntff`, and the magnetic-frill command tests.
- Includes end-to-end subgrid voltage-port, magnetic-frill, antenna-metric, TFSF, and PEC-sphere RCS tests.
- Includes actual CUDA single- and double-precision comparisons of device and CPU plane-wave incident references.
- Python compilation, import sorting for changed imports, and `git diff --check` pass.
- The Sphinx HTML build completes. Strict warning mode reports 10 existing warnings in unrelated documentation and missing legacy files; none originate from the modified pages.
- Exploratory MATLAB/Mie validation scripts, generated HDF5 data, plots, and design material are not included.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update.

## Checklist

- [ ] Did pre-commit pass all checks? The current `devel` versions of several touched files are not clean under the configured Black line length; applying Black would add substantial unrelated formatting changes. Import sorting and whitespace/diff checks pass.
- [x] I have performed a self-review of my code.
- [x] I have added comments for my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.
