### PR TITLE
Fix eigenmode source matplotlib backend override and missing MPI rejection

### DIFF
--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1419,6 +1419,7 @@ solves for the invariant magnetic component.
 .. note::
 
     * The ``#eigenmode_source`` command currently cannot be used with the CUDA, OpenCL, or Apple Metal solvers.
+    * The ``#eigenmode_source`` command currently cannot be used with MPI.
 
 
 #rx:

--- a/gprMax/fdfd_eigenmode_solver/fdfd_1d_mode_solver.py
+++ b/gprMax/fdfd_eigenmode_solver/fdfd_1d_mode_solver.py
@@ -1,7 +1,8 @@
 import math
 
-import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
 from scipy.linalg import eig
 from scipy.sparse import coo_matrix, diags
 from scipy.sparse.linalg import eigs
@@ -319,13 +320,9 @@ class FDFD_1D_mode_solver:
         else:
             fields = ((self.Et, "E_t", "cell"), (self.Ha, "H_a", "cell"), (self.Ew, "E_w", "node"))
 
-        fig, axes = plt.subplots(
-            self.num_modes,
-            3,
-            figsize=(12, 3 * self.num_modes),
-            squeeze=False,
-            constrained_layout=True,
-        )
+        fig = Figure(figsize=(12, 3 * self.num_modes), constrained_layout=True)
+        FigureCanvasAgg(fig)
+        axes = fig.subplots(self.num_modes, 3, squeeze=False)
         node_coordinate = np.arange(self.N + 1) * self.dt
         cell_coordinate = (np.arange(self.N) + 0.5) * self.dt
         for mode in range(self.num_modes):
@@ -354,7 +351,6 @@ class FDFD_1D_mode_solver:
                 ax.grid(True)
                 ax.legend(fontsize=8)
         fig.savefig(output_path, dpi=200)
-        plt.close(fig)
         return output_path
 
     def _passive_positive_neff(self, neff_squared):

--- a/gprMax/fdfd_eigenmode_solver/fdfd_2d_mode_solver.py
+++ b/gprMax/fdfd_eigenmode_solver/fdfd_2d_mode_solver.py
@@ -1,12 +1,10 @@
 import math
 
-import matplotlib
 import numpy as np
 
 import gprMax.config as config
-
-matplotlib.use("Agg")
-from matplotlib import pyplot as plt
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
 from scipy.sparse import bmat, coo_matrix, diags
 from scipy.sparse.linalg import eigs
 
@@ -392,9 +390,21 @@ class FDFD_2D_mode_solver:
         for field in (self.Eu, self.Ev, self.Ew, self.Hu, self.Hv, self.Hw):
             field[:, :, mode] *= phase_factor
 
+    @staticmethod
+    def _new_figure(figsize):
+        """Build a Figure with its own Agg canvas, bypassing pyplot entirely.
+
+        This keeps plot generation headless-safe without ever touching the
+        process-wide matplotlib backend, so importing or using this solver
+        cannot override a backend the host application already selected.
+        """
+        fig = Figure(figsize=figsize, constrained_layout=True)
+        FigureCanvasAgg(fig)
+        return fig
+
     def plot_e_fields(self, output_path="fdfd_modes_eu_ev.png"):
-        fig, axes = plt.subplots(self.num_modes, 2, figsize=(8, 3 * self.num_modes), constrained_layout=True)
-        axes = np.atleast_2d(axes)
+        fig = self._new_figure((8, 3 * self.num_modes))
+        axes = np.atleast_2d(fig.subplots(self.num_modes, 2))
         for mode in range(self.num_modes):
             for ax, field, component in (
                     (axes[mode, 0], np.real(self.Eu[:, :, mode]), "E_u"),
@@ -406,12 +416,11 @@ class FDFD_2D_mode_solver:
                 ax.set_ylabel("v index")
                 fig.colorbar(image, ax=ax)
         fig.savefig(output_path, dpi=200)
-        plt.close(fig)
         return output_path
 
     def plot_h_fields(self, output_path="fdfd_modes_hu_hv.png"):
-        fig, axes = plt.subplots(self.num_modes, 2, figsize=(8, 3 * self.num_modes), constrained_layout=True)
-        axes = np.atleast_2d(axes)
+        fig = self._new_figure((8, 3 * self.num_modes))
+        axes = np.atleast_2d(fig.subplots(self.num_modes, 2))
         for mode in range(self.num_modes):
             for ax, field, component in (
                     (axes[mode, 0], np.real(self.Hu[:, :, mode]), "H_u"),
@@ -423,11 +432,11 @@ class FDFD_2D_mode_solver:
                 ax.set_ylabel("v index")
                 fig.colorbar(image, ax=ax)
         fig.savefig(output_path, dpi=200)
-        plt.close(fig)
         return output_path
 
     def plot_pec_component_masks(self, output_path="fdfd_yee_uvw_pec_masks.png"):
-        fig, axes = plt.subplots(1, 3, figsize=(11, 3), constrained_layout=True)
+        fig = self._new_figure((11, 3))
+        axes = fig.subplots(1, 3)
         masks = [
             (self.pec_u_mask.astype(float), "PEC E_u"),
             (self.pec_v_mask.astype(float), "PEC E_v"),
@@ -440,7 +449,6 @@ class FDFD_2D_mode_solver:
             ax.set_ylabel("v index")
             fig.colorbar(image, ax=ax)
         fig.savefig(output_path, dpi=200)
-        plt.close(fig)
         return output_path
 
     def _passive_positive_neff(self, neff_squared):

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -1921,6 +1921,14 @@ class EigenmodeSource(GridUserObject):
             )
             raise ValueError
 
+        # MPI decomposes the grid across ranks, but the source plane's
+        # bounds/plane-index validation below and the FDFD cross-section
+        # extraction in EigenmodeSource.grid_init() both assume a single,
+        # whole grid with globally-valid coordinates. Neither is currently
+        # rank-aware, so reject MPI outright until that support is added.
+        if config.sim_config.mpi:
+            raise ValueError(f"{self.params_str()} cannot currently be used with MPI.")
+
         if normal not in ["x", "y", "z"]:
             logger.exception(f"{self.params_str()} normal must be x, y, or z.")
             raise ValueError

--- a/tests/cmds_multiuse/test_eigenmode_source_2d.py
+++ b/tests/cmds_multiuse/test_eigenmode_source_2d.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import gprMax
+import gprMax.config as config
 
 INF = float("inf")
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
@@ -145,6 +146,27 @@ def test_2d_pmc_mode_enforces_magnetic_wall_and_injects(tmp_path):
 
     with h5py.File(output.with_suffix(".h5"), "r") as handle:
         assert np.max(np.abs(handle["rxs/rx1/Hz"][...])) > 0
+
+
+def test_eigenmode_source_rejected_with_mpi(monkeypatch):
+    # build() checks MPI before touching grid at all, so a bare object
+    # stands in for the grid here - mirrors the fast, direct-build style
+    # used for #magnetic_frill_source's own MPI-rejection test.
+    monkeypatch.setattr(config, "sim_config", type("_SC", (), {})())
+    config.sim_config.general = {"solver": "cpu"}
+    config.sim_config.mpi = True
+    source = gprMax.EigenmodeSource(
+        normal="x",
+        direction="+",
+        p1=(0.005, 0),
+        p2=(0.045, INF),
+        w=0.015,
+        mode_index=0,
+        frequency=5e9,
+        waveform_id="eig_pulse",
+    )
+    with pytest.raises(ValueError, match="MPI"):
+        source.build(grid=None)
 
 
 def test_2d_eigenmode_normal_cannot_be_invariant_axis(tmp_path):


### PR DESCRIPTION
## Summary

Two follow-up fixes for `#eigenmode_source` (merged in #687), found during review:

- **`matplotlib.use("Agg")` was called at module import time** in `FDFD_2D_mode_solver`, reached unconditionally through `gprMax.sources` → `cmds_multiuse.py` → `gprMax/__init__.py`. This meant plain `import gprMax` silently overrode any matplotlib backend the host application had already selected, whether or not a model actually uses `#eigenmode_source`. Both `FDFD_1D_mode_solver.plot_fields` and `FDFD_2D_mode_solver`'s three plotting methods (`plot_e_fields`, `plot_h_fields`, `plot_pec_component_masks`) only ever save a PNG and never call `plt.show()`, so neither needs pyplot's global state at all. Both now construct their own `Figure` + `FigureCanvasAgg` directly, which is headless-safe without ever touching the process-wide backend.
- **`#eigenmode_source` had no MPI rejection.** `EigenmodeSource.build()`'s plane-index/transverse-bounds validation, and `EigenmodeSource.grid_init()`'s FDFD cross-section material extraction, both assume a single whole grid with globally-valid coordinates - neither is rank-aware, so this would misbehave under `-mpi` (spurious "outside the grid" rejections on some ranks, or a partial/wrong cross-section solved from local-only material data on others). MPI is now rejected outright with a clear error, matching the existing convention for `#transmission_line`/`#magnetic_frill_source`/`#discrete_plane_wave`.

Subgrid support is intentionally **not** addressed here - it needs more thought on how the source should interact with a TFSF surface when embedded in a subgrid.

## Test plan

- [x] `matplotlib.use('pdf')` explicitly, then import each solver module - confirmed backend is no longer silently overridden (previously reverted to `Agg`)
- [x] Ran solver plotting methods standalone and confirmed PNG output is unchanged
- [x] New test `test_eigenmode_source_rejected_with_mpi` added, mirroring `#magnetic_frill_source`'s own MPI-rejection test
- [x] `tests/fdfd_eigenmode_solver/`, `tests/test_eigenmode_source_broadband.py`, `tests/test_eigenmode_source_upstream_compat.py`, `tests/cmds_multiuse/test_eigenmode_source_2d.py` - 39 passed
- [x] Full suite (`pytest tests/`) - 1196 passed, 6 skipped, 0 failed