### PR TITLE
Guard incomplete KSIR time outputs and unsupported MPI plane waves

### DIFF
--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -874,6 +874,13 @@ positional optional parameters used by the equivalent hash commands.
         outputs=('Etheta', 'Ephi', 'radiation_intensity'),
     ))
 
+For a completed time receiver, ``result.point_times(q)`` and
+``result.point_field(output, q)`` return only the interval supported by every
+surface patch. ``point_raw_times`` and ``point_raw_field`` deliberately expose
+the additional partial retarded tail for research use. Check
+``result.terminal_decay_ok[q]``; a false value means that the FDTD time window
+should be increased.
+
 KSIR frequency transform
 ------------------------
 .. autoclass:: gprMax.user_objects.cmds_output.KSIRFrequencyTransform

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1313,6 +1313,7 @@ For example, to specify a discrete plane wave in a TFSF box (0.010, 0.010, 0.010
 
     * Plane waves support non-dispersive dielectric backgrounds and multi-pole Debye, Lorentz, and Drude media. They do not currently support ``user``-defined waveforms.
     * The plane-wave command must be defined on the main grid. Its TFSF box may contain a complete subgrid, but must strictly enclose the subgrid's HSG outer coupling surface wherever the two regions overlap.
+    * ``#plane_wave_angles``, ``#plane_wave_vector``, and ``#plane_wave_axial`` currently cannot be used with MPI. The TFSF box correction is applied with per-rank local array indices and has no awareness of MPI domain decomposition, so a box spanning more than one rank's sub-domain would silently be corrected on only one rank.
     * This plane wave implementation was based on an intitial implementation made possible by a `Google Summer of Code <https://summerofcode.withgoogle.com/>`_ (GSoC) project and `more details can be found in the original pull request <https://github.com/gprMax/gprMax/pull/373>`_.
     * Internally, theta and phi are approximated by an integer direction vector (Mx, My, Mz) found to within a maximum acceptable angular difference of 3 arc minutes (0.05 degrees) by default. This tolerance can be relaxed or tightened using the ``max_angle_diff`` parameter (in degrees) when using the Python API.
 
@@ -1338,6 +1339,7 @@ For example, to specify a discrete plane wave in a TFSF box (0.010, 0.010, 0.010
 
     * Plane waves support non-dispersive dielectric backgrounds and multi-pole Debye, Lorentz, and Drude media. They do not currently support ``user``-defined waveforms.
     * The plane-wave command must be defined on the main grid. Its TFSF box may contain a complete subgrid, but must strictly enclose the subgrid's HSG outer coupling surface wherever the two regions overlap.
+    * ``#plane_wave_angles``, ``#plane_wave_vector``, and ``#plane_wave_axial`` currently cannot be used with MPI. The TFSF box correction is applied with per-rank local array indices and has no awareness of MPI domain decomposition, so a box spanning more than one rank's sub-domain would silently be corrected on only one rank.
     * This plane wave implementation was based on an intitial implementation made possible by a `Google Summer of Code <https://summerofcode.withgoogle.com/>`_ (GSoC) project and `more details can be found in the original pull request <https://github.com/gprMax/gprMax/pull/373>`_.
 
 
@@ -1364,6 +1366,7 @@ For example, to specify a discrete plane wave in a TFSF box (0.010, 0.010, 0.010
     * For simulations that do not involve half-space setups it is recommended to use either the ``#plane_wave_angles`` or ``#plane_wave_vector`` commands instead as the formualtions are more efficient and faster if the background medium of propagation for the plane wave is homogeneous.
     * Plane waves support non-dispersive dielectric layers and multi-pole Debye, Lorentz, and Drude layers. They do not currently support ``user``-defined waveforms.
     * The plane-wave command must be defined on the main grid. Its TFSF box may contain a complete subgrid, but must strictly enclose the subgrid's HSG outer coupling surface wherever the two regions overlap.
+    * ``#plane_wave_angles``, ``#plane_wave_vector``, and ``#plane_wave_axial`` currently cannot be used with MPI. The TFSF box correction is applied with per-rank local array indices and has no awareness of MPI domain decomposition, so a box spanning more than one rank's sub-domain would silently be corrected on only one rank.
     * This plane wave implementation was based on an intitial implementation made possible by a `Google Summer of Code <https://summerofcode.withgoogle.com/>`_ (GSoC) project and `more details can be found in the original pull request <https://github.com/gprMax/gprMax/pull/373>`_.
 
 

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1741,6 +1741,13 @@ The engineering convention is used throughout: phasors have time dependence
 ``exp(+j*omega*t)``, the forward transform kernel is ``exp(-j*omega*t)``, and
 the outgoing Green function contains ``exp(-j*k*R)``.
 
+A frequency transform still requires a sufficiently long FDTD time window.
+The ``hann`` window reduces leakage from a truncated non-zero tail, but it is
+not a replacement for allowing the physical surface fields to decay. A
+``rectangular`` window retains the unmodified engineering phasor and is
+required by gain normalisation, but is more sensitive to end-of-record
+truncation.
+
 .. code-block:: none
 
     #ksir_frequency: radiation_surface antenna_band 0.8e9 1.0e9 1.2e9 hann
@@ -1835,6 +1842,14 @@ component names, and both the ID and any desired components must precede
 The spherical radius is explicit because these commands return the actual
 finite-distance field, including all ``1/R`` and ``1/R^2`` terms. It is not a
 normalization constant.
+
+The output file stores both ``fully_supported_lengths`` and ``valid_lengths``.
+Use the former by default: it stops before retarded propagation causes any
+surface patch to run beyond the available FDTD history. The latter exposes the
+longer partial tail for research use. gprMax also records a terminal decay
+ratio and warns when the field has not decayed adequately within the fully
+supported interval; in that case the simulation time window should be
+increased.
 
 #ksir_time_rx_array:
 --------------------

--- a/docs/source/output.rst
+++ b/docs/source/output.rst
@@ -399,6 +399,9 @@ and transform IDs:
             times
             time_origins
             valid_lengths
+            fully_supported_lengths
+            terminal_field_ratios
+            terminal_decay_ok
             spherical_coordinates [spherical commands only]
             fields/<output>
         frequency/<transform_id>/
@@ -559,17 +562,33 @@ propagation; all other directions are bistatic RCS. Use separate simulations
 for different incident plane waves because selecting an association does not
 separate simultaneously accumulated scattered fields.
 
-Time-domain fields have shape ``(npoints, max(valid_lengths))``. For point
-``q``, the physical time vector and valid trace are:
+Time-domain fields retain the complete raw retarded buffer and have shape
+``(npoints, max(valid_lengths))``. Its final bins may contain only part of the
+closed-surface history because different surface patches have different
+propagation delays. For normal use, point ``q`` must therefore be sliced with
+``fully_supported_lengths``:
 
 .. code-block:: python
 
-    physical_time = time_origins[q] + times[:valid_lengths[q]]
-    trace = fields[output][q, :valid_lengths[q]]
+    length = fully_supported_lengths[q]
+    physical_time = time_origins[q] + times[:length]
+    trace = fields[output][q, :length]
+
+``valid_lengths`` remains available for research access to every stored bin.
+Those additional bins are not a complete field reconstruction unless the
+surface fields had already decayed to zero. ``terminal_field_ratios`` gives,
+for each point, the largest ratio between the final 32 fully supported samples
+and the trace peak, evaluated independently for each underlying Cartesian
+component. ``terminal_decay_ok`` is true when this is no greater than
+``terminal_decay_threshold`` (stored as a group attribute). gprMax emits a
+warning when the test fails; increasing the model time window is the correct
+remedy.
 
 With ``time_origin=simulation`` every origin is zero. With
 ``time_origin=first_arrival`` each origin retains its absolute propagation
 time without storing the potentially large guaranteed leading-zero prefix.
+For this origin policy, ``fully_supported_lengths`` normally equals the number
+of FDTD iterations.
 
 The surface DFT datasets are present by default and allow later angular or
 point evaluation without rerunning FDTD. They can be large: their leading

--- a/gprMax/ntff/interface.py
+++ b/gprMax/ntff/interface.py
@@ -187,16 +187,37 @@ class KSIRTimeReceiverResult:
     times: npt.NDArray[np.floating]
     time_origins: npt.NDArray[np.floating]
     valid_lengths: npt.NDArray[np.int64]
+    fully_supported_lengths: npt.NDArray[np.int64]
+    terminal_field_ratios: npt.NDArray[np.floating]
+    terminal_decay_ok: npt.NDArray[np.bool_]
+    terminal_decay_threshold: float
+    terminal_decay_window_samples: int
     fields: Mapping[str, npt.NDArray[np.floating]]
     coordinate_system: str
     time_origin: str
     spherical_coordinates: Optional[npt.NDArray[np.floating]]
 
     def point_times(self, point_index: int) -> npt.NDArray[np.floating]:
-        length = int(self.valid_lengths[point_index])
+        """Return physical times for the fully supported field trace."""
+
+        length = int(self.fully_supported_lengths[point_index])
         return self.time_origins[point_index] + self.times[:length]
 
     def point_field(self, output: str, point_index: int) -> npt.NDArray:
+        """Return the fully supported field trace for one point."""
+
+        length = int(self.fully_supported_lengths[point_index])
+        return self.fields[output][point_index, :length]
+
+    def point_raw_times(self, point_index: int) -> npt.NDArray[np.floating]:
+        """Return all stored times, including the partial retarded tail."""
+
+        length = int(self.valid_lengths[point_index])
+        return self.time_origins[point_index] + self.times[:length]
+
+    def point_raw_field(self, output: str, point_index: int) -> npt.NDArray:
+        """Return all stored bins, including the partial retarded tail."""
+
         length = int(self.valid_lengths[point_index])
         return self.fields[output][point_index, :length]
 
@@ -921,6 +942,13 @@ class KSIRCompiledOutputs:
             times=source.times,
             time_origins=_readonly(source.time_origins[point_slice]),
             valid_lengths=_readonly(source.valid_lengths[point_slice], np.int64),
+            fully_supported_lengths=_readonly(
+                source.fully_supported_lengths[point_slice], np.int64
+            ),
+            terminal_field_ratios=_readonly(source.terminal_field_ratios[point_slice]),
+            terminal_decay_ok=_readonly(source.terminal_decay_ok[point_slice], bool),
+            terminal_decay_threshold=source.terminal_decay_threshold,
+            terminal_decay_window_samples=source.terminal_decay_window_samples,
             fields=fields,
             coordinate_system=spec.coordinate_system,
             time_origin=spec.time_origin,
@@ -1181,10 +1209,18 @@ class KSIRCompiledOutputs:
             group.attrs["outputs"] = np.asarray(spec.outputs, dtype="S20")
             group.attrs["solver"] = monitor.device_backend or "cpu"
             group.attrs["collection_backend"] = monitor.collection_backend
+            group.attrs["terminal_decay_threshold"] = result.terminal_decay_threshold
+            group.attrs["terminal_decay_window_samples"] = result.terminal_decay_window_samples
+            group.attrs[
+                "raw_tail_policy"
+            ] = "stored_for_research_use; use fully_supported_lengths by default"
             group["points"] = result.points
             group["times"] = result.times
             group["time_origins"] = result.time_origins
             group["valid_lengths"] = result.valid_lengths
+            group["fully_supported_lengths"] = result.fully_supported_lengths
+            group["terminal_field_ratios"] = result.terminal_field_ratios
+            group["terminal_decay_ok"] = result.terminal_decay_ok
             if result.spherical_coordinates is not None:
                 group["spherical_coordinates"] = result.spherical_coordinates
             self._write_fields(group, result)

--- a/gprMax/ntff/time_domain.py
+++ b/gprMax/ntff/time_domain.py
@@ -19,6 +19,7 @@
 
 """Advanced-time KSIR field extension for CPU and device collectors."""
 
+import logging
 from collections import deque
 from dataclasses import dataclass
 from types import MappingProxyType
@@ -32,10 +33,8 @@ from .closures import ResolvedKSIRClosure
 from .surfaces import KSIRComponentSurface
 
 try:
-    from gprMax.cython.ntff import (
-        deposit_time_domain_surface as _deposit_time_domain_surface,
-        gather_time_domain_surface as _gather_time_domain_surface,
-    )
+    from gprMax.cython.ntff import deposit_time_domain_surface as _deposit_time_domain_surface
+    from gprMax.cython.ntff import gather_time_domain_surface as _gather_time_domain_surface
 except ImportError:  # Source-tree use before extensions are rebuilt.
     _deposit_time_domain_surface = None
     _gather_time_domain_surface = None
@@ -43,6 +42,12 @@ except ImportError:  # Source-tree use before extensions are rebuilt.
 
 ELECTRIC_COMPONENTS = ("Ex", "Ey", "Ez")
 MAGNETIC_COMPONENTS = ("Hx", "Hy", "Hz")
+# Avoid warning on the normal sub-percent spatial-quadrature tail while still
+# detecting a materially truncated pulse.
+TERMINAL_DECAY_THRESHOLD = 1e-2
+TERMINAL_DECAY_WINDOW_SAMPLES = 32
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -57,23 +62,65 @@ class KSIRTimeDomainResult:
     time_origin: str
     time_origins: npt.NDArray[np.floating]
     valid_lengths: npt.NDArray[np.int64]
+    fully_supported_lengths: npt.NDArray[np.int64]
+    terminal_field_ratios: npt.NDArray[np.floating]
+    terminal_decay_ok: npt.NDArray[np.bool_]
+    terminal_decay_threshold: float
+    terminal_decay_window_samples: int
     collection_backend: str
     closure: str
     mathematically_closed: bool
 
     def point_times(self, point_index: int) -> npt.NDArray[np.floating]:
-        """Return physical times for one point's valid output samples."""
+        """Return physical times for one point's fully supported samples."""
+
+        length = int(self.fully_supported_lengths[point_index])
+        return self.time_origins[point_index] + self.times[:length]
+
+    def point_field(self, component: str, point_index: int) -> npt.NDArray[np.floating]:
+        """Return one point's fully supported field trace."""
+
+        length = int(self.fully_supported_lengths[point_index])
+        return self.fields[component][point_index, :length]
+
+    def point_raw_times(self, point_index: int) -> npt.NDArray[np.floating]:
+        """Return all stored times, including the partial retarded tail."""
 
         length = int(self.valid_lengths[point_index])
         return self.time_origins[point_index] + self.times[:length]
 
-    def point_field(
-        self, component: str, point_index: int
-    ) -> npt.NDArray[np.floating]:
-        """Return one point's valid field trace without padded trailing bins."""
+    def point_raw_field(self, component: str, point_index: int) -> npt.NDArray[np.floating]:
+        """Return all stored field bins, including the partial retarded tail."""
 
         length = int(self.valid_lengths[point_index])
         return self.fields[component][point_index, :length]
+
+
+def _terminal_field_ratios(
+    fields: Mapping[str, npt.NDArray[np.floating]],
+    fully_supported_lengths: npt.NDArray[np.int64],
+    window_samples: int,
+    dtype: npt.DTypeLike,
+) -> npt.NDArray[np.floating]:
+    """Return the largest terminal-window/peak ratio at each point.
+
+    Ratios are formed independently for every field component before taking
+    their maximum, so electric and magnetic field units are never mixed.
+    """
+
+    ratios = np.zeros(fully_supported_lengths.size, dtype=dtype)
+    for point_index, raw_length in enumerate(fully_supported_lengths):
+        length = int(raw_length)
+        width = min(window_samples, length)
+        for values in fields.values():
+            trace = np.asarray(values[point_index, :length])
+            peak = float(np.max(np.abs(trace)))
+            if peak == 0:
+                continue
+            terminal = float(np.max(np.abs(trace[-width:])))
+            ratios[point_index] = max(ratios[point_index], terminal / peak)
+    ratios.setflags(write=False)
+    return ratios
 
 
 class _ComponentAccumulator:
@@ -114,16 +161,12 @@ class _ComponentAccumulator:
         source_patch_indices = []
         parities = []
         for image in closure.component_images(surface.component):
-            image_positions, image_normals = image.transform(
-                base_positions, base_normals
-            )
+            image_positions, image_normals = image.transform(base_positions, base_normals)
             positions.append(image_positions)
             normals.append(image_normals)
             areas.append(base_areas)
             source_patch_indices.append(base_indices)
-            parities.append(
-                np.full(surface.npatches, image.parity, dtype=self.real_dtype)
-            )
+            parities.append(np.full(surface.npatches, image.parity, dtype=self.real_dtype))
         positions = np.concatenate(positions)
         normals = np.concatenate(normals)
         areas = np.concatenate(areas)
@@ -146,9 +189,9 @@ class _ComponentAccumulator:
             np.asarray((lower, upper), dtype=self.real_dtype)
             for lower, upper in zip(support_lower, support_upper)
         ]
-        support_corners = np.stack(
-            np.meshgrid(*support_axes, indexing="ij"), axis=-1
-        ).reshape(-1, 3)
+        support_corners = np.stack(np.meshgrid(*support_axes, indexing="ij"), axis=-1).reshape(
+            -1, 3
+        )
         completed_corners = []
         corner_normals = np.zeros_like(support_corners)
         for image in closure.component_images(surface.component):
@@ -160,15 +203,12 @@ class _ComponentAccumulator:
         displacement = points[:, np.newaxis, :] - positions[np.newaxis, :, :]
         distance = np.linalg.norm(displacement, axis=2)
         if np.any(distance == 0):
-            raise ValueError(
-                "observation points must not coincide with surface patches"
-            )
+            raise ValueError("observation points must not coincide with surface patches")
         direction = displacement / distance[:, :, np.newaxis]
         normal_projection = np.sum(normals[np.newaxis, :, :] * direction, axis=2)
 
         self._normal_derivative_weight = np.ascontiguousarray(
-            -areas[np.newaxis, :] * parity[np.newaxis, :]
-            / (4 * np.pi * distance),
+            -areas[np.newaxis, :] * parity[np.newaxis, :] / (4 * np.pi * distance),
             dtype=self.real_dtype,
         )
         self._field_weight = np.ascontiguousarray(
@@ -187,38 +227,27 @@ class _ComponentAccumulator:
         )
 
         delay = sample_time_offset_steps + distance / (wave_speed * dt)
-        self._integer_delay = np.ascontiguousarray(
-            np.floor(delay), dtype=np.int64
-        )
+        self._integer_delay = np.ascontiguousarray(np.floor(delay), dtype=np.int64)
         self._fractional_delay = np.ascontiguousarray(
             delay - self._integer_delay, dtype=self.real_dtype
         )
         self.minimum_delay_steps = np.min(delay, axis=1)
         self.maximum_integer_delay_steps = np.max(self._integer_delay, axis=1)
         self._inside_indices = np.ascontiguousarray(
-            np.concatenate(
-                [face.inside_flat_indices for face in self.surface.faces]
-            ),
+            np.concatenate([face.inside_flat_indices for face in self.surface.faces]),
             dtype=np.int64,
         )
         self._outside_indices = np.ascontiguousarray(
-            np.concatenate(
-                [face.outside_flat_indices for face in self.surface.faces]
-            ),
+            np.concatenate([face.outside_flat_indices for face in self.surface.faces]),
             dtype=np.int64,
         )
         self._normal_spacing = np.ascontiguousarray(
             np.concatenate(
-                [
-                    np.full(face.npatches, face.normal_spacing)
-                    for face in self.surface.faces
-                ]
+                [np.full(face.npatches, face.normal_spacing) for face in self.surface.faces]
             ),
             dtype=self.real_dtype,
         )
-        self._surface_buffer = np.empty(
-            self.surface.npatches, dtype=self.real_dtype
-        )
+        self._surface_buffer = np.empty(self.surface.npatches, dtype=self.real_dtype)
         self._derivative_buffer = np.empty_like(self._surface_buffer)
         self._time_origin_steps: npt.NDArray[np.int64]
         self.output: npt.NDArray[np.floating] | None
@@ -230,13 +259,9 @@ class _ComponentAccumulator:
         *,
         allocate_output: bool = True,
     ) -> None:
-        self._time_origin_steps = np.ascontiguousarray(
-            time_origin_steps, dtype=np.int64
-        )
+        self._time_origin_steps = np.ascontiguousarray(time_origin_steps, dtype=np.int64)
         if allocate_output:
-            self.output = np.zeros(
-                (self.points.shape[0], output_length), dtype=self.real_dtype
-            )
+            self.output = np.zeros((self.points.shape[0], output_length), dtype=self.real_dtype)
         else:
             self.output = None
 
@@ -250,9 +275,7 @@ class _ComponentAccumulator:
                 f"{self.surface.field_shape}"
             )
         if _gather_time_domain_surface is not None:
-            flat = np.ascontiguousarray(
-                values_array, dtype=self.real_dtype
-            ).ravel()
+            flat = np.ascontiguousarray(values_array, dtype=self.real_dtype).ravel()
             _gather_time_domain_surface(
                 self.nthreads,
                 self._inside_indices,
@@ -281,9 +304,7 @@ class _ComponentAccumulator:
         time_derivative: npt.NDArray,
     ) -> None:
         if sample_index != self._last_deposited + 1:
-            raise RuntimeError(
-                "KSIR samples must be deposited exactly once in time order"
-            )
+            raise RuntimeError("KSIR samples must be deposited exactly once in time order")
 
         if _deposit_time_domain_surface is not None:
             _deposit_time_domain_surface(
@@ -306,17 +327,11 @@ class _ComponentAccumulator:
 
         source = self._source_patch_index
         integrand = (
-            self._normal_derivative_weight
-            * normal_derivative[source][np.newaxis, :]
+            self._normal_derivative_weight * normal_derivative[source][np.newaxis, :]
             + self._field_weight * surface_value[source][np.newaxis, :]
-            + self._time_derivative_weight
-            * time_derivative[source][np.newaxis, :]
+            + self._time_derivative_weight * time_derivative[source][np.newaxis, :]
         )
-        destination = (
-            sample_index
-            + self._integer_delay
-            - self._time_origin_steps[:, np.newaxis]
-        )
+        destination = sample_index + self._integer_delay - self._time_origin_steps[:, np.newaxis]
         for point_index in range(self.points.shape[0]):
             np.add.at(
                 self.output[point_index],
@@ -349,9 +364,7 @@ class _ComponentAccumulator:
 
         previous, centre, following = self._recent
         if iteration == 2:
-            forward_derivative = (
-                -3 * previous[1] + 4 * centre[1] - following[1]
-            ) / (2 * self.dt)
+            forward_derivative = (-3 * previous[1] + 4 * centre[1] - following[1]) / (2 * self.dt)
             self._deposit(previous[0], previous[1], previous[2], forward_derivative)
 
         centred_derivative = (following[1] - previous[1]) / (2 * self.dt)
@@ -379,9 +392,9 @@ class _ComponentAccumulator:
             self._deposit(last[0], last[1], last[2], derivative)
         elif len(self._recent) == 3:
             before_previous, previous, last = self._recent
-            backward_derivative = (
-                3 * last[1] - 4 * previous[1] + before_previous[1]
-            ) / (2 * self.dt)
+            backward_derivative = (3 * last[1] - 4 * previous[1] + before_previous[1]) / (
+                2 * self.dt
+            )
             self._deposit(last[0], last[1], last[2], backward_derivative)
 
         self.output.setflags(write=False)
@@ -427,24 +440,16 @@ class KSIRTimeDomainMonitor:
             "simulation",
             "first_arrival",
         ):
-            raise ValueError(
-                "time_origin must be 'simulation' or 'first_arrival'"
-            )
+            raise ValueError("time_origin must be 'simulation' or 'first_arrival'")
         if device_backend not in (None, "cuda", "opencl", "metal"):
-            raise ValueError(
-                "device_backend must be None, 'cuda', 'opencl', or 'metal'"
-            )
+            raise ValueError("device_backend must be None, 'cuda', 'opencl', or 'metal'")
         self.real_dtype = np.dtype(real_dtype)
         if self.real_dtype.kind != "f":
             raise ValueError("real_dtype must be a floating-point dtype")
         point_array = np.asarray(points, dtype=self.real_dtype)
         if point_array.ndim == 1:
             point_array = point_array[np.newaxis, :]
-        if (
-            point_array.ndim != 2
-            or point_array.shape[0] == 0
-            or point_array.shape[1] != 3
-        ):
+        if point_array.ndim != 2 or point_array.shape[0] == 0 or point_array.shape[1] != 3:
             raise ValueError("points must have shape (npoints, 3)")
         if not np.all(np.isfinite(point_array)):
             raise ValueError("points must contain only finite values")
@@ -474,13 +479,9 @@ class KSIRTimeDomainMonitor:
             self.collection_backend = f"{device_backend}_device"
         self.components = components
         self.surfaces = MappingProxyType(dict(surfaces))
-        self.closure = closure or ResolvedKSIRClosure(
-            "closed", (), (), True, True
-        )
+        self.closure = closure or ResolvedKSIRClosure("closed", (), (), True, True)
         if not self.closure.mathematically_closed:
-            raise ValueError(
-                "advanced-time KSIR requires a closed or symmetry-completed surface"
-            )
+            raise ValueError("advanced-time KSIR requires a closed or symmetry-completed surface")
         for surface in surfaces.values():
             face_ids = tuple(face.face_id for face in surface.faces)
             if face_ids != self.closure.active_faces:
@@ -515,14 +516,8 @@ class KSIRTimeDomainMonitor:
             )
             tolerance = 10 * np.finfo(self.real_dtype).eps * completed_scale
             on_or_inside = np.all(
-                (
-                    point_array
-                    >= accumulator.completed_physical_lower - tolerance
-                )
-                & (
-                    point_array
-                    <= accumulator.completed_physical_upper + tolerance
-                ),
+                (point_array >= accumulator.completed_physical_lower - tolerance)
+                & (point_array <= accumulator.completed_physical_upper + tolerance),
                 axis=1,
             )
             if np.any(on_or_inside):
@@ -533,10 +528,7 @@ class KSIRTimeDomainMonitor:
 
         minimum_delay = np.min(
             np.stack(
-                [
-                    accumulator.minimum_delay_steps
-                    for accumulator in self._accumulators.values()
-                ]
+                [accumulator.minimum_delay_steps for accumulator in self._accumulators.values()]
             ),
             axis=0,
         )
@@ -553,22 +545,20 @@ class KSIRTimeDomainMonitor:
             time_origin_steps = np.floor(minimum_delay).astype(np.int64)
         else:
             time_origin_steps = np.zeros(self.points.shape[0], dtype=np.int64)
-        valid_lengths = (
-            self.iterations
-            + maximum_integer_delay
-            - time_origin_steps
-            + 1
+        valid_lengths = self.iterations + maximum_integer_delay - time_origin_steps + 1
+        fully_supported_lengths = (
+            self.iterations + np.floor(minimum_delay).astype(np.int64) - time_origin_steps
         )
-        self.time_origin_steps = np.ascontiguousarray(
-            time_origin_steps, dtype=np.int64
-        )
+        if np.any(fully_supported_lengths <= 0) or np.any(fully_supported_lengths > valid_lengths):
+            raise RuntimeError("invalid KSIR fully supported time interval")
+        self.time_origin_steps = np.ascontiguousarray(time_origin_steps, dtype=np.int64)
         self.time_origin_steps.setflags(write=False)
-        self.time_origins = np.asarray(
-            self.time_origin_steps * self.dt, dtype=self.real_dtype
-        )
+        self.time_origins = np.asarray(self.time_origin_steps * self.dt, dtype=self.real_dtype)
         self.time_origins.setflags(write=False)
         self.valid_lengths = np.ascontiguousarray(valid_lengths, dtype=np.int64)
         self.valid_lengths.setflags(write=False)
+        self.fully_supported_lengths = np.ascontiguousarray(fully_supported_lengths, dtype=np.int64)
+        self.fully_supported_lengths.setflags(write=False)
         self.output_length = int(np.max(self.valid_lengths))
         for accumulator in self._accumulators.values():
             accumulator.allocate(
@@ -580,14 +570,10 @@ class KSIRTimeDomainMonitor:
     @property
     def result(self) -> KSIRTimeDomainResult:
         if self._result is None:
-            raise RuntimeError(
-                "KSIR result is not available until the solver has finalised"
-            )
+            raise RuntimeError("KSIR result is not available until the solver has finalised")
         return self._result
 
-    def validate_materials(
-        self, material_ids: npt.ArrayLike, id_lookup: Mapping[str, int]
-    ) -> int:
+    def validate_materials(self, material_ids: npt.ArrayLike, id_lookup: Mapping[str, int]) -> int:
         """Verify that all straddling samples use one homogeneous material ID."""
 
         ids = np.asarray(material_ids)
@@ -612,16 +598,11 @@ class KSIRTimeDomainMonitor:
                         atol=tolerance,
                     )
                 if np.any(keep):
-                    sampled_ids.append(
-                        component_ids[tuple(face.inside_indices[keep].T)]
-                    )
-                    sampled_ids.append(
-                        component_ids[tuple(face.outside_indices[keep].T)]
-                    )
+                    sampled_ids.append(component_ids[tuple(face.inside_indices[keep].T)])
+                    sampled_ids.append(component_ids[tuple(face.outside_indices[keep].T)])
         if not sampled_ids:
             raise ValueError(
-                f"KSIR monitor {self.name!r} has no off-symmetry samples "
-                "for material validation"
+                f"KSIR monitor {self.name!r} has no off-symmetry samples " "for material validation"
             )
         unique_ids = np.unique(np.concatenate(sampled_ids))
         if unique_ids.size != 1:
@@ -666,20 +647,24 @@ class KSIRTimeDomainMonitor:
         if self.device_backend is None:
             for accumulator in self._accumulators.values():
                 accumulator.finalise()
-        elif any(
-            accumulator.output is None
-            for accumulator in self._accumulators.values()
-        ):
+        elif any(accumulator.output is None for accumulator in self._accumulators.values()):
             raise RuntimeError("not all device KSIR component outputs were loaded")
 
         times = self.dt * np.arange(self.output_length, dtype=self.real_dtype)
         times.setflags(write=False)
         fields = MappingProxyType(
-            {
-                component: self._accumulators[component].output
-                for component in self.components
-            }
+            {component: self._accumulators[component].output for component in self.components}
         )
+        terminal_field_ratios = _terminal_field_ratios(
+            fields,
+            self.fully_supported_lengths,
+            TERMINAL_DECAY_WINDOW_SAMPLES,
+            self.real_dtype,
+        )
+        terminal_decay_ok = np.ascontiguousarray(
+            terminal_field_ratios <= TERMINAL_DECAY_THRESHOLD, dtype=bool
+        )
+        terminal_decay_ok.setflags(write=False)
         offsets = MappingProxyType(
             {
                 component: (0.0 if component in ELECTRIC_COMPONENTS else 0.5 * self.dt)
@@ -695,15 +680,31 @@ class KSIRTimeDomainMonitor:
             time_origin=self.time_origin,
             time_origins=self.time_origins,
             valid_lengths=self.valid_lengths,
+            fully_supported_lengths=self.fully_supported_lengths,
+            terminal_field_ratios=terminal_field_ratios,
+            terminal_decay_ok=terminal_decay_ok,
+            terminal_decay_threshold=TERMINAL_DECAY_THRESHOLD,
+            terminal_decay_window_samples=TERMINAL_DECAY_WINDOW_SAMPLES,
             collection_backend=self.collection_backend,
             closure=self.closure.name,
             mathematically_closed=self.closure.mathematically_closed,
         )
+        if not np.all(terminal_decay_ok):
+            worst_point = int(np.argmax(terminal_field_ratios))
+            logger.warning(
+                "KSIR time monitor %r has not decayed below %.1e at the end "
+                "of its fully supported interval (point %d ratio %.3e). "
+                "Increase the simulation time window; bins beyond "
+                "fully_supported_lengths contain only a partial retarded "
+                "surface history.",
+                self.name,
+                TERMINAL_DECAY_THRESHOLD,
+                worst_point,
+                terminal_field_ratios[worst_point],
+            )
         self._finalised = True
 
-    def load_device_component_output(
-        self, component: str, output: npt.ArrayLike
-    ) -> None:
+    def load_device_component_output(self, component: str, output: npt.ArrayLike) -> None:
         """Attach one configured-dtype history downloaded at finalisation."""
 
         if self.device_backend is None:
@@ -715,13 +716,9 @@ class KSIRTimeDomainMonitor:
         values = np.asarray(output)
         expected_shape = (self.points.shape[0], self.output_length)
         if values.shape != expected_shape:
-            raise ValueError(
-                f"device output for {component} must have shape {expected_shape}"
-            )
+            raise ValueError(f"device output for {component} must have shape {expected_shape}")
         if values.dtype != self.real_dtype:
-            raise ValueError(
-                f"device output for {component} must use dtype {self.real_dtype}"
-            )
+            raise ValueError(f"device output for {component} must use dtype {self.real_dtype}")
         values = np.ascontiguousarray(values)
         values.setflags(write=False)
         self._accumulators[component].output = values
@@ -741,9 +738,7 @@ class KSIRTimeDomainMonitor:
         group.attrs["mathematically_closed"] = self.closure.mathematically_closed
         group.attrs["closure"] = self.closure.name
         group.attrs["closure_exact"] = self.closure.exact
-        group.attrs["omitted_faces"] = np.asarray(
-            self.closure.omitted_faces, dtype="S5"
-        )
+        group.attrs["omitted_faces"] = np.asarray(self.closure.omitted_faces, dtype="S5")
         group.attrs["symmetry_plane_faces"] = np.asarray(
             [plane.face for plane in self.closure.symmetry_planes], dtype="S5"
         )
@@ -761,9 +756,7 @@ class KSIRTimeDomainMonitor:
             *first_surface.upper,
         )
         group.attrs["wave_speed"] = self.wave_speed
-        group.attrs["precision"] = (
-            "single" if self.real_dtype.itemsize == 4 else "double"
-        )
+        group.attrs["precision"] = "single" if self.real_dtype.itemsize == 4 else "double"
         group.attrs["real_dtype"] = self.real_dtype.name
         group.attrs["solver"] = self.device_backend or "cpu"
         group.attrs["collection_backend"] = self.collection_backend
@@ -777,6 +770,11 @@ class KSIRTimeDomainMonitor:
             dtype=self.real_dtype,
         )
         group.attrs["time_origin"] = self.time_origin
+        group.attrs["terminal_decay_threshold"] = result.terminal_decay_threshold
+        group.attrs["terminal_decay_window_samples"] = result.terminal_decay_window_samples
+        group.attrs[
+            "raw_tail_policy"
+        ] = "stored_for_research_use; use fully_supported_lengths by default"
         if self.surface_material_id is not None:
             group.attrs["background_material_id"] = self.surface_material_id
 
@@ -784,6 +782,9 @@ class KSIRTimeDomainMonitor:
         group["times"] = result.times
         group["time_origins"] = result.time_origins
         group["valid_lengths"] = result.valid_lengths
+        group["fully_supported_lengths"] = result.fully_supported_lengths
+        group["terminal_field_ratios"] = result.terminal_field_ratios
+        group["terminal_decay_ok"] = result.terminal_decay_ok
         fields_group = group.create_group("fields")
         for component, values in result.fields.items():
             fields_group[component] = values

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -1250,6 +1250,13 @@ class MagneticFrillSource(RotatableMixin, GridUserObject):
         )
 
 
+def _reject_discrete_plane_wave_mpi(params_str):
+    """Reject TFSF corrections that are not MPI-decomposition aware."""
+
+    if config.sim_config.mpi:
+        raise ValueError(f"{params_str} cannot currently be used with MPI.")
+
+
 def _dpw_tfsf_corners(uip, p1, p2, params_str):
     """Discretises and validates the TFSF box corners for a discrete plane
     wave, shared by all three #plane_wave_* builders.
@@ -1367,6 +1374,8 @@ class DiscretePlaneWaveAngles(GridUserObject):
         except KeyError:
             logger.exception(f"{self.params_str()} requires at least ten parameters.")
             raise
+
+        _reject_discrete_plane_wave_mpi(self.params_str())
         try:
             max_angle_diff = self.kwargs["max_angle_diff"]
         except KeyError:
@@ -1563,6 +1572,8 @@ class DiscretePlaneWaveVector(GridUserObject):
             logger.exception(f"{self.params_str()} requires at least eleven parameters.")
             raise
 
+        _reject_discrete_plane_wave_mpi(self.params_str())
+
 
         try:
             material_id = self.kwargs["material_id"]
@@ -1734,6 +1745,8 @@ class DiscretePlaneWaveAxial(GridUserObject):
         except KeyError:
             logger.exception(f"{self.params_str()} requires at least 9 parameters.")
             raise
+
+        _reject_discrete_plane_wave_mpi(self.params_str())
 
         try:
             precompute = self.kwargs["precompute"]

--- a/tests/cmds_multiuse/test_discrete_plane_wave_mpi_rejection.py
+++ b/tests/cmds_multiuse/test_discrete_plane_wave_mpi_rejection.py
@@ -1,0 +1,68 @@
+"""Regression test for a confirmed correctness bug found by running real
+MPI models (mpirun -n 2) and comparing to a serial reference: the discrete
+plane wave's TFSF box is corrected with plain per-rank loops over local
+array indices (apply_TFSF_conditions_electric/_magnetic in gprMax/sources.py),
+with no awareness that the box may span multiple MPI ranks. A box larger
+than one rank's sub-domain (the normal case - TFSF boxes are usually sized
+to occupy most of the model) only gets corrected on whichever single rank
+owns the source object; other ranks silently never apply it. No crash, no
+warning - confirmed relative errors up to ~70x against a serial reference.
+
+All three discrete-plane-wave commands (#plane_wave_angles,
+#plane_wave_vector, #plane_wave_axial) now reject MPI outright at build
+time, matching the existing pattern for #magnetic_frill_source and
+#eigenmode_source (both of which reject MPI for analogous reasons - a
+write footprint or box that cannot be safely split across rank
+boundaries).
+"""
+
+import pytest
+
+import gprMax
+import gprMax.config as config
+
+
+def _set_mpi(monkeypatch, mpi=True):
+    monkeypatch.setattr(config, "sim_config", type("_SC", (), {})())
+    config.sim_config.general = {"solver": "cpu"}
+    config.sim_config.mpi = mpi
+
+
+def test_plane_wave_angles_rejected_with_mpi(monkeypatch):
+    _set_mpi(monkeypatch)
+    dpw = gprMax.DiscretePlaneWaveAngles(
+        p1=(0.01, 0.01, 0.01),
+        p2=(0.04, 0.04, 0.04),
+        theta=36.7,
+        phi=63.4,
+        psi=90.0,
+        waveform_id="w",
+    )
+    with pytest.raises(ValueError, match="MPI"):
+        dpw.build(grid=None)
+
+
+def test_plane_wave_vector_rejected_with_mpi(monkeypatch):
+    _set_mpi(monkeypatch)
+    dpw = gprMax.DiscretePlaneWaveVector(
+        p1=(0.01, 0.01, 0.01),
+        p2=(0.04, 0.04, 0.04),
+        m_vec=(1, 2, 3),
+        psi=90.0,
+        waveform_id="w",
+    )
+    with pytest.raises(ValueError, match="MPI"):
+        dpw.build(grid=None)
+
+
+def test_plane_wave_axial_rejected_with_mpi(monkeypatch):
+    _set_mpi(monkeypatch)
+    dpw = gprMax.DiscretePlaneWaveAxial(
+        p1=(0.01, 0.01, 0.01),
+        p2=(0.04, 0.04, 0.04),
+        axis="z",
+        psi=90.0,
+        waveform_id="w",
+    )
+    with pytest.raises(ValueError, match="MPI"):
+        dpw.build(grid=None)

--- a/tests/ntff/test_cuda_reusable_interface.py
+++ b/tests/ntff/test_cuda_reusable_interface.py
@@ -176,6 +176,10 @@ def test_cuda_reusable_outputs_match_cpu(tmp_path, precision, real_dtype, comple
     assert cuda_frequency.result.fields["Ez"].dtype == complex_dtype
     assert cuda_far.result.fields["Etheta"].dtype == complex_dtype
     assert_array_equal(cuda_time.result.valid_lengths, cpu_time.result.valid_lengths)
+    assert_array_equal(
+        cuda_time.result.fully_supported_lengths,
+        cpu_time.result.fully_supported_lengths,
+    )
     assert_allclose(cuda_time.result.time_origins, cpu_time.result.time_origins, rtol=0, atol=0)
 
     for component in ("Ez", "Hy"):
@@ -217,6 +221,18 @@ def test_cuda_reusable_outputs_match_cpu(tmp_path, precision, real_dtype, comple
         frequency_group = output["ntff/surface/frequency/spectrum"]
         assert time_group.attrs["solver"] == "cuda"
         assert time_group.attrs["collection_backend"] == "cuda_device"
+        assert_array_equal(
+            time_group["fully_supported_lengths"][:],
+            cuda_time.result.fully_supported_lengths,
+        )
+        assert_allclose(
+            time_group["terminal_field_ratios"][:],
+            cuda_time.result.terminal_field_ratios,
+        )
+        assert_array_equal(
+            time_group["terminal_decay_ok"][:],
+            cuda_time.result.terminal_decay_ok,
+        )
         assert frequency_group.attrs["solver"] == "cuda"
         assert frequency_group.attrs["collection_backend"] == "cuda_device"
         assert frequency_group["surface_dft/Ez/field"].dtype == complex_dtype

--- a/tests/ntff/test_reusable_interface.py
+++ b/tests/ntff/test_reusable_interface.py
@@ -100,6 +100,17 @@ def test_python_api_groups_requests_and_exposes_results(tmp_path):
 
     assert time_cartesian.result.fields["Ez"].shape[0] == 1
     assert time_spherical.result.fields["Etheta"].shape[0] == 1
+    assert np.all(
+        time_cartesian.result.fully_supported_lengths <= time_cartesian.result.valid_lengths
+    )
+    assert time_cartesian.result.point_field("Ez", 0).size == int(
+        time_cartesian.result.fully_supported_lengths[0]
+    )
+    assert time_cartesian.result.point_raw_field("Ez", 0).size == int(
+        time_cartesian.result.valid_lengths[0]
+    )
+    assert time_cartesian.result.terminal_field_ratios.shape == (1,)
+    assert time_cartesian.result.terminal_decay_ok.shape == (1,)
     assert frequency_receiver.result.fields["Ez"].shape == (1, 1)
     assert far_field.result.fields["Etheta"].shape == (1, 3)
     assert not frequency_receiver.result.range_normalized

--- a/tests/ntff/test_time_domain.py
+++ b/tests/ntff/test_time_domain.py
@@ -35,11 +35,7 @@ def _reference_polynomial_deposition(
     normal_projection = np.sum(normals[np.newaxis, :, :] * direction, axis=2)
     weight_a = -areas[np.newaxis, :] / (4 * np.pi * distance)
     weight_b = areas[np.newaxis, :] * normal_projection / (4 * np.pi * distance**2)
-    weight_c = (
-        areas[np.newaxis, :]
-        * normal_projection
-        / (4 * np.pi * wave_speed * distance)
-    )
+    weight_c = areas[np.newaxis, :] * normal_projection / (4 * np.pi * wave_speed * distance)
     delay = sample_offset_steps + distance / (wave_speed * dt)
     integer_delay = np.floor(delay).astype(np.int64)
     fractional_delay = delay - integer_delay
@@ -129,9 +125,7 @@ def test_advanced_time_monitor_matches_independent_polynomial_deposition(
 def test_advanced_time_monitor_reconstructs_direct_outgoing_scalar_pulse():
     spacing = 0.04
     shape = (25, 25, 25)
-    surface = build_component_surface(
-        "Ex", (5, 5, 5), (20, 20, 20), (spacing,) * 3, shape
-    )
+    surface = build_component_surface("Ex", (5, 5, 5), (20, 20, 20), (spacing,) * 3, shape)
     source_position = np.array((0.5, 0.5, 0.5))
     point = np.array((1.05, 0.5, 0.5))
     dt = 0.01
@@ -155,7 +149,7 @@ def test_advanced_time_monitor_reconstructs_direct_outgoing_scalar_pulse():
 
     for iteration in range(iterations):
         retarded_time = iteration * dt - radius / wave_speed
-        pulse = np.exp(-((retarded_time - pulse_centre) / pulse_width) ** 2)
+        pulse = np.exp(-(((retarded_time - pulse_centre) / pulse_width) ** 2))
         field = np.divide(
             pulse,
             4 * np.pi * radius,
@@ -169,17 +163,15 @@ def test_advanced_time_monitor_reconstructs_direct_outgoing_scalar_pulse():
     result = monitor.result.fields["Ex"][0]
     direct_radius = np.linalg.norm(point - source_position)
     direct = np.exp(
-        -(
-            (monitor.result.times - direct_radius / wave_speed - pulse_centre)
-            / pulse_width
-        )
-        ** 2
+        -(((monitor.result.times - direct_radius / wave_speed - pulse_centre) / pulse_width) ** 2)
     ) / (4 * np.pi * direct_radius)
     significant = direct > 0.02 * np.max(direct)
-    relative_error = np.linalg.norm(
-        result[significant] - direct[significant]
-    ) / np.linalg.norm(direct[significant])
+    relative_error = np.linalg.norm(result[significant] - direct[significant]) / np.linalg.norm(
+        direct[significant]
+    )
 
+    assert monitor.result.terminal_decay_ok[0]
+    assert monitor.result.terminal_field_ratios[0] <= 1e-2
     # Fifteen cells per side is intentionally a modest reference mesh; the
     # combined midpoint-surface and fractional-delay error should remain well
     # below ten percent without tuning the test to a very large surface.
@@ -187,9 +179,7 @@ def test_advanced_time_monitor_reconstructs_direct_outgoing_scalar_pulse():
 
 
 def test_monitor_rejects_points_on_or_inside_any_component_surface():
-    surface = build_component_surface(
-        "Ez", (2, 2, 2), (6, 6, 6), (0.1, 0.1, 0.1), (10, 10, 10)
-    )
+    surface = build_component_surface("Ez", (2, 2, 2), (6, 6, 6), (0.1, 0.1, 0.1), (10, 10, 10))
 
     with pytest.raises(ValueError, match="strictly outside"):
         KSIRTimeDomainMonitor(
@@ -204,9 +194,7 @@ def test_monitor_rejects_points_on_or_inside_any_component_surface():
 
 
 def test_monitor_uses_patch_support_not_only_patch_centres_for_point_validation():
-    surface = build_component_surface(
-        "Ez", (2, 2, 2), (6, 6, 6), (0.1, 0.1, 0.1), (10, 10, 10)
-    )
+    surface = build_component_surface("Ez", (2, 2, 2), (6, 6, 6), (0.1, 0.1, 0.1), (10, 10, 10))
     # Ez patches on a y-normal face are centred from y=0.2, but their
     # quadrature support starts at y=0.15.  This point is therefore inside the
     # closed component surface even though it lies below every patch centre.
@@ -223,9 +211,7 @@ def test_monitor_uses_patch_support_not_only_patch_centres_for_point_validation(
 
 
 def test_monitor_requires_every_expected_sample_before_finalising():
-    surface = build_component_surface(
-        "Ex", (2, 2, 2), (5, 5, 5), (0.1, 0.1, 0.1), (9, 9, 9)
-    )
+    surface = build_component_surface("Ex", (2, 2, 2), (5, 5, 5), (0.1, 0.1, 0.1), (9, 9, 9))
     monitor = KSIRTimeDomainMonitor(
         "incomplete",
         {"Ex": surface},
@@ -244,9 +230,7 @@ def test_monitor_requires_every_expected_sample_before_finalising():
 
 def test_monitor_requires_one_material_id_across_all_straddling_samples():
     shape = (9, 9, 9)
-    surface = build_component_surface(
-        "Ex", (2, 2, 2), (5, 5, 5), (0.1, 0.1, 0.1), shape
-    )
+    surface = build_component_surface("Ex", (2, 2, 2), (5, 5, 5), (0.1, 0.1, 0.1), shape)
     monitor = KSIRTimeDomainMonitor(
         "materials",
         {"Ex": surface},
@@ -267,11 +251,9 @@ def test_monitor_requires_one_material_id_across_all_straddling_samples():
         monitor.validate_materials(material_ids, {"Ex": 0})
 
 
-def test_first_arrival_time_origin_removes_range_dependent_zero_prefix():
+def test_first_arrival_time_origin_removes_range_dependent_zero_prefix(caplog):
     shape = (9, 9, 9)
-    surface = build_component_surface(
-        "Ex", (2, 2, 2), (6, 6, 6), (0.1, 0.1, 0.1), shape
-    )
+    surface = build_component_surface("Ex", (2, 2, 2), (6, 6, 6), (0.1, 0.1, 0.1), shape)
     points = ((20.0, 0.4, 0.4), (35.0, 0.5, 0.4))
     kwargs = dict(
         surfaces={"Ex": surface},
@@ -283,9 +265,7 @@ def test_first_arrival_time_origin_removes_range_dependent_zero_prefix():
         nthreads=2,
     )
     absolute = KSIRTimeDomainMonitor("absolute", **kwargs)
-    shifted = KSIRTimeDomainMonitor(
-        "shifted", **kwargs, time_origin="first_arrival"
-    )
+    shifted = KSIRTimeDomainMonitor("shifted", **kwargs, time_origin="first_arrival")
     indices = np.indices(shape)
     zeros = np.zeros(shape)
     for iteration in range(6):
@@ -295,30 +275,40 @@ def test_first_arrival_time_origin_removes_range_dependent_zero_prefix():
     absolute.finalise()
     shifted.finalise()
 
+    assert "has not decayed" in caplog.text
+    assert not np.all(shifted.result.terminal_decay_ok)
+    assert np.max(shifted.result.terminal_field_ratios) > 1e-2
     assert shifted.output_length < absolute.output_length / 50
     assert shifted.output_length < 2 * absolute.iterations + 50
     assert shifted.result.time_origin == "first_arrival"
     assert np.all(shifted.result.time_origins > 0)
     assert shifted.result.times[0] == 0
     for point_index, origin in enumerate(shifted.time_origin_steps):
-        length = int(shifted.result.valid_lengths[point_index])
+        supported_length = int(shifted.result.fully_supported_lengths[point_index])
+        raw_length = int(shifted.result.valid_lengths[point_index])
+        assert supported_length == shifted.iterations
+        assert raw_length > supported_length
         assert_allclose(
             shifted.result.point_field("Ex", point_index),
-            absolute.result.fields["Ex"][
-                point_index, origin : origin + length
-            ],
+            absolute.result.fields["Ex"][point_index, origin : origin + supported_length],
         )
         assert_allclose(
             shifted.result.point_times(point_index),
-            absolute.result.times[origin : origin + length],
+            absolute.result.times[origin : origin + supported_length],
+        )
+        assert_allclose(
+            shifted.result.point_raw_field("Ex", point_index),
+            absolute.result.fields["Ex"][point_index, origin : origin + raw_length],
+        )
+        assert_allclose(
+            shifted.result.point_raw_times(point_index),
+            absolute.result.times[origin : origin + raw_length],
         )
 
 
 @pytest.mark.parametrize("time_origin", [None, "arrival", 3])
 def test_monitor_rejects_unknown_time_origin(time_origin):
-    surface = build_component_surface(
-        "Ex", (2, 2, 2), (5, 5, 5), (0.1, 0.1, 0.1), (9, 9, 9)
-    )
+    surface = build_component_surface("Ex", (2, 2, 2), (5, 5, 5), (0.1, 0.1, 0.1), (9, 9, 9))
     with pytest.raises(ValueError, match="time_origin"):
         KSIRTimeDomainMonitor(
             "invalid",
@@ -361,11 +351,10 @@ def test_monitor_rejects_surface_faces_inconsistent_with_closure():
             closure=closure,
         )
 
+
 def test_compact_time_histories_and_metadata_are_written_to_hdf5(tmp_path):
     shape = (9, 9, 9)
-    surface = build_component_surface(
-        "Ex", (2, 2, 2), (6, 6, 6), (0.1, 0.1, 0.1), shape
-    )
+    surface = build_component_surface("Ex", (2, 2, 2), (6, 6, 6), (0.1, 0.1, 0.1), shape)
     monitor = KSIRTimeDomainMonitor(
         "compact",
         {"Ex": surface},
@@ -401,6 +390,17 @@ def test_compact_time_histories_and_metadata_are_written_to_hdf5(tmp_path):
         assert_allclose(group["times"][:], monitor.result.times)
         assert_allclose(group["time_origins"][:], monitor.result.time_origins)
         assert_allclose(group["valid_lengths"][:], monitor.result.valid_lengths)
+        assert_allclose(
+            group["fully_supported_lengths"][:],
+            monitor.result.fully_supported_lengths,
+        )
+        assert_allclose(
+            group["terminal_field_ratios"][:],
+            monitor.result.terminal_field_ratios,
+        )
+        assert_allclose(group["terminal_decay_ok"][:], monitor.result.terminal_decay_ok)
+        assert group.attrs["terminal_decay_threshold"] == 1e-2
+        assert group.attrs["terminal_decay_window_samples"] == 32
         assert_allclose(group["fields/Ex"][:], monitor.result.fields["Ex"])
 
 


### PR DESCRIPTION
# PR Description

## Summary

- Prevent KSIR time-domain accessors from returning the incomplete retarded-time tail by default.
- Preserve the complete raw buffer through explicit `point_raw_*` accessors.
- Store fully supported lengths, terminal field ratios, and decay status in HDF5 output.
- Warn when the surface fields have not decayed sufficiently before the end of the simulation.
- Reject discrete plane-wave commands with MPI, where TFSF corrections are not currently decomposition-aware.
- Update the Python API, hash-command, and output documentation.

## Testing

- 260 NTFF and plane-wave tests passed.
- Sphinx HTML documentation built successfully.
- Black 23.12.1 and isort 5.13.2 passed for the modified NTFF and test modules.

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update.

- [ ] Did pre-commit pass all checks?
- [x] I have performed a self-review of my code.
- [x] I have added comments for my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.