### PR TITLE
fix 621: Auto-save plots on headless backends; fix legacy test scripts executing on import

### DIFF
--- a/gprMax/utilities/utilities.py
+++ b/gprMax/utilities/utilities.py
@@ -20,6 +20,7 @@
 import datetime
 import decimal as d
 import logging
+import os
 import re
 import textwrap
 from shutil import get_terminal_size
@@ -244,3 +245,38 @@ def fft_power(waveform, dt):
 def timer():
     """Time in fractional seconds."""
     return timer_fn()
+
+
+def handle_plot_output(plt, fig, base_filename, suffix="", show=True):
+    """Shows a figure interactively, or saves it to disk when that is not
+        possible (e.g. a headless/non-interactive matplotlib backend), so
+        plotting tools do not crash under a headless backend and do not
+        silently produce nothing when running non-interactively.
+
+    Args:
+        plt: matplotlib.pyplot module (passed in so this can be used from
+            tools that manage their own pyplot import).
+        fig: matplotlib Figure to show or save.
+        base_filename: string/path used to derive the saved PNG's filename.
+        suffix: string appended to the base filename before the extension,
+            e.g. to distinguish multiple figures from the same run.
+        show: bool, whether the caller wants the figure displayed
+            interactively. Ignored (falls back to saving) when the current
+            matplotlib backend is not interactive.
+    """
+
+    is_interactive = plt.get_backend().lower() not in ["agg", "pdf", "svg", "ps", "template"]
+    save_path = os.path.splitext(os.path.abspath(base_filename))[0] + suffix + ".png"
+
+    if not show or not is_interactive:
+        fig.savefig(save_path, dpi=150, format="png", bbox_inches="tight", pad_inches=0.1)
+        logger.info(Fore.GREEN + f"Plot saved to: {save_path}" + Style.RESET_ALL)
+        if show and not is_interactive:
+            logger.warning(
+                Fore.YELLOW
+                + "Non-interactive backend detected. Plot was automatically "
+                + "saved instead of shown."
+                + Style.RESET_ALL
+            )
+    else:
+        plt.show()

--- a/testing/test_experimental.py
+++ b/testing/test_experimental.py
@@ -25,88 +25,92 @@ import h5py
 import matplotlib.pyplot as plt
 import numpy as np
 
+from gprMax.utilities.utilities import handle_plot_output
+
 logger = logging.getLogger(__name__)
 
-"""Plots a comparison of fields between given simulation output and experimental
-    data files.
-"""
 
-# Parse command line arguments
-parser = argparse.ArgumentParser(
-    description="Plots a comparison of fields between "
-    + "given simulation output and experimental data files.",
-    usage="cd gprMax; python -m testing.test_experimental modelfile realfile output",
-)
-parser.add_argument("modelfile", help="name of model output file including path")
-parser.add_argument("realfile", help="name of file containing experimental data including path")
-parser.add_argument("output", help="output to be plotted, i.e. Ex Ey Ez", nargs="+")
-args = parser.parse_args()
+def main():
+    """Plots a comparison of fields between given simulation output and
+    experimental data files.
+    """
 
-modelfile = Path(args.modelfile)
-realfile = Path(args.realfile)
-
-# Model results
-f = h5py.File(Path(modelfile), "r")
-path = "/rxs/rx1/"
-availablecomponents = list(f[path].keys())
-
-# Check for polarity of output and if requested output is in file
-if args.output[0][0] == "m":
-    polarity = -1
-    args.outputs[0] = args.output[0][1:]
-else:
-    polarity = 1
-
-if args.output[0] not in availablecomponents:
-    logger.exception(
-        f"{args.output[0]} output requested to plot, but the "
-        + f"available output for receiver 1 is {', '.join(availablecomponents)}"
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(
+        description="Plots a comparison of fields between "
+        + "given simulation output and experimental data files.",
+        usage="cd gprMax; python -m testing.test_experimental modelfile realfile output",
     )
-    raise ValueError
+    parser.add_argument("modelfile", help="name of model output file including path")
+    parser.add_argument(
+        "realfile", help="name of file containing experimental data including path"
+    )
+    parser.add_argument("output", help="output to be plotted, i.e. Ex Ey Ez", nargs="+")
+    args = parser.parse_args()
 
-floattype = f[path + args.output[0]].dtype
-iterations = f.attrs["Iterations"]
-dt = f.attrs["dt"]
-model = np.zeros(iterations, dtype=floattype)
-model = f[path + args.output[0]][:] * polarity
-model /= np.amax(np.abs(model))
-timemodel = np.linspace(0, 1, iterations)
-timemodel *= iterations * dt
-f.close()
+    modelfile = Path(args.modelfile)
+    realfile = Path(args.realfile)
 
-# Find location of maximum value from model
-modelmax = np.where(np.abs(model) == 1)[0][0]
+    # Model results
+    f = h5py.File(Path(modelfile), "r")
+    path = "/rxs/rx1/"
+    availablecomponents = list(f[path].keys())
 
-# Real results
-with open(realfile, "r") as f:
-    real = np.loadtxt(f)
-real[:, 1] = real[:, 1] / np.amax(np.abs(real[:, 1]))
-realmax = np.where(np.abs(real[:, 1]) == 1)[0][0]
+    # Check for polarity of output and if requested output is in file
+    if args.output[0][0] == "m":
+        polarity = -1
+        args.output[0] = args.output[0][1:]
+    else:
+        polarity = 1
 
-difftime = -(timemodel[modelmax] - real[realmax, 0])
+    if args.output[0] not in availablecomponents:
+        logger.exception(
+            f"{args.output[0]} output requested to plot, but the "
+            + f"available output for receiver 1 is {', '.join(availablecomponents)}"
+        )
+        raise ValueError
 
-# Plot modelled and real data
-fig, ax = plt.subplots(
-    num=f"{modelfile.stem}_vs_{realfile.stem}",
-    figsize=(20, 10),
-    facecolor="w",
-    edgecolor="w",
-)
-ax.plot(timemodel + difftime, model, "r", lw=2, label="Model")
-ax.plot(real[:, 0], real[:, 1], "r", ls="--", lw=2, label="Experiment")
-ax.set_xlabel("Time [s]")
-ax.set_ylabel("Amplitude")
-ax.set_xlim([0, timemodel[-1]])
-# ax.set_ylim([-1, 1])
-ax.legend()
-ax.grid()
+    floattype = f[path + args.output[0]].dtype
+    iterations = f.attrs["Iterations"]
+    dt = f.attrs["dt"]
+    model = np.zeros(iterations, dtype=floattype)
+    model = f[path + args.output[0]][:] * polarity
+    model /= np.amax(np.abs(model))
+    timemodel = np.linspace(0, 1, iterations)
+    timemodel *= iterations * dt
+    f.close()
 
-# Save a PDF/PNG of the figure
-savename = f"{modelfile.stem}_vs_{realfile.stem}"
-savename = modelfile.parent / savename
-# fig.savefig(savename.with_suffix('.pdf'), dpi=None, format='pdf',
-#             bbox_inches='tight', pad_inches=0.1)
-# fig.savefig(savename.with_suffix('.png'), dpi=150, format='png',
-#             bbox_inches='tight', pad_inches=0.1)
+    # Find location of maximum value from model
+    modelmax = np.where(np.abs(model) == 1)[0][0]
 
-plt.show()
+    # Real results
+    with open(realfile, "r") as f:
+        real = np.loadtxt(f)
+    real[:, 1] = real[:, 1] / np.amax(np.abs(real[:, 1]))
+    realmax = np.where(np.abs(real[:, 1]) == 1)[0][0]
+
+    difftime = -(timemodel[modelmax] - real[realmax, 0])
+
+    # Plot modelled and real data
+    fig, ax = plt.subplots(
+        num=f"{modelfile.stem}_vs_{realfile.stem}",
+        figsize=(20, 10),
+        facecolor="w",
+        edgecolor="w",
+    )
+    ax.plot(timemodel + difftime, model, "r", lw=2, label="Model")
+    ax.plot(real[:, 0], real[:, 1], "r", ls="--", lw=2, label="Experiment")
+    ax.set_xlabel("Time [s]")
+    ax.set_ylabel("Amplitude")
+    ax.set_xlim([0, timemodel[-1]])
+    # ax.set_ylim([-1, 1])
+    ax.legend()
+    ax.grid()
+
+    savename = f"{modelfile.stem}_vs_{realfile.stem}"
+    savename = modelfile.parent / savename
+    handle_plot_output(plt, fig, str(savename))
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/test_models.py
+++ b/testing/test_models.py
@@ -31,280 +31,286 @@ from gprMax.utilities.logging import logging_config
 from testing.analytical_solutions import hertzian_dipole_fs
 
 logger = logging.getLogger(__name__)
-logging_config(name=__name__)
-
-if sys.platform == "linux":
-    plt.switch_backend("agg")
 
 
-"""Compare field outputs
+def main():
+    """Compare field outputs
 
     Usage:
         cd gprMax
         python -m testing.test_models
-"""
+    """
 
-# Specify directory with set of models to test
-modelset = "models_basic"
-# modelset += 'models_advanced'
+    logging_config(name=__name__)
 
-basepath = Path(__file__).parents[0] / modelset
+    if sys.platform == "linux":
+        plt.switch_backend("agg")
 
-# List of available basic test models
-testmodels = [
-    "hertzian_dipole_fs_analytical",
-    "2D_ExHyHz",
-    "2D_EyHxHz",
-    "2D_EzHxHy",
-    "cylinder_Ascan_2D",
-    "hertzian_dipole_fs",
-    "hertzian_dipole_hs",
-    "hertzian_dipole_dispersive",
-    "antenna_wire_dipole_fs",
-    "magnetic_dipole_fs",
-]
+    # Specify directory with set of models to test
+    modelset = "models_basic"
+    # modelset += 'models_advanced'
 
-# List of available advanced test models
-# testmodels = ['antenna_GSSI_1500_fs', 'antenna_MALA_1200_fs']
+    basepath = Path(__file__).parents[0] / modelset
 
-# Select a specific model if desired
-# testmodels = [testmodels[0]]
-testresults = dict.fromkeys(testmodels)
-path = "/rxs/rx1/"
+    # List of available basic test models
+    testmodels = [
+        "hertzian_dipole_fs_analytical",
+        "2D_ExHyHz",
+        "2D_EyHxHz",
+        "2D_EzHxHy",
+        "cylinder_Ascan_2D",
+        "hertzian_dipole_fs",
+        "hertzian_dipole_hs",
+        "hertzian_dipole_dispersive",
+        "antenna_wire_dipole_fs",
+        "magnetic_dipole_fs",
+    ]
 
-# Minimum value of difference to plot (dB)
-plotmin = -160
+    # List of available advanced test models
+    # testmodels = ['antenna_GSSI_1500_fs', 'antenna_MALA_1200_fs']
 
-for i, model in enumerate(testmodels):
-    testresults[model] = {}
+    # Select a specific model if desired
+    # testmodels = [testmodels[0]]
+    testresults = dict.fromkeys(testmodels)
+    path = "/rxs/rx1/"
 
-    # Run model
-    file = basepath / model / model
-    gprMax.run(inputfile=file.with_suffix(".in"), gpu=None, opencl=None)
+    # Minimum value of difference to plot (dB)
+    plotmin = -160
 
-    # Special case for analytical comparison
-    if model == "hertzian_dipole_fs_analytical":
-        # Get output for model file
-        filetest = h5py.File(file.with_suffix(".h5"), "r")
-        testresults[model]["Test version"] = filetest.attrs["gprMax"]
+    for i, model in enumerate(testmodels):
+        testresults[model] = {}
 
-        # Get available field output component names
-        outputstest = list(filetest[path].keys())
+        # Run model
+        file = basepath / model / model
+        gprMax.run(inputfile=file.with_suffix(".in"), gpu=None, opencl=None)
 
-        # Arrays for storing time
-        float_or_double = filetest[path + outputstest[0]].dtype
-        timetest = (
-            np.linspace(
-                0,
-                (filetest.attrs["Iterations"] - 1) * filetest.attrs["dt"],
-                num=filetest.attrs["Iterations"],
+        # Special case for analytical comparison
+        if model == "hertzian_dipole_fs_analytical":
+            # Get output for model file
+            filetest = h5py.File(file.with_suffix(".h5"), "r")
+            testresults[model]["Test version"] = filetest.attrs["gprMax"]
+
+            # Get available field output component names
+            outputstest = list(filetest[path].keys())
+
+            # Arrays for storing time
+            float_or_double = filetest[path + outputstest[0]].dtype
+            timetest = (
+                np.linspace(
+                    0,
+                    (filetest.attrs["Iterations"] - 1) * filetest.attrs["dt"],
+                    num=filetest.attrs["Iterations"],
+                )
+                / 1e-9
             )
-            / 1e-9
-        )
-        timeref = timetest
+            timeref = timetest
 
-        # Arrays for storing field data
-        datatest = np.zeros((filetest.attrs["Iterations"], len(outputstest)), dtype=float_or_double)
-        for ID, name in enumerate(outputstest):
-            datatest[:, ID] = filetest[path + str(name)][:]
-            if np.any(np.isnan(datatest[:, ID])):
-                logger.exception("Test data contains NaNs")
+            # Arrays for storing field data
+            datatest = np.zeros((filetest.attrs["Iterations"], len(outputstest)), dtype=float_or_double)
+            for ID, name in enumerate(outputstest):
+                datatest[:, ID] = filetest[path + str(name)][:]
+                if np.any(np.isnan(datatest[:, ID])):
+                    logger.exception("Test data contains NaNs")
+                    raise ValueError
+
+            # Tx/Rx position to feed to analytical solution
+            rxpos = filetest[path].attrs["Position"]
+            txpos = filetest["/srcs/src1/"].attrs["Position"]
+            rxposrelative = (
+                (rxpos[0] - txpos[0]),
+                (rxpos[1] - txpos[1]),
+                (rxpos[2] - txpos[2]),
+            )
+
+            # Analytical solution of a dipole in free space
+            dataref = hertzian_dipole_fs(
+                filetest.attrs["Iterations"],
+                filetest.attrs["dt"],
+                filetest.attrs["dx_dy_dz"],
+                rxposrelative,
+            )
+            filetest.close()
+
+        else:
+            # Get output for model and reference files
+            fileref = f"{file.stem}_ref"
+            fileref = file.parent / Path(fileref)
+            fileref = h5py.File(fileref.with_suffix(".h5"), "r")
+            filetest = h5py.File(file.with_suffix(".h5"), "r")
+            testresults[model]["Ref version"] = fileref.attrs["gprMax"]
+            testresults[model]["Test version"] = filetest.attrs["gprMax"]
+
+            # Get available field output component names
+            outputsref = list(fileref[path].keys())
+            outputstest = list(filetest[path].keys())
+            if outputsref != outputstest:
+                logger.exception("Field output components do not match reference solution")
                 raise ValueError
 
-        # Tx/Rx position to feed to analytical solution
-        rxpos = filetest[path].attrs["Position"]
-        txpos = filetest["/srcs/src1/"].attrs["Position"]
-        rxposrelative = (
-            (rxpos[0] - txpos[0]),
-            (rxpos[1] - txpos[1]),
-            (rxpos[2] - txpos[2]),
-        )
+            # Check that type of float used to store fields matches
+            float_or_doubleref = fileref[path + outputsref[0]].dtype
+            float_or_doubletest = filetest[path + outputstest[0]].dtype
+            if float_or_doubleref != float_or_doubletest:
+                logger.warning(
+                    f"Type of floating point number in test model "
+                    f"({float_or_doubletest}) does not "
+                    f"match type in reference solution ({float_or_doubleref})\n"
+                )
 
-        # Analytical solution of a dipole in free space
-        dataref = hertzian_dipole_fs(
-            filetest.attrs["Iterations"],
-            filetest.attrs["dt"],
-            filetest.attrs["dx_dy_dz"],
-            rxposrelative,
-        )
-        filetest.close()
-
-    else:
-        # Get output for model and reference files
-        fileref = f"{file.stem}_ref"
-        fileref = file.parent / Path(fileref)
-        fileref = h5py.File(fileref.with_suffix(".h5"), "r")
-        filetest = h5py.File(file.with_suffix(".h5"), "r")
-        testresults[model]["Ref version"] = fileref.attrs["gprMax"]
-        testresults[model]["Test version"] = filetest.attrs["gprMax"]
-
-        # Get available field output component names
-        outputsref = list(fileref[path].keys())
-        outputstest = list(filetest[path].keys())
-        if outputsref != outputstest:
-            logger.exception("Field output components do not match reference solution")
-            raise ValueError
-
-        # Check that type of float used to store fields matches
-        float_or_doubleref = fileref[path + outputsref[0]].dtype
-        float_or_doubletest = filetest[path + outputstest[0]].dtype
-        if float_or_doubleref != float_or_doubletest:
-            logger.warning(
-                f"Type of floating point number in test model "
-                f"({float_or_doubletest}) does not "
-                f"match type in reference solution ({float_or_doubleref})\n"
+            # Arrays for storing time
+            timeref = np.zeros((fileref.attrs["Iterations"]), dtype=float_or_doubleref)
+            timeref = (
+                np.linspace(
+                    0,
+                    (fileref.attrs["Iterations"] - 1) * fileref.attrs["dt"],
+                    num=fileref.attrs["Iterations"],
+                )
+                / 1e-9
+            )
+            timetest = np.zeros((filetest.attrs["Iterations"]), dtype=float_or_doubletest)
+            timetest = (
+                np.linspace(
+                    0,
+                    (filetest.attrs["Iterations"] - 1) * filetest.attrs["dt"],
+                    num=filetest.attrs["Iterations"],
+                )
+                / 1e-9
             )
 
-        # Arrays for storing time
-        timeref = np.zeros((fileref.attrs["Iterations"]), dtype=float_or_doubleref)
-        timeref = (
-            np.linspace(
-                0,
-                (fileref.attrs["Iterations"] - 1) * fileref.attrs["dt"],
-                num=fileref.attrs["Iterations"],
+            # Arrays for storing field data
+            dataref = np.zeros((fileref.attrs["Iterations"], len(outputsref)), dtype=float_or_doubleref)
+            datatest = np.zeros(
+                (filetest.attrs["Iterations"], len(outputstest)), dtype=float_or_doubletest
             )
-            / 1e-9
+            for ID, name in enumerate(outputsref):
+                dataref[:, ID] = fileref[path + str(name)][:]
+                datatest[:, ID] = filetest[path + str(name)][:]
+                if np.any(np.isnan(datatest[:, ID])):
+                    logger.exception("Test data contains NaNs")
+                    raise ValueError
+
+            fileref.close()
+            filetest.close()
+
+        # Diffs
+        datadiffs = np.zeros(datatest.shape, dtype=np.float64)
+        for i in range(len(outputstest)):
+            maxi = np.amax(np.abs(dataref[:, i]))
+            datadiffs[:, i] = np.divide(
+                np.abs(dataref[:, i] - datatest[:, i]),
+                maxi,
+                out=np.zeros_like(dataref[:, i]),
+                where=maxi != 0,
+            )  # Replace any division by zero with zero
+
+            # Calculate power (ignore warning from taking a log of any zero values)
+            with np.errstate(divide="ignore"):
+                datadiffs[:, i] = 20 * np.log10(datadiffs[:, i])
+            # Replace any NaNs or Infs from zero division
+            datadiffs[:, i][np.invert(np.isfinite(datadiffs[:, i]))] = 0
+
+        # Store max difference
+        maxdiff = np.amax(np.amax(datadiffs))
+        testresults[model]["Max diff"] = maxdiff
+
+        # Plot datasets
+        fig1, ((ex1, hx1), (ey1, hy1), (ez1, hz1)) = plt.subplots(
+            nrows=3,
+            ncols=2,
+            sharex=False,
+            sharey="col",
+            subplot_kw=dict(xlabel="Time [ns]"),
+            num=model + ".in",
+            figsize=(20, 10),
+            facecolor="w",
+            edgecolor="w",
         )
-        timetest = np.zeros((filetest.attrs["Iterations"]), dtype=float_or_doubletest)
-        timetest = (
-            np.linspace(
-                0,
-                (filetest.attrs["Iterations"] - 1) * filetest.attrs["dt"],
-                num=filetest.attrs["Iterations"],
+        ex1.plot(timetest, datatest[:, 0], "r", lw=2, label=model)
+        ex1.plot(timeref, dataref[:, 0], "g", lw=2, ls="--", label=f"{model}(Ref)")
+        ey1.plot(timetest, datatest[:, 1], "r", lw=2, label=model)
+        ey1.plot(timeref, dataref[:, 1], "g", lw=2, ls="--", label=f"{model}(Ref)")
+        ez1.plot(timetest, datatest[:, 2], "r", lw=2, label=model)
+        ez1.plot(timeref, dataref[:, 2], "g", lw=2, ls="--", label=f"{model}(Ref)")
+        hx1.plot(timetest, datatest[:, 3], "r", lw=2, label=model)
+        hx1.plot(timeref, dataref[:, 3], "g", lw=2, ls="--", label=f"{model}(Ref)")
+        hy1.plot(timetest, datatest[:, 4], "r", lw=2, label=model)
+        hy1.plot(timeref, dataref[:, 4], "g", lw=2, ls="--", label=f"{model}(Ref)")
+        hz1.plot(timetest, datatest[:, 5], "r", lw=2, label=model)
+        hz1.plot(timeref, dataref[:, 5], "g", lw=2, ls="--", label=f"{model}(Ref)")
+        ylabels = [
+            "$E_x$, field strength [V/m]",
+            "$H_x$, field strength [A/m]",
+            "$E_y$, field strength [V/m]",
+            "$H_y$, field strength [A/m]",
+            "$E_z$, field strength [V/m]",
+            "$H_z$, field strength [A/m]",
+        ]
+        for i, ax in enumerate(fig1.axes):
+            ax.set_ylabel(ylabels[i])
+            ax.set_xlim(0, np.amax(timetest))
+            ax.grid()
+            ax.legend()
+
+        # Plot diffs
+        fig2, ((ex2, hx2), (ey2, hy2), (ez2, hz2)) = plt.subplots(
+            nrows=3,
+            ncols=2,
+            sharex=False,
+            sharey="col",
+            subplot_kw=dict(xlabel="Time [ns]"),
+            num="Diffs: " + model + ".in",
+            figsize=(20, 10),
+            facecolor="w",
+            edgecolor="w",
+        )
+        ex2.plot(timeref, datadiffs[:, 0], "r", lw=2, label="Ex")
+        ey2.plot(timeref, datadiffs[:, 1], "r", lw=2, label="Ey")
+        ez2.plot(timeref, datadiffs[:, 2], "r", lw=2, label="Ez")
+        hx2.plot(timeref, datadiffs[:, 3], "r", lw=2, label="Hx")
+        hy2.plot(timeref, datadiffs[:, 4], "r", lw=2, label="Hy")
+        hz2.plot(timeref, datadiffs[:, 5], "r", lw=2, label="Hz")
+        ylabels = [
+            "$E_x$, difference [dB]",
+            "$H_x$, difference [dB]",
+            "$E_y$, difference [dB]",
+            "$H_y$, difference [dB]",
+            "$E_z$, difference [dB]",
+            "$H_z$, difference [dB]",
+        ]
+        for i, ax in enumerate(fig2.axes):
+            ax.set_ylabel(ylabels[i])
+            ax.set_xlim(0, np.amax(timetest))
+            ax.set_ylim([plotmin, np.amax(np.amax(datadiffs))])
+            ax.grid()
+
+        # Save a PDF/PNG of the figure
+        filediffs = f"{file.stem}_diffs"
+        filediffs = file.parent / Path(filediffs)
+        # fig1.savefig(file.with_suffix('.pdf'), dpi=None, format='pdf',
+        #              bbox_inches='tight', pad_inches=0.1)
+        # fig2.savefig(savediffs.with_suffix('.pdf'), dpi=None, format='pdf',
+        #              bbox_inches='tight', pad_inches=0.1)
+        fig1.savefig(
+            file.with_suffix(".png"), dpi=150, format="png", bbox_inches="tight", pad_inches=0.1
+        )
+        fig2.savefig(
+            filediffs.with_suffix(".png"), dpi=150, format="png", bbox_inches="tight", pad_inches=0.1
+        )
+
+    # Summary of results
+    for name, data in sorted(testresults.items()):
+        if "analytical" in name:
+            logger.info(
+                Fore.CYAN + f"Test '{name}.in' using v.{data['Test version']} compared "
+                f"to analytical solution. Max difference {data['Max diff']:.2f}dB." + Style.RESET_ALL
             )
-            / 1e-9
-        )
+        else:
+            logger.info(
+                Fore.CYAN + f"Test '{name}.in' using v.{data['Test version']} compared to "
+                f"reference solution using v.{data['Ref version']}. Max difference "
+                f"{data['Max diff']:.2f}dB." + Style.RESET_ALL
+            )
 
-        # Arrays for storing field data
-        dataref = np.zeros((fileref.attrs["Iterations"], len(outputsref)), dtype=float_or_doubleref)
-        datatest = np.zeros(
-            (filetest.attrs["Iterations"], len(outputstest)), dtype=float_or_doubletest
-        )
-        for ID, name in enumerate(outputsref):
-            dataref[:, ID] = fileref[path + str(name)][:]
-            datatest[:, ID] = filetest[path + str(name)][:]
-            if np.any(np.isnan(datatest[:, ID])):
-                logger.exception("Test data contains NaNs")
-                raise ValueError
 
-        fileref.close()
-        filetest.close()
-
-    # Diffs
-    datadiffs = np.zeros(datatest.shape, dtype=np.float64)
-    for i in range(len(outputstest)):
-        maxi = np.amax(np.abs(dataref[:, i]))
-        datadiffs[:, i] = np.divide(
-            np.abs(dataref[:, i] - datatest[:, i]),
-            maxi,
-            out=np.zeros_like(dataref[:, i]),
-            where=maxi != 0,
-        )  # Replace any division by zero with zero
-
-        # Calculate power (ignore warning from taking a log of any zero values)
-        with np.errstate(divide="ignore"):
-            datadiffs[:, i] = 20 * np.log10(datadiffs[:, i])
-        # Replace any NaNs or Infs from zero division
-        datadiffs[:, i][np.invert(np.isfinite(datadiffs[:, i]))] = 0
-
-    # Store max difference
-    maxdiff = np.amax(np.amax(datadiffs))
-    testresults[model]["Max diff"] = maxdiff
-
-    # Plot datasets
-    fig1, ((ex1, hx1), (ey1, hy1), (ez1, hz1)) = plt.subplots(
-        nrows=3,
-        ncols=2,
-        sharex=False,
-        sharey="col",
-        subplot_kw=dict(xlabel="Time [ns]"),
-        num=model + ".in",
-        figsize=(20, 10),
-        facecolor="w",
-        edgecolor="w",
-    )
-    ex1.plot(timetest, datatest[:, 0], "r", lw=2, label=model)
-    ex1.plot(timeref, dataref[:, 0], "g", lw=2, ls="--", label=f"{model}(Ref)")
-    ey1.plot(timetest, datatest[:, 1], "r", lw=2, label=model)
-    ey1.plot(timeref, dataref[:, 1], "g", lw=2, ls="--", label=f"{model}(Ref)")
-    ez1.plot(timetest, datatest[:, 2], "r", lw=2, label=model)
-    ez1.plot(timeref, dataref[:, 2], "g", lw=2, ls="--", label=f"{model}(Ref)")
-    hx1.plot(timetest, datatest[:, 3], "r", lw=2, label=model)
-    hx1.plot(timeref, dataref[:, 3], "g", lw=2, ls="--", label=f"{model}(Ref)")
-    hy1.plot(timetest, datatest[:, 4], "r", lw=2, label=model)
-    hy1.plot(timeref, dataref[:, 4], "g", lw=2, ls="--", label=f"{model}(Ref)")
-    hz1.plot(timetest, datatest[:, 5], "r", lw=2, label=model)
-    hz1.plot(timeref, dataref[:, 5], "g", lw=2, ls="--", label=f"{model}(Ref)")
-    ylabels = [
-        "$E_x$, field strength [V/m]",
-        "$H_x$, field strength [A/m]",
-        "$E_y$, field strength [V/m]",
-        "$H_y$, field strength [A/m]",
-        "$E_z$, field strength [V/m]",
-        "$H_z$, field strength [A/m]",
-    ]
-    for i, ax in enumerate(fig1.axes):
-        ax.set_ylabel(ylabels[i])
-        ax.set_xlim(0, np.amax(timetest))
-        ax.grid()
-        ax.legend()
-
-    # Plot diffs
-    fig2, ((ex2, hx2), (ey2, hy2), (ez2, hz2)) = plt.subplots(
-        nrows=3,
-        ncols=2,
-        sharex=False,
-        sharey="col",
-        subplot_kw=dict(xlabel="Time [ns]"),
-        num="Diffs: " + model + ".in",
-        figsize=(20, 10),
-        facecolor="w",
-        edgecolor="w",
-    )
-    ex2.plot(timeref, datadiffs[:, 0], "r", lw=2, label="Ex")
-    ey2.plot(timeref, datadiffs[:, 1], "r", lw=2, label="Ey")
-    ez2.plot(timeref, datadiffs[:, 2], "r", lw=2, label="Ez")
-    hx2.plot(timeref, datadiffs[:, 3], "r", lw=2, label="Hx")
-    hy2.plot(timeref, datadiffs[:, 4], "r", lw=2, label="Hy")
-    hz2.plot(timeref, datadiffs[:, 5], "r", lw=2, label="Hz")
-    ylabels = [
-        "$E_x$, difference [dB]",
-        "$H_x$, difference [dB]",
-        "$E_y$, difference [dB]",
-        "$H_y$, difference [dB]",
-        "$E_z$, difference [dB]",
-        "$H_z$, difference [dB]",
-    ]
-    for i, ax in enumerate(fig2.axes):
-        ax.set_ylabel(ylabels[i])
-        ax.set_xlim(0, np.amax(timetest))
-        ax.set_ylim([plotmin, np.amax(np.amax(datadiffs))])
-        ax.grid()
-
-    # Save a PDF/PNG of the figure
-    filediffs = f"{file.stem}_diffs"
-    filediffs = file.parent / Path(filediffs)
-    # fig1.savefig(file.with_suffix('.pdf'), dpi=None, format='pdf',
-    #              bbox_inches='tight', pad_inches=0.1)
-    # fig2.savefig(savediffs.with_suffix('.pdf'), dpi=None, format='pdf',
-    #              bbox_inches='tight', pad_inches=0.1)
-    fig1.savefig(
-        file.with_suffix(".png"), dpi=150, format="png", bbox_inches="tight", pad_inches=0.1
-    )
-    fig2.savefig(
-        filediffs.with_suffix(".png"), dpi=150, format="png", bbox_inches="tight", pad_inches=0.1
-    )
-
-# Summary of results
-for name, data in sorted(testresults.items()):
-    if "analytical" in name:
-        logger.info(
-            Fore.CYAN + f"Test '{name}.in' using v.{data['Test version']} compared "
-            f"to analytical solution. Max difference {data['Max diff']:.2f}dB." + Style.RESET_ALL
-        )
-    else:
-        logger.info(
-            Fore.CYAN + f"Test '{name}.in' using v.{data['Test version']} compared to "
-            f"reference solution using v.{data['Ref version']}. Max difference "
-            f"{data['Max diff']:.2f}dB." + Style.RESET_ALL
-        )
+if __name__ == "__main__":
+    main()

--- a/toolboxes/Plotting/plot_Ascan.py
+++ b/toolboxes/Plotting/plot_Ascan.py
@@ -26,12 +26,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from gprMax.receivers import Rx
-from gprMax.utilities.utilities import fft_power
+from gprMax.utilities.utilities import fft_power, handle_plot_output
 
 logger = logging.getLogger(__name__)
 
 
-def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False, save=False):
+def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False, show=True):
     """Plots electric and magnetic fields and currents from all receiver points
         in the given output file. Each receiver point is plotted in a new figure
         window.
@@ -40,7 +40,9 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False, save=False):
         filename: string of filename (including path) of output file.
         outputs: list of field/current components to plot.
         fft: boolean flag to plot FFT.
-        save: boolean flag to save plot to file.
+        show: boolean flag to display each plot interactively; if False, or
+            if the current matplotlib backend is not interactive, each plot
+            is saved to file instead.
 
     Returns:
         plt: matplotlib plot object.
@@ -168,8 +170,6 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False, save=False):
                         plt.setp(stemlines, "color", "b")
                         plt.setp(markerline, "markerfacecolor", "b", "markeredgecolor", "b")
 
-                    plt.show()
-
                 # Plotting if no FFT required
                 else:
                     fig, ax = plt.subplots(
@@ -263,20 +263,13 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False, save=False):
                     ax.set_xlim([0, np.amax(time)])
                     ax.grid(which="both", axis="both", linestyle="-.")
 
-    f.close()
+            # Show or save this receiver's figure now, rather than after the
+            # loop over all receivers/paths - otherwise only the last
+            # receiver's figure would ever be shown/saved.
+            suffix = "_" + rxpath.strip("/").replace("/", "_")
+            handle_plot_output(plt, fig, str(file), suffix=suffix, show=show)
 
-    if save:
-        # Save a PDF of the figure
-        fig.savefig(
-            filename[:-3] + ".pdf",
-            dpi=None,
-            format="pdf",
-            bbox_inches="tight",
-            pad_inches=0.1,
-        )
-        # Save a PNG of the figure
-        # fig.savefig(filename[:-3] + '.png', dpi=150, format='png',
-        #             bbox_inches='tight', pad_inches=0.1)
+    f.close()
 
     return plt
 
@@ -330,6 +323,4 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    plthandle = mpl_plot(args.outputfile, args.outputs, fft=args.fft, save=args.save)
-
-    plthandle.show()
+    mpl_plot(args.outputfile, args.outputs, fft=args.fft, show=not args.save)

--- a/toolboxes/Plotting/plot_Bscan.py
+++ b/toolboxes/Plotting/plot_Bscan.py
@@ -25,11 +25,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from ..Utilities.outputfiles_merge import get_output_data
+from gprMax.utilities.utilities import handle_plot_output
 
 logger = logging.getLogger(__name__)
 
 
-def mpl_plot(filename, outputdata, dt, rxnumber, rxcomponent, save=False):
+def mpl_plot(filename, outputdata, dt, rxnumber, rxcomponent, show=True):
     """Creates a plot of the B-scan.
 
     Args:
@@ -38,7 +39,9 @@ def mpl_plot(filename, outputdata, dt, rxnumber, rxcomponent, save=False):
         dt: float of temporal resolution of the model.
         rxnumber: int of receiver output number.
         rxcomponent: string of receiver output field/current component.
-        save: boolean flag to save plot to file.
+        show: boolean flag to display the plot interactively; if False, or
+            if the current matplotlib backend is not interactive, the plot
+            is saved to file instead.
 
     Returns:
         plt: matplotlib plot object.
@@ -76,18 +79,8 @@ def mpl_plot(filename, outputdata, dt, rxnumber, rxcomponent, save=False):
     elif "I" in rxcomponent:
         cb.set_label("Current [A]")
 
-    if save:
-        # Save a PDF of the figure
-        fig.savefig(
-            filename[:-3] + ".pdf",
-            dpi=None,
-            format="pdf",
-            bbox_inches="tight",
-            pad_inches=0.1,
-        )
-        # Save a PNG of the figure
-        # fig.savefig(filename[:-3] + '.png', dpi=150, format='png',
-        #             bbox_inches='tight', pad_inches=0.1)
+    suffix = "_rx" + str(rxnumber)
+    handle_plot_output(plt, fig, str(file), suffix=suffix, show=show)
 
     return plt
 
@@ -135,12 +128,10 @@ if __name__ == "__main__":
                 rxsgather = outputdata
             rxsgather = np.column_stack((rxsgather, outputdata))
         else:
-            plthandle = mpl_plot(
-                args.outputfile, outputdata, dt, rx, args.rx_component, save=args.save
+            mpl_plot(
+                args.outputfile, outputdata, dt, rx, args.rx_component, show=not args.save
             )
 
     # Plot all receivers from single output file together if required
     if args.gather:
-        plthandle = mpl_plot(args.outputfile, rxsgather, dt, rx, args.rx_component, save=args.save)
-
-    plthandle.show()
+        mpl_plot(args.outputfile, rxsgather, dt, rx, args.rx_component, show=not args.save)

--- a/toolboxes/Plotting/plot_antenna_params.py
+++ b/toolboxes/Plotting/plot_antenna_params.py
@@ -24,6 +24,8 @@ import h5py
 import matplotlib.pyplot as plt
 import numpy as np
 
+from gprMax.utilities.utilities import handle_plot_output
+
 logger = logging.getLogger(__name__)
 
 
@@ -189,7 +191,7 @@ def mpl_plot(
     zin,
     yin,
     s21=None,
-    save=False,
+    show=True,
 ):
     """Plots antenna parameters - incident, reflected and total voltages and
         currents; s11, (s21) and input impedance.
@@ -209,7 +211,9 @@ def mpl_plot(
                                             current.
         s11, s21: array(s) of s11 and, optionally, s21 parameters.
         zin, yin: arrays of input impedance and input admittance parameters.
-        save: boolean flag to save plot to file.
+        show: boolean flag to display the plots interactively; if False, or
+            if the current matplotlib backend is not interactive, the plots
+            are saved to file instead.
 
     Returns:
         plt: matplotlib plot object.
@@ -438,32 +442,8 @@ def mpl_plot(
     # axs[2, 1].set_ylabel('Phase [degrees]')
     # axs[2, 1].grid(which='both', axis='both', linestyle='-.')
 
-    if save:
-        filepath = Path(filename)
-        savename1 = filepath.stem + "_tl_params"
-        savename1 = filepath.parent / savename1
-        savename2 = filepath.stem + "_ant_params"
-        savename2 = filepath.parent / savename2
-        # Save a PDF of the figure
-        fig1.savefig(
-            savename1.with_suffix(".pdf"),
-            dpi=None,
-            format="pdf",
-            bbox_inches="tight",
-            pad_inches=0.1,
-        )
-        fig2.savefig(
-            savename2.with_suffix(".pdf"),
-            dpi=None,
-            format="pdf",
-            bbox_inches="tight",
-            pad_inches=0.1,
-        )
-        # Save a PNG of the figure
-        # fig1.savefig(savename1.with_suffix('.png'), dpi=150, format='png',
-        #             bbox_inches='tight', pad_inches=0.1)
-        # fig2.savefig(savename2.with_suffix('.png'), dpi=150, format='png',
-        #             bbox_inches='tight', pad_inches=0.1)
+    handle_plot_output(plt, fig1, filename, suffix="_tl_params", show=show)
+    handle_plot_output(plt, fig2, filename, suffix="_ant_params", show=show)
 
     return plt
 
@@ -501,5 +481,4 @@ if __name__ == "__main__":
     antennaparams = calculate_antenna_params(
         args.outputfile, args.tltx_num, args.tlrx_num, args.rx_num, args.rx_component
     )
-    plthandle = mpl_plot(args.outputfile, **antennaparams, save=args.save)
-    plthandle.show()
+    mpl_plot(args.outputfile, **antennaparams, show=not args.save)

--- a/toolboxes/Plotting/plot_source_wave.py
+++ b/toolboxes/Plotting/plot_source_wave.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 
-from gprMax.utilities.utilities import fft_power, round_value
+from gprMax.utilities.utilities import fft_power, handle_plot_output, round_value
 from gprMax.waveforms import Waveform
 
 logging.basicConfig(format="%(message)s", level=logging.INFO)
@@ -60,7 +60,7 @@ def check_timewindow(timewindow, dt):
     return timewindow, iterations
 
 
-def mpl_plot(w, timewindow, dt, iterations, fft=False, save=False):
+def mpl_plot(w, timewindow, dt, iterations, fft=False, show=True):
     """Plots waveform and prints useful information about its properties.
 
     Args:
@@ -69,7 +69,9 @@ def mpl_plot(w, timewindow, dt, iterations, fft=False, save=False):
         dt: float of time discretisation.
         iterations: int of number of iterations.
         fft: boolean flag to plot FFT.
-        save: boolean flag to save plot to file.
+        show: boolean flag to display the plot interactively; if False, or
+            if the current matplotlib backend is not interactive, the plot
+            is saved to file instead.
 
     Returns:
         plt: matplotlib plot object.
@@ -148,24 +150,8 @@ def mpl_plot(w, timewindow, dt, iterations, fft=False, save=False):
     # Turn on grid
     [ax.grid(which="both", axis="both", linestyle="-.") for ax in fig.axes]
 
-    if save:
-        savefile = Path(__file__).parent / w.type
-        # Save a PDF of the figure
-        fig.savefig(
-            savefile.with_suffix(".pdf"),
-            dpi=None,
-            format="pdf",
-            bbox_inches="tight",
-            pad_inches=0.1,
-        )
-        # Save a PNG of the figure
-        # fig.savefig(
-        #     savefile.with_suffix(".png"),
-        #     dpi=150,
-        #     format="png",
-        #     bbox_inches="tight",
-        #     pad_inches=0.1,
-        # )
+    savefile = Path(__file__).parent / w.type
+    handle_plot_output(plt, fig, str(savefile), show=show)
 
     return plt
 
@@ -209,5 +195,4 @@ if __name__ == "__main__":
     w.freq = args.freq
 
     timewindow, iterations = check_timewindow(args.timewindow, args.dt)
-    plthandle = mpl_plot(w, timewindow, args.dt, iterations, fft=args.fft, save=args.save)
-    plthandle.show()
+    mpl_plot(w, timewindow, args.dt, iterations, fft=args.fft, show=not args.save)


### PR DESCRIPTION
# PR Description

## Summary

- Adds `handle_plot_output()` to `gprMax/utilities/utilities.py`: shows a
  plot when the matplotlib backend is interactive and the caller asked
  for it, otherwise saves it to a PNG next to the output file and logs
  where it went. Wired into all four plotting tools
  (`toolboxes/Plotting/plot_Ascan.py`, `plot_Bscan.py`,
  `plot_antenna_params.py`, `plot_source_wave.py`), replacing an
  unconditional `plt.show()` that ran even when `-save` was passed and,
  in `plot_Ascan.py`/`plot_antenna_params.py`, fixing a case where only
  the last of several figures produced by a run was ever saved or shown.
- Wraps `testing/test_experimental.py` and `testing/test_models.py` in
  `main()` + `if __name__ == "__main__"`. Both currently execute their
  full body — including `argparse.parse_args()`, and in
  `test_models.py`'s case actually running gprMax models — at import
  time, which means a bare `pytest` invocation from the repo root
  currently ends in an `INTERNALERROR` before collecting anything.
- Fixes a typo in `test_experimental.py`'s negative-polarity handling:
  `args.outputs[0]` (plural, undefined) instead of `args.output[0]`.

Fixes #621, fixes #627, fixes #561.

## Notes

- #627's own text names `tests/test_models.py`/`tests/test_experimental.py`;
  those were relocated to `testing/` in a 2022 restructure and the same
  import-time-execution problem is still present there today — fixed at
  the current location.
- Supersedes #522, #524, #566, #636, #622, #623, and #672 (see closing
  comments on each).

## Test plan

- [x] Full suite: `python -m pytest tests/` — 1201 passed, 6 skipped,
      8 pre-existing failures in `test_eigenmode_source_2d.py` confirmed
      unrelated (fail identically on unmodified `devel`).
- [x] `pytest --collect-only` from repo root no longer INTERNALERRORs.
- [x] All four plotting tools smoke-tested against real `.h5` output
      files (`examples/cylinder_Ascan_2D.h5`,
      `antenna_wire_dipole_fs.h5`), both default and `-save`, confirming
      correct auto-save-with-warning on a non-interactive (Agg) backend
      and correct per-figure output for multi-receiver/multi-figure runs.
