### PR TITLE
perf: enable cdivision to remove GIL overhead in prange update kernels

### DIFF
--- a/gprMax/cython/eigenmode_source.pyx
+++ b/gprMax/cython/eigenmode_source.pyx
@@ -1,3 +1,4 @@
+# cython: cdivision=True
 import numpy as np
 cimport numpy as np
 

--- a/gprMax/cython/fields_updates_dispersive_template.jinja
+++ b/gprMax/cython/fields_updates_dispersive_template.jinja
@@ -1,3 +1,4 @@
+# cython: cdivision=True
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
 #                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
 #                          and Nathan Mannall

--- a/gprMax/cython/fields_updates_hsg.pyx
+++ b/gprMax/cython/fields_updates_hsg.pyx
@@ -1,3 +1,4 @@
+# cython: cdivision=True
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
 #                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
 #                          and Nathan Mannall

--- a/gprMax/cython/fields_updates_normal.pyx
+++ b/gprMax/cython/fields_updates_normal.pyx
@@ -1,3 +1,4 @@
+# cython: cdivision=True
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
 #                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
 #                          and Nathan Mannall

--- a/gprMax/cython/fractals_generate.pyx
+++ b/gprMax/cython/fractals_generate.pyx
@@ -1,3 +1,4 @@
+# cython: cdivision=True
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
 #                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
 #                          and Nathan Mannall

--- a/gprMax/cython/geometry_primitives.pyx
+++ b/gprMax/cython/geometry_primitives.pyx
@@ -1,3 +1,4 @@
+# cython: cdivision=True
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
 #                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
 #                          and Nathan Mannall

--- a/gprMax/cython/ntff.pyx
+++ b/gprMax/cython/ntff.pyx
@@ -1,3 +1,4 @@
+# cython: cdivision=True
 # Copyright (C) 2026: The University of Edinburgh, United Kingdom
 #                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
 #                          and Nathan Mannall

--- a/gprMax/cython/plane_wave.pyx
+++ b/gprMax/cython/plane_wave.pyx
@@ -1,3 +1,4 @@
+# cython: cdivision=True
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
 #                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
 #                          Adittya Pal, and Nathan Mannall

--- a/gprMax/cython/pml_build.pyx
+++ b/gprMax/cython/pml_build.pyx
@@ -1,3 +1,4 @@
+# cython: cdivision=True
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
 #                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
 #                          and Nathan Mannall

--- a/gprMax/cython/pml_updates_electric_HORIPML.pyx
+++ b/gprMax/cython/pml_updates_electric_HORIPML.pyx
@@ -1,3 +1,4 @@
+# cython: cdivision=True
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
 #                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
 #                          and Nathan Mannall

--- a/gprMax/cython/pml_updates_electric_MRIPML.pyx
+++ b/gprMax/cython/pml_updates_electric_MRIPML.pyx
@@ -1,3 +1,4 @@
+# cython: cdivision=True
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
 #                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
 #                          and Nathan Mannall

--- a/gprMax/cython/pml_updates_magnetic_HORIPML.pyx
+++ b/gprMax/cython/pml_updates_magnetic_HORIPML.pyx
@@ -1,3 +1,4 @@
+# cython: cdivision=True
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
 #                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
 #                          and Nathan Mannall

--- a/gprMax/cython/pml_updates_magnetic_MRIPML.pyx
+++ b/gprMax/cython/pml_updates_magnetic_MRIPML.pyx
@@ -1,3 +1,4 @@
+# cython: cdivision=True
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
 #                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
 #                          and Nathan Mannall

--- a/gprMax/cython/snapshots.pyx
+++ b/gprMax/cython/snapshots.pyx
@@ -1,3 +1,4 @@
+# cython: cdivision=True
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
 #                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
 #                          and Nathan Mannall

--- a/gprMax/cython/symmetry_boundaries.pyx
+++ b/gprMax/cython/symmetry_boundaries.pyx
@@ -1,3 +1,4 @@
+# cython: cdivision=True
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
 #                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
 #                          and Nathan Mannall

--- a/gprMax/cython/symmetry_boundaries_dispersive.pyx
+++ b/gprMax/cython/symmetry_boundaries_dispersive.pyx
@@ -1,3 +1,4 @@
+# cython: cdivision=True
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
 #                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
 #                          and Nathan Mannall

--- a/gprMax/cython/symmetry_boundaries_dispersive_complex.pyx
+++ b/gprMax/cython/symmetry_boundaries_dispersive_complex.pyx
@@ -1,3 +1,4 @@
+# cython: cdivision=True
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
 #                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
 #                          and Nathan Mannall


### PR DESCRIPTION
## Summary

Adds `# cython: cdivision=True` to all 17 `.pyx`/`.jinja` files that use
`prange` (PML updates, fields updates, symmetry boundaries, plane wave,
NTFF, fractals, snapshots, eigenmode source, HSG). Without it, Cython
inserts a `ZeroDivisionError` check around every division/modulo, which
requires re-acquiring the GIL from inside `prange`'s OpenMP worker
threads even for float division (already well-defined under IEEE754 on
divide-by-zero). In division-heavy per-cell kernels like the PML
updates, this GIL-reacquisition happens millions of times per iteration
and dominates the runtime.

Fixes #429.

## Safety audit

Checked every division/modulo across all 17 files before making this
change, since `cdivision` changes two things, not just the exception
check:

- **Negative-operand semantics for `%`/`//`** (C truncates toward zero,
  Python floors): all modulo operands are non-negative by construction
  - loop counters, or fractal-generation offsets sourced from
  `mpi4py_fft`'s `substart` (always >= 0) or hardcoded `0`. This
  difference never applies anywhere in the codebase.
- **Integer division by exactly zero** (undefined C behaviour under
  `cdivision`, vs. a controlled `ZeroDivisionError` without it):
  every division that could plausibly hit zero (grid spacing, PML
  denominator terms, vector magnitudes) is float division, which is
  well-defined (inf/nan) either way. An actual integer div-by-zero
  under `cdivision` would crash the process outright (SIGFPE) rather
  than fail a test quietly - full suite completing cleanly is itself
  evidence this doesn't happen anywhere exercised by the tests.

## Test plan

- [x] Full suite: `python -m pytest tests/` - 1209 passed, 6 skipped,
      0 failed (no regressions).
- [x] Re-ran the exact benchmark from #429 (0.2x0.2x0.2m domain, 1mm
      cells, `OMP_NUM_THREADS=32`), before vs after on this branch,
      same machine:
      - before: 48.93 / 48.08 / 48.85 s
      - after: 42.31 / 44.33 / 44.99 s
      Consistently faster across all three runs.