### PR TITLE
Fix grass height sampling with current NumPy

### DIFF
--- a/gprMax/user_objects/cmds_geometry/add_grass.py
+++ b/gprMax/user_objects/cmds_geometry/add_grass.py
@@ -301,7 +301,7 @@ class AddGrass(RotatableMixin, GeometryUserObject):
         heights = np.zeros((density.shape[0], density.shape[1]))
         for i in range(len(bladesindex[0])):
             heights[bladesindex[0][i], bladesindex[1][i]] = R.randint(
-                surface.fractalrange[0], surface.fractalrange[1], size=1
+                surface.fractalrange[0], surface.fractalrange[1]
             )
 
         if te_axis is not None:


### PR DESCRIPTION
## Summary

- sample each grass-blade height as a scalar rather than a one-element array
- retain the existing seeded random sequence and generated geometry
- restore compatibility with NumPy 2.4, which rejects assigning a one-dimensional array to a scalar element

## Motivation

The standard CPU workflow currently fails six grass regression cases with NumPy 2.4.6. Earlier NumPy releases emitted a deprecation warning for the same assignment.

## Testing

- 8 grass TE/TM invariance tests passed
- 19 complete fractal tests passed
- verified that scalar and former one-element sampling produce identical values for 100 seeded draws
- git diff --check passed

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update required

## Checklist

- [x] I have performed a self-review.
- [x] The focused regression tests pass.
- [x] The change generates no new warnings.
- [x] The PR title describes the change.