### PR TITLE
Improve eigenmode source documentation and guidance

### DIFF
--- a/docs/source/eigenmode.rst
+++ b/docs/source/eigenmode.rst
@@ -241,16 +241,22 @@ The requested linear antenna quantities use
 
 .. math::
 
-   D &= \frac{4\pi U}{P_{\mathrm{rad}}},&
-   G &= \frac{4\pi U}{P_{\mathrm{acc}}},&
-   G_{\mathrm{realized}} &= \frac{4\pi U}{P_{\mathrm{inc}}}.
+   D = \frac{4\pi U}{P_{\mathrm{rad}}},\qquad
+   G = \frac{4\pi U}{P_{\mathrm{acc}}},\qquad
+   G_{\mathrm{realized}} = \frac{4\pi U}{P_{\mathrm{inc}}}.
 
-Directivity removes neither material/radiation loss nor mismatch. Gain uses
-the net accepted port power. Realized gain uses the externally driven
-incident power and therefore includes reflection loss as well. For an
-eigenmode source, the incident denominator is the launched mode's modal
-power; a passive modal receiver contributes zero generator incident power but
-its signed net modal power remains in the multiport accepted-power balance.
+Here :math:`U` is radiation intensity, :math:`P_{\mathrm{rad}}` is total
+radiated power, :math:`P_{\mathrm{acc}}` is the net power accepted across all
+physical ports, and :math:`P_{\mathrm{inc}}` is the externally launched
+incident power. Directivity is normalised by total radiated power, so it does
+not include reductions from dissipative losses or port mismatch. Gain is
+normalised by net accepted port power and therefore includes radiation
+efficiency, including material loss, but not mismatch loss. Realized gain is
+normalised by externally driven incident power and includes both radiation
+efficiency and reflection loss. For an eigenmode source, the incident
+denominator is the launched mode's modal power; a passive modal receiver
+contributes zero generator incident power, but its signed net modal power
+remains in the multiport accepted-power balance.
 
 The far-field group stores ``directivity``, ``gain``, and
 ``realized_gain`` (and their dB forms), radiation and total efficiencies, and
@@ -648,13 +654,13 @@ All component arrays are flattened with Fortran order:
 
 .. code-block:: python
 
-   flat = array.ravel(order=F)
+   flat = array.ravel(order='F')
 
 and modal vectors are reshaped back with:
 
 .. code-block:: python
 
-   array = vector.reshape((*shape, num_modes), order=F)
+   array = vector.reshape((*shape, num_modes), order='F')
 
 There is no axis-order switch. gprMax must pass local ``u``/``v`` slices in the
 same native transverse ordering used by the extracted source plane.

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -47,6 +47,15 @@ one-dimensional transmission-line feeds. The dipoles provide idealised local
 radiators, while voltage and transmission-line sources can feed explicit
 antenna geometries.
 
+Guided structures can be excited with an eigenmode source. gprMax extracts the
+transverse material cross-section, solves its finite-difference
+frequency-domain modes, and launches the selected mode through a
+total-field/scattered-field plane. The source also acts as a modal port, and
+additional eigenmode receivers enable multimode S-parameters. The formulation
+supports 2D TM, 2D TE, and full 3D models, with fixed-profile or broadband
+modal excitation. See :ref:`eigenmode` for the recommended workflow,
+limitations, antenna coupling, and mathematical formulation.
+
 Plane-wave excitation is available through a total-field/scattered-field
 (TFSF) surface. gprMax uses the finite-difference time-domain discrete plane
 wave (FDTD-DPW) formulation of Tan and Potter [TAN2010]_. Its auxiliary
@@ -56,7 +65,7 @@ leakage into the scattered-field region. Plane waves can be specified by
 propagation angles or an integer direction vector in a homogeneous background;
 an axial form is available for normally incident layered-media models.
 
-The source and plane-wave commands are described in
+The source, eigenmode, and plane-wave commands are described in
 :ref:`input-hash-cmds`.
 
 .. _ntff-formulations:

--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -656,6 +656,22 @@ complete subgrid; where the two regions overlap, the box must strictly enclose
 the subgrid's HSG outer coupling surface so that the TFSF correction stencil
 remains on the main grid.
 
+Eigenmode Source
+----------------
+.. autoclass:: gprMax.user_objects.cmds_multiuse.EigenmodeSource
+
+Eigenmode Receiver
+------------------
+.. autoclass:: gprMax.user_objects.cmds_multiuse.EigenmodeRx
+
+An eigenmode source solves and launches a selected mode while simultaneously
+acting as the first modal port. Additional eigenmode receivers measure
+reflection, transmission, and higher-order-mode conversion. Geometry-only
+builds write diagnostic modal-field plots so the selected mode can be checked
+before time stepping. See :ref:`eigenmode` for command examples, mode
+selection, broadband excitation, S-parameters, eigenmode-fed antenna results,
+and the complete formulation.
+
 Excitation File
 ---------------
 .. autoclass:: gprMax.user_objects.cmds_multiuse.ExcitationFile

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1314,7 +1314,7 @@ For example, to specify a discrete plane wave in a TFSF box (0.010, 0.010, 0.010
     * Plane waves support non-dispersive dielectric backgrounds and multi-pole Debye, Lorentz, and Drude media. They do not currently support ``user``-defined waveforms.
     * The plane-wave command must be defined on the main grid. Its TFSF box may contain a complete subgrid, but must strictly enclose the subgrid's HSG outer coupling surface wherever the two regions overlap.
     * ``#plane_wave_angles``, ``#plane_wave_vector``, and ``#plane_wave_axial`` currently cannot be used with MPI. The TFSF box correction is applied with per-rank local array indices and has no awareness of MPI domain decomposition, so a box spanning more than one rank's sub-domain would silently be corrected on only one rank.
-    * This plane wave implementation was based on an intitial implementation made possible by a `Google Summer of Code <https://summerofcode.withgoogle.com/>`_ (GSoC) project and `more details can be found in the original pull request <https://github.com/gprMax/gprMax/pull/373>`_.
+    * This plane wave implementation was based on an initial implementation made possible by a `Google Summer of Code <https://summerofcode.withgoogle.com/>`_ (GSoC) project and `more details can be found in the original pull request <https://github.com/gprMax/gprMax/pull/373>`_.
     * Internally, theta and phi are approximated by an integer direction vector (Mx, My, Mz) found to within a maximum acceptable angular difference of 3 arc minutes (0.05 degrees) by default. This tolerance can be relaxed or tightened using the ``max_angle_diff`` parameter (in degrees) when using the Python API.
 
 #plane_wave_vector:
@@ -1340,13 +1340,13 @@ For example, to specify a discrete plane wave in a TFSF box (0.010, 0.010, 0.010
     * Plane waves support non-dispersive dielectric backgrounds and multi-pole Debye, Lorentz, and Drude media. They do not currently support ``user``-defined waveforms.
     * The plane-wave command must be defined on the main grid. Its TFSF box may contain a complete subgrid, but must strictly enclose the subgrid's HSG outer coupling surface wherever the two regions overlap.
     * ``#plane_wave_angles``, ``#plane_wave_vector``, and ``#plane_wave_axial`` currently cannot be used with MPI. The TFSF box correction is applied with per-rank local array indices and has no awareness of MPI domain decomposition, so a box spanning more than one rank's sub-domain would silently be corrected on only one rank.
-    * This plane wave implementation was based on an intitial implementation made possible by a `Google Summer of Code <https://summerofcode.withgoogle.com/>`_ (GSoC) project and `more details can be found in the original pull request <https://github.com/gprMax/gprMax/pull/373>`_.
+    * This plane wave implementation was based on an initial implementation made possible by a `Google Summer of Code <https://summerofcode.withgoogle.com/>`_ (GSoC) project and `more details can be found in the original pull request <https://github.com/gprMax/gprMax/pull/373>`_.
 
 
 #plane_wave_axial:
 ---------------------
 
-Allows you to introduce a discrete plane wave source [TAN2010]_. Plane wave sources are a useful tool in multiple different scenarios of electromagnetic simulations, especially when the wave is emitted by a source that is quite far away from the target. This command introduces a plane wave that propagates along one of the three grid axes and can be normally incident on mulit-layer setups that span the entire model domain perpenticular to the direction of propagation. It takes its media properties from the background materials of the grid at the direction of the axis that it propagates. This allows for half-space simulations but only for normally incident plane waves. The syntax of the command is:
+Allows you to introduce a discrete plane wave source [TAN2010]_. Plane wave sources are a useful tool in multiple different scenarios of electromagnetic simulations, especially when the wave is emitted by a source that is quite far away from the target. This command introduces a plane wave that propagates along one of the three grid axes and can be normally incident on multi-layer setups that span the entire model domain perpendicular to the direction of propagation. It takes its media properties from the background materials of the grid at the direction of the axis that it propagates. This allows for half-space simulations but only for normally incident plane waves. The syntax of the command is:
 
 .. code-block:: none
 
@@ -1363,11 +1363,11 @@ For example, to specify a discrete plane wave in a TFSF box (0.010, 0.010, 0.010
 
 .. note::
 
-    * For simulations that do not involve half-space setups it is recommended to use either the ``#plane_wave_angles`` or ``#plane_wave_vector`` commands instead as the formualtions are more efficient and faster if the background medium of propagation for the plane wave is homogeneous.
+    * For simulations that do not involve half-space setups it is recommended to use either the ``#plane_wave_angles`` or ``#plane_wave_vector`` commands instead as the formulations are more efficient and faster if the background medium of propagation for the plane wave is homogeneous.
     * Plane waves support non-dispersive dielectric layers and multi-pole Debye, Lorentz, and Drude layers. They do not currently support ``user``-defined waveforms.
     * The plane-wave command must be defined on the main grid. Its TFSF box may contain a complete subgrid, but must strictly enclose the subgrid's HSG outer coupling surface wherever the two regions overlap.
     * ``#plane_wave_angles``, ``#plane_wave_vector``, and ``#plane_wave_axial`` currently cannot be used with MPI. The TFSF box correction is applied with per-rank local array indices and has no awareness of MPI domain decomposition, so a box spanning more than one rank's sub-domain would silently be corrected on only one rank.
-    * This plane wave implementation was based on an intitial implementation made possible by a `Google Summer of Code <https://summerofcode.withgoogle.com/>`_ (GSoC) project and `more details can be found in the original pull request <https://github.com/gprMax/gprMax/pull/373>`_.
+    * This plane wave implementation was based on an initial implementation made possible by a `Google Summer of Code <https://summerofcode.withgoogle.com/>`_ (GSoC) project and `more details can be found in the original pull request <https://github.com/gprMax/gprMax/pull/373>`_.
 
 
 
@@ -1865,9 +1865,9 @@ backplane.
    The NTFF integration surface is not closed. Equivalent-current NTFF normally
    assumes a closed Huygens surface. This option is intended for configurations
    where the omitted face is associated with an eigenmode port or other
-   modelling scenarios the require such approach. Results may be incomplete or
-   inaccurate if the omitted field contribution is not represented correctly
-   or is significant for your calculations.
+   modelling scenarios that require an open Huygens surface. Results may be
+   incomplete or inaccurate if the omitted field contribution is not
+   represented correctly or is significant for your calculations.
 
 Without omitted face names, the surface is physically closed unless one or more
 faces coincide exactly with a declared

--- a/gprMax/ntff/interface.py
+++ b/gprMax/ntff/interface.py
@@ -87,7 +87,8 @@ OPEN_HUYGENS_SURFACE_WARNING = (
     "The NTFF integration surface is not closed. Equivalent-current NTFF "
     "normally assumes a closed Huygens surface. This option is intended for "
     "configurations where the omitted face is associated with an eigenmode "
-    "port or other modelling scenarios the require such approach. Results may "
+    "port or other modelling scenarios that require an open Huygens surface. "
+    "Results may "
     "be incomplete or inaccurate if the omitted field contribution is not "
     "represented correctly or is significant for your calculations."
 )

--- a/tests/ntff/test_hash_command.py
+++ b/tests/ntff/test_hash_command.py
@@ -195,7 +195,8 @@ def test_open_huygens_surface_emits_runtime_warning(tmp_path):
         "The NTFF integration surface is not closed. Equivalent-current NTFF "
         "normally assumes a closed Huygens surface. This option is intended for "
         "configurations where the omitted face is associated with an eigenmode "
-        "port or other modelling scenarios the require such approach. Results may "
+        "port or other modelling scenarios that require an open Huygens surface. "
+        "Results may "
         "be incomplete or inaccurate if the omitted field contribution is not "
         "represented correctly or is significant for your calculations."
     ]


### PR DESCRIPTION
## Summary

- make eigenmode excitation prominent in the software-features overview and Python API source catalogue
- correct the directivity, gain, and realized-gain explanation and fix its MathJax rendering
- clarify the runtime warning for an open equivalent-current Huygens surface
- keep the warning documentation and exact-message regression test consistent
- correct invalid Fortran-order Python snippets and nearby source-command typographical errors

## Type of change

- [x] Bug fix (documentation rendering and warning text)
- [x] Documentation update

## Validation

- [x] `16 passed` in the focused antenna-metric, port-power, open-surface-warning, and eigenmode-antenna tests
- [x] Sphinx HTML build completed successfully
- [x] No new Sphinx warnings (the three existing unreferenced citations remain)
- [x] `git diff --check` passes

## Checklist

- [x] I have performed a self-review of the changes.
- [x] I have made the corresponding documentation changes.
- [x] The changes generate no new warnings.
- [x] The pull-request title is a short description of the changes.
- [ ] Pre-commit was not available in the current environment; focused tests and documentation checks were run directly.
