### PR TITLE
Fix eigenmode solver conventions and automatic anchor guards

### DIFF
--- a/docs/source/eigenmode_port.rst
+++ b/docs/source/eigenmode_port.rst
@@ -847,14 +847,14 @@ For TM, the selected ``E_a`` eigenvector gives:
 .. code-block:: text
 
    H_t = -n_eff E_a / (eta0 mu_t)
-   H_w = -i inv(mu_w) D_nc E_a / eta0
+   H_w = i inv(mu_w) D_nc E_a / eta0
 
 For TE, the selected ``H_a`` eigenvector gives:
 
 .. code-block:: text
 
    E_t = eta0 n_eff H_a / eps_t
-   E_w = i eta0 inv(eps_w) D_cn H_a
+   E_w = -i eta0 inv(eps_w) D_cn H_a
 
 The other three field components are identically zero for the selected 2D
 polarization. The reconstructed electric fields are in V/m and magnetic
@@ -1151,8 +1151,12 @@ of freedom from the eigenproblem:
 
    Omega = Omega[self.free_euv_mask, :][:, self.free_euv_mask]
 
-After ARPACK returns the reduced eigenvectors, the solver expands them back to
-the full transverse field-vector size and explicitly zeros constrained fields.
+When the reduced matrix has only one more degree of freedom than the requested
+mode count, the solver uses a dense eigensolve because ARPACK requires
+``k < N - 1``. Larger systems use shift-invert ARPACK and retry with a
+roundoff-scale shift perturbation if the original shift produces a singular
+factorisation. The reduced eigenvectors are then expanded back to the full
+transverse field-vector size and constrained fields are explicitly zeroed.
 
 The inverse ``eps_r_ww`` and ``mu_r_ww`` operators are built only on free
 longitudinal degrees of freedom. Constrained entries receive zero inverse

--- a/gprMax/eigenmode_ports.py
+++ b/gprMax/eigenmode_ports.py
@@ -53,18 +53,30 @@ except ImportError:  # Source-tree fallback before extensions are rebuilt.
     ):
         hplane = plane_index if direction_sign * magnetic_side > 0 else plane_index - 1
         if normal_axis == 0:
-            measured_eu = 0.5 * (Ey[plane_index, u0:u1, v0:v1] + Ey[plane_index, u0:u1, v0 + 1 : v1 + 1])
-            measured_ev = 0.5 * (Ez[plane_index, u0:u1, v0:v1] + Ez[plane_index, u0 + 1 : u1 + 1, v0:v1])
+            measured_eu = 0.5 * (
+                Ey[plane_index, u0:u1, v0:v1] + Ey[plane_index, u0:u1, v0 + 1 : v1 + 1]
+            )
+            measured_ev = 0.5 * (
+                Ez[plane_index, u0:u1, v0:v1] + Ez[plane_index, u0 + 1 : u1 + 1, v0:v1]
+            )
             measured_hu = 0.5 * (Hy[hplane, u0:u1, v0:v1] + Hy[hplane, u0 + 1 : u1 + 1, v0:v1])
             measured_hv = 0.5 * (Hz[hplane, u0:u1, v0:v1] + Hz[hplane, u0:u1, v0 + 1 : v1 + 1])
         elif normal_axis == 1:
-            measured_eu = 0.5 * (Ex[u0:u1, plane_index, v0:v1] + Ex[u0:u1, plane_index, v0 + 1 : v1 + 1])
-            measured_ev = 0.5 * (Ez[u0:u1, plane_index, v0:v1] + Ez[u0 + 1 : u1 + 1, plane_index, v0:v1])
+            measured_eu = 0.5 * (
+                Ex[u0:u1, plane_index, v0:v1] + Ex[u0:u1, plane_index, v0 + 1 : v1 + 1]
+            )
+            measured_ev = 0.5 * (
+                Ez[u0:u1, plane_index, v0:v1] + Ez[u0 + 1 : u1 + 1, plane_index, v0:v1]
+            )
             measured_hu = 0.5 * (Hx[u0:u1, hplane, v0:v1] + Hx[u0 + 1 : u1 + 1, hplane, v0:v1])
             measured_hv = 0.5 * (Hz[u0:u1, hplane, v0:v1] + Hz[u0:u1, hplane, v0 + 1 : v1 + 1])
         else:
-            measured_eu = 0.5 * (Ex[u0:u1, v0:v1, plane_index] + Ex[u0:u1, v0 + 1 : v1 + 1, plane_index])
-            measured_ev = 0.5 * (Ey[u0:u1, v0:v1, plane_index] + Ey[u0 + 1 : u1 + 1, v0:v1, plane_index])
+            measured_eu = 0.5 * (
+                Ex[u0:u1, v0:v1, plane_index] + Ex[u0:u1, v0 + 1 : v1 + 1, plane_index]
+            )
+            measured_ev = 0.5 * (
+                Ey[u0:u1, v0:v1, plane_index] + Ey[u0 + 1 : u1 + 1, v0:v1, plane_index]
+            )
             measured_hu = 0.5 * (Hx[u0:u1, v0:v1, hplane] + Hx[u0 + 1 : u1 + 1, v0:v1, hplane])
             measured_hv = 0.5 * (Hy[u0:u1, v0:v1, hplane] + Hy[u0:u1, v0 + 1 : v1 + 1, hplane])
         factor = 0.5 * handedness * measure * dt
@@ -139,12 +151,17 @@ class EigenmodePortMonitor:
         dft_start,
         dft_stop,
         dft_points,
+        anchor_mode_valid=None,
+        anchor_mode_propagating=None,
+        mode_anchor_policies=None,
     ):
         self.owner = owner
         self.port_index = int(port_index)
         self.port_id = port_id
         self.is_source = bool(is_source)
-        self.excitation_mode_index = None if excitation_mode_index is None else int(excitation_mode_index)
+        self.excitation_mode_index = (
+            None if excitation_mode_index is None else int(excitation_mode_index)
+        )
         # A TF/SF source must sample H on its total-field side. A passive port
         # uses the upstream half-cell, where either side is physically
         # equivalent in the absence of a field discontinuity.
@@ -154,6 +171,23 @@ class EigenmodePortMonitor:
         self.anchor_e = anchor_e
         self.anchor_h = anchor_h
         self.anchor_neff = np.asarray(anchor_neff, dtype=np.complex128)
+        anchor_shape = (self.anchor_frequencies.size, len(self.mode_indices))
+        self.anchor_mode_valid = (
+            np.ones(anchor_shape, dtype=bool)
+            if anchor_mode_valid is None
+            else np.asarray(anchor_mode_valid, dtype=bool)
+        )
+        self._anchor_mode_propagating_explicit = anchor_mode_propagating is not None
+        self.anchor_mode_propagating = (
+            self.anchor_mode_valid.copy()
+            if anchor_mode_propagating is None
+            else np.asarray(anchor_mode_propagating, dtype=bool)
+        )
+        self.mode_anchor_policies = (
+            tuple("explicit" for _ in self.mode_indices)
+            if mode_anchor_policies is None
+            else tuple(str(value) for value in mode_anchor_policies)
+        )
         self.dft_start = float(dft_start)
         self.dft_stop = float(dft_stop)
         self.dft_points = int(dft_points)
@@ -175,7 +209,9 @@ class EigenmodePortMonitor:
         if self.port_index < 1:
             raise ValueError("Eigenmode port indices must be one-based positive integers.")
         if self.is_source and self.excitation_mode_index not in self.mode_indices:
-            raise ValueError("The source excitation mode must be included in its monitored mode indices.")
+            raise ValueError(
+                "The source excitation mode must be included in its monitored mode indices."
+            )
         if not self.is_source and self.excitation_mode_index is not None:
             raise ValueError("A passive eigenmode port cannot have an excitation mode.")
         if self.dft_points < 1:
@@ -188,6 +224,87 @@ class EigenmodePortMonitor:
             raise ValueError("A one-point eigenmode DFT requires equal start and stop frequencies.")
         if self.dft_points > 1 and self.dft_stop == self.dft_start:
             raise ValueError("A multi-point eigenmode DFT requires stop greater than start.")
+        expected_shape = (self.anchor_frequencies.size, len(self.mode_indices))
+        if self.anchor_mode_valid.shape != expected_shape:
+            raise ValueError(
+                "Eigenmode port anchor validity shape "
+                f"{self.anchor_mode_valid.shape} does not match {expected_shape}."
+            )
+        if self.anchor_mode_propagating.shape != expected_shape:
+            raise ValueError(
+                "Eigenmode port anchor propagation shape "
+                f"{self.anchor_mode_propagating.shape} does not match {expected_shape}."
+            )
+        if np.any(self.anchor_mode_valid & ~self.anchor_mode_propagating):
+            raise ValueError("A usable eigenmode anchor must also carry forward propagating power.")
+        if len(self.mode_anchor_policies) != len(self.mode_indices):
+            raise ValueError("Eigenmode port requires one anchor policy per monitored mode.")
+        if np.any(~np.any(self.anchor_mode_valid, axis=0)):
+            raise ValueError("Every eigenmode port mode requires at least one usable anchor.")
+        for mode_position, mode_index in enumerate(self.mode_indices):
+            runs = self._contiguous_true_runs(self.anchor_mode_valid[:, mode_position])
+            if len(runs) > 1:
+                raise ValueError(
+                    f"Eigenmode port mode {mode_index} has disconnected usable "
+                    "anchor ranges; interpolation across an internal anchor "
+                    "gap is not valid."
+                )
+
+    @staticmethod
+    def _contiguous_true_runs(mask):
+        indices = np.flatnonzero(np.asarray(mask, dtype=bool))
+        if indices.size == 0:
+            return ()
+        breaks = np.flatnonzero(np.diff(indices) > 1)
+        starts = np.concatenate((indices[:1], indices[breaks + 1]))
+        stops = np.concatenate((indices[breaks], indices[-1:]))
+        return tuple(zip(starts, stops))
+
+    def _propagating_frequency_mask(self, frequencies, mode_position):
+        """Return bins supported by contiguous propagating, usable anchors."""
+        frequencies = np.asarray(frequencies, dtype=np.float64)
+        propagating = self.anchor_mode_propagating[:, mode_position]
+        if np.all(propagating):
+            # Constant-basis and guard-trimmed policies intentionally retain
+            # endpoint extrapolation when every candidate anchor propagates.
+            return np.ones(frequencies.shape, dtype=bool)
+
+        usable = self.anchor_mode_valid[:, mode_position]
+        anchors = self.anchor_frequencies
+        tolerance = 1e-12 * max(
+            float(np.max(np.abs(anchors), initial=0.0)),
+            1.0,
+        )
+        supported = np.zeros(frequencies.shape, dtype=bool)
+        intervals = []
+        for start, stop in self._contiguous_true_runs(propagating):
+            run_usable = np.flatnonzero(usable[start : stop + 1]) + start
+            if run_usable.size == 0:
+                continue
+            # Propagation defines the physical support; usability only
+            # selects the basis used within that support. In particular, a
+            # centre-only fallback may extrapolate through the remainder of
+            # the same propagating run.
+            low = float(anchors[start])
+            high = float(anchors[stop])
+            intervals.append((low, high))
+            supported |= (frequencies >= low - tolerance) & (frequencies <= high + tolerance)
+
+        if not intervals:
+            return supported
+
+        policy = self.mode_anchor_policies[mode_position]
+        restrict_endpoints = (
+            self._anchor_mode_propagating_explicit or "nonpropagating_trimmed" in policy
+        )
+        if not restrict_endpoints:
+            # With the compatibility default, a false exterior validity bit
+            # may represent an ordinary spectral-guard trim rather than a
+            # physical cutoff. Preserve the established endpoint behavior,
+            # while still rejecting gaps between separate propagating runs.
+            supported |= frequencies <= intervals[0][0] + tolerance
+            supported |= frequencies >= intervals[-1][1] - tolerance
+        return supported
 
     def prepare(self, grid):
         self._validate()
@@ -208,18 +325,30 @@ class EigenmodePortMonitor:
         )
         self.frequency = np.asarray(nominal_frequency, dtype=real_dtype)
         if self.frequency[-1] > 0.5 / grid.dt:
-            raise ValueError(f"Eigenmode port {self.port_id!r} DFT stop frequency exceeds the FDTD Nyquist frequency.")
+            raise ValueError(
+                f"Eigenmode port {self.port_id!r} DFT stop frequency exceeds the FDTD Nyquist frequency."
+            )
         if self.anchor_frequencies.size > 1 and (
-            nominal_frequency[0] < self.anchor_frequencies[0] or nominal_frequency[-1] > self.anchor_frequencies[-1]
+            nominal_frequency[0] < self.anchor_frequencies[0]
+            or nominal_frequency[-1] > self.anchor_frequencies[-1]
         ):
             logger.warning(
                 f"Eigenmode port {self.port_id!r} DFT range extends outside its modal "
                 "anchor range; endpoint modal profiles will be used."
             )
 
-        weights = self.owner._linear_anchor_weights(self.frequency.astype(np.float64), self.anchor_frequencies)
         nf = self.frequency.size
         nm = len(self.mode_indices)
+        weights = np.zeros(
+            (nm, self.anchor_frequencies.size, nf),
+            dtype=np.float64,
+        )
+        for mode_position in range(nm):
+            usable_anchors = np.flatnonzero(self.anchor_mode_valid[:, mode_position])
+            weights[mode_position, usable_anchors] = self.owner._linear_anchor_weights(
+                self.frequency.astype(np.float64),
+                self.anchor_frequencies[usable_anchors],
+            )
         nu, nv = self.owner._transverse_cell_shape()
         shape = (nf, nm, nu, nv)
         self.eu = np.empty(shape, dtype=complex_dtype)
@@ -227,23 +356,34 @@ class EigenmodePortMonitor:
         self.hu = np.empty(shape, dtype=complex_dtype)
         self.hv = np.empty(shape, dtype=complex_dtype)
         self.neff = np.empty((nf, nm), dtype=complex_dtype)
-        self.mode_power_valid = np.ones((nf, nm), dtype=bool)
+        self.mode_power_valid = np.column_stack(
+            tuple(
+                self._propagating_frequency_mask(
+                    nominal_frequency,
+                    mode_position,
+                )
+                for mode_position in range(nm)
+            )
+        )
         u_axis, v_axis = self.owner.transverse_axes
 
         for frequency_index in range(nf):
             for mode_position in range(nm):
+                mode_weights = weights[mode_position]
                 electric = []
                 magnetic = []
                 for component in range(3):
                     electric.append(
                         sum(
-                            weights[anchor, frequency_index] * self.anchor_e[anchor][mode_position][component]
+                            mode_weights[anchor, frequency_index]
+                            * self.anchor_e[anchor][mode_position][component]
                             for anchor in range(self.anchor_frequencies.size)
                         )
                     )
                     magnetic.append(
                         sum(
-                            weights[anchor, frequency_index] * self.anchor_h[anchor][mode_position][component]
+                            mode_weights[anchor, frequency_index]
+                            * self.anchor_h[anchor][mode_position][component]
                             for anchor in range(self.anchor_frequencies.size)
                         )
                     )
@@ -272,7 +412,7 @@ class EigenmodePortMonitor:
                     magnetic[v_axis], "hv"
                 )
                 self.neff[frequency_index, mode_position] = np.sum(
-                    weights[:, frequency_index] * self.anchor_neff[:, mode_position]
+                    mode_weights[:, frequency_index] * self.anchor_neff[:, mode_position]
                 )
 
         self.eu = np.ascontiguousarray(self.eu)
@@ -322,16 +462,21 @@ class EigenmodePortMonitor:
             0.5 * (self.power_matrix + np.swapaxes(np.conj(self.power_matrix), 1, 2)),
             dtype=complex_dtype,
         )
-        self.power_matrix_valid = np.all(self.mode_power_valid, axis=1)
+        self.power_matrix_valid = np.zeros(nf, dtype=bool)
         for frequency_index, matrix in enumerate(self.power_matrix):
-            if not np.all(np.isfinite(matrix)):
-                self.power_matrix_valid[frequency_index] = False
+            active_modes = np.flatnonzero(self.mode_power_valid[frequency_index])
+            if active_modes.size == 0:
                 continue
-            eigenvalues = np.linalg.eigvalsh(np.asarray(matrix, dtype=np.complex128))
+            active_matrix = np.asarray(
+                matrix[np.ix_(active_modes, active_modes)],
+                dtype=np.complex128,
+            )
+            if not np.all(np.isfinite(active_matrix)):
+                continue
+            eigenvalues = np.linalg.eigvalsh(active_matrix)
             scale = max(float(np.max(np.abs(eigenvalues), initial=0.0)), 1.0)
             tolerance = 64 * np.finfo(real_dtype).eps * scale
-            if np.any(eigenvalues < -tolerance):
-                self.power_matrix_valid[frequency_index] = False
+            self.power_matrix_valid[frequency_index] = not np.any(eigenvalues < -tolerance)
 
         self.measure = real_dtype.type(measure)
         self.handedness = int(handedness)
@@ -351,8 +496,7 @@ class EigenmodePortMonitor:
     def observe(self, grid, iteration):
         if iteration != self._next_iteration:
             raise ValueError(
-                f"expected eigenmode DFT iteration {self._next_iteration}, "
-                f"received {iteration}"
+                f"expected eigenmode DFT iteration {self._next_iteration}, " f"received {iteration}"
             )
         real_signature = config.sim_config.dtypes["C_float_or_double"]
         accumulate_eigenmode_dft[f"{real_signature}|{real_signature} complex"](
@@ -400,15 +544,16 @@ class EigenmodePortMonitor:
     def finalise(self, grid):
         nf, nm = self.electric_dft.shape
         complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
-        component_dtype = (
-            np.float32 if complex_dtype == np.dtype(np.complex64) else np.float64
-        )
+        component_dtype = np.float32 if complex_dtype == np.dtype(np.complex64) else np.float64
         condition_limit = min(
             MAX_CONDITION_NUMBER,
             CONDITION_RELATIVE_ERROR_BUDGET / np.finfo(component_dtype).eps,
         )
-        incident = np.full((nm, nf), np.nan + 1j * np.nan, dtype=complex_dtype)
-        outgoing = np.full_like(incident, np.nan + 1j * np.nan)
+        # Non-propagating modes retain finite coefficients for output and
+        # diagnostics, but are excluded from the modal solve and remain
+        # explicitly invalid as power waves.
+        incident = np.zeros((nm, nf), dtype=complex_dtype)
+        outgoing = np.zeros_like(incident)
         valid = np.zeros((nm, nf), dtype=bool)
         condition = np.full(nf, np.inf, dtype=np.float64)
         magnetic_offset = self.magnetic_side * 0.5 * grid.dl[self.owner.normal_axis]
@@ -417,15 +562,20 @@ class EigenmodePortMonitor:
         backward_phase = np.exp(1j * beta * magnetic_offset)
 
         for frequency_index in range(nf):
+            active_modes = np.flatnonzero(self.mode_power_valid[frequency_index])
+            if active_modes.size == 0 or not self.power_matrix_valid[frequency_index]:
+                continue
             try:
                 # The Gram systems are small. Solve them in complex128 even
                 # when the FDTD arrays use complex64, while retaining a
                 # validity limit based on the precision of the stored inputs.
                 electric_gram = np.asarray(
-                    self.electric_gram[frequency_index], dtype=np.complex128
+                    self.electric_gram[frequency_index][np.ix_(active_modes, active_modes)],
+                    dtype=np.complex128,
                 )
                 magnetic_gram = np.asarray(
-                    self.magnetic_gram[frequency_index], dtype=np.complex128
+                    self.magnetic_gram[frequency_index][np.ix_(active_modes, active_modes)],
+                    dtype=np.complex128,
                 )
                 condition[frequency_index] = max(
                     np.linalg.cond(electric_gram),
@@ -433,30 +583,39 @@ class EigenmodePortMonitor:
                 )
                 electric_coeff = np.linalg.solve(
                     electric_gram,
-                    np.asarray(self.electric_dft[frequency_index], dtype=np.complex128),
+                    np.asarray(
+                        self.electric_dft[frequency_index, active_modes],
+                        dtype=np.complex128,
+                    ),
                 )
                 magnetic_coeff = np.linalg.solve(
                     magnetic_gram,
-                    np.asarray(self.magnetic_dft[frequency_index], dtype=np.complex128),
+                    np.asarray(
+                        self.magnetic_dft[frequency_index, active_modes],
+                        dtype=np.complex128,
+                    ),
                 )
             except np.linalg.LinAlgError:
                 continue
-            denominator = forward_phase[frequency_index] + backward_phase[frequency_index]
+            denominator = (
+                forward_phase[frequency_index, active_modes]
+                + backward_phase[frequency_index, active_modes]
+            )
             usable = np.isfinite(denominator) & (np.abs(denominator) > 1e-12)
-            a = np.full(nm, np.nan + 1j * np.nan, dtype=complex_dtype)
+            a = np.zeros(active_modes.size, dtype=complex_dtype)
             a[usable] = (
-                magnetic_coeff[usable] + backward_phase[frequency_index, usable] * electric_coeff[usable]
+                magnetic_coeff[usable]
+                + backward_phase[frequency_index, active_modes][usable] * electric_coeff[usable]
             ) / denominator[usable]
             b = electric_coeff - a
-            incident[:, frequency_index] = a
-            outgoing[:, frequency_index] = b
-            valid[:, frequency_index] = (
+            incident[active_modes, frequency_index] = a
+            outgoing[active_modes, frequency_index] = b
+            valid[active_modes, frequency_index] = (
                 usable
                 & np.isfinite(a)
                 & np.isfinite(b)
                 & np.isfinite(condition[frequency_index])
                 & (condition[frequency_index] < condition_limit)
-                & self.mode_power_valid[frequency_index]
                 & self.power_matrix_valid[frequency_index]
             )
 
@@ -482,7 +641,10 @@ class EigenmodePortMonitor:
         group.attrs["PhaseReanchorInterval"] = DFT_PHASE_REANCHOR_INTERVAL
         group.attrs["RequestedAnchorPolicy"] = self.owner.requested_anchor_policy
         group.attrs["ResolvedAnchorPolicy"] = self.owner.resolved_anchor_policy
-        group.attrs["AnchorFrequencies"] = self.anchor_frequencies
+        resolved_anchor_union = self.anchor_frequencies[np.any(self.anchor_mode_valid, axis=1)]
+        group.attrs["AnchorFrequencies"] = resolved_anchor_union
+        group.attrs["CandidateAnchorFrequencies"] = self.anchor_frequencies
+        group.attrs["ModeAnchorPolicies"] = self.mode_anchor_policies
         group["frequency"] = self.result.frequency
         group["incident"] = self.result.incident
         group["outgoing"] = self.result.outgoing
@@ -491,6 +653,8 @@ class EigenmodePortMonitor:
         group["electric_cross_power_matrix"] = self.electric_gram
         group["power_matrix"] = self.power_matrix
         group["power_normalization_valid"] = self.mode_power_valid.astype(np.uint8)
+        group["anchor_mode_valid"] = self.anchor_mode_valid.astype(np.uint8)
+        group["anchor_mode_propagating"] = self.anchor_mode_propagating.astype(np.uint8)
         group["power_matrix_valid"] = self.power_matrix_valid.astype(np.uint8)
         if self.s_parameters is not None:
             group["S"] = self.s_parameters
@@ -505,7 +669,8 @@ def finalise_eigenmode_ports(grid):
         return None
     if len(sources) != 1:
         raise ValueError(
-            "Eigenmode S-parameters require one and only one active eigenmode source; " f"found {len(sources)}."
+            "Eigenmode S-parameters require one and only one active eigenmode source; "
+            f"found {len(sources)}."
         )
 
     source = sources[0]
@@ -520,9 +685,7 @@ def finalise_eigenmode_ports(grid):
         & source.power_matrix_valid
         & np.isfinite(denominator)
     )
-    peak = float(
-        np.max(np.abs(denominator[source_decomposition_valid]), initial=0.0)
-    )
+    peak = float(np.max(np.abs(denominator[source_decomposition_valid]), initial=0.0))
     source_valid = (
         source_decomposition_valid
         & (np.abs(denominator) >= peak * 10 ** (INCIDENT_FLOOR_DB / 20))
@@ -542,6 +705,7 @@ def finalise_eigenmode_ports(grid):
             & port.power_matrix_valid[np.newaxis, :]
             & source_valid[np.newaxis, :]
         )
+        port.s_parameters[~port.s_valid] = np.nan + 1j * np.nan
 
     suffix = "" if grid.name == "main_grid" else f"_{grid.name}"
     output_path = config.get_model_config().output_file_path.with_name(

--- a/gprMax/eigenmode_ports.py
+++ b/gprMax/eigenmode_ports.py
@@ -289,6 +289,10 @@ class EigenmodePortMonitor:
             if self.owner.invariant_axis is not None
             else grid.dl[u_axis] * grid.dl[v_axis]
         )
+        if self.owner.invariant_axis is not None and self.owner.domain_polarization == "TE":
+            # Both synthetic invariant cells receive half of each live-layer
+            # TE field during cell averaging, halving their summed overlap.
+            measure *= 2.0
         handedness = self.owner._modal_basis_handedness()
         factor = 0.5 * handedness * measure
         self.electric_gram = np.empty((nf, nm, nm), dtype=complex_dtype)

--- a/gprMax/fdfd_eigenmode_solver/fdfd_1d_mode_solver.py
+++ b/gprMax/fdfd_eigenmode_solver/fdfd_1d_mode_solver.py
@@ -26,6 +26,11 @@ class FDFD_1D_mode_solver:
 
     ``TM`` means the gprMax 2D TM reduction, whose scalar field is ``E_a``.
     ``TE`` means the gprMax 2D TE reduction, whose scalar field is ``H_a``.
+
+    After :meth:`solve`, ``raw_powers`` contains the complex Poynting power
+    before normalization. ``forward_power_metrics`` is its real part divided
+    by a positive, E/H-balanced transverse field norm; ``power_valid`` applies
+    the class tolerance to that signed, scale-independent ratio.
     """
 
     FIELD_SHAPES = {
@@ -42,6 +47,7 @@ class FDFD_1D_mode_solver:
         "pmc_a_mask": "cell",
         "pmc_w_mask": "cell",
     }
+    FORWARD_POWER_METRIC_TOLERANCE = 1e-8
 
     def __init__(
         self,
@@ -122,6 +128,9 @@ class FDFD_1D_mode_solver:
         self.eigenvectors = None
         self.complex_neff = None
         self.real_neff = None
+        self.raw_powers = None
+        self.forward_power_metrics = None
+        self.power_valid = None
         self.powers = None
         self._init_operators()
 
@@ -209,6 +218,7 @@ class FDFD_1D_mode_solver:
         self.real_neff = np.real(self.complex_neff)
         self._calculate_fields(longitudinal_inverse)
         self._zero_constrained_fields()
+        self._orient_backward_modes_to_forward_power(longitudinal_inverse)
         self._normalize_modes_to_power()
         self._align_modes_for_real_profile_power()
         self._set_modal_fields()
@@ -254,14 +264,67 @@ class FDFD_1D_mode_solver:
     def _nodes_to_cells(field):
         return 0.5 * (field[:-1] + field[1:])
 
-    def _calculate_mode_power(self, mode):
+    def _calculate_mode_complex_power(self, mode):
         if self.polarization == "TM":
             ea = self._nodes_to_cells(self.Ea[:, mode])
             ht = self._nodes_to_cells(self.Ht[:, mode])
             flux = -ea * np.conj(ht)
         else:
             flux = self.Et[:, mode] * np.conj(self.Ha[:, mode])
-        return 0.5 * math.fsum(np.ravel(np.real(flux))) * self.dt
+        return (
+            0.5
+            * self.dt
+            * complex(
+                math.fsum(np.ravel(np.real(flux))),
+                math.fsum(np.ravel(np.imag(flux))),
+            )
+        )
+
+    def _calculate_mode_power(self, mode):
+        return float(np.real(self._calculate_mode_complex_power(mode)))
+
+    def _calculate_mode_balanced_power(self, mode):
+        """Return a positive E/H-balanced field scale with units of power."""
+        if self.polarization == "TM":
+            electric = self._nodes_to_cells(self.Ea[:, mode])
+            magnetic = self._nodes_to_cells(self.Ht[:, mode])
+        else:
+            electric = self.Et[:, mode]
+            magnetic = self.Ha[:, mode]
+        density = (np.square(np.abs(electric)) + self.eta0**2 * np.square(np.abs(magnetic))) / (
+            4.0 * self.eta0
+        )
+        return math.fsum(np.ravel(density)) * self.dt
+
+    def _orient_backward_modes_to_forward_power(self, longitudinal_inverse):
+        """Select the passive beta branch whose real power points forward.
+
+        Negative-index media can carry energy opposite to their phase vector.
+        Reversing ``neff`` and reconstructing every dependent field selects
+        the forward-energy solution without the inconsistent H-only flip used
+        by the former normalization guard.
+        """
+
+        reverse = np.zeros(self.num_modes, dtype=bool)
+        for mode in range(self.num_modes):
+            balanced_power = self._calculate_mode_balanced_power(mode)
+            if not np.isfinite(balanced_power) or balanced_power <= 0:
+                continue
+            metric = np.real(self._calculate_mode_complex_power(mode)) / balanced_power
+            candidate = -self.complex_neff[mode]
+            tolerance = 1e-12 * max(1.0, abs(candidate))
+            reverse[mode] = (
+                np.isfinite(metric)
+                and metric < -self.FORWARD_POWER_METRIC_TOLERANCE
+                and np.imag(candidate) <= tolerance
+            )
+        if not np.any(reverse):
+            return
+
+        self.complex_neff[reverse] *= -1
+        self.real_neff = np.real(self.complex_neff)
+        self._calculate_fields(longitudinal_inverse)
+        self._zero_constrained_fields()
 
     def _real_profile_power_from_fields(self, mode):
         if self.polarization == "TM":
@@ -273,16 +336,30 @@ class FDFD_1D_mode_solver:
         return math.fsum(np.ravel(flux)) * self.dt
 
     def _normalize_modes_to_power(self, target_power_per_metre=1.0):
+        """Power-normalize forward modes and safely L2-normalize the rest."""
+        self.raw_powers = np.zeros(self.num_modes, dtype=np.complex128)
+        self.forward_power_metrics = np.full(self.num_modes, np.nan, dtype=np.float64)
+        self.power_valid = np.zeros(self.num_modes, dtype=bool)
         self.powers = np.zeros(self.num_modes, dtype=np.float64)
         for mode in range(self.num_modes):
-            power = self._calculate_mode_power(mode)
-            if not np.isfinite(power) or abs(power) < 1e-300:
-                raise ValueError(f"Cannot normalize mode {mode}: modal power is {power}.")
-            if power < 0:
-                for field in (self.Ht, self.Ha, self.Hw):
-                    field[:, mode] *= -1
-                power = -power
-            scale = np.sqrt(target_power_per_metre / power)
+            raw_power = self._calculate_mode_complex_power(mode)
+            balanced_power = self._calculate_mode_balanced_power(mode)
+            self.raw_powers[mode] = raw_power
+            if np.isfinite(raw_power) and np.isfinite(balanced_power) and balanced_power > 0:
+                metric = float(np.real(raw_power) / balanced_power)
+                self.forward_power_metrics[mode] = metric
+                self.power_valid[mode] = (
+                    np.isfinite(metric) and metric > self.FORWARD_POWER_METRIC_TOLERANCE
+                )
+            if not np.isfinite(balanced_power) or balanced_power <= 0:
+                raise ValueError(
+                    f"Cannot normalize mode {mode}: balanced field power is {balanced_power}."
+                )
+
+            normalization_power = (
+                float(np.real(raw_power)) if self.power_valid[mode] else balanced_power
+            )
+            scale = np.sqrt(target_power_per_metre / normalization_power)
             for field in (self.Et, self.Ea, self.Ew, self.Ht, self.Ha, self.Hw):
                 field[:, mode] *= scale
             self.powers[mode] = self._calculate_mode_power(mode)
@@ -319,6 +396,9 @@ class FDFD_1D_mode_solver:
         self.modal_Hw = self.Hw[:, mode]
         self.modal_complex_neff = self.complex_neff[mode]
         self.modal_real_neff = self.real_neff[mode]
+        self.modal_raw_power = self.raw_powers[mode]
+        self.modal_forward_power_metric = self.forward_power_metrics[mode]
+        self.modal_power_valid = self.power_valid[mode]
         self.modal_power = self.powers[mode]
 
     def plot_fields(self, output_path="fdfd_1d_modes.png"):

--- a/gprMax/fdfd_eigenmode_solver/fdfd_1d_mode_solver.py
+++ b/gprMax/fdfd_eigenmode_solver/fdfd_1d_mode_solver.py
@@ -229,7 +229,7 @@ class FDFD_1D_mode_solver:
                 self.Ea[:, mode] = self.eigenvectors[:, mode]
                 self.Ht[:, mode] = -neff * self.Ea[:, mode] / (self.eta0 * self.mu_r_t)
                 self.Hw[:, mode] = np.asarray(
-                    -1j
+                    1j
                     * (longitudinal_inverse @ (self.D_NODE_TO_CELL @ self.Ea[:, mode]))
                     / self.eta0
                 ).ravel()
@@ -237,7 +237,7 @@ class FDFD_1D_mode_solver:
                 self.Ha[:, mode] = self.eigenvectors[:, mode]
                 self.Et[:, mode] = self.eta0 * neff * self.Ha[:, mode] / self.eps_r_t
                 self.Ew[:, mode] = np.asarray(
-                    1j
+                    -1j
                     * self.eta0
                     * (longitudinal_inverse @ (self.D_CELL_TO_NODE @ self.Ha[:, mode]))
                 ).ravel()
@@ -296,8 +296,18 @@ class FDFD_1D_mode_solver:
             for field in (self.Et, self.Ea, self.Ew, self.Ht, self.Ha, self.Hw):
                 field[:, mode] *= factor
             if self._real_profile_power_from_fields(mode) < 0:
-                for field in (self.Ht, self.Ha, self.Hw):
-                    field[:, mode] *= -1
+                for field in (self.Et, self.Ea, self.Ew, self.Ht, self.Ha, self.Hw):
+                    field[:, mode] *= 1j
+            self._canonicalize_mode_sign(mode)
+
+    def _canonicalize_mode_sign(self, mode):
+        """Fix the remaining plus/minus gauge using tangential electric fields."""
+        pivot_vector = np.concatenate((self.Et[:, mode].ravel(), self.Ea[:, mode].ravel()))
+        pivot = pivot_vector[np.argmax(np.abs(pivot_vector))]
+        tolerance = 1e-12 * max(1.0, abs(pivot))
+        if np.real(pivot) < -tolerance or (abs(np.real(pivot)) <= tolerance and np.imag(pivot) < 0):
+            for field in (self.Et, self.Ea, self.Ew, self.Ht, self.Ha, self.Hw):
+                field[:, mode] *= -1
 
     def _set_modal_fields(self):
         mode = self.mode_index
@@ -375,14 +385,20 @@ class FDFD_1D_mode_solver:
         return float(np.max(finite)) if finite.size else 0.0
 
     def _default_guess(self):
-        return -max(
+        max_epsilon = max(
             self._max_magnitude(values)
             for values in (
                 self.eps_r_t,
                 self.eps_r_a,
                 self.eps_r_w,
+            )
+        )
+        max_permeability = max(
+            self._max_magnitude(values)
+            for values in (
                 self.mu_r_t,
                 self.mu_r_a,
                 self.mu_r_w,
             )
         )
+        return -(max_epsilon * max_permeability)

--- a/gprMax/fdfd_eigenmode_solver/fdfd_2d_mode_solver.py
+++ b/gprMax/fdfd_eigenmode_solver/fdfd_2d_mode_solver.py
@@ -36,27 +36,34 @@ class FDFD_2D_mode_solver:
     Non-finite electric and magnetic material entries are interpreted as PEC
     and PMC respectively, then replaced by finite placeholders after the masks
     have been built.
+
+    After :meth:`solve`, ``raw_powers`` contains the complex Poynting power
+    before normalization. ``forward_power_metrics`` is its real part divided
+    by a positive, E/H-balanced transverse field norm; ``power_valid`` applies
+    the class tolerance to that signed, scale-independent ratio.
     """
 
+    FORWARD_POWER_METRIC_TOLERANCE = 1e-8
+
     def __init__(
-            self,
-            frequency,
-            du,
-            dv,
-            mode_index,
-            eps_r_uu,
-            eps_r_vv,
-            eps_r_ww,
-            mu_r_uu,
-            mu_r_vv,
-            mu_r_ww,
-            pec_u_mask=None,
-            pec_v_mask=None,
-            pec_w_mask=None,
-            pmc_u_mask=None,
-            pmc_v_mask=None,
-            pmc_w_mask=None,
-            guess=None,
+        self,
+        frequency,
+        du,
+        dv,
+        mode_index,
+        eps_r_uu,
+        eps_r_vv,
+        eps_r_ww,
+        mu_r_uu,
+        mu_r_vv,
+        mu_r_ww,
+        pec_u_mask=None,
+        pec_v_mask=None,
+        pec_w_mask=None,
+        pmc_u_mask=None,
+        pmc_v_mask=None,
+        pmc_w_mask=None,
+        guess=None,
     ):
         self.epsilon0 = config.sim_config.em_consts["e0"]
         self.mu0 = config.sim_config.em_consts["m0"]
@@ -132,10 +139,10 @@ class FDFD_2D_mode_solver:
         self.free_hu_mask = ~self.pmc_u_mask.ravel(order="F")
         self.free_hv_mask = ~self.pmc_v_mask.ravel(order="F")
         self.free_hw_mask = ~self.pmc_w_mask.ravel(order="F")
-        self.free_eu_mask &= ~self.pmc_v_mask.ravel(order='F')
-        self.free_ev_mask &= ~self.pmc_u_mask.ravel(order='F')
-        self.free_hu_mask &= ~self.pec_v_mask.ravel(order='F')
-        self.free_hv_mask &= ~self.pec_u_mask.ravel(order='F')
+        self.free_eu_mask &= ~self.pmc_v_mask.ravel(order="F")
+        self.free_ev_mask &= ~self.pmc_u_mask.ravel(order="F")
+        self.free_hu_mask &= ~self.pec_v_mask.ravel(order="F")
+        self.free_hv_mask &= ~self.pec_u_mask.ravel(order="F")
         self.free_euv_mask = np.concatenate((self.free_eu_mask, self.free_ev_mask))
         self.free_huv_mask = np.concatenate((self.free_hu_mask, self.free_hv_mask))
 
@@ -144,6 +151,9 @@ class FDFD_2D_mode_solver:
         self.eigenvectors = None
         self.complex_neff = None
         self.real_neff = None
+        self.raw_powers = None
+        self.forward_power_metrics = None
+        self.power_valid = None
         self.powers = None
 
         self._init_operators()
@@ -164,7 +174,9 @@ class FDFD_2D_mode_solver:
         for name, shape in expected.items():
             actual = getattr(self, name).shape
             if actual != shape:
-                raise ValueError(f"{name} shape {actual} does not match expected local Yee shape {shape}.")
+                raise ValueError(
+                    f"{name} shape {actual} does not match expected local Yee shape {shape}."
+                )
 
     def _component_constraint_mask(self, values, explicit_mask, expected_shape):
         mask = ~np.isfinite(values)
@@ -190,13 +202,17 @@ class FDFD_2D_mode_solver:
         for j in range(out_nv):
             for i in range(out_nu):
                 row = self._flat_index(i, j, out_nu)
-                entries = ((i + 1, j, 1.0), (i, j, -1.0)) if forward else ((i, j, 1.0), (i - 1, j, -1.0))
+                entries = (
+                    ((i + 1, j, 1.0), (i, j, -1.0)) if forward else ((i, j, 1.0), (i - 1, j, -1.0))
+                )
                 for ci, cj, value in entries:
                     if 0 <= ci < in_shape[0] and 0 <= cj < in_shape[1]:
                         rows.append(row)
                         cols.append(self._flat_index(ci, cj, in_nu))
                         data.append(value / scale)
-        return coo_matrix((data, (rows, cols)), shape=(out_nu * out_nv, in_shape[0] * in_shape[1])).tocsr()
+        return coo_matrix(
+            (data, (rows, cols)), shape=(out_nu * out_nv, in_shape[0] * in_shape[1])
+        ).tocsr()
 
     def _difference_matrix_v(self, in_shape, out_shape, scale, forward=True):
         rows = []
@@ -207,22 +223,34 @@ class FDFD_2D_mode_solver:
         for j in range(out_nv):
             for i in range(out_nu):
                 row = self._flat_index(i, j, out_nu)
-                entries = ((i, j + 1, 1.0), (i, j, -1.0)) if forward else ((i, j, 1.0), (i, j - 1, -1.0))
+                entries = (
+                    ((i, j + 1, 1.0), (i, j, -1.0)) if forward else ((i, j, 1.0), (i, j - 1, -1.0))
+                )
                 for ci, cj, value in entries:
                     if 0 <= ci < in_shape[0] and 0 <= cj < in_shape[1]:
                         rows.append(row)
                         cols.append(self._flat_index(ci, cj, in_nu))
                         data.append(value / scale)
-        return coo_matrix((data, (rows, cols)), shape=(out_nu * out_nv, in_shape[0] * in_shape[1])).tocsr()
+        return coo_matrix(
+            (data, (rows, cols)), shape=(out_nu * out_nv, in_shape[0] * in_shape[1])
+        ).tocsr()
 
     def _init_operators(self):
         du = self.normalized_du
         dv = self.normalized_dv
 
-        self.DEU_EW_TO_EU = self._difference_matrix_u(self.shape_ew, self.shape_eu, du, forward=True)
-        self.DEV_EW_TO_EV = self._difference_matrix_v(self.shape_ew, self.shape_ev, dv, forward=True)
-        self.DEU_EV_TO_HW = self._difference_matrix_u(self.shape_ev, self.shape_hw, du, forward=True)
-        self.DEV_EU_TO_HW = self._difference_matrix_v(self.shape_eu, self.shape_hw, dv, forward=True)
+        self.DEU_EW_TO_EU = self._difference_matrix_u(
+            self.shape_ew, self.shape_eu, du, forward=True
+        )
+        self.DEV_EW_TO_EV = self._difference_matrix_v(
+            self.shape_ew, self.shape_ev, dv, forward=True
+        )
+        self.DEU_EV_TO_HW = self._difference_matrix_u(
+            self.shape_ev, self.shape_hw, du, forward=True
+        )
+        self.DEV_EU_TO_HW = self._difference_matrix_v(
+            self.shape_eu, self.shape_hw, dv, forward=True
+        )
 
         self.DHU_HV_TO_EW = -self.DEU_EW_TO_EU.conj().T
         self.DHV_HU_TO_EW = -self.DEV_EW_TO_EV.conj().T
@@ -303,6 +331,11 @@ class FDFD_2D_mode_solver:
         self.real_neff = np.real(self.complex_neff)
 
         self._calculate_fields(Q_reduced, eps_ww_inv, mu_ww_inv)
+        self._orient_backward_modes_to_forward_power(
+            Q_reduced,
+            eps_ww_inv,
+            mu_ww_inv,
+        )
         self._normalize_modes_to_power()
         self._align_modes_for_real_profile_power()
         self._set_modal_fields()
@@ -313,18 +346,26 @@ class FDFD_2D_mode_solver:
         # Reuse the selected propagation branch when reconstructing H.
         sqrt_eigenvalues = 1j * self.complex_neff
         if np.any(np.abs(sqrt_eigenvalues) < 1e-300):
-            raise ValueError("Encountered a near-zero eigenvalue while reconstructing magnetic fields.")
+            raise ValueError(
+                "Encountered a near-zero eigenvalue while reconstructing magnetic fields."
+            )
         eigenvalues_inv = diags(1.0 / sqrt_eigenvalues, format="csr")
 
-        eu_flat = np.asarray(self.eigenvectors[:self.n_eu, :], dtype=np.complex128)
-        ev_flat = np.asarray(self.eigenvectors[self.n_eu:, :], dtype=np.complex128)
+        eu_flat = np.asarray(self.eigenvectors[: self.n_eu, :], dtype=np.complex128)
+        ev_flat = np.asarray(self.eigenvectors[self.n_eu :, :], dtype=np.complex128)
         huv_reduced = Q_reduced @ self.eigenvectors @ eigenvalues_inv
         huv_flat = np.zeros((self.n_h_transverse, self.num_modes), dtype=np.complex128)
         huv_flat[self.free_huv_mask, :] = huv_reduced
-        hu_norm = np.asarray(huv_flat[:self.n_hu, :], dtype=np.complex128)
-        hv_norm = np.asarray(huv_flat[self.n_hu:, :], dtype=np.complex128)
-        ew_flat = np.asarray(eps_ww_inv @ (self.DHU_HV_TO_EW @ hv_norm - self.DHV_HU_TO_EW @ hu_norm), dtype=np.complex128)
-        hw_norm = np.asarray(mu_ww_inv @ (self.DEU_EV_TO_HW @ ev_flat - self.DEV_EU_TO_HW @ eu_flat), dtype=np.complex128)
+        hu_norm = np.asarray(huv_flat[: self.n_hu, :], dtype=np.complex128)
+        hv_norm = np.asarray(huv_flat[self.n_hu :, :], dtype=np.complex128)
+        ew_flat = np.asarray(
+            eps_ww_inv @ (self.DHU_HV_TO_EW @ hv_norm - self.DHV_HU_TO_EW @ hu_norm),
+            dtype=np.complex128,
+        )
+        hw_norm = np.asarray(
+            mu_ww_inv @ (self.DEU_EV_TO_HW @ ev_flat - self.DEV_EU_TO_HW @ eu_flat),
+            dtype=np.complex128,
+        )
 
         self.Eu = self._unflatten_modes(eu_flat, self.shape_eu)
         self.Ev = self._unflatten_modes(ev_flat, self.shape_ev)
@@ -336,7 +377,9 @@ class FDFD_2D_mode_solver:
 
     @staticmethod
     def _unflatten_modes(flat_modes, shape):
-        return np.asarray(flat_modes, dtype=np.complex128).reshape((*shape, flat_modes.shape[1]), order="F")
+        return np.asarray(flat_modes, dtype=np.complex128).reshape(
+            (*shape, flat_modes.shape[1]), order="F"
+        )
 
     def _zero_constrained_fields(self):
         self.Eu[self.eu_constraint_mask, :] = 0.0
@@ -355,31 +398,93 @@ class FDFD_2D_mode_solver:
         self.modal_Hw = self.Hw[:, :, self.mode_index]
         self.modal_complex_neff = self.complex_neff[self.mode_index]
         self.modal_real_neff = self.real_neff[self.mode_index]
+        self.modal_raw_power = self.raw_powers[self.mode_index]
+        self.modal_forward_power_metric = self.forward_power_metrics[self.mode_index]
+        self.modal_power_valid = self.power_valid[self.mode_index]
         self.modal_power = self.powers[self.mode_index]
 
     def _field_to_cells(self, field, component):
         if component in ("u", "hv"):
-            return 0.5 * (field[:, :self.Nv] + field[:, 1:])
+            return 0.5 * (field[:, : self.Nv] + field[:, 1:])
         if component in ("v", "hu"):
-            return 0.5 * (field[:self.Nu, :] + field[1:, :])
+            return 0.5 * (field[: self.Nu, :] + field[1:, :])
         if component == "w_e":
             return 0.25 * (
-                field[:self.Nu, :self.Nv]
-                + field[1:, :self.Nv]
-                + field[:self.Nu, 1:]
+                field[: self.Nu, : self.Nv]
+                + field[1:, : self.Nv]
+                + field[: self.Nu, 1:]
                 + field[1:, 1:]
             )
         if component == "w_h":
             return field
         raise ValueError(f"Unknown component {component!r}.")
 
-    def _calculate_mode_power(self, mode):
+    def _mode_transverse_fields_on_cells(self, mode):
         eu = self._field_to_cells(self.Eu[:, :, mode], "u")
         ev = self._field_to_cells(self.Ev[:, :, mode], "v")
         hu = self._field_to_cells(self.Hu[:, :, mode], "hu")
         hv = self._field_to_cells(self.Hv[:, :, mode], "hv")
+        return eu, ev, hu, hv
+
+    def _calculate_mode_complex_power(self, mode):
+        eu, ev, hu, hv = self._mode_transverse_fields_on_cells(mode)
         poynting_w = eu * np.conj(hv) - ev * np.conj(hu)
-        return 0.5 * math.fsum(np.ravel(np.real(poynting_w))) * self.du * self.dv
+        return (
+            0.5
+            * self.du
+            * self.dv
+            * complex(
+                math.fsum(np.ravel(np.real(poynting_w))),
+                math.fsum(np.ravel(np.imag(poynting_w))),
+            )
+        )
+
+    def _calculate_mode_power(self, mode):
+        return float(np.real(self._calculate_mode_complex_power(mode)))
+
+    def _calculate_mode_balanced_power(self, mode):
+        """Return a positive E/H-balanced field scale with units of power."""
+        eu, ev, hu, hv = self._mode_transverse_fields_on_cells(mode)
+        density = (
+            np.square(np.abs(eu))
+            + np.square(np.abs(ev))
+            + self.eta0**2 * (np.square(np.abs(hu)) + np.square(np.abs(hv)))
+        ) / (4.0 * self.eta0)
+        return math.fsum(np.ravel(density)) * self.du * self.dv
+
+    def _orient_backward_modes_to_forward_power(
+        self,
+        Q_reduced,
+        eps_ww_inv,
+        mu_ww_inv,
+    ):
+        """Select the passive beta branch whose real power points forward.
+
+        A backward-wave mode requires the opposite phase branch, not an
+        H-only sign change. Reconstructing the fields after reversing ``neff``
+        preserves Maxwell consistency while orienting real energy flow along
+        the solver's forward axis.
+        """
+
+        reverse = np.zeros(self.num_modes, dtype=bool)
+        for mode in range(self.num_modes):
+            balanced_power = self._calculate_mode_balanced_power(mode)
+            if not np.isfinite(balanced_power) or balanced_power <= 0:
+                continue
+            metric = np.real(self._calculate_mode_complex_power(mode)) / balanced_power
+            candidate = -self.complex_neff[mode]
+            tolerance = 1e-12 * max(1.0, abs(candidate))
+            reverse[mode] = (
+                np.isfinite(metric)
+                and metric < -self.FORWARD_POWER_METRIC_TOLERANCE
+                and np.imag(candidate) <= tolerance
+            )
+        if not np.any(reverse):
+            return
+
+        self.complex_neff[reverse] *= -1
+        self.real_neff = np.real(self.complex_neff)
+        self._calculate_fields(Q_reduced, eps_ww_inv, mu_ww_inv)
 
     def _real_profile_power_from_fields(self, eu_field, ev_field, hu_field, hv_field):
         eu = self._field_to_cells(np.real(eu_field), "u")
@@ -398,17 +503,30 @@ class FDFD_2D_mode_solver:
         )
 
     def _normalize_modes_to_power(self, target_power=1.0):
+        """Power-normalize forward modes and safely L2-normalize the rest."""
+        self.raw_powers = np.zeros(self.num_modes, dtype=np.complex128)
+        self.forward_power_metrics = np.full(self.num_modes, np.nan, dtype=np.float64)
+        self.power_valid = np.zeros(self.num_modes, dtype=bool)
         self.powers = np.zeros(self.num_modes, dtype=np.float64)
         for mode in range(self.num_modes):
-            power = self._calculate_mode_power(mode)
-            if not np.isfinite(power) or abs(power) < 1e-300:
-                raise ValueError(f"Cannot normalize mode {mode}: modal power is {power}.")
-            if power < 0:
-                self.Hu[:, :, mode] = -self.Hu[:, :, mode]
-                self.Hv[:, :, mode] = -self.Hv[:, :, mode]
-                self.Hw[:, :, mode] = -self.Hw[:, :, mode]
-                power = -power
-            scale = np.sqrt(target_power / power)
+            raw_power = self._calculate_mode_complex_power(mode)
+            balanced_power = self._calculate_mode_balanced_power(mode)
+            self.raw_powers[mode] = raw_power
+            if np.isfinite(raw_power) and np.isfinite(balanced_power) and balanced_power > 0:
+                metric = float(np.real(raw_power) / balanced_power)
+                self.forward_power_metrics[mode] = metric
+                self.power_valid[mode] = (
+                    np.isfinite(metric) and metric > self.FORWARD_POWER_METRIC_TOLERANCE
+                )
+            if not np.isfinite(balanced_power) or balanced_power <= 0:
+                raise ValueError(
+                    f"Cannot normalize mode {mode}: balanced field power is {balanced_power}."
+                )
+
+            normalization_power = (
+                float(np.real(raw_power)) if self.power_valid[mode] else balanced_power
+            )
+            scale = np.sqrt(target_power / normalization_power)
             for field in (self.Eu, self.Ev, self.Ew, self.Hu, self.Hv, self.Hw):
                 field[:, :, mode] *= scale
             self.powers[mode] = self._calculate_mode_power(mode)
@@ -419,10 +537,18 @@ class FDFD_2D_mode_solver:
             ev = self.Ev[:, :, mode]
             hu = self.Hu[:, :, mode]
             hv = self.Hv[:, :, mode]
-            e_real_h_real = self._real_profile_power_from_fields(np.real(eu), np.real(ev), np.real(hu), np.real(hv))
-            e_imag_h_imag = self._real_profile_power_from_fields(np.imag(eu), np.imag(ev), np.imag(hu), np.imag(hv))
-            e_real_h_imag = self._real_profile_power_from_fields(np.real(eu), np.real(ev), np.imag(hu), np.imag(hv))
-            e_imag_h_real = self._real_profile_power_from_fields(np.imag(eu), np.imag(ev), np.real(hu), np.real(hv))
+            e_real_h_real = self._real_profile_power_from_fields(
+                np.real(eu), np.real(ev), np.real(hu), np.real(hv)
+            )
+            e_imag_h_imag = self._real_profile_power_from_fields(
+                np.imag(eu), np.imag(ev), np.imag(hu), np.imag(hv)
+            )
+            e_real_h_imag = self._real_profile_power_from_fields(
+                np.real(eu), np.real(ev), np.imag(hu), np.imag(hv)
+            )
+            e_imag_h_real = self._real_profile_power_from_fields(
+                np.imag(eu), np.imag(ev), np.real(hu), np.real(hv)
+            )
             phase = 0.5 * np.arctan2(
                 -0.5 * (e_real_h_imag + e_imag_h_real),
                 0.5 * (e_real_h_real - e_imag_h_imag),
@@ -463,8 +589,8 @@ class FDFD_2D_mode_solver:
         axes = np.atleast_2d(fig.subplots(self.num_modes, 2))
         for mode in range(self.num_modes):
             for ax, field, component in (
-                    (axes[mode, 0], np.real(self.Eu[:, :, mode]), "E_u"),
-                    (axes[mode, 1], np.real(self.Ev[:, :, mode]), "E_v"),
+                (axes[mode, 0], np.real(self.Eu[:, :, mode]), "E_u"),
+                (axes[mode, 1], np.real(self.Ev[:, :, mode]), "E_v"),
             ):
                 image = ax.imshow(field.T, origin="lower", cmap="RdBu_r", aspect="auto")
                 ax.set_title(f"Mode {mode + 1} {component}, neff={self.complex_neff[mode]:.6g}")
@@ -479,8 +605,8 @@ class FDFD_2D_mode_solver:
         axes = np.atleast_2d(fig.subplots(self.num_modes, 2))
         for mode in range(self.num_modes):
             for ax, field, component in (
-                    (axes[mode, 0], np.real(self.Hu[:, :, mode]), "H_u"),
-                    (axes[mode, 1], np.real(self.Hv[:, :, mode]), "H_v"),
+                (axes[mode, 0], np.real(self.Hu[:, :, mode]), "H_u"),
+                (axes[mode, 1], np.real(self.Hv[:, :, mode]), "H_v"),
             ):
                 image = ax.imshow(field.T, origin="lower", cmap="RdBu_r", aspect="auto")
                 ax.set_title(f"Mode {mode + 1} {component}, neff={self.complex_neff[mode]:.6g}")
@@ -524,12 +650,10 @@ class FDFD_2D_mode_solver:
 
     def _default_guess(self):
         max_epsilon = max(
-            self._max_magnitude(values)
-            for values in (self.eps_r_uu, self.eps_r_vv, self.eps_r_ww)
+            self._max_magnitude(values) for values in (self.eps_r_uu, self.eps_r_vv, self.eps_r_ww)
         )
         max_permeability = max(
-            self._max_magnitude(values)
-            for values in (self.mu_r_uu, self.mu_r_vv, self.mu_r_ww)
+            self._max_magnitude(values) for values in (self.mu_r_uu, self.mu_r_vv, self.mu_r_ww)
         )
         return -(max_epsilon * max_permeability)
 

--- a/gprMax/fdfd_eigenmode_solver/fdfd_2d_mode_solver.py
+++ b/gprMax/fdfd_eigenmode_solver/fdfd_2d_mode_solver.py
@@ -1,12 +1,13 @@
 import math
 
 import numpy as np
-
-import gprMax.config as config
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.figure import Figure
+from scipy.linalg import eig
 from scipy.sparse import bmat, coo_matrix, diags
 from scipy.sparse.linalg import eigs
+
+import gprMax.config as config
 
 
 class FDFD_2D_mode_solver:
@@ -238,6 +239,36 @@ class FDFD_2D_mode_solver:
         inverse[free_mask] = 1.0 / flat[free_mask]
         return diags(inverse, format="csr")
 
+    def _solve_reduced(self, operator):
+        size = operator.shape[0]
+        if size <= self.num_modes:
+            raise ValueError(
+                f"Not enough unconstrained electric DOFs ({size}) to solve {self.num_modes} modes."
+            )
+
+        if size <= self.num_modes + 1:
+            eigenvalues, eigenvectors = eig(operator.toarray())
+            selection = np.argsort(np.abs(eigenvalues - self.guess))[: self.num_modes]
+            eigenvalues = eigenvalues[selection]
+            eigenvectors = eigenvectors[:, selection]
+        else:
+            try:
+                eigenvalues, eigenvectors = eigs(
+                    operator,
+                    k=self.num_modes,
+                    sigma=self.guess,
+                )
+            except RuntimeError:
+                shifted_guess = self.guess * (1.0 + 1e-9) - 1e-12
+                eigenvalues, eigenvectors = eigs(
+                    operator,
+                    k=self.num_modes,
+                    sigma=shifted_guess,
+                )
+
+        order = np.argsort(np.real(eigenvalues))
+        return eigenvalues[order], eigenvectors[:, order]
+
     def solve(self):
         eps_uu_diag = self._diag(self.eps_r_uu)
         eps_vv_diag = self._diag(self.eps_r_vv)
@@ -262,18 +293,12 @@ class FDFD_2D_mode_solver:
         Q_reduced = Q[self.free_huv_mask, :]
         omega_matrix = P_reduced @ Q_reduced
         omega_matrix = omega_matrix[self.free_euv_mask, :][:, self.free_euv_mask]
-        if omega_matrix.shape[0] <= self.num_modes:
-            raise ValueError(
-                f"Not enough unconstrained electric DOFs ({omega_matrix.shape[0]}) to solve {self.num_modes} modes."
-            )
-
-        eigenvalues, reduced_eigenvectors = eigs(omega_matrix, k=self.num_modes, sigma=self.guess)
+        eigenvalues, reduced_eigenvectors = self._solve_reduced(omega_matrix)
         eigenvectors = np.zeros((self.n_e_transverse, self.num_modes), dtype=np.complex128)
         eigenvectors[self.free_euv_mask, :] = reduced_eigenvectors
 
-        order = np.argsort(np.real(eigenvalues))
-        self.eigenvalues = eigenvalues[order]
-        self.eigenvectors = eigenvectors[:, order]
+        self.eigenvalues = eigenvalues
+        self.eigenvectors = eigenvectors
         self.complex_neff = self._passive_positive_neff(-self.eigenvalues)
         self.real_neff = np.real(self.complex_neff)
 
@@ -405,6 +430,16 @@ class FDFD_2D_mode_solver:
             self._rotate_mode(mode, phase)
             if self._calculate_real_profile_power(mode) < 0:
                 self._rotate_mode(mode, 0.5 * np.pi)
+            self._canonicalize_mode_sign(mode)
+
+    def _canonicalize_mode_sign(self, mode):
+        """Fix the remaining plus/minus gauge using tangential electric fields."""
+        pivot_vector = np.concatenate((self.Eu[:, :, mode].ravel(), self.Ev[:, :, mode].ravel()))
+        pivot = pivot_vector[np.argmax(np.abs(pivot_vector))]
+        tolerance = 1e-12 * max(1.0, abs(pivot))
+        if np.real(pivot) < -tolerance or (abs(np.real(pivot)) <= tolerance and np.imag(pivot) < 0):
+            for field in (self.Eu, self.Ev, self.Ew, self.Hu, self.Hv, self.Hw):
+                field[:, :, mode] *= -1
 
     def _rotate_mode(self, mode, phase):
         phase_factor = np.exp(1j * phase)
@@ -488,10 +523,15 @@ class FDFD_2D_mode_solver:
         return real + 1j * imag
 
     def _default_guess(self):
-        return -max(
-            self._max_magnitude(arr)
-            for arr in [self.eps_r_uu, self.eps_r_vv, self.eps_r_ww, self.mu_r_uu, self.mu_r_vv, self.mu_r_ww]
+        max_epsilon = max(
+            self._max_magnitude(values)
+            for values in (self.eps_r_uu, self.eps_r_vv, self.eps_r_ww)
         )
+        max_permeability = max(
+            self._max_magnitude(values)
+            for values in (self.mu_r_uu, self.mu_r_vv, self.mu_r_ww)
+        )
+        return -(max_epsilon * max_permeability)
 
     @staticmethod
     def _max_magnitude(values):

--- a/gprMax/sources.py
+++ b/gprMax/sources.py
@@ -20,15 +20,18 @@
 import logging
 import math
 from copy import deepcopy
+
 import numpy as np
 import numpy.typing as npt
 
 import gprMax.config as config
+from gprMax.eigenmode_plotting import plot_eigenmode_excitation, plot_eigenmode_port_fields
 from gprMax.fdfd_eigenmode_solver.fdfd_1d_mode_solver import FDFD_1D_mode_solver
 from gprMax.fdfd_eigenmode_solver.fdfd_2d_mode_solver import FDFD_2D_mode_solver
-from gprMax.eigenmode_plotting import plot_eigenmode_excitation, plot_eigenmode_port_fields
 from gprMax.waveforms import Waveform
 
+from .cython.eigenmode_source import update_eigenmode_electric as updateEigenmode_electric
+from .cython.eigenmode_source import update_eigenmode_magnetic as updateEigenmode_magnetic
 from .cython.plane_wave import (
     calculate1DWaveformValues,
     getSource,
@@ -38,10 +41,6 @@ from .cython.plane_wave import (
     updatePlaneWave_electric_dispersive_axial,
     updatePlaneWave_magnetic,
     updatePlaneWave_magnetic_axial,
-)
-from .cython.eigenmode_source import (
-    update_eigenmode_magnetic as updateEigenmode_magnetic,
-    update_eigenmode_electric as updateEigenmode_electric,
 )
 from .utilities.utilities import round_value
 
@@ -114,7 +113,7 @@ class Source:
 
 
 class EigenmodeAnchorMismatchError(ValueError):
-    '''Raised when the same modal branch cannot be tracked between anchors.'''
+    """Raised when the same modal branch cannot be tracked between anchors."""
 
     def __init__(
         self,
@@ -134,9 +133,9 @@ class EigenmodeAnchorMismatchError(ValueError):
         self.context = context
         super().__init__(
             message
-            + ' This may indicate a degenerate mode or mode crossing. Use a single '
-            + 'explicit frequency anchor for this port if a constant modal basis '
-            + 'across the band is acceptable.'
+            + " This may indicate a degenerate mode or mode crossing. Use a single "
+            + "explicit frequency anchor for this port if a constant modal basis "
+            + "across the band is acceptable."
         )
 
 
@@ -151,129 +150,93 @@ def _trim_failed_guard_anchors(frequencies, mismatch, fmin, fmax):
     tolerance = 1e-12 * max(abs(float(fmin)), abs(float(fmax)), 1.0)
     if second <= fmin + tolerance:
         trimmed = tuple(value for value in frequencies if value >= second - tolerance)
-        return ('lower', second, trimmed) if len(trimmed) > 1 else None
+        return ("lower", second, trimmed) if len(trimmed) > 1 else None
     if first >= fmax - tolerance:
         trimmed = tuple(value for value in frequencies if value <= first + tolerance)
-        return ('upper', first, trimmed) if len(trimmed) > 1 else None
+        return ("upper", first, trimmed) if len(trimmed) > 1 else None
     return None
 
 
 def initialise_eigenmode_ports(grid):
-    """Resolve one coordinated automatic-anchor policy for every port."""
+    """Initialise each port without allowing passive ports to rebuild a source."""
 
     ports = [*grid.eigenmodesources, *grid.eigenmodereceivers]
     if not ports:
         return
-    requested_policies = {
-        id(port): getattr(port, 'requested_anchor_policy', port.anchor_policy)
-        for port in ports
-    }
-    automatic_ports = [
-        port for port in ports if requested_policies[id(port)] == 'auto'
-    ]
-    if not automatic_ports:
-        for port in ports:
-            port.grid_init(grid)
-        return
-
-    common_anchors = tuple(
-        float(value)
-        for value in (automatic_ports[0].frequencies or (automatic_ports[0].frequency,))
-    )
-    for port in automatic_ports[1:]:
-        anchors = tuple(
-            float(value) for value in (port.frequencies or (port.frequency,))
-        )
-        if anchors != common_anchors:
-            raise ValueError(
-                'Automatic eigenmode ports must start with identical anchor '
-                f'frequencies; got {common_anchors} and {anchors}.'
-            )
-
+    grid.eigenmodeports.clear()
     band = grid.eigenmodeband
-    candidate_anchors = common_anchors
-    guard_trimmed = False
-    while True:
-        grid.eigenmodeports.clear()
-        for port in ports:
-            requested = requested_policies[id(port)]
-            if requested == 'auto':
-                port.frequency = candidate_anchors[0]
-                port.frequencies = candidate_anchors
-                # Suppress the legacy per-port fallback. The coordinator must
-                # see a mismatch before choosing one policy for every auto port.
-                port.anchor_policy = 'coordinated_auto'
-            else:
-                port.anchor_policy = requested
+    for port in ports:
+        requested = getattr(port, "requested_anchor_policy", port.anchor_policy)
+        candidates = tuple(float(value) for value in (port.frequencies or (port.frequency,)))
+        guard_trimmed = False
+        single_fallback = False
+
+        while True:
+            port.frequency = candidates[0]
+            port.frequencies = candidates
+            # Suppress the legacy recursive fallback so this outer loop can
+            # distinguish a guard-local mismatch from an in-band mismatch.
+            port.anchor_policy = "coordinated_auto" if requested == "auto" else requested
             port.port_monitor = None
-
-        source = grid.eigenmodesources[0]
-        source_requested = requested_policies[id(source)]
-        if source_requested == 'auto':
-            source.spectrum_coverage_policy = (
-                'allow' if guard_trimmed else 'error'
-            )
-
-        failing_port = None
-        try:
-            for port in ports:
-                failing_port = port
+            try:
                 port.grid_init(grid)
-        except EigenmodeAnchorMismatchError as mismatch:
-            grid.eigenmodeports.clear()
-            for port in ports:
-                port.anchor_policy = requested_policies[id(port)]
-            if requested_policies[id(failing_port)] != 'auto':
-                raise
+            except EigenmodeAnchorMismatchError as mismatch:
+                port.anchor_policy = requested
+                if requested != "auto":
+                    raise
 
-            guard_result = _trim_failed_guard_anchors(
-                candidate_anchors,
-                mismatch,
-                band.fmin,
-                band.fmax,
-            )
-            if guard_result is not None:
-                side, retained_frequency, trimmed = guard_result
-                if trimmed != candidate_anchors:
-                    detail = mismatch.detail.rstrip(' .')
-                    logger.warning(
-                        f'{detail}, within the {side} spectral guard '
-                        f'outside the requested {band.fmin:g} to {band.fmax:g} Hz '
-                        f'band. All automatic eigenmode ports will retain broadband '
-                        f'tracking from {retained_frequency:g} Hz and use that '
-                        f'endpoint modal profile across the trimmed significant-'
-                        'spectrum tail.'
-                    )
-                    candidate_anchors = trimmed
-                    guard_trimmed = True
-                    continue
+                guard_result = _trim_failed_guard_anchors(
+                    candidates,
+                    mismatch,
+                    band.fmin,
+                    band.fmax,
+                )
+                if guard_result is not None:
+                    side, retained_frequency, trimmed = guard_result
+                    if trimmed != candidates:
+                        detail = mismatch.detail.rstrip(" .")
+                        logger.warning(
+                            f"{detail}, within the {side} spectral guard "
+                            f"outside the requested {band.fmin:g} to "
+                            f"{band.fmax:g} Hz band. Automatic eigenmode port "
+                            f"{port.port_index} will retain broadband tracking "
+                            f"from {retained_frequency:g} Hz and use that "
+                            "endpoint modal profile across the trimmed "
+                            "significant-spectrum tail."
+                        )
+                        candidates = trimmed
+                        guard_trimmed = True
+                        if port in grid.eigenmodesources:
+                            port.spectrum_coverage_policy = "allow"
+                        continue
 
-            fallback = float(failing_port.fallback_frequency)
-            detail = mismatch.detail.rstrip(' .')
-            logger.warning(
-                f'{detail}. All automatic eigenmode ports will therefore '
-                f'use the shared single modal anchor at {fallback:g} Hz. Their '
-                'modal decomposition and S-parameters may be inaccurate toward '
-                'frequencies far from this anchor. Inspect the failed mode for '
-                'cutoff, degeneracy, or an artificial port-boundary mode.'
-            )
-            candidate_anchors = (fallback,)
-            guard_trimmed = False
-            continue
+                fallback = float(port.fallback_frequency)
+                detail = mismatch.detail.rstrip(" .")
+                logger.warning(
+                    f"{detail}. Automatic eigenmode port {port.port_index} will "
+                    f"therefore use the single modal anchor at {fallback:g} Hz. "
+                    "Its modal decomposition and S-parameters may be inaccurate "
+                    "toward frequencies far from this anchor. Inspect the failed "
+                    "mode for cutoff, degeneracy, or an artificial port-boundary "
+                    "mode."
+                )
+                candidates = (fallback,)
+                guard_trimmed = False
+                single_fallback = True
+                continue
 
-        for port in ports:
-            requested = requested_policies[id(port)]
             port.anchor_policy = requested
-            if requested == 'auto':
-                if len(candidate_anchors) == 1:
-                    port.resolved_anchor_policy = 'auto_single_fallback'
+            current_policy = getattr(port, "resolved_anchor_policy", requested)
+            if requested != "auto":
+                port.resolved_anchor_policy = "explicit"
+            elif current_policy in {"auto", "auto_broadband", "explicit"}:
+                if single_fallback:
+                    port.resolved_anchor_policy = "auto_single_fallback"
                 elif guard_trimmed:
-                    port.resolved_anchor_policy = 'auto_broadband_guard_trimmed'
+                    port.resolved_anchor_policy = "auto_broadband_guard_trimmed"
                 else:
-                    port.resolved_anchor_policy = 'auto_broadband'
-            else:
-                port.resolved_anchor_policy = 'explicit'
-        return
+                    port.resolved_anchor_policy = "auto_broadband"
+            break
 
 
 class EigenmodeSource(Source):
@@ -307,12 +270,12 @@ class EigenmodeSource(Source):
         self.mode_indices = ()
         self.frequency = None
         self.frequencies = None
-        self.anchor_policy = 'explicit'
-        self.requested_anchor_policy = 'explicit'
-        self.resolved_anchor_policy = 'explicit'
+        self.anchor_policy = "explicit"
+        self.requested_anchor_policy = "explicit"
+        self.resolved_anchor_policy = "explicit"
         self.fallback_frequency = None
         self.spectral_threshold = 1e-3
-        self.spectrum_coverage_policy = 'error'
+        self.spectrum_coverage_policy = "error"
         self.plane_index = None
         self.complex_eps_r_uu = None
         self.complex_eps_r_vv = None
@@ -332,6 +295,16 @@ class EigenmodeSource(Source):
         self.anchor_modal_h = None
         self.anchor_complex_neff = None
         self.anchor_overlaps = None
+        # Rectangular candidate-anchor bank used by the modal monitor.  The
+        # excitation fields above may be a per-mode subset of this bank.
+        self.port_anchor_frequencies = None
+        self.port_anchor_e = None
+        self.port_anchor_h = None
+        self.port_anchor_neff = None
+        self.port_anchor_mode_valid = None
+        self.port_anchor_mode_propagating = None
+        self.port_mode_anchor_policies = None
+        self.port_mode_solvers = None
         self.broadband_e_envelopes = None
         self.broadband_h_envelopes = None
         self.broadband_modal_e_real = None
@@ -368,23 +341,34 @@ class EigenmodeSource(Source):
             try:
                 self._solve_broadband_eigenmode(G, frequencies)
             except EigenmodeAnchorMismatchError as exc:
-                if self.anchor_policy != 'auto':
+                if self.anchor_policy != "auto":
                     raise
                 self._fallback_to_single_anchor(G, exc)
         else:
             self.frequency = frequencies[0]
             self._extract_frequency_dependent_materials(G)
             self._solve_eigenmode(G)
+            self._require_forward_power(
+                self.mode_solver,
+                self.mode_index,
+                self.frequency,
+                centre=(self.anchor_policy == "auto"),
+            )
+            self._prepare_port_anchor_bank(
+                frequencies,
+                (self.mode_solver,),
+                tuple(self.mode_indices or range(1, self.mode_count + 1)),
+            )
             self._prepare_single_frequency_injection(G)
         self._register_port_monitor(G)
 
     def _fallback_to_single_anchor(self, G, mismatch):
         frequency = float(self.fallback_frequency)
         logger.warning(
-            f'{mismatch} Automatic anchors for eigenmode port {self.port_index} '
-            f'will therefore use a single modal anchor at {frequency:g} Hz. The '
-            'modal field and S-parameters may be inaccurate toward frequencies '
-            'far from this anchor.'
+            f"{mismatch} Automatic anchors for eigenmode port {self.port_index} "
+            f"will therefore use a single modal anchor at {frequency:g} Hz. The "
+            "modal field and S-parameters may be inaccurate toward frequencies "
+            "far from this anchor."
         )
         self.frequency = frequency
         self.frequencies = (frequency,)
@@ -395,86 +379,41 @@ class EigenmodeSource(Source):
         self.anchor_overlaps = None
         self._extract_frequency_dependent_materials(G)
         self._solve_eigenmode(G)
+        self._require_forward_power(
+            self.mode_solver,
+            self.mode_index,
+            self.frequency,
+            centre=True,
+        )
+        mode_indices = tuple(self.mode_indices)
+        if not mode_indices and self.mode_count is not None:
+            mode_indices = tuple(range(1, self.mode_count + 1))
+        if not mode_indices and self.mode_index is not None:
+            mode_indices = (self.mode_index,)
+        # Keep monkeypatched/upstream legacy solvers compatible when they do
+        # not expose a solved mode object. Production ports always populate
+        # both the solver and at least one monitored mode here.
+        if self.mode_solver is not None and mode_indices:
+            self._prepare_port_anchor_bank(
+                (frequency,),
+                (self.mode_solver,),
+                mode_indices,
+                forced_policies=tuple("auto_single_fallback" for _ in mode_indices),
+            )
+        self.resolved_anchor_policy = "auto_single_fallback"
         self._prepare_single_frequency_injection(G)
 
     def _register_port_monitor(self, G):
         """Register the automatic modal monitor owned by this source."""
         from gprMax.eigenmode_ports import EigenmodePortMonitor
 
-        frequencies = tuple(self.frequencies or (self.frequency,))
-        solvers = tuple(self.mode_solvers or (self.mode_solver,))
         mode_indices = tuple(self.mode_indices or range(1, self.mode_count + 1))
-        anchor_e = []
-        anchor_h = []
-        anchor_neff = []
-        for solver in solvers:
-            frequency_e = []
-            frequency_h = []
-            frequency_neff = []
-            for mode_index in mode_indices:
-                electric, magnetic, neff = self._fields_from_solver_mode(solver, mode_index)
-                frequency_e.append(electric)
-                frequency_h.append(magnetic)
-                frequency_neff.append(neff)
-            anchor_e.append(frequency_e)
-            anchor_h.append(frequency_h)
-            anchor_neff.append(frequency_neff)
-
-        if len(frequencies) > 1 and self.anchor_policy == 'auto':
-            for mode_position, mode_index in enumerate(mode_indices):
-                for frequency_index in range(1, len(frequencies)):
-                    overlap = self._modal_overlap(
-                        anchor_e[frequency_index - 1][mode_position],
-                        anchor_h[frequency_index - 1][mode_position],
-                        anchor_e[frequency_index][mode_position],
-                        anchor_h[frequency_index][mode_position],
-                    )
-                    magnitude = float(abs(overlap))
-                    if (
-                        not np.isfinite(magnitude)
-                        or magnitude < self.ANCHOR_OVERLAP_ERROR_THRESHOLD
-                    ):
-                        frequency = float(self.fallback_frequency)
-                        logger.warning(
-                            f'Automatic anchor tracking failed for eigenmode port '
-                            f'{self.port_index}, mode {mode_index}, between '
-                            f'{frequencies[frequency_index - 1]:g} and '
-                            f'{frequencies[frequency_index]:g} Hz with overlap '
-                            f'{magnitude:.6f}. This may indicate a mode crossing or '
-                            f'degeneracy. The port will use a single modal anchor at '
-                            f'{frequency:g} Hz. Its modal decomposition and '
-                            'S-parameters may be inaccurate toward frequencies far '
-                            'from this anchor.'
-                        )
-                        self.frequency = frequency
-                        self.frequencies = (frequency,)
-                        self.mode_solvers = None
-                        return self.grid_init(G)
-
-        for mode_position, mode_index in enumerate(mode_indices):
-            for frequency_index in range(1, len(frequencies)):
-                overlap = self._modal_overlap(
-                    anchor_e[frequency_index - 1][mode_position],
-                    anchor_h[frequency_index - 1][mode_position],
-                    anchor_e[frequency_index][mode_position],
-                    anchor_h[frequency_index][mode_position],
-                )
-                magnitude = float(abs(overlap))
-                self._check_anchor_overlap(
-                    magnitude,
-                    frequencies[frequency_index - 1],
-                    frequencies[frequency_index],
-                    mode_index,
-                    "Broadband eigenmode source monitor",
-                )
-                if np.isfinite(magnitude) and magnitude > 1e-300:
-                    factor = np.exp(-1j * np.angle(overlap))
-                    anchor_e[frequency_index][mode_position] = [
-                        field * factor for field in anchor_e[frequency_index][mode_position]
-                    ]
-                    anchor_h[frequency_index][mode_position] = [
-                        field * factor for field in anchor_h[frequency_index][mode_position]
-                    ]
+        if self.port_anchor_frequencies is None:
+            self._prepare_port_anchor_bank(
+                tuple(self.frequencies or (self.frequency,)),
+                tuple(self.mode_solvers or (self.mode_solver,)),
+                mode_indices,
+            )
 
         monitor = EigenmodePortMonitor(
             owner=self,
@@ -483,13 +422,16 @@ class EigenmodeSource(Source):
             is_source=True,
             excitation_mode_index=self.mode_index,
             mode_indices=mode_indices,
-            anchor_frequencies=frequencies,
-            anchor_e=anchor_e,
-            anchor_h=anchor_h,
-            anchor_neff=np.asarray(anchor_neff, dtype=np.complex128),
+            anchor_frequencies=self.port_anchor_frequencies,
+            anchor_e=self.port_anchor_e,
+            anchor_h=self.port_anchor_h,
+            anchor_neff=self.port_anchor_neff,
             dft_start=self.dft_start,
             dft_stop=self.dft_stop,
             dft_points=self.dft_points,
+            anchor_mode_valid=self.port_anchor_mode_valid,
+            anchor_mode_propagating=self.port_anchor_mode_propagating,
+            mode_anchor_policies=self.port_mode_anchor_policies,
         )
         monitor.prepare(G)
         self.port_monitor = monitor
@@ -500,8 +442,12 @@ class EigenmodeSource(Source):
     def _store_real_modal_fields(self):
         """Store contiguous real modal arrays in the configured CPU precision."""
         dtype = config.sim_config.dtypes["float_or_double"]
-        self.modal_e_real = [np.ascontiguousarray(np.real(field), dtype=dtype) for field in self.modal_e]
-        self.modal_h_real = [np.ascontiguousarray(np.real(field), dtype=dtype) for field in self.modal_h]
+        self.modal_e_real = [
+            np.ascontiguousarray(np.real(field), dtype=dtype) for field in self.modal_e
+        ]
+        self.modal_h_real = [
+            np.ascontiguousarray(np.real(field), dtype=dtype) for field in self.modal_h
+        ]
 
     def _align_tangential_mode_for_real_injection(self):
         """Optimally phase-align injected fields and return their imaginary residual.
@@ -563,8 +509,12 @@ class EigenmodeSource(Source):
             return
 
         self.uses_quadrature = True
-        self.anchor_modal_e = [[np.array(field, dtype=np.complex128, copy=True) for field in self.modal_e]]
-        self.anchor_modal_h = [[np.array(field, dtype=np.complex128, copy=True) for field in self.modal_h]]
+        self.anchor_modal_e = [
+            [np.array(field, dtype=np.complex128, copy=True) for field in self.modal_e]
+        ]
+        self.anchor_modal_h = [
+            [np.array(field, dtype=np.complex128, copy=True) for field in self.modal_h]
+        ]
         self.anchor_complex_neff = np.asarray([complex(self.complex_neff)], dtype=np.complex128)
         self.anchor_overlaps = np.empty(0, dtype=np.float64)
         self.mode_solvers = [self.mode_solver]
@@ -592,49 +542,437 @@ class EigenmodeSource(Source):
             self.complex_mu_r_ww,
         ) = self._extract_local_complex_property_tensors(G, electric=False)
 
-    def _solve_broadband_eigenmode(self, G, frequencies):
-        """Solve, align, validate, and synthesize a multi-frequency mode."""
+    def _automatic_anchor_policy(self):
+        """Return whether this port was configured for automatic anchors."""
+
+        return self.requested_anchor_policy == "auto" or self.anchor_policy in {
+            "auto",
+            "coordinated_auto",
+        }
+
+    @staticmethod
+    def _solver_mode_power_valid(solver, mode_index):
+        """Return the solver's scale-independent forward-power decision.
+
+        Solvers supplied by older downstream integrations do not expose the
+        new diagnostic arrays, so retain their historical behaviour rather
+        than failing on a missing optional attribute.
+        """
+
+        values = getattr(solver, "power_valid", None)
+        if values is None:
+            return True
+        position = int(mode_index) - 1
+        return bool(np.asarray(values, dtype=bool)[position])
+
+    @staticmethod
+    def _solver_mode_power_diagnostics(solver, mode_index):
+        position = int(mode_index) - 1
+
+        def value(name, default):
+            values = getattr(solver, name, None)
+            if values is None:
+                return default
+            return np.asarray(values)[position]
+
+        neff = value("complex_neff", complex(np.nan, np.nan))
+        raw_power = value("raw_powers", complex(np.nan, np.nan))
+        metric = value("forward_power_metrics", float("nan"))
+        return complex(neff), complex(raw_power), float(metric)
+
+    def _require_forward_power(self, solver, mode_index, frequency, *, centre=False):
+        if self._solver_mode_power_valid(solver, mode_index):
+            return
+        neff, raw_power, metric = self._solver_mode_power_diagnostics(
+            solver,
+            mode_index,
+        )
+        anchor = "centre-frequency anchor" if centre else "anchor"
+        raise ValueError(
+            f"Eigenmode port {self.port_index} mode {mode_index} {anchor} at "
+            f"{float(frequency):g} Hz is non-propagating: neff={neff!s}, "
+            f"raw complex power={raw_power!s}, and signed forward-power "
+            f"metric={metric:g}."
+        )
+
+    def _centre_anchor_index(self, frequencies):
+        frequency = (
+            float(self.fallback_frequency)
+            if self.fallback_frequency is not None
+            else 0.5 * (float(self.dft_start) + float(self.dft_stop))
+        )
+        frequencies = np.asarray(frequencies, dtype=np.float64)
+        tolerance = 1e-12 * max(abs(frequency), 1.0)
+        matches = np.flatnonzero(np.abs(frequencies - frequency) <= tolerance)
+        if matches.size != 1:
+            raise ValueError(
+                f"Automatic eigenmode port {self.port_index} requires its "
+                f"centre-frequency anchor at {frequency:g} Hz among the solved "
+                "candidate anchors."
+            )
+        return int(matches[0])
+
+    @staticmethod
+    def _anchor_policy_name(*, automatic, guard_trimmed, nonpropagating_trimmed, fallback):
+        if fallback:
+            return "auto_single_fallback"
+        policy = "auto_broadband" if automatic else "explicit"
+        if guard_trimmed:
+            policy += "_guard_trimmed"
+        if nonpropagating_trimmed:
+            policy += "_nonpropagating_trimmed"
+        return policy
+
+    def _prepare_port_anchor_bank(
+        self,
+        frequencies,
+        solvers,
+        mode_indices,
+        *,
+        forced_policies=None,
+    ):
+        """Build one rectangular field bank and resolve anchors per mode."""
+
+        frequencies = tuple(float(value) for value in frequencies)
+        solvers = tuple(solvers)
+        mode_indices = tuple(int(value) for value in mode_indices)
         anchor_e = []
         anchor_h = []
         anchor_neff = []
+        propagating = np.empty((len(frequencies), len(mode_indices)), dtype=bool)
+        for frequency_position, solver in enumerate(solvers):
+            frequency_e = []
+            frequency_h = []
+            frequency_neff = []
+            for mode_position, mode_index in enumerate(mode_indices):
+                electric, magnetic, neff = self._fields_from_solver_mode(
+                    solver,
+                    mode_index,
+                )
+                frequency_e.append(
+                    [np.array(field, dtype=np.complex128, copy=True) for field in electric]
+                )
+                frequency_h.append(
+                    [np.array(field, dtype=np.complex128, copy=True) for field in magnetic]
+                )
+                frequency_neff.append(complex(neff))
+                propagating[frequency_position, mode_position] = self._solver_mode_power_valid(
+                    solver, mode_index
+                )
+            anchor_e.append(frequency_e)
+            anchor_h.append(frequency_h)
+            anchor_neff.append(frequency_neff)
+
+        valid, policies, overlaps = self._resolve_mode_anchor_masks(
+            frequencies,
+            solvers,
+            mode_indices,
+            anchor_e,
+            anchor_h,
+            propagating,
+        )
+        if forced_policies is not None:
+            policies = tuple(str(value) for value in forced_policies)
+
+        self.port_anchor_frequencies = frequencies
+        self.port_anchor_e = anchor_e
+        self.port_anchor_h = anchor_h
+        self.port_anchor_neff = np.asarray(anchor_neff, dtype=np.complex128)
+        self.port_anchor_mode_valid = valid
+        self.port_anchor_mode_propagating = propagating
+        self.port_mode_anchor_policies = policies
+        self.port_mode_solvers = solvers
+        self.anchor_overlaps = overlaps
+
+        if len(set(policies)) == 1:
+            self.resolved_anchor_policy = policies[0]
+        elif self.mode_index in mode_indices and not isinstance(self, EigenmodeReceiver):
+            self.resolved_anchor_policy = policies[mode_indices.index(self.mode_index)]
+        else:
+            self.resolved_anchor_policy = (
+                "auto_mixed_mode_policies"
+                if self._automatic_anchor_policy()
+                else "explicit_mixed_mode_policies"
+            )
+        return valid, policies
+
+    def _resolve_mode_anchor_masks(
+        self,
+        frequencies,
+        solvers,
+        mode_indices,
+        anchor_e,
+        anchor_h,
+        propagating,
+    ):
+        """Track raw modes first, then retain only forward-power anchors."""
+
+        automatic = self._automatic_anchor_policy()
+        anchor_count = len(frequencies)
+        valid = np.zeros_like(propagating, dtype=bool)
+        overlaps = np.full(
+            (max(anchor_count - 1, 0), len(mode_indices)),
+            np.nan,
+            dtype=np.float64,
+        )
+        policies = []
+        band_low = float(self.dft_start) if self.dft_start is not None else -np.inf
+        band_high = float(self.dft_stop) if self.dft_stop is not None else np.inf
+
+        for mode_position, mode_index in enumerate(mode_indices):
+            retained = list(range(anchor_count))
+            guard_trimmed = False
+            fallback = False
+            while len(retained) > 1:
+                mismatch = None
+                for pair_position in range(1, len(retained)):
+                    first = retained[pair_position - 1]
+                    second = retained[pair_position]
+                    overlap = self._modal_overlap(
+                        anchor_e[first][mode_position],
+                        anchor_h[first][mode_position],
+                        anchor_e[second][mode_position],
+                        anchor_h[second][mode_position],
+                    )
+                    magnitude = float(abs(overlap))
+                    try:
+                        self._check_anchor_overlap(
+                            magnitude,
+                            frequencies[first],
+                            frequencies[second],
+                            mode_index,
+                            f"Eigenmode port {self.port_index}",
+                        )
+                    except EigenmodeAnchorMismatchError as exc:
+                        mismatch = exc
+                        break
+                if mismatch is None:
+                    break
+                if not automatic:
+                    raise mismatch
+
+                guard = _trim_failed_guard_anchors(
+                    tuple(frequencies[index] for index in retained),
+                    mismatch,
+                    band_low,
+                    band_high,
+                )
+                if guard is not None:
+                    side, endpoint, trimmed_frequencies = guard
+                    tolerance = 1e-12 * max(
+                        max((abs(value) for value in frequencies), default=1.0),
+                        1.0,
+                    )
+                    trimmed = [
+                        index
+                        for index in retained
+                        if any(
+                            abs(frequencies[index] - value) <= tolerance
+                            for value in trimmed_frequencies
+                        )
+                    ]
+                    if trimmed != retained:
+                        detail = mismatch.detail.rstrip(" .")
+                        logger.warning(
+                            f"{detail}, within the {side} spectral guard outside "
+                            f"the requested {band_low:g} to {band_high:g} Hz "
+                            f"band. Automatic eigenmode port {self.port_index} "
+                            f"mode {mode_index} will retain broadband tracking "
+                            f"from {endpoint:g} Hz and use that endpoint modal "
+                            "profile across the trimmed significant-spectrum tail."
+                        )
+                        retained = trimmed
+                        guard_trimmed = True
+                        continue
+
+                centre = self._centre_anchor_index(frequencies)
+                self._require_forward_power(
+                    solvers[centre],
+                    mode_index,
+                    frequencies[centre],
+                    centre=True,
+                )
+                detail = mismatch.detail.rstrip(" .")
+                logger.warning(
+                    f"{detail}. Automatic eigenmode port {self.port_index} mode "
+                    f"{mode_index} will therefore use only the centre-frequency "
+                    f"anchor at {frequencies[centre]:g} Hz. Its modal "
+                    "decomposition and S-parameters may be inaccurate toward "
+                    "frequencies far from this anchor."
+                )
+                retained = [centre]
+                fallback = True
+                break
+
+            # Phase is transported through every successfully tracked raw mode,
+            # including an evanescent anchor, before physical filtering.
+            for pair_position in range(1, len(retained)):
+                first = retained[pair_position - 1]
+                second = retained[pair_position]
+                overlap = self._modal_overlap(
+                    anchor_e[first][mode_position],
+                    anchor_h[first][mode_position],
+                    anchor_e[second][mode_position],
+                    anchor_h[second][mode_position],
+                )
+                magnitude = float(abs(overlap))
+                if second == first + 1 and first < overlaps.shape[0]:
+                    overlaps[first, mode_position] = magnitude
+                if np.isfinite(magnitude) and magnitude > 1e-300:
+                    factor = np.exp(-1j * np.angle(overlap))
+                    anchor_e[second][mode_position] = [
+                        field * factor for field in anchor_e[second][mode_position]
+                    ]
+                    anchor_h[second][mode_position] = [
+                        field * factor for field in anchor_h[second][mode_position]
+                    ]
+
+            usable = [index for index in retained if propagating[index, mode_position]]
+            rejected = [index for index in retained if not propagating[index, mode_position]]
+            nonpropagating_trimmed = bool(rejected)
+            if rejected:
+                details = []
+                for index in rejected:
+                    neff, raw_power, metric = self._solver_mode_power_diagnostics(
+                        solvers[index],
+                        mode_index,
+                    )
+                    details.append(
+                        f"{frequencies[index]:g} Hz (neff={neff!s}, "
+                        f"raw power={raw_power!s}, metric={metric:g})"
+                    )
+                logger.warning(
+                    f"Eigenmode port {self.port_index} mode {mode_index} has "
+                    "non-propagating anchor(s) that carry no forward real power: "
+                    + "; ".join(details)
+                    + ". They will be excluded from modal interpolation and the "
+                    "corresponding non-propagating power-wave bins will be marked invalid."
+                )
+
+            if not usable:
+                if automatic:
+                    centre = self._centre_anchor_index(frequencies)
+                    self._require_forward_power(
+                        solvers[centre],
+                        mode_index,
+                        frequencies[centre],
+                        centre=True,
+                    )
+                raise ValueError(
+                    f"Eigenmode port {self.port_index} mode {mode_index} has no "
+                    "propagating anchor with forward real power."
+                )
+
+            if len(usable) > 1 and np.any(np.diff(usable) > 1):
+                if not automatic:
+                    raise ValueError(
+                        f"Eigenmode port {self.port_index} mode {mode_index} has "
+                        "disconnected propagating anchor ranges. Use separate "
+                        "bands or a single explicit anchor; interpolation across "
+                        "a non-propagating gap is not valid."
+                    )
+                centre = self._centre_anchor_index(frequencies)
+                self._require_forward_power(
+                    solvers[centre],
+                    mode_index,
+                    frequencies[centre],
+                    centre=True,
+                )
+                logger.warning(
+                    f"Eigenmode port {self.port_index} mode {mode_index} has "
+                    "disconnected propagating anchor ranges. It will use only "
+                    f"the centre-frequency anchor at {frequencies[centre]:g} Hz "
+                    "instead of interpolating across a non-propagating gap."
+                )
+                usable = [centre]
+                fallback = True
+
+            valid[usable, mode_position] = True
+            policies.append(
+                self._anchor_policy_name(
+                    automatic=automatic,
+                    guard_trimmed=guard_trimmed,
+                    nonpropagating_trimmed=nonpropagating_trimmed,
+                    fallback=fallback,
+                )
+            )
+
+        return valid, tuple(policies), overlaps
+
+    def _solve_broadband_eigenmode(self, G, frequencies):
+        """Solve candidate anchors, resolve each mode, and synthesize the source."""
         solvers = []
 
         for frequency in frequencies:
             self.frequency = frequency
             self._extract_frequency_dependent_materials(G)
             self._solve_eigenmode(G)
-            anchor_e.append([np.array(field, dtype=np.complex128, copy=True) for field in self.modal_e])
-            anchor_h.append([np.array(field, dtype=np.complex128, copy=True) for field in self.modal_h])
-            anchor_neff.append(complex(self.complex_neff))
             solvers.append(self.mode_solver)
 
-        self._validate_solver_mode_tracking(solvers, frequencies)
-        overlaps = self._align_and_validate_anchors(anchor_e, anchor_h, frequencies)
-        self.anchor_modal_e = anchor_e
-        self.anchor_modal_h = anchor_h
-        self.anchor_complex_neff = np.asarray(anchor_neff, dtype=np.complex128)
-        self.anchor_overlaps = np.asarray(overlaps, dtype=np.float64)
-        self.mode_solvers = solvers
-        self._prepare_broadband_time_traces(G, frequencies)
+        mode_indices = tuple(self.mode_indices or range(1, self.mode_count + 1))
+        valid, policies = self._prepare_port_anchor_bank(
+            frequencies,
+            solvers,
+            mode_indices,
+        )
+        excitation_position = mode_indices.index(self.mode_index)
+        used = np.flatnonzero(valid[:, excitation_position])
+        excitation_frequencies = tuple(float(frequencies[index]) for index in used)
+        self.frequencies = excitation_frequencies
+        self.anchor_modal_e = [self.port_anchor_e[index][excitation_position] for index in used]
+        self.anchor_modal_h = [self.port_anchor_h[index][excitation_position] for index in used]
+        self.anchor_complex_neff = np.asarray(
+            [self.port_anchor_neff[index, excitation_position] for index in used],
+            dtype=np.complex128,
+        )
+        self.mode_solvers = [solvers[index] for index in used]
+        excitation_policy = policies[excitation_position]
+        if "nonpropagating_trimmed" in excitation_policy or (
+            self._automatic_anchor_policy()
+            and (
+                "guard_trimmed" in excitation_policy or excitation_policy == "auto_single_fallback"
+            )
+        ):
+            # The physical filtering warning supersedes the generic spectrum
+            # coverage error; endpoint extrapolation keeps the time trace finite.
+            self.spectrum_coverage_policy = "allow"
+
+        if excitation_policy == "auto_single_fallback":
+            self.frequency = excitation_frequencies[0]
+            self.modal_e = self.anchor_modal_e[0]
+            self.modal_h = self.anchor_modal_h[0]
+            self.mode_solver = self.mode_solvers[0]
+            self.complex_neff = self.anchor_complex_neff[0]
+            self.neff = float(np.real(self.complex_neff))
+            self._prepare_single_frequency_injection(G)
+            return
+        else:
+            self._prepare_broadband_time_traces(G, excitation_frequencies)
 
         # Keep representative modal data available to diagnostics and callers.
         representative = (
-            len(frequencies) // 2
+            len(excitation_frequencies) // 2
             if self.representative_frequency is None
             else min(
-                range(len(frequencies)),
-                key=lambda index: abs(frequencies[index] - self.representative_frequency),
+                range(len(excitation_frequencies)),
+                key=lambda index: abs(
+                    excitation_frequencies[index] - self.representative_frequency
+                ),
             )
         )
-        self.frequency = frequencies[representative]
+        self.frequency = excitation_frequencies[representative]
         self.modal_e = self.anchor_modal_e[representative]
         self.modal_h = self.anchor_modal_h[representative]
         self.mode_solver = self.mode_solvers[representative]
         self.complex_neff = self.anchor_complex_neff[representative]
         self.neff = float(np.real(self.complex_neff))
         dtype = config.sim_config.dtypes["float_or_double"]
-        self.modal_e_real = [np.ascontiguousarray(np.real(field), dtype=dtype) for field in self.modal_e]
-        self.modal_h_real = [np.ascontiguousarray(np.real(field), dtype=dtype) for field in self.modal_h]
+        self.modal_e_real = [
+            np.ascontiguousarray(np.real(field), dtype=dtype) for field in self.modal_e
+        ]
+        self.modal_h_real = [
+            np.ascontiguousarray(np.real(field), dtype=dtype) for field in self.modal_h
+        ]
 
     def _validate_solver_mode_tracking(self, solvers, frequencies):
         mode_indices = tuple(self.mode_indices or (self.mode_index,))
@@ -650,7 +988,7 @@ class EigenmodeSource(Source):
                         frequencies[frequency_index - 1],
                         frequencies[frequency_index],
                         mode_index,
-                        f'Eigenmode port {self.port_index}',
+                        f"Eigenmode port {self.port_index}",
                     )
                 previous_e = electric
                 previous_h = magnetic
@@ -685,7 +1023,9 @@ class EigenmodeSource(Source):
         solver.solve()
 
         self.mode_solver = solver
-        self.modal_e, self.modal_h, self.complex_neff = self._fields_from_solver_mode(solver, self.mode_index)
+        self.modal_e, self.modal_h, self.complex_neff = self._fields_from_solver_mode(
+            solver, self.mode_index
+        )
         self.neff = float(np.real(self.complex_neff))
         self._validate_modal_field_shapes()
         self._store_real_modal_fields()
@@ -703,7 +1043,9 @@ class EigenmodeSource(Source):
         solver.solve()
 
         self.mode_solver = solver
-        self.modal_e, self.modal_h, self.complex_neff = self._fields_from_solver_mode(solver, self.mode_index)
+        self.modal_e, self.modal_h, self.complex_neff = self._fields_from_solver_mode(
+            solver, self.mode_index
+        )
         self.neff = float(np.real(self.complex_neff))
 
         self._validate_modal_field_shapes()
@@ -713,15 +1055,23 @@ class EigenmodeSource(Source):
         """Map one solved, one-based mode onto global Yee components."""
         mode = public_mode_index - 1
         if mode < 0 or mode >= solver.num_modes:
-            raise ValueError(f"Mode index {public_mode_index} is outside the solved 1-{solver.num_modes} range.")
+            raise ValueError(
+                f"Mode index {public_mode_index} is outside the solved 1-{solver.num_modes} range."
+            )
         if isinstance(solver, FDFD_2D_mode_solver):
             local_e = (solver.Eu[:, :, mode], solver.Ev[:, :, mode], solver.Ew[:, :, mode])
             local_h = (solver.Hu[:, :, mode], solver.Hv[:, :, mode], solver.Hw[:, :, mode])
         else:
             t_local = self.transverse_axes.index(self.physical_transverse_axis)
             a_local = self.transverse_axes.index(self.invariant_axis)
-            local_e = [np.zeros(shape, dtype=np.complex128) for shape in self._expected_local_field_shapes("E")]
-            local_h = [np.zeros(shape, dtype=np.complex128) for shape in self._expected_local_field_shapes("H")]
+            local_e = [
+                np.zeros(shape, dtype=np.complex128)
+                for shape in self._expected_local_field_shapes("E")
+            ]
+            local_h = [
+                np.zeros(shape, dtype=np.complex128)
+                for shape in self._expected_local_field_shapes("H")
+            ]
             if self.domain_polarization == "TM":
                 local_e[a_local] = self._embed_1d_profile(solver.Ea[:, mode], a_local, "E")
                 local_h[t_local] = self._embed_1d_profile(solver.Ht[:, mode], t_local, "H")
@@ -918,7 +1268,11 @@ class EigenmodeSource(Source):
             logger.info(
                 f"Eigenmode anchor overlap {magnitude:.6f} between "
                 f"{frequencies[index - 1]:g} Hz and {frequencies[index]:g} Hz; "
-                + ("the latter anchor was phase-aligned." if phase_aligned else "its phase was left unchanged.")
+                + (
+                    "the latter anchor was phase-aligned."
+                    if phase_aligned
+                    else "its phase was left unchanged."
+                )
             )
         return overlaps
 
@@ -981,7 +1335,12 @@ class EigenmodeSource(Source):
         )
         if self.domain_polarization == "TM":
             flux_sign *= -1
-        return 0.5 * flux_sign * np.sum(electric_profile * np.conj(magnetic_profile)) * G.dl[transverse_axis]
+        return (
+            0.5
+            * flux_sign
+            * np.sum(electric_profile * np.conj(magnetic_profile))
+            * G.dl[transverse_axis]
+        )
 
     @staticmethod
     def _linear_anchor_weights(bin_frequencies, anchor_frequencies):
@@ -997,7 +1356,9 @@ class EigenmodeSource(Source):
         weights = np.zeros((anchor_frequencies.size, bin_frequencies.size), dtype=np.float64)
         weights[0, bin_frequencies < anchor_frequencies[0]] = 1.0
         weights[-1, bin_frequencies > anchor_frequencies[-1]] = 1.0
-        inside = (bin_frequencies >= anchor_frequencies[0]) & (bin_frequencies <= anchor_frequencies[-1])
+        inside = (bin_frequencies >= anchor_frequencies[0]) & (
+            bin_frequencies <= anchor_frequencies[-1]
+        )
         for bin_index in np.flatnonzero(inside):
             frequency = bin_frequencies[bin_index]
             if frequency == anchor_frequencies[-1]:
@@ -1076,17 +1437,17 @@ class EigenmodeSource(Source):
             and significant_indices.size
             and (significant_low < frequencies[0] or significant_high > frequencies[-1])
         ):
-            if self.spectrum_coverage_policy == 'error':
+            if self.spectrum_coverage_policy == "error":
                 raise ValueError(
-                    'Eigenmode anchors do not cover the significant excitation '
-                    f'spectrum: anchors span {frequencies[0]:g} to '
-                    f'{frequencies[-1]:g} Hz, while significant bins span '
-                    f'{significant_low:g} to {significant_high:g} Hz. Use '
-                    'per-port anchors=\'auto\', provide wider explicit anchors, or '
-                    'use EigenmodeExcitation with waveform=\'auto\' for a validated '
-                    'bandpass spectrum.'
+                    "Eigenmode anchors do not cover the significant excitation "
+                    f"spectrum: anchors span {frequencies[0]:g} to "
+                    f"{frequencies[-1]:g} Hz, while significant bins span "
+                    f"{significant_low:g} to {significant_high:g} Hz. Use "
+                    "per-port anchors='auto', provide wider explicit anchors, or "
+                    "use EigenmodeExcitation with waveform='auto' for a validated "
+                    "bandpass spectrum."
                 )
-            if self.spectrum_coverage_policy == 'warn':
+            if self.spectrum_coverage_policy == "warn":
                 logger.warning(
                     "Broadband eigenmode anchor frequencies do not cover the significant waveform spectrum: "
                     f"anchors span {frequencies[0]:g} to {frequencies[-1]:g} Hz, while bins above "
@@ -1121,7 +1482,13 @@ class EigenmodeSource(Source):
             usable = np.isfinite(partition) & (np.abs(partition) > 1e-300)
             weights[:, usable] /= partition[usable]
             for bin_index in np.flatnonzero(~usable):
-                nearest = int(np.argmin(np.abs(np.asarray(frequencies, dtype=np.float64) - bin_frequencies[bin_index])))
+                nearest = int(
+                    np.argmin(
+                        np.abs(
+                            np.asarray(frequencies, dtype=np.float64) - bin_frequencies[bin_index]
+                        )
+                    )
+                )
                 weights[:, bin_index] = 0.0
                 weights[nearest, bin_index] = 1.0
             partition = np.sum(weights, axis=0)
@@ -1134,9 +1501,13 @@ class EigenmodeSource(Source):
                     self.anchor_modal_h[h_index],
                     G,
                 )
-        interpolated_power = np.real(np.einsum("kn,kl,ln->n", weights, power_matrix, weights, optimize=True))
+        interpolated_power = np.real(
+            np.einsum("kn,kl,ln->n", weights, power_matrix, weights, optimize=True)
+        )
         active_bins = np.sum(weights, axis=0) > 0
-        invalid_power = active_bins & (~np.isfinite(interpolated_power) | (interpolated_power <= 1e-12))
+        invalid_power = active_bins & (
+            ~np.isfinite(interpolated_power) | (interpolated_power <= 1e-12)
+        )
         if np.any(invalid_power):
             invalid_indices = np.flatnonzero(invalid_power)
             bad_frequency = float(bin_frequencies[invalid_indices[0]])
@@ -1147,7 +1518,11 @@ class EigenmodeSource(Source):
                 "frequency, narrow the bandwidth, or use the single-frequency eigenmode source. "
                 f"Continuing with fallback normalization for {invalid_indices.size} FFT bin(s)."
             )
-            finite_nonzero = invalid_power & np.isfinite(interpolated_power) & (np.abs(interpolated_power) > 1e-12)
+            finite_nonzero = (
+                invalid_power
+                & np.isfinite(interpolated_power)
+                & (np.abs(interpolated_power) > 1e-12)
+            )
             interpolated_power[finite_nonzero] = np.abs(interpolated_power[finite_nonzero])
             unresolved = np.flatnonzero(invalid_power & ~finite_nonzero)
             if unresolved.size:
@@ -1196,25 +1571,29 @@ class EigenmodeSource(Source):
         self.broadband_e_envelopes = np.empty((anchor_count, 2, sample_count), dtype=dtype)
         self.broadband_h_envelopes = np.empty((anchor_count, 2, sample_count), dtype=dtype)
         for anchor in range(anchor_count):
-            self.broadband_e_envelopes[anchor, 0] = np.fft.irfft(electric_weights[anchor], n=padded_count)[
-                :sample_count
-            ]
-            self.broadband_e_envelopes[anchor, 1] = np.fft.irfft(1j * electric_weights[anchor], n=padded_count)[
-                :sample_count
-            ]
-            self.broadband_h_envelopes[anchor, 0] = np.fft.irfft(magnetic_weights[anchor], n=padded_count)[
-                :sample_count
-            ]
-            self.broadband_h_envelopes[anchor, 1] = np.fft.irfft(1j * magnetic_weights[anchor], n=padded_count)[
-                :sample_count
-            ]
+            self.broadband_e_envelopes[anchor, 0] = np.fft.irfft(
+                electric_weights[anchor], n=padded_count
+            )[:sample_count]
+            self.broadband_e_envelopes[anchor, 1] = np.fft.irfft(
+                1j * electric_weights[anchor], n=padded_count
+            )[:sample_count]
+            self.broadband_h_envelopes[anchor, 0] = np.fft.irfft(
+                magnetic_weights[anchor], n=padded_count
+            )[:sample_count]
+            self.broadband_h_envelopes[anchor, 1] = np.fft.irfft(
+                1j * magnetic_weights[anchor], n=padded_count
+            )[:sample_count]
 
         def split_fields(anchor_fields):
             real_fields = []
             imag_fields = []
             for fields in anchor_fields:
-                real_fields.append([np.ascontiguousarray(np.real(field), dtype=dtype) for field in fields])
-                imag_fields.append([np.ascontiguousarray(np.imag(field), dtype=dtype) for field in fields])
+                real_fields.append(
+                    [np.ascontiguousarray(np.real(field), dtype=dtype) for field in fields]
+                )
+                imag_fields.append(
+                    [np.ascontiguousarray(np.imag(field), dtype=dtype) for field in fields]
+                )
             return real_fields, imag_fields
 
         (
@@ -1243,7 +1622,11 @@ class EigenmodeSource(Source):
 
     def _should_plot_eigenmode_fields(self):
         """Return the explicit setting or the geometry-only default."""
-        return bool(config.sim_config.geometry_only) if self.plot_fields is None else bool(self.plot_fields)
+        return (
+            bool(config.sim_config.geometry_only)
+            if self.plot_fields is None
+            else bool(self.plot_fields)
+        )
 
     def _should_plot_eigenmode_excitation(self):
         """Return the excitation-plot setting or the geometry-only default."""
@@ -1257,11 +1640,13 @@ class EigenmodeSource(Source):
 
         input_path = config.sim_config.input_file_path
         output_dir = input_path.parent
-        frequencies = tuple(self.frequencies or (self.frequency,))
-        solvers = tuple(self.mode_solvers or (self.mode_solver,))
+        frequencies = tuple(self.port_anchor_frequencies or self.frequencies or (self.frequency,))
+        solvers = tuple(self.port_mode_solvers or self.mode_solvers or (self.mode_solver,))
         mode_indices = tuple(self.mode_indices or range(1, self.mode_count + 1))
         for mode_index in mode_indices:
-            field_path = output_dir / f"{input_path.stem}_Port{self.port_index}_Mode{mode_index}.png"
+            field_path = (
+                output_dir / f"{input_path.stem}_Port{self.port_index}_Mode{mode_index}.png"
+            )
             plot_eigenmode_port_fields(
                 solvers=solvers,
                 frequencies=frequencies,
@@ -1325,7 +1710,9 @@ class EigenmodeSource(Source):
         materials_by_id = {material.numID: material for material in G.materials}
         for material_id in used_ids:
             material = materials_by_id[int(material_id)]
-            material_values[material_id] = self._complex_er(material) if electric else self._complex_mur(material)
+            material_values[material_id] = (
+                self._complex_er(material) if electric else self._complex_mur(material)
+            )
 
         return tuple(material_values[ids].copy() for ids in component_ids)
 
@@ -1422,7 +1809,9 @@ class EigenmodeSource(Source):
         u0, v0 = self.transverse_start
         u1, v1 = self.transverse_stop
         normal_indices = [
-            index for index in (self.plane_index - 1, self.plane_index) if 0 <= index < G.solid.shape[self.normal_axis]
+            index
+            for index in (self.plane_index - 1, self.plane_index)
+            if 0 <= index < G.solid.shape[self.normal_axis]
         ]
         if not normal_indices:
             return np.zeros((u1 - u0, v1 - v0), dtype=bool)
@@ -1771,83 +2160,16 @@ class EigenmodeReceiver(EigenmodeSource):
         if not mode_indices:
             raise ValueError("An eigenmode receiver requires at least one mode index.")
         self.mode_index = max(mode_indices)
-        anchor_e = []
-        anchor_h = []
-        anchor_neff = []
         solvers = []
 
         for frequency in frequencies:
             self.frequency = frequency
             self._extract_frequency_dependent_materials(G)
             self._solve_eigenmode(G)
-            frequency_e = []
-            frequency_h = []
-            frequency_neff = []
-            for mode_index in mode_indices:
-                electric, magnetic, neff = self._fields_from_solver_mode(self.mode_solver, mode_index)
-                frequency_e.append(electric)
-                frequency_h.append(magnetic)
-                frequency_neff.append(neff)
-            anchor_e.append(frequency_e)
-            anchor_h.append(frequency_h)
-            anchor_neff.append(frequency_neff)
             solvers.append(self.mode_solver)
 
-        if len(frequencies) > 1 and self.anchor_policy == 'auto':
-            for mode_position, mode_index in enumerate(mode_indices):
-                for frequency_index in range(1, len(frequencies)):
-                    overlap = self._modal_overlap(
-                        anchor_e[frequency_index - 1][mode_position],
-                        anchor_h[frequency_index - 1][mode_position],
-                        anchor_e[frequency_index][mode_position],
-                        anchor_h[frequency_index][mode_position],
-                    )
-                    magnitude = float(abs(overlap))
-                    if (
-                        not np.isfinite(magnitude)
-                        or magnitude < self.ANCHOR_OVERLAP_ERROR_THRESHOLD
-                    ):
-                        frequency = float(self.fallback_frequency)
-                        logger.warning(
-                            f'Automatic anchor tracking failed for eigenmode port '
-                            f'{self.port_index}, mode {mode_index}, between '
-                            f'{frequencies[frequency_index - 1]:g} and '
-                            f'{frequencies[frequency_index]:g} Hz with overlap '
-                            f'{magnitude:.6f}. This may indicate a mode crossing or '
-                            f'degeneracy. The port will use a single modal anchor at '
-                            f'{frequency:g} Hz. Its modal decomposition and '
-                            'S-parameters may be inaccurate toward frequencies far '
-                            'from this anchor.'
-                        )
-                        self.frequency = frequency
-                        self.frequencies = (frequency,)
-                        self.mode_solvers = None
-                        return self.grid_init(G)
-
-        for mode_position, mode_index in enumerate(mode_indices):
-            for frequency_index in range(1, len(frequencies)):
-                overlap = self._modal_overlap(
-                    anchor_e[frequency_index - 1][mode_position],
-                    anchor_h[frequency_index - 1][mode_position],
-                    anchor_e[frequency_index][mode_position],
-                    anchor_h[frequency_index][mode_position],
-                )
-                magnitude = float(abs(overlap))
-                self._check_anchor_overlap(
-                    magnitude,
-                    frequencies[frequency_index - 1],
-                    frequencies[frequency_index],
-                    mode_index,
-                    "Broadband eigenmode receiver",
-                )
-                if np.isfinite(magnitude) and magnitude > 1e-300:
-                    factor = np.exp(-1j * np.angle(overlap))
-                    anchor_e[frequency_index][mode_position] = [
-                        field * factor for field in anchor_e[frequency_index][mode_position]
-                    ]
-                    anchor_h[frequency_index][mode_position] = [
-                        field * factor for field in anchor_h[frequency_index][mode_position]
-                    ]
+        self._prepare_port_anchor_bank(frequencies, solvers, mode_indices)
+        self.mode_solvers = solvers
 
         from gprMax.eigenmode_ports import EigenmodePortMonitor
 
@@ -1858,18 +2180,20 @@ class EigenmodeReceiver(EigenmodeSource):
             is_source=False,
             excitation_mode_index=None,
             mode_indices=mode_indices,
-            anchor_frequencies=frequencies,
-            anchor_e=anchor_e,
-            anchor_h=anchor_h,
-            anchor_neff=np.asarray(anchor_neff, dtype=np.complex128),
+            anchor_frequencies=self.port_anchor_frequencies,
+            anchor_e=self.port_anchor_e,
+            anchor_h=self.port_anchor_h,
+            anchor_neff=self.port_anchor_neff,
             dft_start=self.dft_start,
             dft_stop=self.dft_stop,
             dft_points=self.dft_points,
+            anchor_mode_valid=self.port_anchor_mode_valid,
+            anchor_mode_propagating=self.port_anchor_mode_propagating,
+            mode_anchor_policies=self.port_mode_anchor_policies,
         )
         monitor.prepare(G)
         self.port_monitor = monitor
         G.eigenmodeports.append(monitor)
-        self.mode_solvers = solvers
         self._plot_eigenmode_fields()
 
 
@@ -1922,7 +2246,9 @@ class VoltageSource(Source):
 
         if not src_match:
             waveform = next(x for x in G.waveforms if x.ID == self.waveformID)
-            self.waveformvalues_halfdt = np.zeros((G.iterations + 1), dtype=config.sim_config.dtypes["float_or_double"])
+            self.waveformvalues_halfdt = np.zeros(
+                (G.iterations + 1), dtype=config.sim_config.dtypes["float_or_double"]
+            )
             self.waveformvalues_wholedt = np.zeros(
                 (G.iterations + 1), dtype=config.sim_config.dtypes["float_or_double"]
             )
@@ -1933,7 +2259,9 @@ class VoltageSource(Source):
                     # Set the time of the waveform evaluation to account for any
                     # delay in the start
                     time -= self.start
-                    self.waveformvalues_halfdt[iteration] = waveform.calculate_value(time + 0.5 * G.dt, G.dt)
+                    self.waveformvalues_halfdt[iteration] = waveform.calculate_value(
+                        time + 0.5 * G.dt, G.dt
+                    )
                     self.waveformvalues_wholedt[iteration] = waveform.calculate_value(time, G.dt)
 
     def update_electric(self, iteration, updatecoeffsE, ID, Ex, Ey, Ez, G):
@@ -2056,7 +2384,9 @@ class HertzianDipole(Source):
 
         if not src_match:
             waveform = next(x for x in G.waveforms if x.ID == self.waveformID)
-            self.waveformvalues_halfdt = np.zeros((G.iterations + 1), dtype=config.sim_config.dtypes["float_or_double"])
+            self.waveformvalues_halfdt = np.zeros(
+                (G.iterations + 1), dtype=config.sim_config.dtypes["float_or_double"]
+            )
 
             for iteration in range(G.iterations + 1):
                 time = G.dt * iteration
@@ -2064,7 +2394,9 @@ class HertzianDipole(Source):
                     # Set the time of the waveform evaluation to account for any
                     # delay in the start
                     time -= self.start
-                    self.waveformvalues_halfdt[iteration] = waveform.calculate_value(time + 0.5 * G.dt, G.dt)
+                    self.waveformvalues_halfdt[iteration] = waveform.calculate_value(
+                        time + 0.5 * G.dt, G.dt
+                    )
 
     def update_electric(self, iteration, updatecoeffsE, ID, Ex, Ey, Ez, G):
         """Updates electric field values for a Hertzian dipole.
@@ -2204,7 +2536,9 @@ def htod_src_arrays(sources, G, queue=None):
 
     srcinfo1 = np.zeros((len(sources), 4), dtype=np.int32)
     srcinfo2 = np.zeros((len(sources)), dtype=config.sim_config.dtypes["float_or_double"])
-    srcwaves = np.zeros((len(sources), G.iterations + 1), dtype=config.sim_config.dtypes["float_or_double"])
+    srcwaves = np.zeros(
+        (len(sources), G.iterations + 1), dtype=config.sim_config.dtypes["float_or_double"]
+    )
     for i, src in enumerate(sources):
         srcinfo1[i, 0] = src.xcoord
         srcinfo1[i, 1] = src.ycoord
@@ -2246,9 +2580,15 @@ def htod_src_arrays(sources, G, queue=None):
     elif config.sim_config.general["solver"] == "metal":
         # Metal doesn't use a queue parameter, need to get device from config
         dev = config.get_model_config().device["dev"]
-        srcinfo1_dev = dev.newBufferWithBytes_length_options_(srcinfo1.tobytes(), srcinfo1.nbytes, 0)
-        srcinfo2_dev = dev.newBufferWithBytes_length_options_(srcinfo2.tobytes(), srcinfo2.nbytes, 0)
-        srcwaves_dev = dev.newBufferWithBytes_length_options_(srcwaves.tobytes(), srcwaves.nbytes, 0)
+        srcinfo1_dev = dev.newBufferWithBytes_length_options_(
+            srcinfo1.tobytes(), srcinfo1.nbytes, 0
+        )
+        srcinfo2_dev = dev.newBufferWithBytes_length_options_(
+            srcinfo2.tobytes(), srcinfo2.nbytes, 0
+        )
+        srcwaves_dev = dev.newBufferWithBytes_length_options_(
+            srcwaves.tobytes(), srcwaves.nbytes, 0
+        )
 
     return srcinfo1_dev, srcinfo2_dev, srcwaves_dev
 
@@ -2439,8 +2779,12 @@ class TransmissionLine(Source):
         self.current = np.zeros(self.nl, dtype=config.sim_config.dtypes["float_or_double"])
         self.Vinc = np.zeros(self.iterations + 1, dtype=config.sim_config.dtypes["float_or_double"])
         self.Iinc = np.zeros(self.iterations + 1, dtype=config.sim_config.dtypes["float_or_double"])
-        self.Vtotal = np.zeros(self.iterations + 1, dtype=config.sim_config.dtypes["float_or_double"])
-        self.Itotal = np.zeros(self.iterations + 1, dtype=config.sim_config.dtypes["float_or_double"])
+        self.Vtotal = np.zeros(
+            self.iterations + 1, dtype=config.sim_config.dtypes["float_or_double"]
+        )
+        self.Itotal = np.zeros(
+            self.iterations + 1, dtype=config.sim_config.dtypes["float_or_double"]
+        )
         # Bound after the grid materials and time axis have been finalised.
         # Kept here rather than in the update loop because all spectral port
         # processing is post-solve.
@@ -2470,7 +2814,9 @@ class TransmissionLine(Source):
             self.waveformvalues_wholedt = np.zeros(
                 (G.iterations + 1), dtype=config.sim_config.dtypes["float_or_double"]
             )
-            self.waveformvalues_halfdt = np.zeros((G.iterations + 1), dtype=config.sim_config.dtypes["float_or_double"])
+            self.waveformvalues_halfdt = np.zeros(
+                (G.iterations + 1), dtype=config.sim_config.dtypes["float_or_double"]
+            )
 
             for iteration in range(G.iterations + 1):
                 time = G.dt * iteration
@@ -2479,7 +2825,9 @@ class TransmissionLine(Source):
                     # delay in the start
                     time -= self.start
                     self.waveformvalues_wholedt[iteration] = waveform.calculate_value(time, G.dt)
-                    self.waveformvalues_halfdt[iteration] = waveform.calculate_value(time + 0.5 * G.dt, G.dt)
+                    self.waveformvalues_halfdt[iteration] = waveform.calculate_value(
+                        time + 0.5 * G.dt, G.dt
+                    )
 
     def calculate_incident_V_I(self, G):
         """Calculates the incident voltage and current with a long length
@@ -2542,11 +2890,15 @@ class TransmissionLine(Source):
 
         # Update all the voltage values along the line
         self.voltage[1 : self.nl] -= (
-            self.resistance * (config.c * G.dt / self.dl) * (self.current[1 : self.nl] - self.current[0 : self.nl - 1])
+            self.resistance
+            * (config.c * G.dt / self.dl)
+            * (self.current[1 : self.nl] - self.current[0 : self.nl - 1])
         )
 
         # Update the voltage at the position of the one-way injector excitation
-        self.voltage[self.srcpos] += (config.c * G.dt / self.dl) * self.waveformvalues_wholedt[iteration]
+        self.voltage[self.srcpos] += (config.c * G.dt / self.dl) * self.waveformvalues_wholedt[
+            iteration
+        ]
 
         # Update ABC before updating current
         self.update_abc(G)
@@ -2568,7 +2920,9 @@ class TransmissionLine(Source):
 
         # Update the current one cell before the position of the one-way injector excitation
         self.current[self.srcpos - 1] += (
-            (1 / self.resistance) * (config.c * G.dt / self.dl) * self.waveformvalues_halfdt[iteration]
+            (1 / self.resistance)
+            * (config.c * G.dt / self.dl)
+            * self.waveformvalues_halfdt[iteration]
         )
 
     def update_electric(self, iteration, updatecoeffsE, ID, Ex, Ey, Ez, G):
@@ -2687,7 +3041,8 @@ def magnetic_frill_source_host_arrays(magneticfrillsources, G):
         nterms = len(frill._drive_terms)
         if not 1 <= nterms <= MAGNETIC_FRILL_MAX_TERMS:
             raise ValueError(
-                f"{frill.ID} has {nterms} magnetic feed terms; expected between " f"1 and {MAGNETIC_FRILL_MAX_TERMS}."
+                f"{frill.ID} has {nterms} magnetic feed terms; expected between "
+                f"1 and {MAGNETIC_FRILL_MAX_TERMS}."
             )
 
         term_counts[i] = nterms
@@ -2760,7 +3115,11 @@ def dtoh_magnetic_frill_source_outputs(Vinc, Vtotal, Itot, G):
                     "Magnetic-frill Metal output buffer has the wrong size: "
                     f"expected {nbytes} bytes, got {buffer.length()}."
                 )
-            return np.frombuffer(buffer.contents().as_buffer(nbytes), dtype=dtype).reshape(expected).copy()
+            return (
+                np.frombuffer(buffer.contents().as_buffer(nbytes), dtype=dtype)
+                .reshape(expected)
+                .copy()
+            )
 
         Vinc, Vtotal, Itot = map(_metal_to_numpy, (Vinc, Vtotal, Itot))
 
@@ -2840,7 +3199,9 @@ class MagneticFrillSource(Source):
         self._previous_half_current = 0.0
 
         self.Vinc = np.zeros(self.iterations + 1, dtype=config.sim_config.dtypes["float_or_double"])
-        self.Vtotal = np.zeros(self.iterations + 1, dtype=config.sim_config.dtypes["float_or_double"])
+        self.Vtotal = np.zeros(
+            self.iterations + 1, dtype=config.sim_config.dtypes["float_or_double"]
+        )
         self.Itot = np.zeros(self.iterations + 1, dtype=config.sim_config.dtypes["float_or_double"])
 
         # Bound after materials/update coefficients and time/frequency axes
@@ -2856,7 +3217,9 @@ class MagneticFrillSource(Source):
             G: FDTDGrid class describing a grid in a model.
         """
         waveform = next(x for x in G.waveforms if x.ID == self.waveformID)
-        self.waveformvalues_wholedt = np.zeros((G.iterations + 1), dtype=config.sim_config.dtypes["float_or_double"])
+        self.waveformvalues_wholedt = np.zeros(
+            (G.iterations + 1), dtype=config.sim_config.dtypes["float_or_double"]
+        )
         for iteration in range(G.iterations + 1):
             time = G.dt * iteration
             if time >= self.start and time <= self.stop:
@@ -3042,13 +3405,20 @@ class MagneticFrillSource(Source):
 
                 factor_f = float(material.thin_wire_factors["F"])
                 radial_step = radial_steps[radial_axis]
-                source_gain = source_sign * G.updatecoeffsH[material_numID, 4] * factor_f / (axial_step * radial_step)
+                source_gain = (
+                    source_sign
+                    * G.updatecoeffsH[material_numID, 4]
+                    * factor_f
+                    / (axial_step * radial_step)
+                )
                 terms.append((component, x, y, z, float(current_weight), float(source_gain)))
 
         self._drive_terms = terms
         self._G_coeff = float(sum(term[-2] * term[-1] for term in terms))
         if not np.isfinite(self._G_coeff) or self._G_coeff <= 0:
-            raise ValueError(f"{self.ID} produced invalid feed-cell self-admittance " f"G={self._G_coeff!r}.")
+            raise ValueError(
+                f"{self.ID} produced invalid feed-cell self-admittance " f"G={self._G_coeff!r}."
+            )
 
         # Two independently advanced feedback relations cannot safely write
         # the same H edge: their result would depend on source order on CPU
@@ -3057,7 +3427,11 @@ class MagneticFrillSource(Source):
         registry = getattr(G, "_magnetic_frill_drive_edges", {})
         drive_edges = {(term[0], term[1], term[2], term[3]) for term in terms}
         overlap = next(
-            ((edge, registry[edge]) for edge in drive_edges if edge in registry and registry[edge] is not self),
+            (
+                (edge, registry[edge])
+                for edge in drive_edges
+                if edge in registry and registry[edge] is not self
+            ),
             None,
         )
         if overlap is not None:
@@ -3081,7 +3455,10 @@ class MagneticFrillSource(Source):
         """Return the image-completed Ampere-loop current from stored H."""
 
         fields = {"Hx": Hx, "Hy": Hy, "Hz": Hz}
-        return sum(weight * fields[component][x, y, z] for component, x, y, z, weight, _ in self._drive_terms)
+        return sum(
+            weight * fields[component][x, y, z]
+            for component, x, y, z, weight, _ in self._drive_terms
+        )
 
     def update_magnetic(self, iteration, updatecoeffsH, ID, Hx, Hy, Hz, G):
         """Apply Hyun's time-average implicit feed update in closed form.
@@ -3103,7 +3480,9 @@ class MagneticFrillSource(Source):
             + 2 * self._G_coeff * self.Vinc[iteration]
             - zeta * (1 - self._theta) * self._previous_half_current
         ) / (1 + zeta * self._theta)
-        current_centred = (1 - self._theta) * self._previous_half_current + self._theta * current_new
+        current_centred = (
+            1 - self._theta
+        ) * self._previous_half_current + self._theta * current_new
         self.Itot[iteration] = current_centred
         V_ab = 2 * self.Vinc[iteration] - self.Z0 * current_centred
         self.Vtotal[iteration] = V_ab
@@ -3157,7 +3536,9 @@ class DiscretePlaneWave(Source):
         self.origin[2] = 0
         self.length = 0
         # self.projections = np.zeros(6, dtype=config.sim_config.dtypes["float_or_double"])
-        self.projections = np.zeros(6, dtype=np.float64)  # Use float64 for better precision in projections
+        self.projections = np.zeros(
+            6, dtype=np.float64
+        )  # Use float64 for better precision in projections
         self.corners = None
         self.materialID = None
         self.ds = 0
@@ -3238,7 +3619,12 @@ class DiscretePlaneWave(Source):
         # check for plane wave definition using angles and in this case m vector should be zero and needs to be calculated
         if self.m[0] == 0 and self.m[1] == 0 and self.m[2] == 0:
             # Find the integer mappings m_x, m_y, m_z for the DPW using partial fractions
-            self.m[:3], self.actual_angles, self.angle_errors, self.total_error = self.find_dpw_integers_optimized(
+            (
+                self.m[:3],
+                self.actual_angles,
+                self.angle_errors,
+                self.total_error,
+            ) = self.find_dpw_integers_optimized(
                 self.theta, self.phi, [G.dx, G.dy, G.dz], self.max_angle_diff
             )
 
@@ -3333,10 +3719,16 @@ class DiscretePlaneWave(Source):
 
         # get the number of 1D DPW grid PML cells from the number of 3D FDTD PML cells used for terminating the 1D grid. This is set to 20 cells by default.
         self.pml_length = (
-            np.abs(self.m[0]) * self.pml_cells + np.abs(self.m[1]) * self.pml_cells + np.abs(self.m[2]) * self.pml_cells
+            np.abs(self.m[0]) * self.pml_cells
+            + np.abs(self.m[1]) * self.pml_cells
+            + np.abs(self.m[2]) * self.pml_cells
         )
         # Set few buffer FDTD cells as extra
-        buffercells = np.abs(self.m[0]) * self.max_m + np.abs(self.m[1]) * self.max_m + np.abs(self.m[2]) * self.max_m
+        buffercells = (
+            np.abs(self.m[0]) * self.max_m
+            + np.abs(self.m[1]) * self.max_m
+            + np.abs(self.m[2]) * self.max_m
+        )
 
         # Total length of the 1D grid if not axial propagation
         if self.axial == 0:
@@ -3391,34 +3783,52 @@ class DiscretePlaneWave(Source):
         # Izjyx means correcting an E_z field due to a H_y field variation in x derivative direction array position 1
         # Izmxy means correcting an H_z field due to an E_x field variation in y derivative direction array position 2
         # Izmyx means correcting an H_z field due to an E_y field variation in x derivative direction array position 3
-        self.Iz = np.zeros((4, self.pml_length), order="C", dtype=config.sim_config.dtypes["float_or_double"])
+        self.Iz = np.zeros(
+            (4, self.pml_length), order="C", dtype=config.sim_config.dtypes["float_or_double"]
+        )
 
         # Allocate memory for the 1D DPW PML integrals for axial propagation case
         if self.axial != 0:
-            self.Iz_s = np.zeros((4, self.pml_length), order="C", dtype=config.sim_config.dtypes["float_or_double"])
-            self.Iz0 = np.zeros((4, self.pml_length), order="C", dtype=config.sim_config.dtypes["float_or_double"])
+            self.Iz_s = np.zeros(
+                (4, self.pml_length), order="C", dtype=config.sim_config.dtypes["float_or_double"]
+            )
+            self.Iz0 = np.zeros(
+                (4, self.pml_length), order="C", dtype=config.sim_config.dtypes["float_or_double"]
+            )
 
         # Iyjxz means correcting an E_y field due to a H_x field variation in z derivative direction array position 0
         # Iyjzx means correcting an E_y field due to a H_z field variation in x derivative direction array position 1
         # Iymxz means correcting an H_y field due to an E_x field variation in z derivative direction array position 2
         # Iymzx means correcting an H_y field due to an E_z field variation in x derivative direction array position 3
-        self.Iy = np.zeros((4, self.pml_length), order="C", dtype=config.sim_config.dtypes["float_or_double"])
+        self.Iy = np.zeros(
+            (4, self.pml_length), order="C", dtype=config.sim_config.dtypes["float_or_double"]
+        )
 
         # Allocate memory for the 1D DPW PML integrals for axial propagation case
         if self.axial != 0:
-            self.Iy_s = np.zeros((4, self.pml_length), order="C", dtype=config.sim_config.dtypes["float_or_double"])
-            self.Iy0 = np.zeros((4, self.pml_length), order="C", dtype=config.sim_config.dtypes["float_or_double"])
+            self.Iy_s = np.zeros(
+                (4, self.pml_length), order="C", dtype=config.sim_config.dtypes["float_or_double"]
+            )
+            self.Iy0 = np.zeros(
+                (4, self.pml_length), order="C", dtype=config.sim_config.dtypes["float_or_double"]
+            )
 
         # Ixjyz means correcting an E_x field due to a H_y field variation in z derivative direction array position 0
         # Ixjzy means correcting an E_x field due to a H_z field variation in y derivative direction array position 1
         # Ixmyz means correcting an H_x field due to an E_y field variation in z derivative direction array position 2
         # Ixmzy means correcting an H_x field due to an E_z field variation in y derivative direction array position 3
-        self.Ix = np.zeros((4, self.pml_length), order="C", dtype=config.sim_config.dtypes["float_or_double"])
+        self.Ix = np.zeros(
+            (4, self.pml_length), order="C", dtype=config.sim_config.dtypes["float_or_double"]
+        )
 
         # Allocate memory for the 1D DPW PML integrals for axial propagation case
         if self.axial != 0:
-            self.Ix_s = np.zeros((4, self.pml_length), order="C", dtype=config.sim_config.dtypes["float_or_double"])
-            self.Ix0 = np.zeros((4, self.pml_length), order="C", dtype=config.sim_config.dtypes["float_or_double"])
+            self.Ix_s = np.zeros(
+                (4, self.pml_length), order="C", dtype=config.sim_config.dtypes["float_or_double"]
+            )
+            self.Ix0 = np.zeros(
+                (4, self.pml_length), order="C", dtype=config.sim_config.dtypes["float_or_double"]
+            )
 
         # When no grid IDs are used Get the background material object with the matching ID and add it to the PlaneWave object
         if self.axial == 0:
@@ -3438,7 +3848,9 @@ class DiscretePlaneWave(Source):
                 self.materialZ = math.sqrt(
                     config.m0 * self.material.mr / (config.e0 * self.material.er)
                 )  # Impedance in the material
-                self.speed = config.c / math.sqrt(self.material.er * self.material.mr)  # Speed in the material
+                self.speed = config.c / math.sqrt(
+                    self.material.er * self.material.mr
+                )  # Speed in the material
 
             # Calculate the projections for sourcing the electric and magnetic fields
             # using double precision for better accuracy
@@ -3473,7 +3885,9 @@ class DiscretePlaneWave(Source):
             if abs(self.projections[4]) <= 1e-15:
                 self.projections[4] = 0
 
-            self.projections[5] = (-math.cos(self.psi_rad) * math.sin(self.theta_est_rad)) / self.materialZ
+            self.projections[5] = (
+                -math.cos(self.psi_rad) * math.sin(self.theta_est_rad)
+            ) / self.materialZ
             if abs(self.projections[5]) <= 1e-15:
                 self.projections[5] = 0
 
@@ -3516,7 +3930,9 @@ class DiscretePlaneWave(Source):
             dead = [a, 3 + t1, 3 + t2]
             hint = "for a mode invariant in z, TE requires psi = 0 or 180 degrees"
 
-        nonzero = [f"{names[c]} = {self.projections[c]:g}" for c in dead if self.projections[c] != 0]
+        nonzero = [
+            f"{names[c]} = {self.projections[c]:g}" for c in dead if self.projections[c] != 0
+        ]
         if nonzero:
             logger.exception(
                 f"Discrete plane wave: in {config.get_model_config().mode} mode the "
@@ -3592,10 +4008,14 @@ class DiscretePlaneWave(Source):
             pos_solid = list(self.transverse_pos)
 
             pos_solid[prop] = 2
-            self.material = next((x for x in G.materials if x.numID == G.solid[tuple(pos_solid)]), None)
+            self.material = next(
+                (x for x in G.materials if x.numID == G.solid[tuple(pos_solid)]), None
+            )
 
             pos_solid[prop] = n_prop - 2
-            self.materialPML = next((x for x in G.materials if x.numID == G.solid[tuple(pos_solid)]), None)
+            self.materialPML = next(
+                (x for x in G.materials if x.numID == G.solid[tuple(pos_solid)]), None
+            )
 
             # Reference material properties for the source-side auxiliary
             # grid. All Debye, Lorentz, and Drude pole dynamics are handled
@@ -3608,7 +4028,9 @@ class DiscretePlaneWave(Source):
                 self.materialZ = math.sqrt(
                     config.m0 * self.material.mr / (config.e0 * self.material.er)
                 )  # Impedance in the material
-                self.speed = config.c / math.sqrt(self.material.er * self.material.mr)  # Speed in the material
+                self.speed = config.c / math.sqrt(
+                    self.material.er * self.material.mr
+                )  # Speed in the material
 
             # Set the material ID of the PML region at origin as the same as the material next to the grid origin
             self.materialPML0 = self.material
@@ -3618,13 +4040,17 @@ class DiscretePlaneWave(Source):
             # Reference properties at the far-side DPW PML.
             if getattr(self.materialPML, "poles", 0) > 0:
                 material_pml_er = np.real(self.materialPML.calculate_er(self.waveform.freq))
-                self.materialPMLZ = math.sqrt(config.m0 * self.materialPML.mr / (config.e0 * material_pml_er))
+                self.materialPMLZ = math.sqrt(
+                    config.m0 * self.materialPML.mr / (config.e0 * material_pml_er)
+                )
                 self.PMLspeed = config.c / math.sqrt(material_pml_er * self.materialPML.mr)
             else:
                 self.materialPMLZ = math.sqrt(
                     config.m0 * self.materialPML.mr / (config.e0 * self.materialPML.er)
                 )  # Impedance in the material
-                self.PMLspeed = config.c / math.sqrt(self.materialPML.er * self.materialPML.mr)  # Speed in the material
+                self.PMLspeed = config.c / math.sqrt(
+                    self.materialPML.er * self.materialPML.mr
+                )  # Speed in the material
 
             self.dispersive = bool(sampled_dispersive_materials)
             self.max_poles = max(
@@ -3665,7 +4091,9 @@ class DiscretePlaneWave(Source):
             if abs(self.projections[4]) <= 1e-15:
                 self.projections[4] = 0
 
-            self.projections[5] = (-math.cos(self.psi_rad) * math.sin(self.theta_est_rad)) / self.materialZ
+            self.projections[5] = (
+                -math.cos(self.psi_rad) * math.sin(self.theta_est_rad)
+            ) / self.materialZ
             if abs(self.projections[5]) <= 1e-15:
                 self.projections[5] = 0
 
@@ -3734,7 +4162,14 @@ class DiscretePlaneWave(Source):
                     for r in range(self.m[3]):
                         time1 = (
                             G.dt * (iteration + 0.5)
-                            - (r + (np.abs(self.m[(dimension + 1) % 3]) + np.abs(self.m[(dimension + 2) % 3])) * 0.5)
+                            - (
+                                r
+                                + (
+                                    np.abs(self.m[(dimension + 1) % 3])
+                                    + np.abs(self.m[(dimension + 2) % 3])
+                                )
+                                * 0.5
+                            )
                             * self.ds
                             / self.speed
                         )
@@ -3743,14 +4178,17 @@ class DiscretePlaneWave(Source):
                             # Set the time of the waveform evaluation to account for any
                             # delay in the start
                             time1 -= self.start
-                            self.waveformvalues_halfdt[iteration, dimension, r] = self.waveform.calculate_value(
-                                time1, G.dt
-                            )
+                            self.waveformvalues_halfdt[
+                                iteration, dimension, r
+                            ] = self.waveform.calculate_value(time1, G.dt)
 
                     for r in range(self.m[3]):
                         time2 = (
                             G.dt * (iteration)
-                            - (r + (np.abs(self.m[(dimension)]) + np.abs(self.m[(dimension)])) * 0.5)
+                            - (
+                                r
+                                + (np.abs(self.m[(dimension)]) + np.abs(self.m[(dimension)])) * 0.5
+                            )
                             * self.ds
                             / self.speed
                         )
@@ -3759,9 +4197,9 @@ class DiscretePlaneWave(Source):
                             # Set the time of the waveform evaluation to account for any
                             # delay in the start
                             time2 -= self.start
-                            self.waveformvalues_wholedt[iteration, dimension, r] = self.waveform.calculate_value(
-                                time2, G.dt
-                            )
+                            self.waveformvalues_wholedt[
+                                iteration, dimension, r
+                            ] = self.waveform.calculate_value(time2, G.dt)
 
     def update_plane_wave_magnetic(
         self,
@@ -3780,7 +4218,6 @@ class DiscretePlaneWave(Source):
         precompute=True,
     ):
         if self.axial != 0:
-
             updatePlaneWave_magnetic_axial(
                 self.length,
                 self.pml_length,
@@ -3843,9 +4280,7 @@ class DiscretePlaneWave(Source):
             )
 
         else:
-
             if cythonize:
-
                 updatePlaneWave_magnetic(
                     self.length,
                     self.pml_length,
@@ -3909,7 +4344,6 @@ class DiscretePlaneWave(Source):
         cythonize=True,
         precompute=True,
     ):
-
         if self.axial != 0:
             updatePlaneWave_electric_axial(
                 self.length,
@@ -3973,7 +4407,6 @@ class DiscretePlaneWave(Source):
             )
 
         else:
-
             if cythonize:
                 updatePlaneWave_electric(
                     self.length,
@@ -4110,7 +4543,6 @@ class DiscretePlaneWave(Source):
             )
 
         else:
-
             if cythonize:
                 updatePlaneWave_electric_dispersive(
                     self.length,
@@ -4169,7 +4601,8 @@ class DiscretePlaneWave(Source):
                 for r in range(self.m[3]):
                     # Assign source values of magnetic field to first few gridpoints
                     self.H_fields[dimension, r] = (
-                        self.projections[dimension] * self.waveformvalues_halfdt[iteration, dimension, r]
+                        self.projections[dimension]
+                        * self.waveformvalues_halfdt[iteration, dimension, r]
                     )
                     # self.getSource(self.real_time - (j+(self.m[(i+1)%3]+self.m[(i+2)%3])*0.5)*self.ds/config.c)#, self.waveformID, G.dt)
         else:
@@ -4192,7 +4625,8 @@ class DiscretePlaneWave(Source):
                 for r in range(self.m[3]):
                     # Assign source values of magnetic field to first few gridpoints
                     self.E_fields[dimension, r] = (
-                        self.projections[dimension] * self.waveformvalues_wholedt[iteration + 1, dimension, r]
+                        self.projections[dimension]
+                        * self.waveformvalues_wholedt[iteration + 1, dimension, r]
                     )
                     # self.getSource(self.real_time - (j+(self.m[(i+1)%3]+self.m[(i+2)%3])*0.5)*self.ds/config.c)#, self.waveformID, G.dt)
         else:
@@ -4200,7 +4634,8 @@ class DiscretePlaneWave(Source):
                 for r in range(self.m[3]):
                     # Assign source values of magnetic field to first few gridpoints
                     self.E_fields[dimension, r] = self.projections[dimension] * getSource(
-                        (iteration + 1) * G.dt - (r + np.abs(self.m[dimension]) * 0.5) * self.ds / self.speed,
+                        (iteration + 1) * G.dt
+                        - (r + np.abs(self.m[dimension]) * 0.5) * self.ds / self.speed,
                         self.waveform.freq,
                         self.waveform.type.encode("UTF-8"),
                         G.dt,
@@ -4241,9 +4676,15 @@ class DiscretePlaneWave(Source):
                 self.H_fields[i, j] = (
                     G.updatecoeffsH[materialH, 0] * self.H_fields[i, j]
                     + G.updatecoeffsH[materialH, (i + 2) % 3 + 1]
-                    * (self.E_fields[(i + 1) % 3, j + self.m[(i + 2) % 3]] - self.E_fields[(i + 1) % 3, j])
+                    * (
+                        self.E_fields[(i + 1) % 3, j + self.m[(i + 2) % 3]]
+                        - self.E_fields[(i + 1) % 3, j]
+                    )
                     - G.updatecoeffsH[materialH, (i + 1) % 3 + 1]
-                    * (self.E_fields[(i + 2) % 3, j + self.m[(i + 1) % 3]] - self.E_fields[(i + 2) % 3, j])
+                    * (
+                        self.E_fields[(i + 2) % 3, j + self.m[(i + 1) % 3]]
+                        - self.E_fields[(i + 2) % 3, j]
+                    )
                 )  # equation 8 of Tan, Potter paper
 
     def update_electric_field_1D(self, G, iteration, precompute=True):
@@ -4281,13 +4722,21 @@ class DiscretePlaneWave(Source):
                 self.E_fields[i, j] = (
                     G.updatecoeffsE[materialE, 0] * self.E_fields[i, j]
                     + G.updatecoeffsE[materialE, (i + 2) % 3 + 1]
-                    * (self.H_fields[(i + 2) % 3, j] - self.H_fields[(i + 2) % 3, j - self.m[(i + 1) % 3]])
+                    * (
+                        self.H_fields[(i + 2) % 3, j]
+                        - self.H_fields[(i + 2) % 3, j - self.m[(i + 1) % 3]]
+                    )
                     - G.updatecoeffsE[materialE, (i + 1) % 3 + 1]
-                    * (self.H_fields[(i + 1) % 3, j] - self.H_fields[(i + 1) % 3, j - self.m[(i + 2) % 3]])
+                    * (
+                        self.H_fields[(i + 1) % 3, j]
+                        - self.H_fields[(i + 1) % 3, j - self.m[(i + 2) % 3]]
+                    )
                 )  # equation 9 of Tan, Potter paper
 
     def getField(self, i, j, k, array, m, origin, component):
-        return array[component, np.dot(m[:-1], np.array([i - origin[0], j - origin[1], k - origin[2]]))]
+        return array[
+            component, np.dot(m[:-1], np.array([i - origin[0], j - origin[1], k - origin[2]]))
+        ]
 
     def apply_TFSF_conditions_magnetic(self, G):
         if self.skip_axis != 0:
@@ -4537,7 +4986,11 @@ class DiscretePlaneWave(Source):
         #  vector. This vector is the "target direction" of the plane wave. It
         #  is automatically a "unit vector" (length of 1).
         u_vec_target = np.array(
-            [math.sin(theta_rad) * math.cos(phi_rad), math.sin(theta_rad) * math.sin(phi_rad), math.cos(theta_rad)]
+            [
+                math.sin(theta_rad) * math.cos(phi_rad),
+                math.sin(theta_rad) * math.sin(phi_rad),
+                math.cos(theta_rad),
+            ]
         )
 
         #  Snap floating-point residue on components that are analytically
@@ -4592,9 +5045,16 @@ class DiscretePlaneWave(Source):
                 # with max|m|) and would overflow the C long conversion
                 # below. Computed in Python ints, so this check itself
                 # cannot overflow.
-                if max(abs(p1 * (common_denom // q1)), abs(p2 * (common_denom // q2)), common_denom) > 10**6:
+                if (
+                    max(
+                        abs(p1 * (common_denom // q1)), abs(p2 * (common_denom // q2)), common_denom
+                    )
+                    > 10**6
+                ):
                     continue
-                m_perm = np.array([p1 * (common_denom // q1), p2 * (common_denom // q2), common_denom], dtype=int)
+                m_perm = np.array(
+                    [p1 * (common_denom // q1), p2 * (common_denom // q2), common_denom], dtype=int
+                )
 
                 # Apply the crucial sign correction for the correct quadrant
                 if np.sign(u_perm[2]) < 0:
@@ -4613,7 +5073,9 @@ class DiscretePlaneWave(Source):
                 # Store the candidate with its error and "size" metric. The size
                 # is the largest integer component, a good measure of cost.
                 size = np.max(np.abs(m_vec_candidate))
-                candidates.append({"m_vec": m_vec_candidate, "error": total_error_deg, "size": size})
+                candidates.append(
+                    {"m_vec": m_vec_candidate, "error": total_error_deg, "size": size}
+                )
 
         # From our list, we keep only those that meet the error criteria, then
         # sort them by size to find the one with the smallest integers.
@@ -4636,13 +5098,20 @@ class DiscretePlaneWave(Source):
 
         # Define local spherical basis vectors for error projection
         u_theta = np.array(
-            [math.cos(theta_rad) * math.cos(phi_rad), math.cos(theta_rad) * math.sin(phi_rad), -math.sin(theta_rad)]
+            [
+                math.cos(theta_rad) * math.cos(phi_rad),
+                math.cos(theta_rad) * math.sin(phi_rad),
+                -math.sin(theta_rad),
+            ]
         )
         u_phi = np.array([-math.sin(phi_rad), math.cos(phi_rad), 0])
 
         # Project the 3D error vector onto the basis vectors
         diff_vec = phys_vec_norm - u_vec_target
-        errors_deg = (math.degrees(np.dot(diff_vec, u_theta)), math.degrees(np.dot(diff_vec, u_phi)))
+        errors_deg = (
+            math.degrees(np.dot(diff_vec, u_theta)),
+            math.degrees(np.dot(diff_vec, u_phi)),
+        )
 
         # Calculate the final angles for user information
         actual_angles_deg = (
@@ -4671,13 +5140,13 @@ class DiscretePlaneWave(Source):
             AOrder = 1
             # Sigma Max is calcualted in the same way to the main grid PMls. It must take into account the
             # actual physical step size of the DPW grid when calcualting the step value which is not just ds.
-            sigma_max = 0.8 * (Order + 1) / (Z * np.sqrt(self.m[0] ** 2 + self.m[1] ** 2 + self.m[2] ** 2) * self.ds)
-            Kappa_max = (
-                1.0  # No kappa grading for DPW as it is not needed. You can change this value for testing purposes.
+            sigma_max = (
+                0.8
+                * (Order + 1)
+                / (Z * np.sqrt(self.m[0] ** 2 + self.m[1] ** 2 + self.m[2] ** 2) * self.ds)
             )
-            Alpha_max = (
-                0.0  # No alpha grading for DPW as it is not needed. You can change this value for testing purposes.
-            )
+            Kappa_max = 1.0  # No kappa grading for DPW as it is not needed. You can change this value for testing purposes.
+            Alpha_max = 0.0  # No alpha grading for DPW as it is not needed. You can change this value for testing purposes.
 
             # --- Create helper arrays for vectorized calculations ---
             # 'depth' array runs from 0 to PMLSize-1  (for sigma and kappa calculations)
@@ -4764,23 +5233,35 @@ class DiscretePlaneWave(Source):
             # Creates 2D arrays (4 rows x pml_length columns) for the PML coefficients RA row: 0, RB row: 1, RC rowe:2 and RD row: 3 for the Ex,Ey,Ez,
             # Hz, Hy, Hz components
             self.pml_rex = np.array(
-                [RAEx, RBEx, RCEx, RDEx], order="C", dtype=config.sim_config.dtypes["float_or_double"]
+                [RAEx, RBEx, RCEx, RDEx],
+                order="C",
+                dtype=config.sim_config.dtypes["float_or_double"],
             )
             self.pml_rey = np.array(
-                [RAEy, RBEy, RCEy, RDEy], order="C", dtype=config.sim_config.dtypes["float_or_double"]
+                [RAEy, RBEy, RCEy, RDEy],
+                order="C",
+                dtype=config.sim_config.dtypes["float_or_double"],
             )
             self.pml_rez = np.array(
-                [RAEz, RBEz, RCEz, RDEz], order="C", dtype=config.sim_config.dtypes["float_or_double"]
+                [RAEz, RBEz, RCEz, RDEz],
+                order="C",
+                dtype=config.sim_config.dtypes["float_or_double"],
             )
 
             self.pml_rhx = np.array(
-                [RAHx, RBHx, RCHx, RDHx], order="C", dtype=config.sim_config.dtypes["float_or_double"]
+                [RAHx, RBHx, RCHx, RDHx],
+                order="C",
+                dtype=config.sim_config.dtypes["float_or_double"],
             )
             self.pml_rhy = np.array(
-                [RAHy, RBHy, RCHy, RDHy], order="C", dtype=config.sim_config.dtypes["float_or_double"]
+                [RAHy, RBHy, RCHy, RDHy],
+                order="C",
+                dtype=config.sim_config.dtypes["float_or_double"],
             )
             self.pml_rhz = np.array(
-                [RAHz, RBHz, RCHz, RDHz], order="C", dtype=config.sim_config.dtypes["float_or_double"]
+                [RAHz, RBHz, RCHz, RDHz],
+                order="C",
+                dtype=config.sim_config.dtypes["float_or_double"],
             )
 
         else:
@@ -4792,13 +5273,13 @@ class DiscretePlaneWave(Source):
             AOrder = 1
             # Sigma Max is calcualted in the same way to the main grid PMls. It must take into account the
             # actual physical step size of the DPW grid when calcualting the step value which is not just ds.
-            sigma_max = 0.8 * (Order + 1) / (Z * np.sqrt(self.m[0] ** 2 + self.m[1] ** 2 + self.m[2] ** 2) * self.ds)
-            Kappa_max = (
-                1.0  # No kappa grading for DPW as it is not needed. You can change this value for testing purposes.
+            sigma_max = (
+                0.8
+                * (Order + 1)
+                / (Z * np.sqrt(self.m[0] ** 2 + self.m[1] ** 2 + self.m[2] ** 2) * self.ds)
             )
-            Alpha_max = (
-                0.0  # No alpha grading for DPW as it is not needed. You can change this value for testing purposes.
-            )
+            Kappa_max = 1.0  # No kappa grading for DPW as it is not needed. You can change this value for testing purposes.
+            Alpha_max = 0.0  # No alpha grading for DPW as it is not needed. You can change this value for testing purposes.
 
             # --- Create helper arrays for vectorized calculations ---
             # 'depth' array runs from 0 to PMLSize-1  (for sigma and kappa calculations)
@@ -4885,23 +5366,35 @@ class DiscretePlaneWave(Source):
             # Creates 2D arrays (4 rows x pml_length columns) for the PML coefficients RA row: 0, RB row: 1, RC rowe:2 and RD row: 3 for the Ex,Ey,Ez,
             # Hz, Hy, Hz components
             self.pml_rex = np.array(
-                [RAEx, RBEx, RCEx, RDEx], order="C", dtype=config.sim_config.dtypes["float_or_double"]
+                [RAEx, RBEx, RCEx, RDEx],
+                order="C",
+                dtype=config.sim_config.dtypes["float_or_double"],
             )
             self.pml_rey = np.array(
-                [RAEy, RBEy, RCEy, RDEy], order="C", dtype=config.sim_config.dtypes["float_or_double"]
+                [RAEy, RBEy, RCEy, RDEy],
+                order="C",
+                dtype=config.sim_config.dtypes["float_or_double"],
             )
             self.pml_rez = np.array(
-                [RAEz, RBEz, RCEz, RDEz], order="C", dtype=config.sim_config.dtypes["float_or_double"]
+                [RAEz, RBEz, RCEz, RDEz],
+                order="C",
+                dtype=config.sim_config.dtypes["float_or_double"],
             )
 
             self.pml_rhx = np.array(
-                [RAHx, RBHx, RCHx, RDHx], order="C", dtype=config.sim_config.dtypes["float_or_double"]
+                [RAHx, RBHx, RCHx, RDHx],
+                order="C",
+                dtype=config.sim_config.dtypes["float_or_double"],
             )
             self.pml_rhy = np.array(
-                [RAHy, RBHy, RCHy, RDHy], order="C", dtype=config.sim_config.dtypes["float_or_double"]
+                [RAHy, RBHy, RCHy, RDHy],
+                order="C",
+                dtype=config.sim_config.dtypes["float_or_double"],
             )
             self.pml_rhz = np.array(
-                [RAHz, RBHz, RCHz, RDHz], order="C", dtype=config.sim_config.dtypes["float_or_double"]
+                [RAHz, RBHz, RCHz, RDHz],
+                order="C",
+                dtype=config.sim_config.dtypes["float_or_double"],
             )
 
             # --- Repeat for PML0 ---
@@ -4914,13 +5407,13 @@ class DiscretePlaneWave(Source):
             AOrder = 1
             # Sigma Max is calcualted in the same way to the main grid PMls. It must take into account the
             # actual physical step size of the DPW grid when calcualting the step value which is not just ds.
-            sigma_max = 0.8 * (Order + 1) / (Z * np.sqrt(self.m[0] ** 2 + self.m[1] ** 2 + self.m[2] ** 2) * self.ds)
-            Kappa_max = (
-                1.0  # No kappa grading for DPW as it is not needed. You can change this value for testing purposes.
+            sigma_max = (
+                0.8
+                * (Order + 1)
+                / (Z * np.sqrt(self.m[0] ** 2 + self.m[1] ** 2 + self.m[2] ** 2) * self.ds)
             )
-            Alpha_max = (
-                0.0  # No alpha grading for DPW as it is not needed. You can change this value for testing purposes.
-            )
+            Kappa_max = 1.0  # No kappa grading for DPW as it is not needed. You can change this value for testing purposes.
+            Alpha_max = 0.0  # No alpha grading for DPW as it is not needed. You can change this value for testing purposes.
 
             # --- Create helper arrays for vectorized calculations ---
             # 'depth' array runs from 0 to PMLSize-1  (for sigma and kappa calculations)
@@ -5007,21 +5500,33 @@ class DiscretePlaneWave(Source):
             # Creates 2D arrays (4 rows x pml_length columns) for the PML coefficients RA row: 0, RB row: 1, RC rowe:2 and RD row: 3 for the Ex,Ey,Ez,
             # Hz, Hy, Hz components
             self.pml_rex0 = np.array(
-                [RAEx, RBEx, RCEx, RDEx], order="C", dtype=config.sim_config.dtypes["float_or_double"]
+                [RAEx, RBEx, RCEx, RDEx],
+                order="C",
+                dtype=config.sim_config.dtypes["float_or_double"],
             )
             self.pml_rey0 = np.array(
-                [RAEy, RBEy, RCEy, RDEy], order="C", dtype=config.sim_config.dtypes["float_or_double"]
+                [RAEy, RBEy, RCEy, RDEy],
+                order="C",
+                dtype=config.sim_config.dtypes["float_or_double"],
             )
             self.pml_rez0 = np.array(
-                [RAEz, RBEz, RCEz, RDEz], order="C", dtype=config.sim_config.dtypes["float_or_double"]
+                [RAEz, RBEz, RCEz, RDEz],
+                order="C",
+                dtype=config.sim_config.dtypes["float_or_double"],
             )
 
             self.pml_rhx0 = np.array(
-                [RAHx, RBHx, RCHx, RDHx], order="C", dtype=config.sim_config.dtypes["float_or_double"]
+                [RAHx, RBHx, RCHx, RDHx],
+                order="C",
+                dtype=config.sim_config.dtypes["float_or_double"],
             )
             self.pml_rhy0 = np.array(
-                [RAHy, RBHy, RCHy, RDHy], order="C", dtype=config.sim_config.dtypes["float_or_double"]
+                [RAHy, RBHy, RCHy, RDHy],
+                order="C",
+                dtype=config.sim_config.dtypes["float_or_double"],
             )
             self.pml_rhz0 = np.array(
-                [RAHz, RBHz, RCHz, RDHz], order="C", dtype=config.sim_config.dtypes["float_or_double"]
+                [RAHz, RBHz, RCHz, RDHz],
+                order="C",
+                dtype=config.sim_config.dtypes["float_or_double"],
             )

--- a/gprMax/sources.py
+++ b/gprMax/sources.py
@@ -737,7 +737,11 @@ class EigenmodeSource(Source):
         for local_axis, global_axis in enumerate(local_to_global):
             electric[global_axis] = np.array(local_e[local_axis], dtype=np.complex128, copy=True)
             magnetic[global_axis] = np.array(local_h[local_axis], dtype=np.complex128, copy=True)
-        if self._modal_basis_handedness() < 0:
+        if isinstance(solver, FDFD_1D_mode_solver):
+            handedness = self._one_dimensional_mapping_handedness()
+        else:
+            handedness = self._modal_basis_handedness()
+        if handedness < 0:
             magnetic = [-field for field in magnetic]
         return electric, magnetic, complex(solver.complex_neff[mode])
 
@@ -823,6 +827,13 @@ class EigenmodeSource(Source):
         transverse_v = basis[self.transverse_axes[1]]
         normal = basis[self.normal_axis]
         return int(np.dot(np.cross(transverse_u, transverse_v), normal))
+
+    def _one_dimensional_mapping_handedness(self):
+        basis = np.eye(3, dtype=np.int32)
+        transverse = basis[self.physical_transverse_axis]
+        invariant = basis[self.invariant_axis]
+        normal = basis[self.normal_axis]
+        return int(np.dot(np.cross(transverse, invariant), normal))
 
     def _modal_overlap(self, first_e, first_h, second_e, second_h):
         """Return the normalized complex overlap of two modal field sets."""

--- a/tests/cmds_multiuse/test_eigenmode_source_2d.py
+++ b/tests/cmds_multiuse/test_eigenmode_source_2d.py
@@ -290,7 +290,9 @@ def test_eigenmode_port_rejected_with_mpi(monkeypatch):
 
 def test_2d_eigenmode_normal_cannot_be_invariant_axis(tmp_path):
     scene = _scene("TM")
-    scene.grid_objects = [obj for obj in scene.grid_objects if not isinstance(obj, gprMax.EigenmodePort)]
+    scene.grid_objects = [
+        obj for obj in scene.grid_objects if not isinstance(obj, gprMax.EigenmodePort)
+    ]
     scene.add(
         gprMax.EigenmodePort(
             port=1,
@@ -313,7 +315,9 @@ def test_2d_eigenmode_normal_cannot_be_invariant_axis(tmp_path):
 
 def test_positive_direction_eigenmode_rejects_lower_boundary(tmp_path):
     scene = _scene("TM")
-    scene.grid_objects = [obj for obj in scene.grid_objects if not isinstance(obj, gprMax.EigenmodePort)]
+    scene.grid_objects = [
+        obj for obj in scene.grid_objects if not isinstance(obj, gprMax.EigenmodePort)
+    ]
     scene.add(
         gprMax.EigenmodePort(
             port=1,
@@ -487,7 +491,9 @@ def test_2d_eigenmode_builds_for_every_invariant_axis(tmp_path, mode, invariant_
     ],
 )
 def test_2d_regression_example_builds(tmp_path, relative_path, snapshot_count):
-    source = REPOSITORY_ROOT / "testing" / "regression" / "eigenmode_sources" / "cases" / relative_path
+    source = (
+        REPOSITORY_ROOT / "testing" / "regression" / "eigenmode_sources" / "cases" / relative_path
+    )
     copied_input = tmp_path / source.name
     shutil.copyfile(source, copied_input)
 
@@ -569,24 +575,18 @@ def test_straight_example_auto_ports_share_broadband_anchors(tmp_path):
             values = np.squeeze(snapshot["Ez"][...])
             x_energy = np.sum(np.abs(values) ** 2, axis=1)
             total_energy = float(np.sum(x_energy))
-            centroid = float(
-                np.sum(np.arange(values.shape[0]) * x_energy) / total_energy
-            )
-            snapshot_metrics.append(
-                (float(snapshot.attrs["time"]), centroid, total_energy)
-            )
+            centroid = float(np.sum(np.arange(values.shape[0]) * x_energy) / total_energy)
+            snapshot_metrics.append((float(snapshot.attrs["time"]), centroid, total_energy))
     snapshot_metrics.sort()
     propagating = min(
         snapshot_metrics,
         key=lambda metric: abs(metric[0] - 1.6e-9),
     )
     assert propagating[1] > snapshot_metrics[0][1] + 40
-    assert snapshot_metrics[-1][2] < 0.05 * max(
-        metric[2] for metric in snapshot_metrics
-    )
+    assert snapshot_metrics[-1][2] < 0.05 * max(metric[2] for metric in snapshot_metrics)
 
 
-def test_spurious_modes_apply_one_anchor_policy_to_all_ports(
+def test_spurious_modes_resolve_automatic_anchors_per_port_and_mode(
     tmp_path,
     monkeypatch,
 ):
@@ -605,23 +605,52 @@ def test_spurious_modes_apply_one_anchor_policy_to_all_ports(
     with h5py.File(outputfile.with_suffix(".h5"), "r") as output:
         port1 = output["eigenmode_ports/port1"]
         port2 = output["eigenmode_ports/port2"]
-        policy = port1.attrs["ResolvedAnchorPolicy"]
-        assert policy in {"auto_broadband", "auto_broadband_guard_trimmed"}
-        assert port2.attrs["ResolvedAnchorPolicy"] == policy
-        np.testing.assert_array_equal(
-            port1.attrs["AnchorFrequencies"],
-            port2.attrs["AnchorFrequencies"],
-        )
-        anchors = port1.attrs["AnchorFrequencies"]
-        assert np.any(np.isclose(anchors, 4e9))
-        assert anchors[-1] >= 6e9
-    if policy == "auto_broadband_guard_trimmed":
-        assert anchors[0] > 2.4842e9
-        assert anchors[0] <= 4e9
+
+        def text_values(values):
+            return tuple(
+                value.decode() if isinstance(value, bytes) else str(value) for value in values
+            )
+
+        source_candidates = np.asarray(port1.attrs["CandidateAnchorFrequencies"])
+        receiver_candidates = np.asarray(port2.attrs["CandidateAnchorFrequencies"])
+        np.testing.assert_array_equal(source_candidates, receiver_candidates)
+        assert np.any(np.isclose(source_candidates, 4e9))
+        assert source_candidates[-1] >= 6e9
+
+        all_policies = []
+        for port in (port1, port2):
+            candidates = np.asarray(port.attrs["CandidateAnchorFrequencies"])
+            resolved = np.asarray(port.attrs["AnchorFrequencies"])
+            valid = port["anchor_mode_valid"][...].astype(bool)
+            propagating = port["anchor_mode_propagating"][...].astype(bool)
+            policies = text_values(port.attrs["ModeAnchorPolicies"])
+            all_policies.extend(policies)
+
+            assert valid.shape == propagating.shape == (len(candidates), 4)
+            assert len(policies) == 4
+            assert np.all(np.any(valid, axis=0))
+            assert np.all(valid <= propagating)
+            np.testing.assert_array_equal(
+                resolved,
+                candidates[np.any(valid, axis=1)],
+            )
+            for mode_position in range(valid.shape[1]):
+                indices = np.flatnonzero(valid[:, mode_position])
+                assert np.all(np.diff(indices) == 1)
+
+            unique_policies = set(policies)
+            expected_scalar = (
+                policies[0]
+                if port.attrs["IsSource"]
+                else (policies[0] if len(unique_policies) == 1 else "auto_mixed_mode_policies")
+            )
+            assert port.attrs["ResolvedAnchorPolicy"] == expected_scalar
+
+    if any("guard_trimmed" in policy for policy in all_policies):
         assert any("spectral guard" in warning for warning in warnings)
         assert any("endpoint modal profile" in warning for warning in warnings)
-    else:
-        assert anchors[0] == pytest.approx(2.4842025e9, rel=1e-6)
+    if any("nonpropagating_trimmed" in policy for policy in all_policies):
+        assert any("non-propagating anchor" in warning for warning in warnings)
 
 
 @pytest.mark.parametrize(
@@ -645,9 +674,7 @@ def test_hash_modal_plot_control_overrides_geometry_only_default(
     lines = source.read_text().splitlines()
     copied_input.write_text(
         "\n".join(
-            f"{line} {plot_control}"
-            if line.startswith("#eigenmode_port:")
-            else line
+            f"{line} {plot_control}" if line.startswith("#eigenmode_port:") else line
             for line in lines
         )
         + "\n"
@@ -707,7 +734,5 @@ def test_hash_excitation_plot_control_is_independent_of_modal_plots(
     )
 
     assert not list(tmp_path.glob(f"{copied_input.stem}_Port*_Mode*.png"))
-    waveform_plot_count = len(
-        list(tmp_path.glob(f"{copied_input.stem}_EigenmodeExcitation.png"))
-    )
+    waveform_plot_count = len(list(tmp_path.glob(f"{copied_input.stem}_EigenmodeExcitation.png")))
     assert waveform_plot_count == expected_plot_count

--- a/tests/eigenmode_auto_guard_failure.in
+++ b/tests/eigenmode_auto_guard_failure.in
@@ -1,0 +1,19 @@
+#title: Eigenmode automatic guard failure below TE10 cutoff
+#domain: 0.044 0.008 0.006
+#dx_dy_dz: 0.0002 0.0002 0.0002
+#time_window: 2e-9
+#pml_cells: 12 0 0 12 0 0
+
+## Air-filled 6 mm x 4 mm rectangular PEC waveguide. Its analytical TE10
+## cutoff is c / (2a) = 24.9827 GHz.
+#box: 0 0 0 0.044 0.001 0.006 pec
+#box: 0 0.007 0 0.044 0.008 0.006 pec
+#box: 0 0 0 0.044 0.008 0.001 pec
+#box: 0 0 0.005 0.044 0.008 0.006 pec
+
+## The requested band is entirely above cutoff. Automatic spectral coverage
+## adds a 22.6604 GHz lower guard anchor, which is below cutoff.
+#eigenmode_band: canonical_band 28e9 35e9 29
+#eigenmode_port: 1 0.004 0.001 0.001 0.004 0.007 0.005 + 1 auto n
+#eigenmode_port: 2 0.028 0.001 0.001 0.028 0.007 0.005 - 1 auto n
+#eigenmode_excitation: 1 1 auto n

--- a/tests/fdfd_eigenmode_solver/test_fdfd_1d_mode_solver.py
+++ b/tests/fdfd_eigenmode_solver/test_fdfd_1d_mode_solver.py
@@ -41,9 +41,7 @@ def _solver(polarization, n=80, frequency=10e9, **kwargs):
     return FDFD_1D_mode_solver(**defaults)
 
 
-@pytest.mark.parametrize(
-    'solver_class', [FDFD_1D_mode_solver, FDFD_2D_mode_solver]
-)
+@pytest.mark.parametrize("solver_class", [FDFD_1D_mode_solver, FDFD_2D_mode_solver])
 def test_passive_neff_branch_preserves_loss_and_evanescent_decay(solver_class):
     epsilon = 9 - 7.19004143381j
     expected = np.sqrt(epsilon)
@@ -57,20 +55,20 @@ def test_passive_neff_branch_preserves_loss_and_evanescent_decay(solver_class):
     assert evanescent_neff == pytest.approx(-2j)
 
 
-@pytest.mark.parametrize('polarization', ['TM', 'TE'])
+@pytest.mark.parametrize("polarization", ["TM", "TE"])
 def test_lossy_homogeneous_mode_uses_passive_forward_neff(polarization):
     n = 40
     frequency = 5e9
     epsilon = 9 - 1j * 2 / (2 * np.pi * frequency * 8.8541878128e-12)
     kwargs = {
-        'eps_r_t': np.full(n, epsilon),
-        'eps_r_a': np.full(n + 1, epsilon),
-        'eps_r_w': np.full(n + 1, epsilon),
+        "eps_r_t": np.full(n, epsilon),
+        "eps_r_a": np.full(n + 1, epsilon),
+        "eps_r_w": np.full(n + 1, epsilon),
     }
-    if polarization == 'TE':
+    if polarization == "TE":
         pec_w = np.zeros(n + 1, dtype=bool)
         pec_w[[0, -1]] = True
-        kwargs['pec_w_mask'] = pec_w
+        kwargs["pec_w_mask"] = pec_w
 
     solver = _solver(
         polarization,
@@ -86,8 +84,11 @@ def test_lossy_homogeneous_mode_uses_passive_forward_neff(polarization):
     assert np.real(solver.modal_complex_neff) > 0
     assert np.imag(solver.modal_complex_neff) < 0
     assert abs(forward_factor) < 1
+    assert solver.modal_power_valid
+    assert solver.modal_forward_power_metric > solver.FORWARD_POWER_METRIC_TOLERANCE
+    assert np.real(solver.modal_raw_power) > 0
     assert solver.modal_power == pytest.approx(1.0, rel=1e-12)
-    if polarization == 'TM':
+    if polarization == "TM":
         active = np.abs(solver.modal_Ea) > 1e-12 * np.max(np.abs(solver.modal_Ea))
         ratio = solver.modal_Ht[active] / solver.modal_Ea[active]
         expected_ratio = -solver.modal_complex_neff / solver.eta0
@@ -96,6 +97,87 @@ def test_lossy_homogeneous_mode_uses_passive_forward_neff(polarization):
         ratio = solver.modal_Et[active] / solver.modal_Ha[active]
         expected_ratio = solver.eta0 * solver.modal_complex_neff / epsilon
     np.testing.assert_allclose(ratio, expected_ratio, rtol=1e-9, atol=1e-12)
+
+
+@pytest.mark.parametrize("polarization", ["TM", "TE"])
+def test_backward_wave_uses_passive_forward_power_branch(polarization):
+    n = 40
+    frequency = 5e9
+    material = -2 - 0.05j
+    solver = _solver(
+        polarization,
+        n=n,
+        frequency=frequency,
+        eps_r_t=np.full(n, material),
+        eps_r_a=np.full(n + 1, material),
+        eps_r_w=np.full(n + 1, material),
+        mu_r_t=np.full(n + 1, material),
+        mu_r_a=np.full(n, material),
+        mu_r_w=np.full(n, material),
+    )
+
+    solver.solve()
+
+    forward_factor = np.exp(-1j * solver.k0 * solver.modal_complex_neff * 0.5e-3)
+    assert np.real(solver.modal_complex_neff) < 0
+    assert np.imag(solver.modal_complex_neff) < 0
+    assert abs(forward_factor) < 1
+    assert solver.modal_power_valid
+    assert solver.modal_forward_power_metric > solver.FORWARD_POWER_METRIC_TOLERANCE
+    assert np.real(solver.modal_raw_power) > 0
+    assert solver.modal_power == pytest.approx(1.0, rel=1e-12)
+
+
+def test_below_cutoff_mode_is_kept_with_finite_balanced_normalization():
+    n = 40
+    pec_a = np.zeros(n + 1, dtype=bool)
+    pec_a[[0, -1]] = True
+    solver = _solver(
+        "TM",
+        n=n,
+        frequency=5e9,
+        pec_a_mask=pec_a,
+    )
+
+    solver.solve()
+
+    assert solver.modal_complex_neff.real == 0
+    assert solver.modal_complex_neff.imag < 0
+    assert not solver.modal_power_valid
+    assert abs(solver.modal_forward_power_metric) < solver.FORWARD_POWER_METRIC_TOLERANCE
+    assert abs(solver.modal_raw_power.imag) > abs(solver.modal_raw_power.real)
+    assert solver._calculate_mode_balanced_power(0) == pytest.approx(1.0, rel=1e-12)
+    assert solver.modal_power == pytest.approx(solver.modal_forward_power_metric, abs=1e-14)
+    for field in (
+        solver.modal_Et,
+        solver.modal_Ea,
+        solver.modal_Ew,
+        solver.modal_Ht,
+        solver.modal_Ha,
+        solver.modal_Hw,
+    ):
+        assert np.all(np.isfinite(field))
+
+
+def test_propagation_validity_is_classified_per_mode():
+    n = 40
+    pec_a = np.zeros(n + 1, dtype=bool)
+    pec_a[[0, -1]] = True
+    solver = _solver(
+        "TM",
+        n=n,
+        frequency=10e9,
+        mode_index=1,
+        pec_a_mask=pec_a,
+    )
+
+    solver.solve()
+
+    np.testing.assert_array_equal(solver.power_valid, (True, False))
+    assert solver.powers[0] == pytest.approx(1.0, rel=1e-12)
+    assert abs(solver.powers[1]) < solver.FORWARD_POWER_METRIC_TOLERANCE
+    assert np.all(np.isfinite(solver.Ea))
+    assert np.all(np.isfinite(solver.Ht))
 
 
 def test_tm_pec_parallel_plate_neff_and_yee_shapes():

--- a/tests/fdfd_eigenmode_solver/test_fdfd_1d_mode_solver.py
+++ b/tests/fdfd_eigenmode_solver/test_fdfd_1d_mode_solver.py
@@ -131,6 +131,118 @@ def test_te_uniform_mode_uses_pec_longitudinal_boundary():
     assert solver.modal_power == pytest.approx(1.0, rel=1e-12)
 
 
+def test_default_guess_targets_magnetic_medium_fundamental():
+    n = 80
+    epsilon = 4.0
+    permeability = 4.0
+    solver = _solver(
+        "TE",
+        n=n,
+        eps_r_t=np.full(n, epsilon),
+        eps_r_a=np.full(n + 1, epsilon),
+        eps_r_w=np.full(n + 1, epsilon),
+        mu_r_t=np.full(n + 1, permeability),
+        mu_r_a=np.full(n, permeability),
+        mu_r_w=np.full(n, permeability),
+    )
+
+    assert solver.guess == pytest.approx(-(epsilon * permeability))
+    solver.solve()
+
+    assert solver.modal_real_neff == pytest.approx(
+        np.sqrt(epsilon * permeability),
+        rel=5e-3,
+    )
+
+
+@pytest.mark.parametrize("polarization", ("TM", "TE"))
+def test_real_profile_alignment_canonicalizes_global_mode_sign(polarization):
+    phase = np.exp(0.37j)
+    aligned_fields = []
+    for sign in (1.0, -1.0):
+        solver = object.__new__(FDFD_1D_mode_solver)
+        solver.num_modes = 1
+        solver.polarization = polarization
+        solver.dt = 1.0
+        solver.Et = np.zeros((2, 1), dtype=np.complex128)
+        solver.Ea = np.zeros((3, 1), dtype=np.complex128)
+        solver.Ew = np.zeros((3, 1), dtype=np.complex128)
+        solver.Ht = np.zeros((3, 1), dtype=np.complex128)
+        solver.Ha = np.zeros((2, 1), dtype=np.complex128)
+        solver.Hw = np.zeros((2, 1), dtype=np.complex128)
+        if polarization == "TM":
+            solver.Ea[:, 0] = sign * phase * np.asarray((1.0, 2.0, 1.0))
+            solver.Ht[:, 0] = -sign * phase * np.asarray((0.5, 1.0, 0.5))
+        else:
+            solver.Et[:, 0] = sign * phase * np.asarray((1.0, 2.0))
+            solver.Ha[:, 0] = sign * phase * np.asarray((0.5, 1.0))
+
+        solver._align_modes_for_real_profile_power()
+        aligned_fields.append(
+            tuple(
+                field.copy()
+                for field in (solver.Et, solver.Ea, solver.Ew, solver.Ht, solver.Ha, solver.Hw)
+            )
+        )
+
+    for positive, negative in zip(*aligned_fields):
+        np.testing.assert_allclose(positive, negative, rtol=0, atol=1e-14)
+
+    pivot_vector = np.concatenate((aligned_fields[0][0].ravel(), aligned_fields[0][1].ravel()))
+    pivot = pivot_vector[np.argmax(np.abs(pivot_vector))]
+    assert np.real(pivot) > 0
+
+
+@pytest.mark.parametrize("polarization", ("TM", "TE"))
+def test_longitudinal_field_satisfies_discrete_curl_equation(polarization):
+    n = 40
+    kwargs = {}
+    if polarization == "TM":
+        pec_a = np.zeros(n + 1, dtype=bool)
+        pec_a[[0, -1]] = True
+        kwargs["pec_a_mask"] = pec_a
+    else:
+        pmc_a = np.zeros(n, dtype=bool)
+        pmc_a[[0, -1]] = True
+        kwargs["pmc_a_mask"] = pmc_a
+    solver = _solver(polarization, n=n, **kwargs)
+
+    solver.solve()
+
+    if polarization == "TM":
+        expected = 1j * (solver.D_NODE_TO_CELL @ solver.modal_Ea) / (solver.eta0 * solver.mu_r_w)
+        actual = solver.modal_Hw
+    else:
+        expected = -1j * solver.eta0 * (solver.D_CELL_TO_NODE @ solver.modal_Ha) / solver.eps_r_w
+        actual = solver.modal_Ew
+
+    assert np.max(np.abs(expected)) > 0
+    np.testing.assert_allclose(actual, expected, rtol=1e-12, atol=1e-12)
+
+
+def test_negative_real_power_fallback_rotates_all_fields_together():
+    solver = object.__new__(FDFD_1D_mode_solver)
+    solver.num_modes = 1
+    solver.polarization = "TE"
+    solver.dt = 1.0
+    solver.Et = np.asarray(((1.0,), (2.0,)), dtype=np.complex128)
+    solver.Ea = np.asarray(((0.1,), (0.2,), (0.1,)), dtype=np.complex128)
+    solver.Ew = np.asarray(((0.2,), (0.3,), (0.2,)), dtype=np.complex128)
+    solver.Ht = np.asarray(((0.1,), (0.2,), (0.1,)), dtype=np.complex128)
+    solver.Ha = np.asarray(((0.5,), (1.0,)), dtype=np.complex128)
+    solver.Hw = np.asarray(((0.2,), (0.4,)), dtype=np.complex128)
+    fields = (solver.Et, solver.Ea, solver.Ew, solver.Ht, solver.Ha, solver.Hw)
+    original_fields = tuple(field.copy() for field in fields)
+    original_power = solver._calculate_mode_power(0)
+    solver._real_profile_power_from_fields = lambda mode: -1.0
+
+    solver._align_modes_for_real_profile_power()
+
+    for actual, original in zip(fields, original_fields):
+        np.testing.assert_allclose(actual, 1j * original, rtol=0, atol=1e-14)
+    assert solver._calculate_mode_power(0) == pytest.approx(original_power)
+
+
 def test_tm_dielectric_slab_mode_decays_across_air_margin():
     n = 70
     dt = 1e-3

--- a/tests/fdfd_eigenmode_solver/test_fdfd_2d_mode_solver.py
+++ b/tests/fdfd_eigenmode_solver/test_fdfd_2d_mode_solver.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 import numpy as np
 import pytest
+from scipy.sparse import diags
 
 import gprMax.config as config
 from gprMax.fdfd_eigenmode_solver.fdfd_2d_mode_solver import FDFD_2D_mode_solver
@@ -189,3 +190,86 @@ def test_rectangular_pmc_tm10_enforces_normal_e_and_matches_theory():
     fitted_impedance = abs(np.vdot(cell_eu, cell_eu) / np.vdot(cell_eu, cell_hv))
     expected_impedance = solver.eta0 * solver.modal_real_neff
     assert fitted_impedance == pytest.approx(expected_impedance, rel=1e-3)
+
+
+def test_default_guess_targets_magnetic_medium_fundamental():
+    nu, nv = 30, 25
+    epsilon = 4.0
+    permeability = 4.0
+    solver = FDFD_2D_mode_solver(
+        frequency=10e9,
+        du=0.5e-3,
+        dv=0.5e-3,
+        mode_index=0,
+        eps_r_uu=np.full((nu, nv + 1), epsilon),
+        eps_r_vv=np.full((nu + 1, nv), epsilon),
+        eps_r_ww=np.full((nu + 1, nv + 1), epsilon),
+        mu_r_uu=np.full((nu + 1, nv), permeability),
+        mu_r_vv=np.full((nu, nv + 1), permeability),
+        mu_r_ww=np.full((nu, nv), permeability),
+    )
+
+    assert solver.guess == pytest.approx(-(epsilon * permeability))
+    solver.solve()
+
+    assert solver.modal_real_neff == pytest.approx(
+        np.sqrt(epsilon * permeability),
+        rel=4e-2,
+    )
+
+
+def test_real_profile_alignment_canonicalizes_global_mode_sign():
+    phase = np.exp(0.37j)
+    aligned_fields = []
+    for sign in (1.0, -1.0):
+        solver = object.__new__(FDFD_2D_mode_solver)
+        solver.num_modes = 1
+        solver.Nu = 2
+        solver.Nv = 2
+        solver.du = 1.0
+        solver.dv = 1.0
+        solver.Eu = sign * phase * np.ones((2, 3, 1), dtype=np.complex128)
+        solver.Ev = np.zeros((3, 2, 1), dtype=np.complex128)
+        solver.Ew = np.zeros((3, 3, 1), dtype=np.complex128)
+        solver.Hu = np.zeros((3, 2, 1), dtype=np.complex128)
+        solver.Hv = sign * phase * np.ones((2, 3, 1), dtype=np.complex128)
+        solver.Hw = np.zeros((2, 2, 1), dtype=np.complex128)
+
+        solver._align_modes_for_real_profile_power()
+        aligned_fields.append(
+            tuple(
+                field.copy()
+                for field in (solver.Eu, solver.Ev, solver.Ew, solver.Hu, solver.Hv, solver.Hw)
+            )
+        )
+
+    for positive, negative in zip(*aligned_fields):
+        np.testing.assert_allclose(positive, negative, rtol=0, atol=1e-14)
+
+    pivot_vector = np.concatenate((aligned_fields[0][0].ravel(), aligned_fields[0][1].ravel()))
+    pivot = pivot_vector[np.argmax(np.abs(pivot_vector))]
+    assert np.real(pivot) > 0
+
+
+def test_small_reduced_system_uses_dense_eigensolve():
+    solver = object.__new__(FDFD_2D_mode_solver)
+    solver.num_modes = 2
+    solver.guess = -4.0
+    matrix = diags((-9.0, -4.0, -1.0), format="csr")
+
+    eigenvalues, eigenvectors = solver._solve_reduced(matrix)
+
+    np.testing.assert_allclose(eigenvalues, (-4.0, -1.0), rtol=0, atol=1e-12)
+    assert eigenvectors.shape == (3, 2)
+
+
+def test_sparse_eigensolve_retries_perturbed_singular_shift():
+    solver = object.__new__(FDFD_2D_mode_solver)
+    solver.num_modes = 1
+    solver.guess = -4.0
+    matrix = diags((-4.0, -2.0, -1.0), format="csr")
+
+    eigenvalues, eigenvectors = solver._solve_reduced(matrix)
+
+    np.testing.assert_allclose(eigenvalues, (-4.0,), rtol=0, atol=1e-12)
+    assert eigenvectors.shape == (3, 1)

--- a/tests/fdfd_eigenmode_solver/test_fdfd_2d_mode_solver.py
+++ b/tests/fdfd_eigenmode_solver/test_fdfd_2d_mode_solver.py
@@ -64,14 +64,15 @@ def test_lossy_pec_waveguide_mode_uses_same_passive_branch_for_neff_and_h():
 
     width = nu * spacing
     expected = np.sqrt(epsilon - (np.pi / (solver.k0 * width)) ** 2)
-    forward_factor = np.exp(
-        -1j * solver.k0 * solver.modal_complex_neff * 0.5e-3
-    )
+    forward_factor = np.exp(-1j * solver.k0 * solver.modal_complex_neff * 0.5e-3)
 
     assert solver.modal_complex_neff == pytest.approx(expected, rel=1e-3)
     assert np.real(solver.modal_complex_neff) > 0
     assert np.imag(solver.modal_complex_neff) < 0
     assert abs(forward_factor) < 1
+    assert solver.modal_power_valid
+    assert solver.modal_forward_power_metric > solver.FORWARD_POWER_METRIC_TOLERANCE
+    assert np.real(solver.modal_raw_power) > 0
     assert solver.modal_power == pytest.approx(1.0, rel=1e-12)
     np.testing.assert_allclose(
         np.square(1j * solver.complex_neff),
@@ -79,6 +80,114 @@ def test_lossy_pec_waveguide_mode_uses_same_passive_branch_for_neff_and_h():
         rtol=1e-12,
         atol=1e-12,
     )
+
+
+def test_backward_wave_uses_passive_forward_power_branch():
+    nu, nv = 8, 6
+    spacing = 5e-3
+    frequency = 5e9
+    material = -2 - 0.05j
+    eps_uu = np.full((nu, nv + 1), material)
+    eps_vv = np.full((nu + 1, nv), material)
+    eps_ww = np.full((nu + 1, nv + 1), material)
+    mu_uu = np.full((nu + 1, nv), material)
+    mu_vv = np.full((nu, nv + 1), material)
+    mu_ww = np.full((nu, nv), material)
+    pec_u = np.zeros_like(eps_uu, dtype=bool)
+    pec_v = np.zeros_like(eps_vv, dtype=bool)
+    pec_w = np.zeros_like(eps_ww, dtype=bool)
+    pec_u[:, [0, -1]] = True
+    pec_v[[0, -1], :] = True
+    pec_w[[0, -1], :] = True
+    pec_w[:, [0, -1]] = True
+    solver = FDFD_2D_mode_solver(
+        frequency=frequency,
+        du=spacing,
+        dv=spacing,
+        mode_index=0,
+        eps_r_uu=eps_uu,
+        eps_r_vv=eps_vv,
+        eps_r_ww=eps_ww,
+        mu_r_uu=mu_uu,
+        mu_r_vv=mu_vv,
+        mu_r_ww=mu_ww,
+        pec_u_mask=pec_u,
+        pec_v_mask=pec_v,
+        pec_w_mask=pec_w,
+    )
+
+    solver.solve()
+
+    forward_factor = np.exp(-1j * solver.k0 * solver.modal_complex_neff * 0.5e-3)
+    assert np.real(solver.modal_complex_neff) < 0
+    assert np.imag(solver.modal_complex_neff) < 0
+    assert abs(forward_factor) < 1
+    assert solver.modal_power_valid
+    assert solver.modal_forward_power_metric > solver.FORWARD_POWER_METRIC_TOLERANCE
+    assert np.real(solver.modal_raw_power) > 0
+    assert solver.modal_power == pytest.approx(1.0, rel=1e-12)
+    np.testing.assert_allclose(
+        np.square(1j * solver.complex_neff),
+        solver.eigenvalues,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+
+
+def test_below_cutoff_mode_is_kept_with_finite_balanced_normalization():
+    nu, nv = 12, 8
+    spacing = 1e-3
+    frequency = 10e9
+    eps_uu = np.ones((nu, nv + 1))
+    eps_vv = np.ones((nu + 1, nv))
+    eps_ww = np.ones((nu + 1, nv + 1))
+    mu_uu = np.ones((nu + 1, nv))
+    mu_vv = np.ones((nu, nv + 1))
+    mu_ww = np.ones((nu, nv))
+    pec_u = np.zeros_like(eps_uu, dtype=bool)
+    pec_v = np.zeros_like(eps_vv, dtype=bool)
+    pec_w = np.zeros_like(eps_ww, dtype=bool)
+    pec_u[:, [0, -1]] = True
+    pec_v[[0, -1], :] = True
+    pec_w[[0, -1], :] = True
+    pec_w[:, [0, -1]] = True
+    cutoff = config.sim_config.em_consts["c"] / (2 * nu * spacing)
+    expected_neff = -1j * np.sqrt((cutoff / frequency) ** 2 - 1)
+    solver = FDFD_2D_mode_solver(
+        frequency=frequency,
+        du=spacing,
+        dv=spacing,
+        mode_index=0,
+        eps_r_uu=eps_uu,
+        eps_r_vv=eps_vv,
+        eps_r_ww=eps_ww,
+        mu_r_uu=mu_uu,
+        mu_r_vv=mu_vv,
+        mu_r_ww=mu_ww,
+        pec_u_mask=pec_u,
+        pec_v_mask=pec_v,
+        pec_w_mask=pec_w,
+        guess=-(expected_neff**2),
+    )
+
+    solver.solve()
+
+    assert solver.modal_complex_neff.real == 0
+    assert solver.modal_complex_neff.imag < 0
+    assert not solver.modal_power_valid
+    assert abs(solver.modal_forward_power_metric) < solver.FORWARD_POWER_METRIC_TOLERANCE
+    assert abs(solver.modal_raw_power.imag) > abs(solver.modal_raw_power.real)
+    assert solver._calculate_mode_balanced_power(0) == pytest.approx(1.0, rel=1e-12)
+    assert solver.modal_power == pytest.approx(solver.modal_forward_power_metric, abs=1e-14)
+    for field in (
+        solver.modal_Eu,
+        solver.modal_Ev,
+        solver.modal_Ew,
+        solver.modal_Hu,
+        solver.modal_Hv,
+        solver.modal_Hw,
+    ):
+        assert np.all(np.isfinite(field))
 
 
 def test_rectangular_te10_enforces_pec_normal_h_and_wave_impedance():
@@ -102,9 +211,7 @@ def test_rectangular_te10_enforces_pec_normal_h_and_wave_impedance():
     pec_w[:, [0, -1]] = True
 
     width = nu * spacing
-    expected_neff = np.sqrt(
-        1 - (config.sim_config.em_consts['c'] / (2 * width * frequency)) ** 2
-    )
+    expected_neff = np.sqrt(1 - (config.sim_config.em_consts["c"] / (2 * width * frequency)) ** 2)
     solver = FDFD_2D_mode_solver(
         frequency=frequency,
         du=spacing,
@@ -158,9 +265,7 @@ def test_rectangular_pmc_tm10_enforces_normal_e_and_matches_theory():
     # Transverse PMC samples lie at cell centres, so their plane separation
     # is one cell smaller than the corresponding array extent.
     width = (nu - 1) * spacing
-    expected_neff = np.sqrt(
-        1 - (config.sim_config.em_consts['c'] / (2 * width * frequency)) ** 2
-    )
+    expected_neff = np.sqrt(1 - (config.sim_config.em_consts["c"] / (2 * width * frequency)) ** 2)
     solver = FDFD_2D_mode_solver(
         frequency=frequency,
         du=spacing,

--- a/tests/test_eigenmode_anchor_policy.py
+++ b/tests/test_eigenmode_anchor_policy.py
@@ -1,0 +1,247 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import gprMax.config as config
+import gprMax.sources as sources_module
+from gprMax.sources import EigenmodeSource
+
+FREQUENCIES = (32e9, 45e9, 55e9, 65e9, 78e9)
+
+
+def _fields(vector):
+    values = np.asarray(vector, dtype=np.complex128)
+    zero = np.zeros_like(values)
+    return [values, zero.copy(), zero.copy()], [
+        zero.copy(),
+        zero.copy(),
+        zero.copy(),
+    ]
+
+
+class _FakeSolver:
+    def __init__(self, vectors, power_valid):
+        self.num_modes = len(vectors)
+        self.power_valid = np.asarray(power_valid, dtype=bool)
+        self.complex_neff = np.asarray(
+            [0.5 if valid else -0.5j for valid in self.power_valid],
+            dtype=np.complex128,
+        )
+        self.raw_powers = np.asarray(
+            [1.0 if valid else 1.0j for valid in self.power_valid],
+            dtype=np.complex128,
+        )
+        self.forward_power_metrics = np.asarray(
+            [1.0 if valid else 0.0 for valid in self.power_valid],
+            dtype=np.float64,
+        )
+        self.fields = [
+            (*_fields(vector), self.complex_neff[index]) for index, vector in enumerate(vectors)
+        ]
+
+
+def _solvers(vectors, power_valid):
+    return tuple(
+        _FakeSolver(frequency_vectors, frequency_valid)
+        for frequency_vectors, frequency_valid in zip(vectors, power_valid)
+    )
+
+
+def _source(monkeypatch, *, automatic=True):
+    monkeypatch.setattr(
+        config,
+        "sim_config",
+        SimpleNamespace(
+            em_consts={"z0": 376.730313668, "c": 299792458.0},
+            dtypes={"float_or_double": np.float64},
+        ),
+    )
+    source = EigenmodeSource(None)
+    source.port_index = 1
+    source.mode_index = 1
+    source.mode_count = 2
+    source.mode_indices = (1, 2)
+    source.dft_start = 45e9
+    source.dft_stop = 65e9
+    source.fallback_frequency = 55e9
+    source.requested_anchor_policy = "auto" if automatic else "explicit"
+    source.anchor_policy = source.requested_anchor_policy
+    source._fields_from_solver_mode = lambda solver, mode_index: solver.fields[mode_index - 1]
+    return source
+
+
+def test_tracked_nonpropagating_guard_is_excluded_per_mode(monkeypatch):
+    source = _source(monkeypatch)
+    vectors = [((1, 0), (0, 1))] * len(FREQUENCIES)
+    solvers = _solvers(
+        vectors,
+        [
+            (False, True),
+            (True, True),
+            (True, True),
+            (True, True),
+            (True, True),
+        ],
+    )
+    warnings = []
+    monkeypatch.setattr(sources_module.logger, "warning", warnings.append)
+
+    valid, policies = source._prepare_port_anchor_bank(
+        FREQUENCIES,
+        solvers,
+        (1, 2),
+    )
+
+    assert valid[:, 0].tolist() == [False, True, True, True, True]
+    assert valid[:, 1].tolist() == [True, True, True, True, True]
+    assert source.port_anchor_mode_propagating.tolist() == valid.tolist()
+    assert policies == (
+        "auto_broadband_nonpropagating_trimmed",
+        "auto_broadband",
+    )
+    assert any("mode 1" in warning and "non-propagating anchor" in warning for warning in warnings)
+
+
+def test_in_band_tracking_failure_falls_back_only_the_affected_mode(monkeypatch):
+    source = _source(monkeypatch)
+    vectors = [
+        ((1, 0), (0, 1)),
+        ((1, 0), (0, 1)),
+        ((1, 0), (1, 0)),
+        ((1, 0), (0, 1)),
+        ((1, 0), (0, 1)),
+    ]
+    solvers = _solvers(vectors, [(True, True)] * len(FREQUENCIES))
+    warnings = []
+    monkeypatch.setattr(sources_module.logger, "warning", warnings.append)
+
+    valid, policies = source._prepare_port_anchor_bank(
+        FREQUENCIES,
+        solvers,
+        (1, 2),
+    )
+
+    assert valid[:, 0].tolist() == [True, True, True, True, True]
+    assert valid[:, 1].tolist() == [False, False, True, False, False]
+    assert policies == ("auto_broadband", "auto_single_fallback")
+    assert any(
+        "mode 2" in warning and "only the centre-frequency anchor" in warning
+        for warning in warnings
+    )
+
+
+def test_nonpropagating_centre_after_in_band_tracking_failure_raises(monkeypatch):
+    source = _source(monkeypatch)
+    vectors = [
+        ((1, 0), (0, 1)),
+        ((1, 0), (0, 1)),
+        ((1, 0), (1, 0)),
+        ((1, 0), (0, 1)),
+        ((1, 0), (0, 1)),
+    ]
+    power_valid = [(True, True)] * len(FREQUENCIES)
+    power_valid[2] = (True, False)
+    solvers = _solvers(vectors, power_valid)
+
+    with pytest.raises(
+        ValueError,
+        match=r"mode 2 centre-frequency anchor.*non-propagating",
+    ):
+        source._prepare_port_anchor_bank(FREQUENCIES, solvers, (1, 2))
+
+
+def test_guard_tracking_failure_is_trimmed_before_centre_fallback(monkeypatch):
+    source = _source(monkeypatch)
+    vectors = [
+        ((1, 0), (1, 0)),
+        ((1, 0), (0, 1)),
+        ((1, 0), (0, 1)),
+        ((1, 0), (0, 1)),
+        ((1, 0), (0, 1)),
+    ]
+    solvers = _solvers(vectors, [(True, True)] * len(FREQUENCIES))
+    warnings = []
+    monkeypatch.setattr(sources_module.logger, "warning", warnings.append)
+
+    valid, policies = source._prepare_port_anchor_bank(
+        FREQUENCIES,
+        solvers,
+        (1, 2),
+    )
+
+    assert valid[:, 0].tolist() == [True, True, True, True, True]
+    assert valid[:, 1].tolist() == [False, True, True, True, True]
+    assert policies == ("auto_broadband", "auto_broadband_guard_trimmed")
+    assert any("mode 2" in warning and "lower spectral guard" in warning for warning in warnings)
+    assert not any("only the centre-frequency anchor" in warning for warning in warnings)
+
+
+def test_disconnected_propagating_anchors_fall_back_only_for_auto(monkeypatch):
+    vectors = [((1, 0), (0, 1))] * len(FREQUENCIES)
+    power_valid = [
+        (True, True),
+        (False, True),
+        (True, True),
+        (True, True),
+        (True, True),
+    ]
+    solvers = _solvers(vectors, power_valid)
+    automatic = _source(monkeypatch)
+
+    valid, policies = automatic._prepare_port_anchor_bank(
+        FREQUENCIES,
+        solvers,
+        (1, 2),
+    )
+
+    assert valid[:, 0].tolist() == [False, False, True, False, False]
+    assert valid[:, 1].tolist() == [True, True, True, True, True]
+    assert policies == ("auto_single_fallback", "auto_broadband")
+
+    explicit = _source(monkeypatch, automatic=False)
+    with pytest.raises(ValueError, match="disconnected propagating anchor ranges"):
+        explicit._prepare_port_anchor_bank(FREQUENCIES, solvers, (1, 2))
+
+
+def test_active_excitation_uses_only_its_propagating_anchor_subset(monkeypatch):
+    source = _source(monkeypatch)
+    vectors = [((1, 0), (0, 1))] * len(FREQUENCIES)
+    solvers = _solvers(
+        vectors,
+        [
+            (False, True),
+            (True, True),
+            (True, True),
+            (True, True),
+            (True, True),
+        ],
+    )
+    by_frequency = dict(zip(FREQUENCIES, solvers))
+    source.frequencies = FREQUENCIES
+    source._extract_frequency_dependent_materials = lambda grid: None
+    source._solve_eigenmode = lambda grid: setattr(
+        source,
+        "mode_solver",
+        by_frequency[source.frequency],
+    )
+    prepared = []
+    source._prepare_broadband_time_traces = lambda grid, frequencies: prepared.append(
+        tuple(frequencies)
+    )
+
+    source._solve_broadband_eigenmode(SimpleNamespace(), FREQUENCIES)
+
+    expected = FREQUENCIES[1:]
+    assert source.port_anchor_frequencies == FREQUENCIES
+    assert source.port_anchor_mode_valid[:, 0].tolist() == [
+        False,
+        True,
+        True,
+        True,
+        True,
+    ]
+    assert source.frequencies == expected
+    assert len(source.anchor_modal_e) == len(expected)
+    assert len(source.mode_solvers) == len(expected)
+    assert prepared == [expected]

--- a/tests/test_eigenmode_auto_guard_failure.py
+++ b/tests/test_eigenmode_auto_guard_failure.py
@@ -1,0 +1,110 @@
+import csv
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+import gprMax.sources as sources_module
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_automatic_guard_below_cutoff_does_not_corrupt_through_s21(
+    tmp_path,
+    monkeypatch,
+):
+    """Exercise the reported rectangular-waveguide automatic-guard failure."""
+
+    source = Path(__file__).with_name("eigenmode_auto_guard_failure.in")
+    inputfile = tmp_path / source.name
+    input_text = source.read_text(encoding="utf-8")
+    inputfile.write_text(input_text, encoding="utf-8")
+    outputfile = tmp_path / "auto_guard_failure"
+    warnings = []
+    monkeypatch.setattr(sources_module.logger, "warning", warnings.append)
+
+    gprMax.run(
+        inputfile=inputfile,
+        n=1,
+        outputfile=outputfile,
+        hide_progress_bars=True,
+    )
+
+    with h5py.File(outputfile.with_suffix(".h5"), "r") as output:
+        source_port = output["eigenmode_ports/port1"]
+        assert source_port.attrs["RequestedAnchorPolicy"] == "auto"
+        resolved_anchors = np.asarray(source_port.attrs["AnchorFrequencies"])
+        candidate_anchors = np.asarray(source_port.attrs["CandidateAnchorFrequencies"])
+        usable = source_port["anchor_mode_valid"][...][:, 0].astype(bool)
+        reported_guard = np.isclose(candidate_anchors, 22.660393e9, rtol=1e-6)
+        assert np.any(reported_guard)
+        assert not np.any(usable[reported_guard])
+        assert not np.any((candidate_anchors < 24.9827048e9) & usable)
+        assert np.all(source_port["power_normalization_valid"][...])
+        source_signature = {
+            "resolved_policy": source_port.attrs["ResolvedAnchorPolicy"],
+            "resolved_anchors": resolved_anchors.copy(),
+            "candidate_anchors": candidate_anchors.copy(),
+            "mode_policies": np.asarray(source_port.attrs["ModeAnchorPolicies"]).copy(),
+            "valid": source_port["anchor_mode_valid"][...].copy(),
+            "propagating": source_port["anchor_mode_propagating"][...].copy(),
+        }
+
+    passive_input = tmp_path / "auto_guard_with_passive_plane.in"
+    passive_input.write_text(
+        input_text.replace(
+            "#eigenmode_excitation:",
+            "#eigenmode_port: 3 0.006 0.001 0.001 0.006 0.007 0.005 - 1 auto n\n"
+            "#eigenmode_excitation:",
+            1,
+        ),
+        encoding="utf-8",
+    )
+    passive_output = tmp_path / "auto_guard_with_passive_plane"
+    gprMax.run(
+        inputfile=passive_input,
+        n=1,
+        outputfile=passive_output,
+        hide_progress_bars=True,
+    )
+    with h5py.File(passive_output.with_suffix(".h5"), "r") as output:
+        source_port = output["eigenmode_ports/port1"]
+        assert source_port.attrs["ResolvedAnchorPolicy"] == source_signature["resolved_policy"]
+        np.testing.assert_array_equal(
+            source_port.attrs["AnchorFrequencies"],
+            source_signature["resolved_anchors"],
+        )
+        np.testing.assert_array_equal(
+            source_port.attrs["CandidateAnchorFrequencies"],
+            source_signature["candidate_anchors"],
+        )
+        np.testing.assert_array_equal(
+            source_port.attrs["ModeAnchorPolicies"],
+            source_signature["mode_policies"],
+        )
+        np.testing.assert_array_equal(
+            source_port["anchor_mode_valid"][...],
+            source_signature["valid"],
+        )
+        np.testing.assert_array_equal(
+            source_port["anchor_mode_propagating"][...],
+            source_signature["propagating"],
+        )
+
+    csv_path = outputfile.with_name(outputfile.name + "_sparameters.csv")
+    with csv_path.open(newline="", encoding="utf-8") as stream:
+        s21 = [
+            row
+            for row in csv.DictReader(stream)
+            if row["source_port"] == "1"
+            and row["source_mode"] == "1"
+            and row["destination_port"] == "2"
+            and row["destination_mode"] == "1"
+        ]
+
+    assert len(s21) == 29
+    assert all(row["valid"] == "1" for row in s21)
+    assert max(abs(float(row["S_magnitude_db"])) for row in s21) < 0.1
+    assert any("non-propagating" in warning for warning in warnings)

--- a/tests/test_eigenmode_config.py
+++ b/tests/test_eigenmode_config.py
@@ -5,16 +5,12 @@ import pytest
 
 import gprMax.sources as sources_module
 from gprMax.eigenmode_config import (
-    EigenmodeBandSpec,
     EigenmodeBandpassWaveform,
+    EigenmodeBandSpec,
     EigenmodePortSpec,
     sampled_waveform_spectrum,
 )
-from gprMax.sources import (
-    EigenmodeAnchorMismatchError,
-    EigenmodeSource,
-    initialise_eigenmode_ports,
-)
+from gprMax.sources import EigenmodeAnchorMismatchError, EigenmodeSource, initialise_eigenmode_ports
 from gprMax.waveforms import Waveform
 
 
@@ -22,7 +18,7 @@ def test_automatic_bandpass_tracks_requested_band_and_avoids_dc_nyquist():
     dt = 0.2e-12
     sample_count = 2048
     waveform = EigenmodeBandpassWaveform(
-        band_id='wg',
+        band_id="wg",
         fmin=45e9,
         fmax=65e9,
         amplitude=1.0,
@@ -50,13 +46,13 @@ def test_automatic_bandpass_tracks_requested_band_and_avoids_dc_nyquist():
 
 def test_bad_custom_waveform_recommends_automatic_bandpass():
     waveform = Waveform()
-    waveform.type = 'gaussiandot'
+    waveform.type = "gaussiandot"
     waveform.amp = 1.0
     waveform.freq = 55e9
     grid = SimpleNamespace(dt=0.2e-12, iterations=2048)
-    band = EigenmodeBandSpec(id='wg', fmin=45e9, fmax=65e9, points=81)
+    band = EigenmodeBandSpec(id="wg", fmin=45e9, fmax=65e9, points=81)
 
-    with pytest.raises(ValueError, match='waveform=\'auto\''):
+    with pytest.raises(ValueError, match="waveform='auto'"):
         band.resolve_spectrum(grid, waveform, generated_waveform=False)
 
 
@@ -65,8 +61,8 @@ def _port(port, anchors):
         port=port,
         p1=(0.0, 0.0, 0.0),
         p2=(0.0, 1.0, 1.0),
-        normal='x',
-        direction='+',
+        normal="x",
+        direction="+",
         normal_axis=0,
         transverse_axes=(1, 2),
         invariant_axis=None,
@@ -77,10 +73,10 @@ def _port(port, anchors):
 
 
 def test_all_auto_ports_cover_the_same_significant_spectrum():
-    band = EigenmodeBandSpec(id='wg', fmin=45e9, fmax=65e9, points=81)
+    band = EigenmodeBandSpec(id="wg", fmin=45e9, fmax=65e9, points=81)
     band.significant_range = (32e9, 78e9)
-    source = _port(1, 'auto')
-    receiver = _port(2, 'auto')
+    source = _port(1, "auto")
+    receiver = _port(2, "auto")
 
     source.resolve_anchors(band, is_source=True)
     receiver.resolve_anchors(band, is_source=False)
@@ -91,10 +87,10 @@ def test_all_auto_ports_cover_the_same_significant_spectrum():
 
 
 def test_explicit_multiple_anchors_require_coverage_but_single_is_allowed():
-    band = EigenmodeBandSpec(id='wg', fmin=45e9, fmax=65e9, points=81)
+    band = EigenmodeBandSpec(id="wg", fmin=45e9, fmax=65e9, points=81)
     band.significant_range = (32e9, 78e9)
 
-    with pytest.raises(ValueError, match='Suggested coverage anchors'):
+    with pytest.raises(ValueError, match="Suggested coverage anchors"):
         _port(1, (45e9, 55e9, 65e9)).resolve_anchors(band, is_source=True)
 
     single = _port(1, (55e9,))
@@ -106,69 +102,93 @@ def test_auto_anchor_mode_mismatch_falls_back_to_band_centre(monkeypatch):
     source = EigenmodeSource(None)
     source.plane_index = 1
     source.port_index = 3
+    source.mode_index = 1
+    source.mode_count = 1
+    source.mode_indices = (1,)
     source.frequency = 45e9
     source.frequencies = (45e9, 55e9, 65e9)
-    source.anchor_policy = 'auto'
+    source.anchor_policy = "auto"
     source.fallback_frequency = 55e9
     calls = []
 
     def fail_broadband(grid, frequencies):
-        raise EigenmodeAnchorMismatchError('mode mismatch')
+        raise EigenmodeAnchorMismatchError("mode mismatch")
 
     source._solve_broadband_eigenmode = fail_broadband
-    source._extract_frequency_dependent_materials = lambda grid: calls.append('extract')
-    source._solve_eigenmode = lambda grid: calls.append('solve')
-    source._prepare_single_frequency_injection = lambda grid: calls.append('prepare')
-    source._register_port_monitor = lambda grid: calls.append('monitor')
+    source._extract_frequency_dependent_materials = lambda grid: calls.append("extract")
+    field = np.ones(2, dtype=np.complex128)
+    zero = np.zeros_like(field)
+    solver = SimpleNamespace(
+        num_modes=1,
+        power_valid=np.asarray([True]),
+        complex_neff=np.asarray([1.0 + 0.0j]),
+        raw_powers=np.asarray([1.0 + 0.0j]),
+        forward_power_metrics=np.asarray([1.0]),
+        fields=[([field, zero, zero], [zero, zero, zero], 1.0 + 0.0j)],
+    )
+
+    def solve(grid):
+        calls.append("solve")
+        source.mode_solver = solver
+
+    source._solve_eigenmode = solve
+    source._fields_from_solver_mode = lambda solved, mode_index: solved.fields[mode_index - 1]
+    source._prepare_single_frequency_injection = lambda grid: calls.append("prepare")
+    source._register_port_monitor = lambda grid: calls.append("monitor")
     warnings = []
-    monkeypatch.setattr(sources_module.logger, 'warning', warnings.append)
+    monkeypatch.setattr(sources_module.logger, "warning", warnings.append)
 
     source.grid_init(SimpleNamespace())
 
     assert source.frequencies == (55e9,)
-    assert calls == ['extract', 'solve', 'prepare', 'monitor']
-    assert 'may be inaccurate toward frequencies far from this anchor' in warnings[0]
+    assert calls == ["extract", "solve", "prepare", "monitor"]
+    assert "may be inaccurate toward frequencies far from this anchor" in warnings[0]
 
 
 def test_explicit_anchor_mode_mismatch_remains_an_error():
     with pytest.raises(
         EigenmodeAnchorMismatchError,
-        match='single explicit frequency anchor',
+        match="single explicit frequency anchor",
     ):
         EigenmodeSource._check_anchor_overlap(
             0.2,
             45e9,
             65e9,
             1,
-            'Eigenmode port 1',
+            "Eigenmode port 1",
         )
 
 
 class _CoordinatedPort:
-    def __init__(self, port, frequencies, failure=None):
+    def __init__(self, port, frequencies, failure=None, *, centre_nonpropagating=False):
         self.port_index = port
         self.frequency = frequencies[0]
         self.frequencies = frequencies
-        self.anchor_policy = 'auto'
-        self.requested_anchor_policy = 'auto'
-        self.resolved_anchor_policy = 'auto'
+        self.anchor_policy = "auto"
+        self.requested_anchor_policy = "auto"
+        self.resolved_anchor_policy = "auto"
         self.fallback_frequency = 55e9
-        self.spectrum_coverage_policy = 'error'
+        self.spectrum_coverage_policy = "error"
         self.port_monitor = None
         self.failure = failure
+        self.centre_nonpropagating = centre_nonpropagating
         self.attempts = []
 
     def grid_init(self, grid):
         frequencies = tuple(self.frequencies)
         self.attempts.append(frequencies)
+        if self.centre_nonpropagating and frequencies == (self.fallback_frequency,):
+            raise ValueError(
+                f"Eigenmode port {self.port_index} centre-frequency anchor " "is non-propagating"
+            )
         if self.failure is not None and self.failure(frequencies):
             raise EigenmodeAnchorMismatchError(
-                'test tracking failure',
+                "test tracking failure",
                 first_frequency=self.failure.first,
                 second_frequency=self.failure.second,
                 mode_index=2,
                 overlap=0.2,
-                context=f'Eigenmode port {self.port_index}',
+                context=f"Eigenmode port {self.port_index}",
             )
         grid.eigenmodeports.append(self)
 
@@ -179,7 +199,7 @@ def _failure(first, second, predicate):
     return predicate
 
 
-def test_guard_band_tracking_failure_trims_all_auto_ports(monkeypatch):
+def test_guard_band_tracking_failure_trims_only_the_affected_auto_port(monkeypatch):
     anchors = (32e9, 45e9, 55e9, 65e9, 78e9)
     failure = _failure(32e9, 45e9, lambda values: values[0] == 32e9)
     source = _CoordinatedPort(1, anchors, failure)
@@ -189,7 +209,7 @@ def test_guard_band_tracking_failure_trims_all_auto_ports(monkeypatch):
         eigenmodereceivers=[receiver],
         eigenmodeports=[],
         eigenmodeband=EigenmodeBandSpec(
-            id='wg',
+            id="wg",
             fmin=45e9,
             fmax=65e9,
             points=81,
@@ -197,20 +217,21 @@ def test_guard_band_tracking_failure_trims_all_auto_ports(monkeypatch):
         ),
     )
     warnings = []
-    monkeypatch.setattr(sources_module.logger, 'warning', warnings.append)
+    monkeypatch.setattr(sources_module.logger, "warning", warnings.append)
 
     initialise_eigenmode_ports(grid)
 
-    expected = (45e9, 55e9, 65e9, 78e9)
-    assert source.frequencies == expected
-    assert receiver.frequencies == expected
-    assert source.spectrum_coverage_policy == 'allow'
-    assert source.resolved_anchor_policy == 'auto_broadband_guard_trimmed'
-    assert receiver.resolved_anchor_policy == 'auto_broadband_guard_trimmed'
-    assert 'endpoint modal profile' in warnings[0]
+    assert source.frequencies == (45e9, 55e9, 65e9, 78e9)
+    assert receiver.frequencies == anchors
+    assert source.spectrum_coverage_policy == "allow"
+    assert source.resolved_anchor_policy == "auto_broadband_guard_trimmed"
+    assert receiver.resolved_anchor_policy == "auto_broadband"
+    assert source.attempts == [anchors, (45e9, 55e9, 65e9, 78e9)]
+    assert receiver.attempts == [anchors]
+    assert "endpoint modal profile" in warnings[0]
 
 
-def test_in_band_tracking_failure_falls_back_all_auto_ports(monkeypatch):
+def test_passive_in_band_tracking_failure_does_not_mutate_source(monkeypatch):
     anchors = (32e9, 45e9, 55e9, 65e9, 78e9)
     failure = _failure(45e9, 55e9, lambda values: len(values) > 1)
     source = _CoordinatedPort(1, anchors)
@@ -220,7 +241,7 @@ def test_in_band_tracking_failure_falls_back_all_auto_ports(monkeypatch):
         eigenmodereceivers=[receiver],
         eigenmodeports=[],
         eigenmodeband=EigenmodeBandSpec(
-            id='wg',
+            id="wg",
             fmin=45e9,
             fmax=65e9,
             points=81,
@@ -228,12 +249,47 @@ def test_in_band_tracking_failure_falls_back_all_auto_ports(monkeypatch):
         ),
     )
     warnings = []
-    monkeypatch.setattr(sources_module.logger, 'warning', warnings.append)
+    monkeypatch.setattr(sources_module.logger, "warning", warnings.append)
 
     initialise_eigenmode_ports(grid)
 
-    assert source.frequencies == (55e9,)
+    assert source.frequencies == anchors
     assert receiver.frequencies == (55e9,)
-    assert source.resolved_anchor_policy == 'auto_single_fallback'
-    assert receiver.resolved_anchor_policy == 'auto_single_fallback'
-    assert 'All automatic eigenmode ports' in warnings[0]
+    assert source.resolved_anchor_policy == "auto_broadband"
+    assert receiver.resolved_anchor_policy == "auto_single_fallback"
+    assert source.attempts == [anchors]
+    assert receiver.attempts == [anchors, (55e9,)]
+    assert "eigenmode port 2" in warnings[0]
+
+
+def test_nonpropagating_centre_anchor_after_tracking_fallback_is_an_error(
+    monkeypatch,
+):
+    anchors = (32e9, 45e9, 55e9, 65e9, 78e9)
+    failure = _failure(45e9, 55e9, lambda values: len(values) > 1)
+    source = _CoordinatedPort(
+        1,
+        anchors,
+        failure,
+        centre_nonpropagating=True,
+    )
+    receiver = _CoordinatedPort(2, anchors)
+    grid = SimpleNamespace(
+        eigenmodesources=[source],
+        eigenmodereceivers=[receiver],
+        eigenmodeports=[],
+        eigenmodeband=EigenmodeBandSpec(
+            id="wg",
+            fmin=45e9,
+            fmax=65e9,
+            points=81,
+            significant_range=(32e9, 78e9),
+        ),
+    )
+    monkeypatch.setattr(sources_module.logger, "warning", lambda message: None)
+
+    with pytest.raises(ValueError, match="centre-frequency anchor.*non-propagating"):
+        initialise_eigenmode_ports(grid)
+
+    assert source.attempts == [anchors, (55e9,)]
+    assert receiver.attempts == []

--- a/tests/test_eigenmode_ports.py
+++ b/tests/test_eigenmode_ports.py
@@ -12,6 +12,7 @@ from gprMax.eigenmode_ports import (
     accumulate_eigenmode_dft,
     finalise_eigenmode_ports,
 )
+from gprMax.sources import EigenmodeSource
 
 
 @pytest.mark.parametrize(
@@ -153,6 +154,69 @@ def test_complex64_eigenmode_phase_drift_is_bounded_by_periodic_reanchoring(
     assert monitor.magnetic_phase.dtype == np.complex64
     assert max(errors.values()) < 2e-5
     assert errors[DFT_PHASE_REANCHOR_INTERVAL] < 2e-7
+
+
+def test_2d_te_monitor_preserves_absolute_power_after_cell_averaging(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "sim_config",
+        SimpleNamespace(
+            dtypes={
+                "float_or_double": np.float64,
+                "complex": np.complex128,
+            }
+        ),
+    )
+    owner = EigenmodeSource(None)
+    owner.normal_axis = 0
+    owner.transverse_axes = (1, 2)
+    owner.invariant_axis = 2
+    owner.physical_transverse_axis = 1
+    owner.domain_polarization = "TE"
+    owner.transverse_start = np.zeros(2, dtype=np.int32)
+    owner.transverse_stop = np.asarray((2, 2), dtype=np.int32)
+
+    electric = [
+        np.zeros((3, 3), dtype=np.complex128),
+        np.zeros((2, 3), dtype=np.complex128),
+        np.zeros((3, 2), dtype=np.complex128),
+    ]
+    magnetic = [
+        np.zeros((2, 2), dtype=np.complex128),
+        np.zeros((3, 2), dtype=np.complex128),
+        np.zeros((2, 3), dtype=np.complex128),
+    ]
+    electric[1][:, 1] = 1.0
+    magnetic[2][:, 1] = 1.0
+    grid = SimpleNamespace(
+        dt=1e-12,
+        dl=np.ones(3),
+        eigenmodeports=[],
+    )
+    assert owner._modal_cross_power(electric, magnetic, grid) == pytest.approx(1.0)
+
+    monitor = EigenmodePortMonitor(
+        owner=owner,
+        port_index=1,
+        port_id="te",
+        is_source=False,
+        excitation_mode_index=None,
+        mode_indices=(1,),
+        anchor_frequencies=np.asarray([1e9]),
+        anchor_e=[[electric]],
+        anchor_h=[[magnetic]],
+        anchor_neff=np.asarray([[1.0]]),
+        dft_start=1e9,
+        dft_stop=1e9,
+        dft_points=1,
+    )
+
+    monitor.prepare(grid)
+
+    assert monitor.measure == pytest.approx(2.0)
+    assert monitor.electric_gram[0, 0, 0] == pytest.approx(1.0)
+    assert monitor.magnetic_gram[0, 0, 0] == pytest.approx(1.0)
+    assert monitor.power_matrix[0, 0, 0] == pytest.approx(1.0)
 
 
 def test_multimode_gram_solve_separates_incident_and_outgoing_waves(monkeypatch):

--- a/tests/test_eigenmode_ports.py
+++ b/tests/test_eigenmode_ports.py
@@ -219,6 +219,102 @@ def test_2d_te_monitor_preserves_absolute_power_after_cell_averaging(monkeypatch
     assert monitor.power_matrix[0, 0, 0] == pytest.approx(1.0)
 
 
+def test_monitor_excludes_nonpropagating_anchor_and_invalidates_its_tail(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        config,
+        "sim_config",
+        SimpleNamespace(
+            dtypes={
+                "float_or_double": np.float64,
+                "complex": np.complex128,
+            }
+        ),
+    )
+    owner = SimpleNamespace(
+        transverse_axes=(1, 2),
+        invariant_axis=None,
+        normal_axis=0,
+        direction="+",
+        _linear_anchor_weights=EigenmodeSource._linear_anchor_weights,
+        _transverse_cell_shape=lambda: (1, 1),
+        _modal_cross_power=lambda electric, magnetic, grid: 1.0,
+        _average_to_transverse_cells=lambda values, component: values,
+        _modal_basis_handedness=lambda: 1,
+    )
+    zero = np.zeros((1, 1), dtype=np.complex128)
+
+    def modal_fields(value):
+        field = np.full((1, 1), value, dtype=np.complex128)
+        return [zero, field, zero], [zero, zero, field]
+
+    first_mode = [modal_fields(value) for value in (99, 2, 3)]
+    second_mode = [modal_fields(value) for value in (4, 5, 88)]
+    monitor = EigenmodePortMonitor(
+        owner=owner,
+        port_index=1,
+        port_id="cutoff",
+        is_source=False,
+        excitation_mode_index=None,
+        mode_indices=(1, 2),
+        anchor_frequencies=np.asarray([22e9, 28e9, 34e9]),
+        anchor_e=[[first_mode[index][0], second_mode[index][0]] for index in range(3)],
+        anchor_h=[[first_mode[index][1], second_mode[index][1]] for index in range(3)],
+        anchor_neff=np.asarray([[-0.5j, 0.2], [0.4, 0.4], [0.7, -0.3j]]),
+        anchor_mode_valid=np.asarray([[False, True], [True, True], [True, False]]),
+        anchor_mode_propagating=np.asarray([[False, True], [True, True], [True, False]]),
+        mode_anchor_policies=(
+            "auto_nonpropagating_trimmed",
+            "auto_nonpropagating_trimmed",
+        ),
+        dft_start=22e9,
+        dft_stop=34e9,
+        dft_points=3,
+    )
+    grid = SimpleNamespace(
+        dt=1e-12,
+        dl=np.ones(3),
+        eigenmodeports=[],
+    )
+
+    monitor.prepare(grid)
+
+    # Endpoint extrapolation below cutoff must use the first propagating
+    # profile, never the finite-normalized evanescent profile with value 99.
+    assert monitor.eu[:, 0, 0, 0] == pytest.approx([2, 2, 3])
+    assert monitor.eu[:, 1, 0, 0] == pytest.approx([4, 5, 5])
+    assert monitor.mode_power_valid.tolist() == [
+        [False, True],
+        [True, True],
+        [True, False],
+    ]
+
+
+def test_monitor_rejects_disconnected_usable_anchor_ranges():
+    monitor = EigenmodePortMonitor(
+        owner=SimpleNamespace(),
+        port_index=1,
+        port_id="gap",
+        is_source=False,
+        excitation_mode_index=None,
+        mode_indices=(1,),
+        anchor_frequencies=np.asarray([1e9, 2e9, 3e9]),
+        anchor_e=[None, None, None],
+        anchor_h=[None, None, None],
+        anchor_neff=np.ones((3, 1)),
+        anchor_mode_valid=np.asarray([[True], [False], [True]]),
+        anchor_mode_propagating=np.asarray([[True], [False], [True]]),
+        mode_anchor_policies=("explicit",),
+        dft_start=1e9,
+        dft_stop=3e9,
+        dft_points=3,
+    )
+
+    with pytest.raises(ValueError, match="disconnected usable anchor ranges"):
+        monitor._validate()
+
+
 def test_multimode_gram_solve_separates_incident_and_outgoing_waves(monkeypatch):
     monkeypatch.setattr(
         config,
@@ -300,6 +396,35 @@ def test_finalise_rejects_fallback_power_normalization(monkeypatch):
     assert not result.valid[0, 0]
 
 
+def test_finalise_solves_propagating_sibling_when_other_mode_is_nonpropagating(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        config,
+        "sim_config",
+        SimpleNamespace(dtypes={"complex": np.complex128}),
+    )
+    monitor = EigenmodePortMonitor.__new__(EigenmodePortMonitor)
+    gram = np.diag([0.0, 1.0]).astype(np.complex128)
+    monitor.electric_gram = gram[np.newaxis]
+    monitor.magnetic_gram = gram[np.newaxis]
+    monitor.electric_dft = np.asarray([[123.0, 2.0]], dtype=np.complex128)
+    monitor.magnetic_dft = np.asarray([[456.0, 2.0]], dtype=np.complex128)
+    monitor.frequency = np.asarray([28e9])
+    monitor.neff = np.zeros((1, 2), dtype=np.complex128)
+    monitor.mode_power_valid = np.asarray([[False, True]])
+    monitor.power_matrix_valid = np.asarray([True])
+    monitor.owner = SimpleNamespace(normal_axis=0)
+    monitor.magnetic_side = -1
+
+    result = monitor.finalise(SimpleNamespace(dl=np.zeros(3)))
+
+    assert result.incident[:, 0] == pytest.approx([0.0, 2.0])
+    assert result.outgoing[:, 0] == pytest.approx([0.0, 0.0])
+    assert result.valid[:, 0].tolist() == [False, True]
+    assert result.condition_number[0] == pytest.approx(1.0)
+
+
 def test_sparameter_csv_contains_s11_and_each_s21_mode(tmp_path, monkeypatch):
     frequency = np.asarray([5e9])
     source = SimpleNamespace(
@@ -348,7 +473,10 @@ def test_sparameter_csv_contains_s11_and_each_s21_mode(tmp_path, monkeypatch):
         rows = list(csv.DictReader(stream))
     assert "coefficient_magnitude_squared" in rows[0]
     assert "power_ratio" not in rows[0]
-    values = {(int(row["destination_port"]), int(row["destination_mode"])): float(row["S_magnitude"]) for row in rows}
+    values = {
+        (int(row["destination_port"]), int(row["destination_mode"])): float(row["S_magnitude"])
+        for row in rows
+    }
     assert values[(1, 1)] == pytest.approx(0.5)
     assert values[(1, 2)] == pytest.approx(0.25)
     assert values[(2, 1)] == pytest.approx(0.5)
@@ -356,9 +484,7 @@ def test_sparameter_csv_contains_s11_and_each_s21_mode(tmp_path, monkeypatch):
     assert {int(row["source_mode"]) for row in rows} == {2}
 
 
-def test_invalid_source_bin_does_not_invalidate_other_sparameter_bins(
-    tmp_path, monkeypatch
-):
+def test_invalid_source_bin_does_not_invalidate_other_sparameter_bins(tmp_path, monkeypatch):
     frequency = np.asarray([5e9, 6e9])
     source = SimpleNamespace(
         is_source=True,
@@ -411,9 +537,60 @@ def test_invalid_source_bin_does_not_invalidate_other_sparameter_bins(
     assert all(np.isnan(float(row["S_magnitude_db"])) for row in invalid_rows)
 
 
-def test_fallback_normalized_source_marks_every_csv_row_invalid(
-    tmp_path, monkeypatch
+def test_nonpropagating_power_wave_bin_is_invalid_but_above_cutoff_bin_is_valid(
+    tmp_path,
+    monkeypatch,
 ):
+    frequency = np.asarray([22e9, 28e9])
+    source = SimpleNamespace(
+        is_source=True,
+        port_index=1,
+        excitation_mode_index=1,
+        mode_indices=(1,),
+        result=EigenmodePortResult(
+            frequency=frequency,
+            incident=np.asarray([[2 + 0j, 2 + 0j]]),
+            outgoing=np.asarray([[0.2 + 0j, 0.2 + 0j]]),
+            valid=np.asarray([[True, True]]),
+            condition_number=np.ones(2),
+        ),
+        finalise=lambda grid: None,
+        mode_power_valid=np.asarray([[False], [True]]),
+        power_matrix_valid=np.ones(2, dtype=bool),
+    )
+    receiver = SimpleNamespace(
+        is_source=False,
+        port_index=2,
+        mode_indices=(1,),
+        result=EigenmodePortResult(
+            frequency=frequency,
+            incident=np.zeros((1, 2), dtype=np.complex128),
+            outgoing=np.asarray([[1 + 0j, 1 + 0j]]),
+            valid=np.asarray([[True, True]]),
+            condition_number=np.ones(2),
+        ),
+        finalise=lambda grid: None,
+        mode_power_valid=np.asarray([[False], [True]]),
+        power_matrix_valid=np.ones(2, dtype=bool),
+    )
+    grid = SimpleNamespace(name="main_grid", eigenmodeports=[source, receiver])
+    monkeypatch.setattr(
+        config,
+        "get_model_config",
+        lambda: SimpleNamespace(output_file_path=tmp_path / "cutoff_band"),
+    )
+
+    csv_path = finalise_eigenmode_ports(grid)
+
+    assert receiver.s_valid[0].tolist() == [False, True]
+    assert np.isnan(receiver.s_parameters[0, 0])
+    assert receiver.s_parameters[0, 1] == pytest.approx(0.5)
+    with csv_path.open(newline="", encoding="utf-8") as stream:
+        rows = [row for row in csv.DictReader(stream) if row["destination_port"] == "2"]
+    assert [row["valid"] for row in rows] == ["0", "1"]
+
+
+def test_fallback_normalized_source_marks_every_csv_row_invalid(tmp_path, monkeypatch):
     monkeypatch.setattr(
         config,
         "sim_config",

--- a/tests/test_eigenmode_source_broadband.py
+++ b/tests/test_eigenmode_source_broadband.py
@@ -5,6 +5,7 @@ import pytest
 
 import gprMax.config as config
 import gprMax.sources as sources_module
+from gprMax.fdfd_eigenmode_solver.fdfd_1d_mode_solver import FDFD_1D_mode_solver
 from gprMax.sources import EigenmodeSource
 from gprMax.waveforms import Waveform
 
@@ -334,6 +335,54 @@ def test_modal_cross_power_2d_te_uses_only_live_invariant_layer(monkeypatch):
     grid = SimpleNamespace(dl=np.asarray([0.5, 0.25, 1.0]))
 
     assert source._modal_cross_power(electric, magnetic, grid) == pytest.approx(0.375)
+
+
+@pytest.mark.parametrize("polarization", ("TM", "TE"))
+@pytest.mark.parametrize(
+    ("invariant_axis", "normal_axis"),
+    ((0, 1), (0, 2), (1, 0), (1, 2), (2, 0), (2, 1)),
+)
+def test_1d_solver_mapping_has_positive_forward_power(
+    invariant_axis,
+    normal_axis,
+    polarization,
+):
+    physical_transverse_axis = next(
+        axis for axis in range(3) if axis not in (invariant_axis, normal_axis)
+    )
+    transverse_axes = tuple(axis for axis in range(3) if axis != normal_axis)
+    source = EigenmodeSource(None)
+    source.normal_axis = normal_axis
+    source.transverse_axes = transverse_axes
+    source.invariant_axis = invariant_axis
+    source.physical_transverse_axis = physical_transverse_axis
+    source.domain_polarization = polarization
+    source.transverse_start = np.zeros(2, dtype=np.int32)
+    source.transverse_stop = np.asarray(
+        [2 if axis == physical_transverse_axis else 1 for axis in transverse_axes],
+        dtype=np.int32,
+    )
+
+    solver = object.__new__(FDFD_1D_mode_solver)
+    solver.num_modes = 1
+    solver.complex_neff = np.asarray([1.0 + 0j])
+    if polarization == "TM":
+        solver.Ea = np.ones((3, 1), dtype=np.complex128)
+        solver.Ht = -np.ones((3, 1), dtype=np.complex128)
+        solver.Hw = np.zeros((2, 1), dtype=np.complex128)
+    else:
+        solver.Et = np.ones((2, 1), dtype=np.complex128)
+        solver.Ha = np.ones((2, 1), dtype=np.complex128)
+        solver.Ew = np.zeros((3, 1), dtype=np.complex128)
+
+    electric, magnetic, _ = source._fields_from_solver_mode(solver, 1)
+    power = source._modal_cross_power(
+        electric,
+        magnetic,
+        SimpleNamespace(dl=np.ones(3)),
+    )
+
+    assert power == pytest.approx(1.0)
 
 
 def test_single_frequency_global_phase_shift_uses_real_profile(monkeypatch):

--- a/tests/test_eigenmode_source_broadband.py
+++ b/tests/test_eigenmode_source_broadband.py
@@ -157,7 +157,7 @@ def test_broadband_quality_safeguards_warn_and_continue(monkeypatch):
     source.start = 0.0
     source.normal_axis = 0
     source.spectral_threshold = 1e-3
-    source.spectrum_coverage_policy = 'warn'
+    source.spectrum_coverage_policy = "warn"
     source.anchor_complex_neff = np.ones(2, dtype=np.complex128)
     modal_fields = [
         np.ones((1, 1), dtype=np.complex128),
@@ -463,14 +463,16 @@ def test_single_frequency_phase_residual_matches_rotated_imaginary_norm(
         np.asarray([0.8 * np.exp(0.45j), 0.3 * np.exp(-0.8j)]) / impedance,
     ]
     total_energy = sum(
-        np.sum(np.abs(source.modal_e[axis]) ** 2) + np.sum(np.abs(impedance * source.modal_h[axis]) ** 2)
+        np.sum(np.abs(source.modal_e[axis]) ** 2)
+        + np.sum(np.abs(impedance * source.modal_h[axis]) ** 2)
         for axis in source.transverse_axes
     )
 
     residual = source._align_tangential_mode_for_real_injection()
 
     rotated_imaginary_energy = sum(
-        np.sum(np.imag(source.modal_e[axis]) ** 2) + np.sum(np.imag(impedance * source.modal_h[axis]) ** 2)
+        np.sum(np.imag(source.modal_e[axis]) ** 2)
+        + np.sum(np.imag(impedance * source.modal_h[axis]) ** 2)
         for axis in source.transverse_axes
     )
     independently_measured_residual = np.sqrt(rotated_imaginary_energy / total_energy)
@@ -569,7 +571,8 @@ def test_single_frequency_complex_mode_reuses_fft_quadrature(monkeypatch):
     electric_real = source.broadband_modal_e_real[0][1][1]
     electric_imag = source.broadband_modal_e_imag[0][1][1]
     actual_electric = (
-        electric_real * source.broadband_e_envelopes[0, 0] + electric_imag * source.broadband_e_envelopes[0, 1]
+        electric_real * source.broadband_e_envelopes[0, 0]
+        + electric_imag * source.broadband_e_envelopes[0, 1]
     )
     electric_field = source.anchor_modal_e[0][1][1]
     expected_electric = np.fft.irfft(electric_field * spectrum, n=padded_count)[:sample_count]
@@ -582,7 +585,8 @@ def test_single_frequency_complex_mode_reuses_fft_quadrature(monkeypatch):
     magnetic_real = source.broadband_modal_h_real[0][2][1]
     magnetic_imag = source.broadband_modal_h_imag[0][2][1]
     actual_magnetic = (
-        magnetic_real * source.broadband_h_envelopes[0, 0] + magnetic_imag * source.broadband_h_envelopes[0, 1]
+        magnetic_real * source.broadband_h_envelopes[0, 0]
+        + magnetic_imag * source.broadband_h_envelopes[0, 1]
     )
     magnetic_field = source.anchor_modal_h[0][2][1]
     expected_magnetic = np.fft.irfft(


### PR DESCRIPTION
# PR Description

This PR fixes broadband eigenmode excitation when an automatically generated guard anchor is non-propagating, while also improving eigenmode solver conventions, normalization, and numerical robustness.

The reported failure occurred in a 6 mm × 4 mm air-filled rectangular waveguide. The automatic policy generated a 22.660393 GHz lower guard anchor, below the analytical TE10 cutoff of 24.982705 GHz. The evanescent solution had essentially zero real propagating power, but roundoff in the real part of its complex Poynting flux was normalized to one watt. This greatly amplified the reactive field and corrupted broadband interpolation, producing approximately -16 to -9 dB through response instead of 0 dB.

Adding a passive eigenmode plane could also change the source anchor policy because tracking failures were handled through coordinated retries across ports.

The changes:

- Classify propagation using signed, scale-independent real Poynting power rather than `neff` alone.
- Preserve support for lossy propagating modes with complex `neff`.
- Correctly orient backward-wave branches before power normalization.
- Keep finite, balanced evanescent fields available for mode tracking without treating them as valid power-wave anchors.
- Track modes before filtering non-propagating anchors.
- Exclude non-propagating anchors per mode and emit a clear warning.
- Trim tracking failures in automatic guard regions instead of falling back to a single center anchor.
- Fall back only the affected mode when tracking fails inside the requested band.
- Raise an error when the required center-frequency fallback is itself non-propagating.
- Prevent passive receiver failures from changing the source excitation policy.
- Handle non-propagating modes independently during modal power decomposition so they do not invalidate propagating sibling modes.
- Persist candidate, usable, and propagating anchor masks in the HDF5 output.
- Improve FDFD field conventions, eigensolver edge-case handling, deterministic mode phase, and modal handedness.
- Add solver, policy, monitor, backward-wave, and exact reported-bug regression tests.
- Update the eigenmode-port documentation.

## 🛠️ Related Issue (Number)

N/A — this bug was reported directly and no matching public GitHub issue was found.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update.

## Validation

- Pre-commit hooks passed: whitespace, EOF, large-file, Black, and isort checks.
- Eigenmode regression suite: `166 passed in 152.41s`.
- The 22.660393 GHz below-cutoff anchor is now marked non-propagating and excluded.
- The five propagating anchors from 28 GHz upward are retained.
- All 29 S21 bins are valid.
- S21 ranges from `-0.00891` to `+0.00920 dB`, within the `0.01 dB` acceptance criterion.
- Adding an incidental passive plane leaves the source policy, anchors, and validity masks unchanged.
- All changed text files use LF line endings.

## Checklist

- [x] Did pre-commit pass all checks?
- [x] I have performed a self-review of my code.
- [x] I have added comments for my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no unexpected warnings; the new cutoff and fallback warnings are intentional and tested.
- [x] The title of my pull request is a short description of my changes.
