### PR TITLE
Fix OpenCL receiver, snapshot and NTFF execution

### DIFF
--- a/gprMax/ntff/device.py
+++ b/gprMax/ntff/device.py
@@ -573,11 +573,16 @@ class OpenCLKSIRCollector(_DeviceKSIRCollector):
             record.device[name] = self.clarray.zeros(self.queue, record.total, self.real_dtype)
 
     def _accumulate(self, record, field, multiplier) -> None:
+        # ``multiplier`` is complex, so its ``.real`` and ``.imag`` views
+        # normally retain the interleaved complex stride. PyCUDA accepts
+        # those strided views, but ``pyopencl.array.Array.set`` requires a
+        # C-contiguous host array (enforced by recent PyOpenCL releases).
+        # Materialise the two scalar arrays before uploading them.
         record.device["multiplier_real"].set(
-            np.asarray(multiplier.real, dtype=self.real_dtype), queue=self.queue
+            np.ascontiguousarray(multiplier.real, dtype=self.real_dtype), queue=self.queue
         )
         record.device["multiplier_imag"].set(
-            np.asarray(multiplier.imag, dtype=self.real_dtype), queue=self.queue
+            np.ascontiguousarray(multiplier.imag, dtype=self.real_dtype), queue=self.queue
         )
         self.kernel(
             self.queue,

--- a/gprMax/updates/opencl_updates.py
+++ b/gprMax/updates/opencl_updates.py
@@ -341,6 +341,19 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
             preamble=self.knl_common,
             options=config.sim_config.devices["compiler_opts"],
         )
+        if self.nrxcurrent:
+            self.store_current_outputs_dev = self.elwiseknl(
+                self.ctx,
+                knl_store_outputs.store_current_outputs["args_opencl"].substitute(
+                    {"REAL": config.sim_config.dtypes["C_float_or_double"]}
+                ),
+                knl_store_outputs.store_current_outputs["func"].substitute(
+                    {"CUDA_IDX": "", "REAL": config.sim_config.dtypes["C_float_or_double"]}
+                ),
+                "store_current_outputs",
+                preamble=self.knl_common,
+                options=config.sim_config.devices["compiler_opts"],
+            )
 
     def _set_src_knls(self):
         """Sources - initialises arrays on compute device, prepares kernel and
@@ -432,20 +445,6 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
             preamble=self.knl_common,
             options=config.sim_config.devices["compiler_opts"],
         )
-        if self.nrxcurrent:
-            self.store_current_outputs_dev = self.elwiseknl(
-                self.ctx,
-                knl_store_outputs.store_current_outputs["args_opencl"].substitute(
-                    {"REAL": config.sim_config.dtypes["C_float_or_double"]}
-                ),
-                knl_store_outputs.store_current_outputs["func"].substitute(
-                    {"CUDA_IDX": "", "REAL": config.sim_config.dtypes["C_float_or_double"]}
-                ),
-                "store_current_outputs",
-                preamble=self.knl_common,
-                options=config.sim_config.devices["compiler_opts"],
-            )
-
     def _set_snapshot_knl(self):
         """Snapshots - initialises arrays on compute device, prepares kernel and
         gets kernel function.
@@ -466,6 +465,7 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
             knl_snapshots.store_snapshot["func"].substitute(
                 {
                     "CUDA_IDX": "",
+                    "REAL": config.sim_config.dtypes["C_float_or_double"],
                     "NX_SNAPS": Snapshot.nx_max,
                     "NY_SNAPS": Snapshot.ny_max,
                     "NZ_SNAPS": Snapshot.nz_max,
@@ -491,6 +491,20 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
                 self.grid.Hy_dev,
                 self.grid.Hz_dev,
             )
+            if self.nrxcurrent:
+                real = config.sim_config.dtypes["float_or_double"]
+                self.store_current_outputs_dev(
+                    np.int32(self.nrxcurrent),
+                    np.int32(iteration),
+                    self.rxcurrentinfo_dev,
+                    self.rxcurrents_dev,
+                    real(self.grid.dx),
+                    real(self.grid.dy),
+                    real(self.grid.dz),
+                    self.grid.Hx_dev,
+                    self.grid.Hy_dev,
+                    self.grid.Hz_dev,
+                )
 
     def store_snapshots(self, iteration):
         """Stores any snapshots.

--- a/tests/ntff/test_device_collection.py
+++ b/tests/ntff/test_device_collection.py
@@ -286,8 +286,10 @@ class _FakeArray:
         self.gpudata = f"ptr:{name}"
         self.data = f"buffer:{name}"
         self.set_value = None
+        self.set_input_contiguous = None
 
     def set(self, value, **kwargs):
+        self.set_input_contiguous = np.asarray(value).flags.c_contiguous
         self.set_value = np.asarray(value).copy()
 
 
@@ -355,6 +357,8 @@ def test_opencl_dispatch_uses_split_configured_real_buffers():
         "buffer:outside_imag",
     )
     assert record.device["multiplier_real"].set_value.dtype == np.dtype("f8")
+    assert record.device["multiplier_real"].set_input_contiguous
+    assert record.device["multiplier_imag"].set_input_contiguous
 
 
 class _FakeMetalEncoder:

--- a/tests/updates/test_gpu_snapshot_indexing.py
+++ b/tests/updates/test_gpu_snapshot_indexing.py
@@ -37,6 +37,8 @@ dispatch argument order/contract for CUDA and OpenCL (mirroring the
 existing Metal dispatch tests), and update_snapshot_max_dims() in
 isolation.
 """
+from types import SimpleNamespace
+
 import numpy as np
 
 from gprMax.snapshots import Snapshot, update_snapshot_max_dims
@@ -208,3 +210,42 @@ def test_opencl_store_snapshots_passes_local_sample_counts_not_absolute_finish(m
     assert args[18] == "dev:Hz"
     assert args[19] == "dev:snapEx"
     assert args[24] == "dev:snapHz"
+
+
+def test_opencl_snapshot_kernel_substitutes_real_type(monkeypatch):
+    import gprMax.config as config
+    import gprMax.updates.opencl_updates as opencl_updates
+    from gprMax.updates.opencl_updates import OpenCLUpdates
+
+    monkeypatch.setattr(
+        config,
+        "sim_config",
+        SimpleNamespace(
+            dtypes={"C_float_or_double": "double"},
+            devices={"compiler_opts": []},
+        ),
+    )
+    monkeypatch.setattr(
+        opencl_updates,
+        "htod_snapshot_array",
+        lambda snapshots, queue: tuple(f"snap:{name}" for name in "Ex Ey Ez Hx Hy Hz".split()),
+    )
+
+    captured = {}
+    updates = OpenCLUpdates.__new__(OpenCLUpdates)
+    updates.grid = SimpleNamespace(snapshots=[object()])
+    updates.queue = object()
+    updates.ctx = object()
+    updates.knl_common = ""
+
+    def fake_elementwise(context, arguments, body, name, **kwargs):
+        captured.update(arguments=arguments, body=body, name=name)
+        return object()
+
+    updates.elwiseknl = fake_elementwise
+    updates._set_snapshot_knl()
+
+    assert captured["name"] == "store_snapshot"
+    assert "$" not in captured["arguments"]
+    assert "$" not in captured["body"]
+    assert "(double)0.25" in captured["body"]

--- a/tests/updates/test_opencl_current_output_dispatch.py
+++ b/tests/updates/test_opencl_current_output_dispatch.py
@@ -1,0 +1,95 @@
+"""OpenCL receiver-current kernel construction and dispatch tests."""
+
+from types import SimpleNamespace
+
+import numpy as np
+
+import gprMax.config as config
+import gprMax.updates.opencl_updates as opencl_updates
+from gprMax.updates.opencl_updates import OpenCLUpdates
+
+
+def _set_config(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "sim_config",
+        SimpleNamespace(
+            dtypes={
+                "C_float_or_double": "double",
+                "float_or_double": np.float64,
+            },
+            devices={"compiler_opts": []},
+        ),
+    )
+
+
+def test_opencl_receiver_setup_builds_requested_current_kernel(monkeypatch):
+    _set_config(monkeypatch)
+    device_arrays = tuple(f"device:{name}" for name in ("coords", "fields", "info", "current"))
+    monkeypatch.setattr(
+        opencl_updates,
+        "htod_rx_arrays",
+        lambda grid, queue: device_arrays,
+    )
+    monkeypatch.setattr(
+        opencl_updates,
+        "requested_current_outputs",
+        lambda grid: [(0, "Ix"), (0, "Iz")],
+    )
+
+    kernels = {}
+
+    def fake_elementwise(context, arguments, body, name, **kwargs):
+        kernels[name] = SimpleNamespace(arguments=arguments, body=body)
+        return f"kernel:{name}"
+
+    updates = OpenCLUpdates.__new__(OpenCLUpdates)
+    updates.grid = SimpleNamespace()
+    updates.queue = object()
+    updates.ctx = object()
+    updates.knl_common = ""
+    updates.elwiseknl = fake_elementwise
+    updates._set_rx_knl()
+
+    assert updates.nrxcurrent == 2
+    assert set(kernels) == {"store_outputs", "store_current_outputs"}
+    assert updates.store_current_outputs_dev == "kernel:store_current_outputs"
+    assert "$" not in kernels["store_current_outputs"].arguments
+    assert "$" not in kernels["store_current_outputs"].body
+
+
+def test_opencl_store_outputs_dispatches_requested_currents(monkeypatch):
+    _set_config(monkeypatch)
+    field_call = []
+    current_call = []
+
+    updates = OpenCLUpdates.__new__(OpenCLUpdates)
+    updates.nrxcurrent = 2
+    updates.rxcoords_dev = "rxcoords"
+    updates.rxs_dev = "rxfields"
+    updates.rxcurrentinfo_dev = "rxcurrentinfo"
+    updates.rxcurrents_dev = "rxcurrents"
+    updates.store_outputs_dev = lambda *args: field_call.append(args)
+    updates.store_current_outputs_dev = lambda *args: current_call.append(args)
+    updates.grid = SimpleNamespace(
+        rxs=[object()],
+        dx=0.1,
+        dy=0.2,
+        dz=0.3,
+        Ex_dev="Ex",
+        Ey_dev="Ey",
+        Ez_dev="Ez",
+        Hx_dev="Hx",
+        Hy_dev="Hy",
+        Hz_dev="Hz",
+    )
+
+    updates.store_outputs(7)
+
+    assert len(field_call) == 1
+    assert len(current_call) == 1
+    arguments = current_call[0]
+    assert tuple(int(value) for value in arguments[:2]) == (2, 7)
+    assert arguments[2:4] == ("rxcurrentinfo", "rxcurrents")
+    assert arguments[4:7] == (np.float64(0.1), np.float64(0.2), np.float64(0.3))
+    assert arguments[7:] == ("Hx", "Hy", "Hz")


### PR DESCRIPTION
# PR Description

## Summary

Fixes several OpenCL execution issues discovered during CUDA/OpenCL backend comparison:

- uploads contiguous real and imaginary NTFF arrays to OpenCL devices;
- provides the configured real type when compiling snapshot kernels;
- correctly constructs and dispatches receiver current-output kernels for `Ix`, `Iy`, and `Iz`;
- adds regression tests for these paths.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update.

## Testing

- Focused tests: 24 passed
- Broader suite: 391 passed, 6 skipped
- CUDA/OpenCL hardware comparisons passed in single and double precision.
- Receiver currents and snapshots were bit-identical.
- Maximum single-precision KSIR time-domain difference was approximately 2.1e-7.

## Checklist

- [ ] Did pre-commit pass all checks?  
  `pre-commit` is not installed in the current environment.
- [x] I have performed a self-review of my code.
- [x] I have added comments where required.
- [x] My changes generate no new warnings.
- [x] The title is a short description of the changes.