### PR TITLE
Add OpenCL transmission-line support

### DIFF
--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1154,7 +1154,7 @@ For example, to specify a y directed voltage source with an internal resistance 
 #transmission_line:
 -------------------
 
-Allows you to introduce a one-dimensional transmission line model [MAL1994]_ at an electric field location. The transmission line can have a specified resistance greater than zero and less than the impedance of free space (376.73 Ohms). It is useful for exciting antennas when the physical properties of the antenna are included in the model. Transmission lines are supported by the CPU and CUDA solvers; OpenCL and Metal support is not currently enabled. The syntax of the command is:
+Allows you to introduce a one-dimensional transmission line model [MAL1994]_ at an electric field location. The transmission line can have a specified resistance greater than zero and less than the impedance of free space (376.73 Ohms). It is useful for exciting antennas when the physical properties of the antenna are included in the model. Transmission lines are supported by the CPU, CUDA, and OpenCL solvers; Metal support is not currently enabled. The syntax of the command is:
 
 .. code-block:: none
 

--- a/gprMax/updates/opencl_updates.py
+++ b/gprMax/updates/opencl_updates.py
@@ -31,6 +31,7 @@ from gprMax.cuda_opencl import (
     knl_source_updates,
     knl_store_outputs,
     knl_symmetry_boundaries,
+    knl_transmission_line,
 )
 from gprMax.grid.opencl_grid import OpenCLGrid
 from gprMax.ntff.device import OpenCLCombinedKSIRCollector
@@ -45,8 +46,10 @@ from gprMax.snapshots import (
 from gprMax.sources import (
     MAGNETIC_FRILL_MAX_TERMS,
     dtoh_magnetic_frill_source_outputs,
+    dtoh_transmission_line_outputs,
     htod_magnetic_frill_source_arrays,
     htod_src_arrays,
+    htod_transmission_line_arrays,
 )
 from gprMax.updates.updates import Updates
 
@@ -94,6 +97,8 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
             self._set_rx_knl()
         if self.grid.voltagesources + self.grid.hertziandipoles + self.grid.magneticdipoles:
             self._set_src_knls()
+        if self.grid.transmissionlines:
+            self._set_transmission_line_knls()
         if self.grid.magneticfrillsources:
             self._set_magnetic_frill_knl()
         if self.grid.snapshots:
@@ -445,6 +450,55 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
             preamble=self.knl_common,
             options=config.sim_config.devices["compiler_opts"],
         )
+
+    def _set_transmission_line_knls(self):
+        """Initialise device-resident transmission lines and their kernels."""
+
+        arrays = htod_transmission_line_arrays(
+            self.grid.transmissionlines, self.grid, self.queue
+        )
+        for name, array in arrays.items():
+            setattr(self, f"tl_{name}_dev", array)
+
+        real = config.sim_config.dtypes["float_or_double"]
+        line = self.grid.transmissionlines[0]
+        self.tl_line_coefficient = real(config.c * self.grid.dt / line.dl)
+        self.tl_abc_coefficient = real(
+            (config.c * self.grid.dt - line.dl) / (config.c * self.grid.dt + line.dl)
+        )
+
+        substitutions = {
+            "CUDA_IDX": "",
+            "REAL": config.sim_config.dtypes["C_float_or_double"],
+            "NY_TLINFO": 10,
+            "NY_TLWAVES": self.grid.iterations + 1,
+            "NY_TLOUTPUTS": self.grid.iterations + 1,
+        }
+        self.update_transmission_line_magnetic_dev = self.elwiseknl(
+            self.ctx,
+            knl_transmission_line.update_transmission_line_magnetic[
+                "args_opencl"
+            ].substitute({"REAL": config.sim_config.dtypes["C_float_or_double"]}),
+            knl_transmission_line.update_transmission_line_magnetic["func"].substitute(
+                substitutions
+            ),
+            "update_transmission_line_magnetic",
+            preamble=self.knl_common,
+            options=config.sim_config.devices["compiler_opts"],
+        )
+        self.update_transmission_line_electric_dev = self.elwiseknl(
+            self.ctx,
+            knl_transmission_line.update_transmission_line_electric[
+                "args_opencl"
+            ].substitute({"REAL": config.sim_config.dtypes["C_float_or_double"]}),
+            knl_transmission_line.update_transmission_line_electric["func"].substitute(
+                substitutions
+            ),
+            "update_transmission_line_electric",
+            preamble=self.knl_common,
+            options=config.sim_config.devices["compiler_opts"],
+        )
+
     def _set_snapshot_knl(self):
         """Snapshots - initialises arrays on compute device, prepares kernel and
         gets kernel function.
@@ -593,6 +647,27 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
 
     def update_magnetic_sources(self, iteration):
         """Updates magnetic field components from sources."""
+        if self.grid.transmissionlines:
+            self.update_transmission_line_magnetic_dev(
+                np.int32(len(self.grid.transmissionlines)),
+                np.int32(iteration),
+                config.sim_config.dtypes["float_or_double"](self.grid.dx),
+                config.sim_config.dtypes["float_or_double"](self.grid.dy),
+                config.sim_config.dtypes["float_or_double"](self.grid.dz),
+                self.tl_line_coefficient,
+                self.tl_info_dev,
+                self.tl_resistance_dev,
+                self.tl_waveform_half_dev,
+                self.tl_voltage_dev,
+                self.tl_current_dev,
+                self.tl_Vtotal_dev,
+                self.tl_Itotal_dev,
+                self.grid.Hx_dev,
+                self.grid.Hy_dev,
+                self.grid.Hz_dev,
+                range=slice(0, len(self.grid.transmissionlines)),
+            )
+
         if self.grid.magneticdipoles:
             self.update_magnetic_dipole_dev(
                 np.int32(len(self.grid.magneticdipoles)),
@@ -722,6 +797,28 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
                 self.grid.Ez_dev,
             )
 
+        if self.grid.transmissionlines:
+            self.update_transmission_line_electric_dev(
+                np.int32(len(self.grid.transmissionlines)),
+                np.int32(iteration),
+                config.sim_config.dtypes["float_or_double"](self.grid.dx),
+                config.sim_config.dtypes["float_or_double"](self.grid.dy),
+                config.sim_config.dtypes["float_or_double"](self.grid.dz),
+                self.tl_line_coefficient,
+                self.tl_abc_coefficient,
+                self.tl_info_dev,
+                self.tl_resistance_dev,
+                self.tl_waveform_whole_dev,
+                self.tl_voltage_dev,
+                self.tl_current_dev,
+                self.tl_abcv0_dev,
+                self.tl_abcv1_dev,
+                self.grid.Ex_dev,
+                self.grid.Ey_dev,
+                self.grid.Ez_dev,
+                range=slice(0, len(self.grid.transmissionlines)),
+            )
+
         if self.grid.hertziandipoles:
             self.update_hertzian_dipole_dev(
                 np.int32(len(self.grid.hertziandipoles)),
@@ -804,6 +901,11 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
                 self.frill_Vtotal_dev.get(),
                 self.frill_Itot_dev.get(),
                 self.grid,
+            )
+
+        if self.grid.transmissionlines:
+            dtoh_transmission_line_outputs(
+                self.tl_Vtotal_dev.get(), self.tl_Itotal_dev.get(), self.grid
             )
 
         # Copy data from any snapshots back to correct snapshot objects

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -903,13 +903,12 @@ class TransmissionLine(RotatableMixin, GridUserObject):
             self._log(grid, transmission_line, *position)
 
     def _validate_parameters(self, grid: FDTDGrid):
-        # CUDA has a device-resident transmission-line update. OpenCL and
-        # Metal use the same kernel template but do not yet have their host
-        # buffer/launch lifecycle enabled and verified.
-        if config.sim_config.general["solver"] in ["opencl", "metal"]:
+        # Metal uses the same kernel template, but its host buffer/launch
+        # lifecycle has not yet been enabled and verified.
+        if config.sim_config.general["solver"] == "metal":
             raise ValueError(
                 f"{self.params_str()} cannot currently be used "
-                "with the OpenCL or Metal-based solver. Consider "
+                "with the Metal-based solver. Consider "
                 "using a #voltage_source instead."
             )
 

--- a/tests/cmds_multiuse/test_metal_gpu_restriction_gaps.py
+++ b/tests/cmds_multiuse/test_metal_gpu_restriction_gaps.py
@@ -32,9 +32,8 @@ def _set_solver(monkeypatch, solver):
     config.sim_config.em_consts = {"z0": 376.730313668}
 
 
-@pytest.mark.parametrize("solver", ["opencl", "metal"])
-def test_transmission_line_rejected_on_unimplemented_gpu_solvers(monkeypatch, solver):
-    _set_solver(monkeypatch, solver)
+def test_transmission_line_rejected_on_unimplemented_metal_solver(monkeypatch):
+    _set_solver(monkeypatch, "metal")
 
     tl = TransmissionLine(
         p1=(0.01, 0.01, 0.01), polarisation="x", resistance=50, waveform_id="w"
@@ -44,8 +43,9 @@ def test_transmission_line_rejected_on_unimplemented_gpu_solvers(monkeypatch, so
         tl._validate_parameters(grid=None)
 
 
-def test_transmission_line_is_allowed_on_cuda(monkeypatch):
-    _set_solver(monkeypatch, "cuda")
+@pytest.mark.parametrize("solver", ["cuda", "opencl"])
+def test_transmission_line_is_allowed_on_implemented_gpu_solvers(monkeypatch, solver):
+    _set_solver(monkeypatch, solver)
     monkeypatch.setattr(
         config,
         "get_model_config",

--- a/tests/updates/test_cuda_transmission_line_solve.py
+++ b/tests/updates/test_cuda_transmission_line_solve.py
@@ -1,4 +1,4 @@
-"""End-to-end CUDA/CPU parity for a device-resident transmission line."""
+"""End-to-end CPU/GPU parity for a device-resident transmission line."""
 
 import h5py
 import numpy as np
@@ -16,6 +16,13 @@ try:
     HAS_CUDA = _cuda_driver.Device.count() > 0
 except Exception:
     HAS_CUDA = False
+
+try:
+    import pyopencl as _cl
+
+    HAS_OPENCL = bool(_cl.get_platforms())
+except Exception:
+    HAS_OPENCL = False
 
 
 def _scene():
@@ -38,11 +45,16 @@ def _scene():
     return scene
 
 
-@pytest.mark.skipif(not HAS_CUDA, reason="No CUDA device/pycuda available")
+@pytest.mark.parametrize("backend", ["cuda", "opencl"])
 @pytest.mark.parametrize("precision", ["single", "double"])
-def test_cuda_transmission_line_matches_cpu(tmp_path, gpu_device, precision):
+def test_device_transmission_line_matches_cpu(tmp_path, gpu_device, backend, precision):
+    if backend == "cuda" and not HAS_CUDA:
+        pytest.skip("No CUDA device/pycuda available")
+    if backend == "opencl" and not HAS_OPENCL:
+        pytest.skip("No OpenCL platform/pyopencl available")
+
     cpu_path = tmp_path / f"cpu_tl_{precision}"
-    cuda_path = tmp_path / f"cuda_tl_{precision}"
+    device_path = tmp_path / f"{backend}_tl_{precision}"
     gprMax.run(
         scenes=[_scene()],
         n=1,
@@ -53,10 +65,10 @@ def test_cuda_transmission_line_matches_cpu(tmp_path, gpu_device, precision):
     gprMax.run(
         scenes=[_scene()],
         n=1,
-        outputfile=cuda_path,
+        outputfile=device_path,
         hide_progress_bars=True,
-        gpu=[gpu_device],
         gpu_precision=precision,
+        **({"gpu": [gpu_device]} if backend == "cuda" else {"opencl": [0]}),
     )
 
     with h5py.File(str(cpu_path) + ".h5", "r") as output:
@@ -66,33 +78,36 @@ def test_cuda_transmission_line_matches_cpu(tmp_path, gpu_device, precision):
         cpu["Zin"] = output["tls/tl1/Zin"][:]
         cpu["valid"] = output["tls/tl1/valid_Zin"][:].astype(bool)
         cpu["Ez"] = output["rxs/rx1/Ez"][:]
-    with h5py.File(str(cuda_path) + ".h5", "r") as output:
-        cuda = {name: output[f"tls/tl1/{name}"][:] for name in ("Vinc", "Iinc", "Vtotal", "Itotal")}
-        cuda["frequency"] = output["tls/tl1/frequency"][:]
-        cuda["S11"] = output["tls/tl1/S11"][:]
-        cuda["Zin"] = output["tls/tl1/Zin"][:]
-        cuda["valid"] = output["tls/tl1/valid_Zin"][:].astype(bool)
-        cuda["Ez"] = output["rxs/rx1/Ez"][:]
+    with h5py.File(str(device_path) + ".h5", "r") as output:
+        device = {
+            name: output[f"tls/tl1/{name}"][:]
+            for name in ("Vinc", "Iinc", "Vtotal", "Itotal")
+        }
+        device["frequency"] = output["tls/tl1/frequency"][:]
+        device["S11"] = output["tls/tl1/S11"][:]
+        device["Zin"] = output["tls/tl1/Zin"][:]
+        device["valid"] = output["tls/tl1/valid_Zin"][:].astype(bool)
+        device["Ez"] = output["rxs/rx1/Ez"][:]
 
     assert np.max(np.abs(cpu["Vtotal"])) > 1e-3
     for name in ("Vinc", "Iinc", "Vtotal", "Itotal", "Ez"):
         scale = max(float(np.max(np.abs(cpu[name]))), 1e-12)
-        assert np.isfinite(cuda[name]).all()
+        assert np.isfinite(device[name]).all()
         tolerance = 2e-5 if precision == "single" else 2e-12
-        assert_allclose(cuda[name], cpu[name], rtol=tolerance, atol=tolerance * scale)
+        assert_allclose(device[name], cpu[name], rtol=tolerance, atol=tolerance * scale)
 
-    assert_allclose(cuda["frequency"], cpu["frequency"], rtol=0, atol=0)
-    valid = cpu["valid"] & cuda["valid"]
+    assert_allclose(device["frequency"], cpu["frequency"], rtol=0, atol=0)
+    valid = cpu["valid"] & device["valid"]
     assert valid.any()
     tolerance = 4e-5 if precision == "single" else 4e-12
-    assert_allclose(cuda["S11"][valid], cpu["S11"][valid], rtol=tolerance, atol=tolerance)
+    assert_allclose(device["S11"][valid], cpu["S11"][valid], rtol=tolerance, atol=tolerance)
     impedance_scale = max(float(np.max(np.abs(cpu["Zin"][valid]))), 1.0)
     # Near an open circuit, Zin = Z0(1 + S11)/(1 - S11) amplifies a small
     # single-precision S11 difference. Keep the tighter comparison on S11
     # above and allow the corresponding conditioning in this secondary value.
     impedance_tolerance = 2e-4 if precision == "single" else 4e-12
     assert_allclose(
-        cuda["Zin"][valid],
+        device["Zin"][valid],
         cpu["Zin"][valid],
         rtol=impedance_tolerance,
         atol=impedance_tolerance * impedance_scale,


### PR DESCRIPTION
# PR Description

## Summary

Adds device-resident transmission-line source support to the OpenCL solver.

- Uses the shared CUDA/OpenCL transmission-line kernel templates.
- Supports magnetic and electric update stages.
- Copies voltage and current histories back for normal HDF5 output.
- Preserves S11 and Zin post-processing.
- Keeps transmission lines unsupported on Metal.
- Updates documentation and backend restrictions.

## Testing

- CPU/CUDA/OpenCL comparisons in single and double precision.
- 4 hardware tests passed.
- Maximum OpenCL trace error versus CPU:
  - single precision: 8.02e-7
  - double precision: 9.34e-16
- S11 maximum error:
  - single precision: 1.79e-7
  - double precision: 4.58e-16

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] This change requires a documentation update.

## Checklist

- [ ] Did pre-commit pass all checks?
- [x] I have performed a self-review of my code.
- [x] I have added comments where necessary.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title is a short description of the changes.