### PR TITLE
Complete local accelerator feature parity

### DIFF
--- a/docs/source/eigenmode_port.rst
+++ b/docs/source/eigenmode_port.rst
@@ -283,8 +283,9 @@ VTK-HDF geometry before running the more expensive 3D model. Then run:
    python -m gprMax examples/features/eigenmode_ports/example_3_antenna_and_farfield/horn_antenna.in -outputfile examples/features/eigenmode_ports/example_3_antenna_and_farfield/horn_antenna
    python examples/features/eigenmode_ports/example_3_antenna_and_farfield/plot_results.py
 
-Eigenmode sources currently require the CPU solver. Do not add ``-gpu`` to
-this simulation command.
+The example may also be run with CUDA, OpenCL, or Metal by selecting the
+corresponding accelerator option. The FDFD setup remains a host-side setup
+step; modal injection and monitoring then run on the selected compute device.
 The plotting script writes three figures:
 
 * ``horn_sparameters.png`` shows input reflection over 8--12 GHz;
@@ -366,13 +367,14 @@ The HDF5 file then contains raw incident and outgoing modal spectra, but no
 S-parameters are formed because no incident source spectrum exists for
 normalization.
 
-Virtual waveguides are an experimental CPU feature. They currently require a
-3D internal port plane, a locally uniform and non-dispersive cross-section,
-and at least two cells along each transverse axis. MPI, subgrids, CUDA,
-OpenCL, and Metal are rejected. Use convergence tests for guide length, PML
-thickness, source clearance, mesh resolution, and NTFF-surface position before
-using quantitative results. GPU support is intended to follow a fully
-device-resident eigenmode-port implementation.
+Virtual waveguides are experimental. They run on the CPU, CUDA, OpenCL, and
+Metal solvers and keep both the auxiliary-grid fields and aperture coupling on
+the selected compute device throughout time stepping. They currently require
+a 3D internal port plane, a locally uniform and non-dispersive cross-section,
+and at least two cells along each transverse axis. MPI and subgrids are not yet
+supported. Use convergence tests for guide length, PML thickness, source
+clearance, mesh resolution, and NTFF-surface position before using
+quantitative results.
 
 How automatic excitation and frequency anchors work
 ====================================================
@@ -939,7 +941,7 @@ profiles used by the FDTD injection carry positive real-profile power.
 
 ``EigenmodeSource`` samples component materials from the mode's live invariant
 layer, supplies the corresponding PEC/PMC masks, and maps the returned line
-profiles back into the thin 3D Yee arrays used by the CPU update kernels.
+profiles back into the thin 3D Yee arrays used by the FDTD source kernels.
 The TM source uses the single live invariant layer; the TE source uses the
 shared interior layer of its two-cell invariant thickness. Inactive components
 and TE outer boundary planes are explicitly zero.
@@ -1886,7 +1888,8 @@ For reliable broadband excitation:
 * compare forward and backward modal power or receiver phase when reflections
   and mode purity matter.
 
-The current implementation is CPU-only and cannot be used with MPI. Material
-dispersion is sampled at each anchor frequency, but interpolation between
-anchors remains piecewise linear; additional anchors are the normal way to
-resolve stronger frequency dependence.
+Eigenmode injection and modal monitoring run on the CPU, CUDA, OpenCL, and
+Metal solvers, but cannot yet be used with MPI. Material dispersion is sampled
+at each anchor frequency, but interpolation between anchors remains piecewise
+linear; additional anchors are the normal way to resolve stronger frequency
+dependence.

--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -610,9 +610,11 @@ convolution treatment of Giannakis and Giannopoulos [GIA2014]_: every pole
 current is evaluated analytically at the electric half-step for a linearly
 varying voltage, rather than estimated by averaging its two integer-time
 values. State is stored only for placed terminals. Independent one-port
-networks are supported in 3-D, non-MPI CPU models, including within CPU
-subgrids. Coupled multiport admittance matrices are reserved for a later
-extension.
+networks are supported in 3-D, non-MPI models on the CPU, CUDA, OpenCL, and
+Metal solvers; terminals inside subgrids currently use the CPU solver. Device
+runs keep the network recurrence and field correction on the compute device
+and copy the completed histories back after the solve. Coupled multiport
+admittance matrices are reserved for a later extension.
 
 For :math:`Y=1/R`, ``NetworkExcitation`` and a conventional finite-resistance
 ``VoltageSource`` are the same discrete Thévenin source when their position,
@@ -777,7 +779,7 @@ total-field box. For example, choose one of:
     ))
 
 Here ``pulse`` must identify a built-in analytic waveform. Discrete plane waves
-use the CPU, CUDA, and OpenCL solvers; Apple Metal is not currently supported.
+use the CPU, CUDA, OpenCL, and Apple Metal solvers.
 Homogeneous angle/vector plane waves and layered axial plane waves support
 non-dispersive materials and multi-pole Debye, Lorentz, and Drude materials.
 Their auxiliary dispersive state uses the same real or complex precision
@@ -1204,8 +1206,9 @@ Modified one-step transient far fields
 
 .. autoclass:: gprMax.user_objects.cmds_output.NTFFTimeFarFieldArray
 
-These CPU-only classes implement the modified time-domain equivalent-current
-method of Giannopoulos *et al.* [GIAFF1997]_. Their ``times`` are reduced
+These classes implement the modified time-domain equivalent-current method of
+Giannopoulos *et al.* [GIAFF1997]_ on the CPU, CUDA, OpenCL, and Metal
+solvers. Their ``times`` are reduced
 times for range-normalized far fields, and only samples supported by every
 surface patch are returned. The time placement of both current derivatives is
 defined in :ref:`ntff-formulations`.

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1194,12 +1194,14 @@ discretely identical to a finite-resistance ``#voltage_source`` having the
 same :math:`R`, waveform, position, and polarisation. A zero-resistance hard
 source is not equivalent.
 
-This initial implementation supports 3-D, non-MPI CPU models and a
-nondispersive terminal edge; dispersive materials may exist elsewhere in the
-model. A terminal may be placed in a CPU subgrid, where it uses the fine
-spatial and temporal steps. Several independent terminals may be used, but a
-coupled multiport admittance matrix is not yet supported. See [CHE2007]_ for
-the general PLRC lumped-network formulation and :ref:`Analytical comparisons
+This implementation supports 3-D, non-MPI models on the CPU, CUDA, OpenCL,
+and Metal solvers and a nondispersive terminal edge; dispersive materials may
+exist elsewhere in the model. A terminal may be placed in a CPU subgrid, where
+it uses the fine spatial and temporal steps. On an accelerator the complete
+recurrence and local field correction remain device-resident during time
+stepping. Several independent terminals may be used, but a coupled multiport
+admittance matrix is not yet supported. See [CHE2007]_ for the general PLRC
+lumped-network formulation and :ref:`Analytical comparisons
 <rational-network-validation>` for a complete loaded-guide comparison.
 
 
@@ -1228,7 +1230,7 @@ For example, to specify a y directed voltage source with an internal resistance 
 #transmission_line:
 -------------------
 
-Allows you to introduce a one-dimensional transmission line model [MAL1994]_ at an electric field location. The transmission line can have a specified resistance greater than zero and less than the impedance of free space (376.73 Ohms). It is useful for exciting antennas when the physical properties of the antenna are included in the model. Transmission lines are supported by the CPU, CUDA, and OpenCL solvers; Metal support is not currently enabled. The syntax of the command is:
+Allows you to introduce a one-dimensional transmission line model [MAL1994]_ at an electric field location. The transmission line can have a specified resistance greater than zero and less than the impedance of free space (376.73 Ohms). It is useful for exciting antennas when the physical properties of the antenna are included in the model. Transmission lines are supported by the CPU, CUDA, OpenCL, and Metal solvers. The syntax of the command is:
 
 .. code-block:: none
 
@@ -1642,7 +1644,8 @@ and output definitions.
 
 .. note::
 
-    * Eigenmode commands currently support only the main grid and CPU solver.
+    * Eigenmode commands support the main grid with the CPU, CUDA, OpenCL, and
+      Metal solvers, but not subgrids.
     * Eigenmode commands currently cannot be used with MPI.
 
 #virtual_waveguide:
@@ -1678,9 +1681,9 @@ but no S-parameters can be normalized without an active port.
 
 The port plane must be internal, locally uniform along the guide axis, and at
 least two cells wide in each transverse direction. The minimum guide length
-is ``i3 + i4 + 3`` cells. Virtual waveguides currently support 3D,
-non-dispersive guide cross-sections with the CPU solver only; MPI, subgrids,
-and GPU solvers are not yet supported.
+is ``i3 + i4 + 3`` cells. Virtual waveguides support 3D, non-dispersive guide
+cross-sections with the CPU, CUDA, OpenCL, and Metal solvers; MPI and subgrids
+are not yet supported.
 
 Unlike a direct eigenmode source, a virtual-waveguide source lies outside the
 main FDTD domain. A closed equivalent-current or KSIR NTFF surface may
@@ -1958,13 +1961,13 @@ The following conventions apply to every NTFF command:
   it cannot touch or cut the coupling region. Both time- and frequency-domain
   KSIR collection and frequency-domain equivalent-current collection are
   available with CPU, CUDA, OpenCL, and Metal. Equivalent-current transient
-  far fields currently require the CPU solver;
+  far fields are also available with all four local solvers;
 * CPU collection uses the Cython/OpenMP implementation. Accelerator surface
   state and time-domain output storage remain on the device during FDTD
-  iterations and are transferred to the host once, after the solve. CUDA is
-  hardware-qualified on the development server. OpenCL and Metal have source-
-  generation and dispatch coverage, but still require execution tests on
-  suitable hardware.
+  iterations and are transferred to the host once, after the solve. CUDA and
+  OpenCL are hardware-qualified on the development server. Metal has complete
+  source-generation and dispatch coverage, but still requires execution tests
+  on suitable Apple hardware.
 
 Directivity, gain, efficiency, and port normalisation are post-processing
 operations after the FDTD solve. Angular KSIR and equivalent-current
@@ -2343,8 +2346,9 @@ This prevents an incomplete retarded-time tail being mistaken for a physical
 late-time response. Increase ``#time_window`` if the stored terminal-decay
 test fails.
 
-The current implementation is CPU-only, requires a homogeneous lossless
-background and all six physical faces, and supports 3-D serial models. KSIR
+The current implementation supports the CPU, CUDA, OpenCL, and Metal solvers,
+requires a homogeneous lossless background and all six physical faces, and
+supports 3-D serial models. KSIR
 remains available for finite-distance time-domain points and for
 symmetry-completed surfaces.
 
@@ -2570,7 +2574,9 @@ simulated half. This KSIR workflow is supported by the local CPU, CUDA,
 OpenCL, and Metal solvers for nondispersive models. Equivalent-current
 transforms do not yet support symmetry image completion; physical faces can
 instead be omitted explicitly for an open frequency-domain Huygens surface.
-OpenCL and Metal still require end-to-end qualification on suitable hardware.
+OpenCL has end-to-end qualification on the development server. Metal has
+source-generation and dispatch coverage but still requires qualification on
+suitable Apple hardware.
 
 
 PML commands
@@ -2734,6 +2740,5 @@ For example:
 .. note::
 
     * The PML thickness on a symmetry face is set to zero automatically.
-    * PEC boundaries and nondispersive PMC boundaries are supported by the CPU, CUDA, OpenCL, and Metal solvers.
-    * PMC boundaries in models containing dispersive materials are currently CPU-only.
+    * PEC and PMC boundaries, including PMC boundaries in models containing dispersive materials, are supported by the CPU, CUDA, OpenCL, and Metal solvers.
     * Symmetry boundaries are not currently supported in 2D mode, with MPI, or on a subgrid. They may be used on the main grid of a model that contains subgrids.

--- a/gprMax/cuda_opencl/knl_eigenmode.py
+++ b/gprMax/cuda_opencl/knl_eigenmode.py
@@ -1,0 +1,338 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""Shared device kernels for eigenmode TF/SF injection and modal DFTs."""
+
+from string import Template
+
+
+def _arguments(name, fields, backend):
+    qualifiers = {
+        "cuda": ("__global__ void", "const $REAL* __restrict__", "$REAL*", ""),
+        "opencl": ("", "__global const $REAL* restrict", "__global $REAL*", ""),
+        "metal": (
+            "kernel void",
+            "device const $REAL*",
+            "device $REAL*",
+            ", uint i [[thread_position_in_grid]]",
+        ),
+    }
+    prefix, const_real, real, suffix = qualifiers[backend]
+    scalar = "device const int&" if backend == "metal" else "int"
+    scalar_real = "device const $REAL&" if backend == "metal" else "$REAL"
+    id_pointer = (
+        "device const uint*"
+        if backend == "metal"
+        else (
+            "const unsigned int* __restrict__"
+            if backend == "cuda"
+            else "__global const uint* restrict"
+        )
+    )
+    arguments = [
+        f"{scalar} NPOINTS",
+        f"{scalar} normal_axis",
+        f"{scalar} direction_sign",
+        f"{scalar} u0",
+        f"{scalar} v0",
+        f"{scalar} u1",
+        f"{scalar} v1",
+        f"{scalar} plane_index",
+        f"{scalar} basis",
+        f"{scalar_real} envelope",
+        f"{const_real} profile",
+        f"{const_real} material_coeffs",
+        f"{id_pointer} ID",
+    ]
+    arguments.extend(f"{real} {field}" for field in fields)
+    if backend == "cuda":
+        return Template(f"{prefix} {name}(" + ",\n            ".join(arguments) + ")")
+    if backend == "metal":
+        return Template(f"{prefix} {name}(" + ",\n            ".join(arguments) + suffix + ")")
+    return Template(",\n            ".join(arguments))
+
+
+update_eigenmode_magnetic = {
+    "args_cuda": _arguments("update_eigenmode_magnetic", ("Hx", "Hy", "Hz"), "cuda"),
+    "args_opencl": _arguments("update_eigenmode_magnetic", ("Hx", "Hy", "Hz"), "opencl"),
+    "args_metal": _arguments("update_eigenmode_magnetic", ("Hx", "Hy", "Hz"), "metal"),
+    "func": Template(
+        """
+    $CUDA_IDX
+    if (i < NPOINTS) {
+        int nv = v1 - v0;
+        int stride_v = nv + 1;
+        int local_u = i / stride_v;
+        int local_v = i - local_u * stride_v;
+        int nu = u1 - u0;
+        int profile_plane = (nu + 1) * (nv + 1);
+        int profile_offset = basis * 3 * profile_plane;
+        int u = u0 + local_u;
+        int v = v0 + local_v;
+        int x, y, z, target, material;
+        $REAL coefficient;
+
+        if (normal_axis == 0) {
+            target = plane_index - (direction_sign > 0 ? 1 : 0);
+            x = target; y = u; z = v;
+            if (local_u <= nu && local_v < nv) {
+                material = ID[IDX4D_ID(4,x,y,z)];
+                coefficient = material_coeffs[IDX2D_MAT(material,1)];
+                Hy[IDX3D_FIELDS(x,y,z)] -= direction_sign * coefficient * envelope
+                    * profile[profile_offset + 2 * profile_plane + local_u * stride_v + local_v];
+            }
+            if (local_u < nu && local_v <= nv) {
+                material = ID[IDX4D_ID(5,x,y,z)];
+                coefficient = material_coeffs[IDX2D_MAT(material,1)];
+                Hz[IDX3D_FIELDS(x,y,z)] += direction_sign * coefficient * envelope
+                    * profile[profile_offset + profile_plane + local_u * stride_v + local_v];
+            }
+        }
+        else if (normal_axis == 1) {
+            target = plane_index - (direction_sign > 0 ? 1 : 0);
+            x = u; y = target; z = v;
+            if (local_u <= nu && local_v < nv) {
+                material = ID[IDX4D_ID(3,x,y,z)];
+                coefficient = material_coeffs[IDX2D_MAT(material,2)];
+                Hx[IDX3D_FIELDS(x,y,z)] += direction_sign * coefficient * envelope
+                    * profile[profile_offset + 2 * profile_plane + local_u * stride_v + local_v];
+            }
+            if (local_u < nu && local_v <= nv) {
+                material = ID[IDX4D_ID(5,x,y,z)];
+                coefficient = material_coeffs[IDX2D_MAT(material,2)];
+                Hz[IDX3D_FIELDS(x,y,z)] -= direction_sign * coefficient * envelope
+                    * profile[profile_offset + local_u * stride_v + local_v];
+            }
+        }
+        else {
+            target = plane_index - (direction_sign > 0 ? 1 : 0);
+            x = u; y = v; z = target;
+            if (local_u < nu && local_v <= nv) {
+                material = ID[IDX4D_ID(4,x,y,z)];
+                coefficient = material_coeffs[IDX2D_MAT(material,3)];
+                Hy[IDX3D_FIELDS(x,y,z)] += direction_sign * coefficient * envelope
+                    * profile[profile_offset + local_u * stride_v + local_v];
+            }
+            if (local_u <= nu && local_v < nv) {
+                material = ID[IDX4D_ID(3,x,y,z)];
+                coefficient = material_coeffs[IDX2D_MAT(material,3)];
+                Hx[IDX3D_FIELDS(x,y,z)] -= direction_sign * coefficient * envelope
+                    * profile[profile_offset + profile_plane + local_u * stride_v + local_v];
+            }
+        }
+    }
+"""
+    ),
+}
+
+
+update_eigenmode_electric = {
+    "args_cuda": _arguments("update_eigenmode_electric", ("Ex", "Ey", "Ez"), "cuda"),
+    "args_opencl": _arguments("update_eigenmode_electric", ("Ex", "Ey", "Ez"), "opencl"),
+    "args_metal": _arguments("update_eigenmode_electric", ("Ex", "Ey", "Ez"), "metal"),
+    "func": Template(
+        """
+    $CUDA_IDX
+    if (i < NPOINTS) {
+        int nv = v1 - v0;
+        int stride_v = nv + 1;
+        int local_u = i / stride_v;
+        int local_v = i - local_u * stride_v;
+        int nu = u1 - u0;
+        int profile_plane = (nu + 1) * (nv + 1);
+        int profile_offset = basis * 3 * profile_plane;
+        int u = u0 + local_u;
+        int v = v0 + local_v;
+        int x, y, z, material;
+        $REAL coefficient;
+
+        if (normal_axis == 0) {
+            x = plane_index; y = u; z = v;
+            if (local_u <= nu && local_v < nv) {
+                material = ID[IDX4D_ID(2,x,y,z)];
+                coefficient = material_coeffs[IDX2D_MAT(material,1)];
+                Ez[IDX3D_FIELDS(x,y,z)] -= coefficient * envelope
+                    * profile[profile_offset + profile_plane + local_u * stride_v + local_v];
+            }
+            if (local_u < nu && local_v <= nv) {
+                material = ID[IDX4D_ID(1,x,y,z)];
+                coefficient = material_coeffs[IDX2D_MAT(material,1)];
+                Ey[IDX3D_FIELDS(x,y,z)] += coefficient * envelope
+                    * profile[profile_offset + 2 * profile_plane + local_u * stride_v + local_v];
+            }
+        }
+        else if (normal_axis == 1) {
+            x = u; y = plane_index; z = v;
+            if (local_u <= nu && local_v < nv) {
+                material = ID[IDX4D_ID(2,x,y,z)];
+                coefficient = material_coeffs[IDX2D_MAT(material,2)];
+                Ez[IDX3D_FIELDS(x,y,z)] += coefficient * envelope
+                    * profile[profile_offset + local_u * stride_v + local_v];
+            }
+            if (local_u < nu && local_v <= nv) {
+                material = ID[IDX4D_ID(0,x,y,z)];
+                coefficient = material_coeffs[IDX2D_MAT(material,2)];
+                Ex[IDX3D_FIELDS(x,y,z)] -= coefficient * envelope
+                    * profile[profile_offset + 2 * profile_plane + local_u * stride_v + local_v];
+            }
+        }
+        else {
+            x = u; y = v; z = plane_index;
+            if (local_u <= nu && local_v < nv) {
+                material = ID[IDX4D_ID(1,x,y,z)];
+                coefficient = material_coeffs[IDX2D_MAT(material,3)];
+                Ey[IDX3D_FIELDS(x,y,z)] -= coefficient * envelope
+                    * profile[profile_offset + local_u * stride_v + local_v];
+            }
+            if (local_u < nu && local_v <= nv) {
+                material = ID[IDX4D_ID(0,x,y,z)];
+                coefficient = material_coeffs[IDX2D_MAT(material,3)];
+                Ex[IDX3D_FIELDS(x,y,z)] += coefficient * envelope
+                    * profile[profile_offset + profile_plane + local_u * stride_v + local_v];
+            }
+        }
+    }
+"""
+    ),
+}
+
+
+accumulate_eigenmode_dft = {
+    "args_cuda": Template(
+        """
+        __global__ void accumulate_eigenmode_dft(
+            int NF, int NM, int normal_axis, int direction_sign,
+            int magnetic_side, int u0, int v0, int u1, int v1,
+            int plane_index, $REAL dt, $REAL measure, int handedness,
+            $REAL* electric_phase_real, $REAL* electric_phase_imag,
+            $REAL* magnetic_phase_real, $REAL* magnetic_phase_imag,
+            const $REAL* __restrict__ phase_step_real,
+            const $REAL* __restrict__ phase_step_imag,
+            const $REAL* __restrict__ conj_eu_real,
+            const $REAL* __restrict__ conj_eu_imag,
+            const $REAL* __restrict__ conj_ev_real,
+            const $REAL* __restrict__ conj_ev_imag,
+            const $REAL* __restrict__ conj_hu_real,
+            const $REAL* __restrict__ conj_hu_imag,
+            const $REAL* __restrict__ conj_hv_real,
+            const $REAL* __restrict__ conj_hv_imag,
+            $REAL* electric_dft_real, $REAL* electric_dft_imag,
+            $REAL* magnetic_dft_real, $REAL* magnetic_dft_imag,
+            const $REAL* __restrict__ Ex, const $REAL* __restrict__ Ey,
+            const $REAL* __restrict__ Ez, const $REAL* __restrict__ Hx,
+            const $REAL* __restrict__ Hy, const $REAL* __restrict__ Hz)
+        """
+    ),
+    "args_opencl": Template(
+        """
+            int NF, int NM, int normal_axis, int direction_sign,
+            int magnetic_side, int u0, int v0, int u1, int v1,
+            int plane_index, $REAL dt, $REAL measure, int handedness,
+            __global $REAL* electric_phase_real,
+            __global $REAL* electric_phase_imag,
+            __global $REAL* magnetic_phase_real,
+            __global $REAL* magnetic_phase_imag,
+            __global const $REAL* restrict phase_step_real,
+            __global const $REAL* restrict phase_step_imag,
+            __global const $REAL* restrict conj_eu_real,
+            __global const $REAL* restrict conj_eu_imag,
+            __global const $REAL* restrict conj_ev_real,
+            __global const $REAL* restrict conj_ev_imag,
+            __global const $REAL* restrict conj_hu_real,
+            __global const $REAL* restrict conj_hu_imag,
+            __global const $REAL* restrict conj_hv_real,
+            __global const $REAL* restrict conj_hv_imag,
+            __global $REAL* electric_dft_real,
+            __global $REAL* electric_dft_imag,
+            __global $REAL* magnetic_dft_real,
+            __global $REAL* magnetic_dft_imag,
+            __global const $REAL* restrict Ex,
+            __global const $REAL* restrict Ey,
+            __global const $REAL* restrict Ez,
+            __global const $REAL* restrict Hx,
+            __global const $REAL* restrict Hy,
+            __global const $REAL* restrict Hz
+        """
+    ),
+    "args_metal": Template(
+        """
+        struct EigenmodeDFTParameters {
+            int NF;
+            int NM;
+            int normal_axis;
+            int direction_sign;
+            int magnetic_side;
+            int u0;
+            int v0;
+            int u1;
+            int v1;
+            int plane_index;
+            $REAL dt;
+            $REAL measure;
+            int handedness;
+        };
+
+        kernel void accumulate_eigenmode_dft(
+            constant EigenmodeDFTParameters& parameters,
+            device $REAL* electric_phase_real, device $REAL* electric_phase_imag,
+            device $REAL* magnetic_phase_real, device $REAL* magnetic_phase_imag,
+            device const $REAL* phase_step_real, device const $REAL* phase_step_imag,
+            device const $REAL* conj_eu_real, device const $REAL* conj_eu_imag,
+            device const $REAL* conj_ev_real, device const $REAL* conj_ev_imag,
+            device const $REAL* conj_hu_real, device const $REAL* conj_hu_imag,
+            device const $REAL* conj_hv_real, device const $REAL* conj_hv_imag,
+            device $REAL* electric_dft_real, device $REAL* electric_dft_imag,
+            device $REAL* magnetic_dft_real, device $REAL* magnetic_dft_imag,
+            device const $REAL* Ex, device const $REAL* Ey, device const $REAL* Ez,
+            device const $REAL* Hx, device const $REAL* Hy, device const $REAL* Hz,
+            uint i [[thread_position_in_grid]])
+        """
+    ),
+    "func": Template(
+        """
+    $CUDA_IDX
+    $METAL_DFT_PARAMETERS
+    if (i < NF) {
+        int nu = u1 - u0;
+        int nv = v1 - v0;
+        int hplane = direction_sign * magnetic_side > 0 ? plane_index : plane_index - 1;
+        $REAL factor = ($REAL)0.5 * handedness * measure * dt;
+        for (int mode = 0; mode < NM; mode++) {
+            $REAL esr=0, esi=0, msr=0, msi=0;
+            for (int u=0; u<nu; u++) {
+                for (int v=0; v<nv; v++) {
+                    $REAL eu,ev,hu,hv;
+                    if(normal_axis==0){eu=($REAL)0.5*(Ey[IDX3D_FIELDS(plane_index,u0+u,v0+v)]+Ey[IDX3D_FIELDS(plane_index,u0+u,v0+v+1)]);ev=($REAL)0.5*(Ez[IDX3D_FIELDS(plane_index,u0+u,v0+v)]+Ez[IDX3D_FIELDS(plane_index,u0+u+1,v0+v)]);hu=($REAL)0.5*(Hy[IDX3D_FIELDS(hplane,u0+u,v0+v)]+Hy[IDX3D_FIELDS(hplane,u0+u+1,v0+v)]);hv=($REAL)0.5*(Hz[IDX3D_FIELDS(hplane,u0+u,v0+v)]+Hz[IDX3D_FIELDS(hplane,u0+u,v0+v+1)]);}
+                    else if(normal_axis==1){eu=($REAL)0.5*(Ex[IDX3D_FIELDS(u0+u,plane_index,v0+v)]+Ex[IDX3D_FIELDS(u0+u,plane_index,v0+v+1)]);ev=($REAL)0.5*(Ez[IDX3D_FIELDS(u0+u,plane_index,v0+v)]+Ez[IDX3D_FIELDS(u0+u+1,plane_index,v0+v)]);hu=($REAL)0.5*(Hx[IDX3D_FIELDS(u0+u,hplane,v0+v)]+Hx[IDX3D_FIELDS(u0+u+1,hplane,v0+v)]);hv=($REAL)0.5*(Hz[IDX3D_FIELDS(u0+u,hplane,v0+v)]+Hz[IDX3D_FIELDS(u0+u,hplane,v0+v+1)]);}
+                    else{eu=($REAL)0.5*(Ex[IDX3D_FIELDS(u0+u,v0+v,plane_index)]+Ex[IDX3D_FIELDS(u0+u,v0+v+1,plane_index)]);ev=($REAL)0.5*(Ey[IDX3D_FIELDS(u0+u,v0+v,plane_index)]+Ey[IDX3D_FIELDS(u0+u+1,v0+v,plane_index)]);hu=($REAL)0.5*(Hx[IDX3D_FIELDS(u0+u,v0+v,hplane)]+Hx[IDX3D_FIELDS(u0+u+1,v0+v,hplane)]);hv=($REAL)0.5*(Hy[IDX3D_FIELDS(u0+u,v0+v,hplane)]+Hy[IDX3D_FIELDS(u0+u,v0+v+1,hplane)]);}
+                    int p=((i*NM+mode)*nu+u)*nv+v;
+                    esr += eu*conj_hv_real[p]-ev*conj_hu_real[p];
+                    esi += eu*conj_hv_imag[p]-ev*conj_hu_imag[p];
+                    msr += direction_sign*(conj_eu_real[p]*hv-conj_ev_real[p]*hu);
+                    msi += direction_sign*(conj_eu_imag[p]*hv-conj_ev_imag[p]*hu);
+                }
+            }
+            int out=i*NM+mode;
+            electric_dft_real[out]+=factor*(electric_phase_real[i]*esr-electric_phase_imag[i]*esi);
+            electric_dft_imag[out]+=factor*(electric_phase_real[i]*esi+electric_phase_imag[i]*esr);
+            magnetic_dft_real[out]+=factor*(magnetic_phase_real[i]*msr-magnetic_phase_imag[i]*msi);
+            magnetic_dft_imag[out]+=factor*(magnetic_phase_real[i]*msi+magnetic_phase_imag[i]*msr);
+        }
+        $REAL er=electric_phase_real[i],ei=electric_phase_imag[i];
+        electric_phase_real[i]=er*phase_step_real[i]-ei*phase_step_imag[i];
+        electric_phase_imag[i]=er*phase_step_imag[i]+ei*phase_step_real[i];
+        $REAL mr=magnetic_phase_real[i],mi=magnetic_phase_imag[i];
+        magnetic_phase_real[i]=mr*phase_step_real[i]-mi*phase_step_imag[i];
+        magnetic_phase_imag[i]=mr*phase_step_imag[i]+mi*phase_step_real[i];
+    }
+"""
+    ),
+}

--- a/gprMax/cuda_opencl/knl_ntff.py
+++ b/gprMax/cuda_opencl/knl_ntff.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax. If not, see <http://www.gnu.org/licenses/>.
 
-"""Runtime kernels for device-resident frequency- and time-domain KSIR."""
+"""Runtime kernels for device-resident KSIR and Love-current transforms."""
 
 from string import Template
 
@@ -352,3 +352,204 @@ def build_time_domain_ntff_kernel_source(c_real: str, backend: str = "cuda") -> 
         f"{preamble}\n{gather_declaration}{{\n{gather_body}}}\n"
         f"{deposit_declaration}{{\n{deposit_body}}}\n"
     )
+
+
+_EQUIVALENT_CURRENT_GATHER_ARGS = {
+    "cuda": Template(
+        """
+extern "C" __global__ void gather_equivalent_current_time(
+    int npatches, int max_samples,
+    const int* __restrict__ count_x,
+    const int* __restrict__ count_y,
+    const int* __restrict__ count_z,
+    const int* __restrict__ stencil_x,
+    const int* __restrict__ stencil_y,
+    const int* __restrict__ stencil_z,
+    const $REAL* __restrict__ normals,
+    $REAL scale,
+    const $REAL* __restrict__ field_x,
+    const $REAL* __restrict__ field_y,
+    const $REAL* __restrict__ field_z,
+    $REAL* current)
+"""
+    ),
+    "opencl": Template(
+        """
+__kernel void gather_equivalent_current_time(
+    int npatches, int max_samples,
+    __global const int* restrict count_x,
+    __global const int* restrict count_y,
+    __global const int* restrict count_z,
+    __global const int* restrict stencil_x,
+    __global const int* restrict stencil_y,
+    __global const int* restrict stencil_z,
+    __global const $REAL* restrict normals,
+    $REAL scale,
+    __global const $REAL* restrict field_x,
+    __global const $REAL* restrict field_y,
+    __global const $REAL* restrict field_z,
+    __global $REAL* current)
+"""
+    ),
+    "metal": Template(
+        """
+kernel void gather_equivalent_current_time(
+    device const int& npatches, device const int& max_samples,
+    device const int* count_x,
+    device const int* count_y,
+    device const int* count_z,
+    device const int* stencil_x,
+    device const int* stencil_y,
+    device const int* stencil_z,
+    device const $REAL* normals,
+    device const $REAL& scale,
+    device const $REAL* field_x,
+    device const $REAL* field_y,
+    device const $REAL* field_z,
+    device $REAL* current,
+    uint patch [[thread_position_in_grid]])
+"""
+    ),
+}
+
+
+_EQUIVALENT_CURRENT_GATHER_BODY = Template(
+    r"""
+    $INDEX
+    if (patch < npatches) {
+        $REAL values[3] = {($REAL)0, ($REAL)0, ($REAL)0};
+        int offset = patch * max_samples;
+        for (int sample = 0; sample < count_x[patch]; sample++)
+            values[0] += field_x[stencil_x[offset + sample]];
+        for (int sample = 0; sample < count_y[patch]; sample++)
+            values[1] += field_y[stencil_y[offset + sample]];
+        for (int sample = 0; sample < count_z[patch]; sample++)
+            values[2] += field_z[stencil_z[offset + sample]];
+        if (count_x[patch] > 0) values[0] /= ($REAL)count_x[patch];
+        if (count_y[patch] > 0) values[1] /= ($REAL)count_y[patch];
+        if (count_z[patch] > 0) values[2] /= ($REAL)count_z[patch];
+        $REAL nx = normals[patch * 3];
+        $REAL ny = normals[patch * 3 + 1];
+        $REAL nz = normals[patch * 3 + 2];
+        current[patch * 3] = scale * (ny * values[2] - nz * values[1]);
+        current[patch * 3 + 1] = scale * (nz * values[0] - nx * values[2]);
+        current[patch * 3 + 2] = scale * (nx * values[1] - ny * values[0]);
+    }
+"""
+)
+
+
+_EQUIVALENT_CURRENT_DEPOSIT_ARGS = {
+    "cuda": Template(
+        """
+extern "C" __global__ void deposit_equivalent_current_time(
+    int ndirections, int npatches, int output_length,
+    int sample_index, int time_origin_step, $REAL inverse_dt,
+    const $REAL* __restrict__ current,
+    const $REAL* __restrict__ previous,
+    const $REAL* __restrict__ theta_basis,
+    const $REAL* __restrict__ phi_basis,
+    const int* __restrict__ integer_delay,
+    const $REAL* __restrict__ fractional_delay,
+    const $REAL* __restrict__ area_weights,
+    $REAL* output_theta, $REAL* output_phi)
+"""
+    ),
+    "opencl": Template(
+        """
+__kernel void deposit_equivalent_current_time(
+    int ndirections, int npatches, int output_length,
+    int sample_index, int time_origin_step, $REAL inverse_dt,
+    __global const $REAL* restrict current,
+    __global const $REAL* restrict previous,
+    __global const $REAL* restrict theta_basis,
+    __global const $REAL* restrict phi_basis,
+    __global const int* restrict integer_delay,
+    __global const $REAL* restrict fractional_delay,
+    __global const $REAL* restrict area_weights,
+    __global $REAL* output_theta,
+    __global $REAL* output_phi)
+"""
+    ),
+    "metal": Template(
+        """
+kernel void deposit_equivalent_current_time(
+    device const int& ndirections, device const int& npatches,
+    device const int& output_length, device const int& sample_index,
+    device const int& time_origin_step, device const $REAL& inverse_dt,
+    device const $REAL* current,
+    device const $REAL* previous,
+    device const $REAL* theta_basis,
+    device const $REAL* phi_basis,
+    device const int* integer_delay,
+    device const $REAL* fractional_delay,
+    device const $REAL* area_weights,
+    device $REAL* output_theta,
+    device $REAL* output_phi,
+    uint direction [[thread_position_in_grid]])
+"""
+    ),
+}
+
+
+_EQUIVALENT_CURRENT_DEPOSIT_BODY = Template(
+    r"""
+    $INDEX
+    if (direction < ndirections) {
+        int basis = direction * 3;
+        int delay = direction * npatches;
+        int output = direction * output_length;
+        for (int patch = 0; patch < npatches; patch++) {
+            int vector = patch * 3;
+            $REAL dx = (current[vector] - previous[vector]) * inverse_dt;
+            $REAL dy = (current[vector + 1] - previous[vector + 1]) * inverse_dt;
+            $REAL dz = (current[vector + 2] - previous[vector + 2]) * inverse_dt;
+            $REAL theta_value = dx * theta_basis[basis]
+                + dy * theta_basis[basis + 1] + dz * theta_basis[basis + 2];
+            $REAL phi_value = dx * phi_basis[basis]
+                + dy * phi_basis[basis + 1] + dz * phi_basis[basis + 2];
+            int destination = sample_index + integer_delay[delay + patch]
+                - time_origin_step;
+            $REAL fraction = fractional_delay[delay + patch];
+            $REAL area = area_weights[patch];
+            output_theta[output + destination] +=
+                (($REAL)1 - fraction) * area * theta_value;
+            output_theta[output + destination + 1] +=
+                fraction * area * theta_value;
+            output_phi[output + destination] +=
+                (($REAL)1 - fraction) * area * phi_value;
+            output_phi[output + destination + 1] += fraction * area * phi_value;
+        }
+    }
+"""
+)
+
+
+def build_equivalent_current_time_kernel_source(c_real: str, backend: str) -> str:
+    """Render the 1997 Love-current gather and delayed-deposition kernels."""
+
+    if c_real not in ("float", "double"):
+        raise ValueError("c_real must be 'float' or 'double'")
+    if backend not in ("cuda", "opencl", "metal"):
+        raise ValueError("backend must be 'cuda', 'opencl', or 'metal'")
+    if backend == "cuda":
+        preamble = ""
+        gather_index = "int patch = blockIdx.x * blockDim.x + threadIdx.x;"
+        deposit_index = "int direction = blockIdx.x * blockDim.x + threadIdx.x;"
+    elif backend == "opencl":
+        preamble = "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n" if c_real == "double" else ""
+        gather_index = "int patch = get_global_id(0);"
+        deposit_index = "int direction = get_global_id(0);"
+    else:
+        preamble = "#include <metal_stdlib>\nusing namespace metal;\n"
+        gather_index = ""
+        deposit_index = ""
+    gather = _EQUIVALENT_CURRENT_GATHER_ARGS[backend].substitute(REAL=c_real)
+    gather_body = _EQUIVALENT_CURRENT_GATHER_BODY.substitute(
+        REAL=c_real, INDEX=gather_index
+    )
+    deposit = _EQUIVALENT_CURRENT_DEPOSIT_ARGS[backend].substitute(REAL=c_real)
+    deposit_body = _EQUIVALENT_CURRENT_DEPOSIT_BODY.substitute(
+        REAL=c_real, INDEX=deposit_index
+    )
+    return f"{preamble}{gather}{{\n{gather_body}}}\n{deposit}{{\n{deposit_body}}}\n"

--- a/gprMax/cuda_opencl/knl_rational_network.py
+++ b/gprMax/cuda_opencl/knl_rational_network.py
@@ -1,0 +1,190 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""Shared CUDA/OpenCL/Metal kernel for sparse rational-network terminals."""
+
+from string import Template
+
+update_rational_network = {
+    "args_cuda": Template(
+        """
+        __global__ void update_rational_network(
+            int NTERMINALS,
+            int iteration,
+            $REAL dt,
+            const int* __restrict__ info,
+            const $REAL* __restrict__ params,
+            const $REAL* __restrict__ waveform_whole,
+            const $REAL* __restrict__ waveform_half,
+            $REAL* voltage,
+            $REAL* current,
+            const $REAL* __restrict__ exp_half_real,
+            const $REAL* __restrict__ exp_half_imag,
+            const $REAL* __restrict__ coeff_half_new_real,
+            const $REAL* __restrict__ coeff_half_new_imag,
+            const $REAL* __restrict__ coeff_half_old_real,
+            const $REAL* __restrict__ coeff_half_old_imag,
+            const $REAL* __restrict__ exp_full_real,
+            const $REAL* __restrict__ exp_full_imag,
+            const $REAL* __restrict__ coeff_full_new_real,
+            const $REAL* __restrict__ coeff_full_new_imag,
+            const $REAL* __restrict__ coeff_full_old_real,
+            const $REAL* __restrict__ coeff_full_old_imag,
+            $REAL* state_real,
+            $REAL* state_imag,
+            $REAL* Ex,
+            $REAL* Ey,
+            $REAL* Ez)
+        """
+    ),
+    "args_opencl": Template(
+        """
+            int NTERMINALS,
+            int iteration,
+            $REAL dt,
+            __global const int* restrict info,
+            __global const $REAL* restrict params,
+            __global const $REAL* restrict waveform_whole,
+            __global const $REAL* restrict waveform_half,
+            __global $REAL* voltage,
+            __global $REAL* current,
+            __global const $REAL* restrict exp_half_real,
+            __global const $REAL* restrict exp_half_imag,
+            __global const $REAL* restrict coeff_half_new_real,
+            __global const $REAL* restrict coeff_half_new_imag,
+            __global const $REAL* restrict coeff_half_old_real,
+            __global const $REAL* restrict coeff_half_old_imag,
+            __global const $REAL* restrict exp_full_real,
+            __global const $REAL* restrict exp_full_imag,
+            __global const $REAL* restrict coeff_full_new_real,
+            __global const $REAL* restrict coeff_full_new_imag,
+            __global const $REAL* restrict coeff_full_old_real,
+            __global const $REAL* restrict coeff_full_old_imag,
+            __global $REAL* state_real,
+            __global $REAL* state_imag,
+            __global $REAL* Ex,
+            __global $REAL* Ey,
+            __global $REAL* Ez
+        """
+    ),
+    "args_metal": Template(
+        """
+        kernel void update_rational_network(
+            device const int& NTERMINALS,
+            device const int& iteration,
+            device const $REAL& dt,
+            device const int* info,
+            device const $REAL* params,
+            device const $REAL* waveform_whole,
+            device const $REAL* waveform_half,
+            device $REAL* voltage,
+            device $REAL* current,
+            device const $REAL* exp_half_real,
+            device const $REAL* exp_half_imag,
+            device const $REAL* coeff_half_new_real,
+            device const $REAL* coeff_half_new_imag,
+            device const $REAL* coeff_half_old_real,
+            device const $REAL* coeff_half_old_imag,
+            device const $REAL* exp_full_real,
+            device const $REAL* exp_full_imag,
+            device const $REAL* coeff_full_new_real,
+            device const $REAL* coeff_full_new_imag,
+            device const $REAL* coeff_full_old_real,
+            device const $REAL* coeff_full_old_imag,
+            device $REAL* state_real,
+            device $REAL* state_imag,
+            device $REAL* Ex,
+            device $REAL* Ey,
+            device $REAL* Ez,
+            uint i [[thread_position_in_grid]])
+        """
+    ),
+    "func": Template(
+        """
+    $CUDA_IDX
+
+    if (i < NTERMINALS) {
+        int x = info[i * $NY_RNINFO + 0];
+        int y = info[i * $NY_RNINFO + 1];
+        int z = info[i * $NY_RNINFO + 2];
+        int polarisation = info[i * $NY_RNINFO + 3];
+        int pole_offset = info[i * $NY_RNINFO + 4];
+        int pole_count = info[i * $NY_RNINFO + 5];
+
+        $REAL dl = params[i * $NY_RNPARAMS + 0];
+        $REAL area = params[i * $NY_RNPARAMS + 1];
+        $REAL source_coefficient = params[i * $NY_RNPARAMS + 2];
+        $REAL denominator = params[i * $NY_RNPARAMS + 3];
+        $REAL alpha = params[i * $NY_RNPARAMS + 4];
+        $REAL conductance = params[i * $NY_RNPARAMS + 5];
+        $REAL capacitance = params[i * $NY_RNPARAMS + 6];
+
+        int whole_offset = i * $NY_RNWAVEWHOLE;
+        int half_offset = i * $NY_RNWAVEHALF;
+        int voltage_offset = i * $NY_RNVOLTAGE;
+        int current_offset = i * $NY_RNCURRENT;
+        $REAL voltage_old = voltage[voltage_offset + iteration];
+        $REAL generator_old = waveform_whole[whole_offset + iteration];
+        $REAL generator_new = waveform_whole[whole_offset + iteration + 1];
+        $REAL generator_half = waveform_half[half_offset + iteration];
+        $REAL input_old = voltage_old - generator_old;
+        $REAL history =
+            (conductance / ($REAL)2.0 - capacitance / dt) * voltage_old
+            - conductance * generator_half
+            - capacitance * (generator_new - generator_old) / dt;
+
+        for (int local_pole = 0; local_pole < pole_count; local_pole++) {
+            int p = pole_offset + local_pole;
+            $REAL half_real =
+                exp_half_real[p] * state_real[p]
+                - exp_half_imag[p] * state_imag[p]
+                + coeff_half_old_real[p] * input_old
+                - coeff_half_new_real[p] * generator_new;
+            history += half_real;
+        }
+
+        int field_index = IDX3D_FIELDS(x,y,z);
+        $REAL electric;
+        if (polarisation == 0) {
+            electric = (Ex[field_index] + source_coefficient * history / area) / denominator;
+            Ex[field_index] = electric;
+        }
+        else if (polarisation == 1) {
+            electric = (Ey[field_index] + source_coefficient * history / area) / denominator;
+            Ey[field_index] = electric;
+        }
+        else {
+            electric = (Ez[field_index] + source_coefficient * history / area) / denominator;
+            Ez[field_index] = electric;
+        }
+
+        $REAL voltage_new = -dl * electric;
+        $REAL input_new = voltage_new - generator_new;
+        voltage[voltage_offset + iteration + 1] = voltage_new;
+        current[current_offset + iteration] = alpha * voltage_new + history;
+
+        for (int local_pole = 0; local_pole < pole_count; local_pole++) {
+            int p = pole_offset + local_pole;
+            $REAL old_real = state_real[p];
+            $REAL old_imag = state_imag[p];
+            state_real[p] =
+                exp_full_real[p] * old_real - exp_full_imag[p] * old_imag
+                + coeff_full_new_real[p] * input_new
+                + coeff_full_old_real[p] * input_old;
+            state_imag[p] =
+                exp_full_real[p] * old_imag + exp_full_imag[p] * old_real
+                + coeff_full_new_imag[p] * input_new
+                + coeff_full_old_imag[p] * input_old;
+        }
+    }
+"""
+    ),
+}

--- a/gprMax/cuda_opencl/knl_symmetry_boundaries.py
+++ b/gprMax/cuda_opencl/knl_symmetry_boundaries.py
@@ -87,6 +87,7 @@ kernel void update_electric_pmc(
     if (x >= 0 && x < NX && y >= 0 && y <= NY && z >= 0 && z <= NZ
             && ex_on_pmc) {
         int material = ID[IDX4D_ID(0,x_ID,y_ID,z_ID)];
+        $DISP_EX
         $REAL dHz_dy = ($REAL)0;
         $REAL dHy_dz = ($REAL)0;
         if (y == 0) {
@@ -106,7 +107,7 @@ kernel void update_electric_pmc(
         Ex[IDX3D_FIELDS(x,y,z)] =
             updatecoeffsE[IDX2D_MAT(material,0)] * Ex[IDX3D_FIELDS(x,y,z)]
             + updatecoeffsE[IDX2D_MAT(material,2)] * dHz_dy
-            - updatecoeffsE[IDX2D_MAT(material,3)] * dHy_dz;
+            - updatecoeffsE[IDX2D_MAT(material,3)] * dHy_dz $PHI_EX;
     }
 
     int ey_on_pmc = (x == 0 && PMC_X0) || (x == NX && PMC_XMAX)
@@ -114,6 +115,7 @@ kernel void update_electric_pmc(
     if (x >= 0 && x <= NX && y >= 0 && y < NY && z >= 0 && z <= NZ
             && ey_on_pmc) {
         int material = ID[IDX4D_ID(1,x_ID,y_ID,z_ID)];
+        $DISP_EY
         $REAL dHx_dz = ($REAL)0;
         $REAL dHz_dx = ($REAL)0;
         if (z == 0) {
@@ -133,7 +135,7 @@ kernel void update_electric_pmc(
         Ey[IDX3D_FIELDS(x,y,z)] =
             updatecoeffsE[IDX2D_MAT(material,0)] * Ey[IDX3D_FIELDS(x,y,z)]
             + updatecoeffsE[IDX2D_MAT(material,3)] * dHx_dz
-            - updatecoeffsE[IDX2D_MAT(material,1)] * dHz_dx;
+            - updatecoeffsE[IDX2D_MAT(material,1)] * dHz_dx $PHI_EY;
     }
 
     int ez_on_pmc = (x == 0 && PMC_X0) || (x == NX && PMC_XMAX)
@@ -141,6 +143,7 @@ kernel void update_electric_pmc(
     if (x >= 0 && x <= NX && y >= 0 && y <= NY && z >= 0 && z < NZ
             && ez_on_pmc) {
         int material = ID[IDX4D_ID(2,x_ID,y_ID,z_ID)];
+        $DISP_EZ
         $REAL dHy_dx = ($REAL)0;
         $REAL dHx_dy = ($REAL)0;
         if (x == 0) {
@@ -160,8 +163,212 @@ kernel void update_electric_pmc(
         Ez[IDX3D_FIELDS(x,y,z)] =
             updatecoeffsE[IDX2D_MAT(material,0)] * Ez[IDX3D_FIELDS(x,y,z)]
             + updatecoeffsE[IDX2D_MAT(material,1)] * dHy_dx
-            - updatecoeffsE[IDX2D_MAT(material,2)] * dHx_dy;
+            - updatecoeffsE[IDX2D_MAT(material,2)] * dHx_dy $PHI_EZ;
     }
 """
     ),
 }
+
+
+update_electric_pmc_dispersive = {
+    "args_cuda": Template(
+        """
+__global__ void update_electric_pmc_dispersive(
+    int NX, int NY, int NZ, int MAXPOLES,
+    int PMC_X0, int PMC_XMAX,
+    int PMC_Y0, int PMC_YMAX,
+    int PMC_Z0, int PMC_ZMAX,
+    const $COMPLEX* __restrict__ updatecoeffsdispersive,
+    $COMPLEX* __restrict__ Tx,
+    $COMPLEX* __restrict__ Ty,
+    $COMPLEX* __restrict__ Tz,
+    const unsigned int* __restrict__ ID,
+    $REAL* Ex, $REAL* Ey, $REAL* Ez,
+    const $REAL* __restrict__ Hx,
+    const $REAL* __restrict__ Hy,
+    const $REAL* __restrict__ Hz)
+"""
+    ),
+    "args_opencl": Template(
+        """
+    int NX, int NY, int NZ, int MAXPOLES,
+    int PMC_X0, int PMC_XMAX,
+    int PMC_Y0, int PMC_YMAX,
+    int PMC_Z0, int PMC_ZMAX,
+    __global const unsigned int* restrict ID,
+    __global $REAL* Ex, __global $REAL* Ey, __global $REAL* Ez,
+    __global const $REAL* restrict Hx,
+    __global const $REAL* restrict Hy,
+    __global const $REAL* restrict Hz,
+    __global const $COMPLEX* restrict updatecoeffsdispersive,
+    __global $COMPLEX* restrict Tx,
+    __global $COMPLEX* restrict Ty,
+    __global $COMPLEX* restrict Tz
+"""
+    ),
+    "args_metal": Template(
+        """
+kernel void update_electric_pmc_dispersive(
+    device const int& NX, device const int& NY, device const int& NZ,
+    device const int& MAXPOLES,
+    device const int& PMC_X0, device const int& PMC_XMAX,
+    device const int& PMC_Y0, device const int& PMC_YMAX,
+    device const int& PMC_Z0, device const int& PMC_ZMAX,
+    device const $COMPLEX* updatecoeffsdispersive,
+    device $COMPLEX* Tx, device $COMPLEX* Ty, device $COMPLEX* Tz,
+    device const uint* ID,
+    device $REAL* Ex, device $REAL* Ey, device $REAL* Ez,
+    device const $REAL* Hx, device const $REAL* Hy, device const $REAL* Hz,
+    uint i [[thread_position_in_grid]])
+"""
+    ),
+    "func": update_electric_pmc["func"],
+}
+
+
+_DISPERSION_SNIPPET = Template(
+    """
+        $REAL phi = ($REAL)0;
+        for (int pole = 0; pole < MAXPOLES; pole++) {
+            int state = IDX4D_T(pole,x,y,z);
+            phi += GPRMAX_CREAL(GPRMAX_CMUL(
+                updatecoeffsdispersive[IDX2D_MATDISP(material,pole*3)],
+                $T[state]));
+            $T[state] = GPRMAX_CADD(
+                GPRMAX_CMUL(
+                    updatecoeffsdispersive[IDX2D_MATDISP(material,1+pole*3)],
+                    $T[state]),
+                GPRMAX_CRMUL(
+                    updatecoeffsdispersive[IDX2D_MATDISP(material,2+pole*3)],
+                    $E[IDX3D_FIELDS(x,y,z)]));
+        }
+"""
+)
+
+
+update_electric_pmc_dispersive_b = {
+    "args_cuda": Template(
+        """
+__global__ void update_electric_pmc_dispersive_b(
+    int NX, int NY, int NZ, int MAXPOLES,
+    int PMC_X0, int PMC_XMAX,
+    int PMC_Y0, int PMC_YMAX,
+    int PMC_Z0, int PMC_ZMAX,
+    const $COMPLEX* __restrict__ updatecoeffsdispersive,
+    $COMPLEX* __restrict__ Tx,
+    $COMPLEX* __restrict__ Ty,
+    $COMPLEX* __restrict__ Tz,
+    const unsigned int* __restrict__ ID,
+    const $REAL* __restrict__ Ex,
+    const $REAL* __restrict__ Ey,
+    const $REAL* __restrict__ Ez)
+"""
+    ),
+    "args_opencl": Template(
+        """
+    int NX, int NY, int NZ, int MAXPOLES,
+    int PMC_X0, int PMC_XMAX,
+    int PMC_Y0, int PMC_YMAX,
+    int PMC_Z0, int PMC_ZMAX,
+    __global const unsigned int* restrict ID,
+    __global const $REAL* restrict Ex,
+    __global const $REAL* restrict Ey,
+    __global const $REAL* restrict Ez,
+    __global const $COMPLEX* restrict updatecoeffsdispersive,
+    __global $COMPLEX* restrict Tx,
+    __global $COMPLEX* restrict Ty,
+    __global $COMPLEX* restrict Tz
+"""
+    ),
+    "args_metal": Template(
+        """
+kernel void update_electric_pmc_dispersive_b(
+    device const int& NX, device const int& NY, device const int& NZ,
+    device const int& MAXPOLES,
+    device const int& PMC_X0, device const int& PMC_XMAX,
+    device const int& PMC_Y0, device const int& PMC_YMAX,
+    device const int& PMC_Z0, device const int& PMC_ZMAX,
+    device const $COMPLEX* updatecoeffsdispersive,
+    device $COMPLEX* Tx, device $COMPLEX* Ty, device $COMPLEX* Tz,
+    device const uint* ID,
+    device const $REAL* Ex, device const $REAL* Ey, device const $REAL* Ez,
+    uint i [[thread_position_in_grid]])
+"""
+    ),
+    "func": Template(
+        r"""
+    $CUDA_IDX
+    int x = i / ($NY_FIELDS * $NZ_FIELDS);
+    int y = (i % ($NY_FIELDS * $NZ_FIELDS)) / $NZ_FIELDS;
+    int z = (i % ($NY_FIELDS * $NZ_FIELDS)) % $NZ_FIELDS;
+    int x_ID = (i % ($NX_ID * $NY_ID * $NZ_ID)) / ($NY_ID * $NZ_ID);
+    int y_ID = ((i % ($NX_ID * $NY_ID * $NZ_ID)) %
+        ($NY_ID * $NZ_ID)) / $NZ_ID;
+    int z_ID = ((i % ($NX_ID * $NY_ID * $NZ_ID)) %
+        ($NY_ID * $NZ_ID)) % $NZ_ID;
+
+    int ex_on_pmc = (y == 0 && PMC_Y0) || (y == NY && PMC_YMAX)
+        || (z == 0 && PMC_Z0) || (z == NZ && PMC_ZMAX);
+    if (x >= 0 && x < NX && y >= 0 && y <= NY && z >= 0 && z <= NZ
+            && ex_on_pmc) {
+        int material = ID[IDX4D_ID(0,x_ID,y_ID,z_ID)];
+        for (int pole = 0; pole < MAXPOLES; pole++) {
+            int state = IDX4D_T(pole,x,y,z);
+            Tx[state] = GPRMAX_CSUB(Tx[state], GPRMAX_CRMUL(
+                updatecoeffsdispersive[IDX2D_MATDISP(material,2+pole*3)],
+                Ex[IDX3D_FIELDS(x,y,z)]));
+        }
+    }
+    int ey_on_pmc = (x == 0 && PMC_X0) || (x == NX && PMC_XMAX)
+        || (z == 0 && PMC_Z0) || (z == NZ && PMC_ZMAX);
+    if (x >= 0 && x <= NX && y >= 0 && y < NY && z >= 0 && z <= NZ
+            && ey_on_pmc) {
+        int material = ID[IDX4D_ID(1,x_ID,y_ID,z_ID)];
+        for (int pole = 0; pole < MAXPOLES; pole++) {
+            int state = IDX4D_T(pole,x,y,z);
+            Ty[state] = GPRMAX_CSUB(Ty[state], GPRMAX_CRMUL(
+                updatecoeffsdispersive[IDX2D_MATDISP(material,2+pole*3)],
+                Ey[IDX3D_FIELDS(x,y,z)]));
+        }
+    }
+    int ez_on_pmc = (x == 0 && PMC_X0) || (x == NX && PMC_XMAX)
+        || (y == 0 && PMC_Y0) || (y == NY && PMC_YMAX);
+    if (x >= 0 && x <= NX && y >= 0 && y <= NY && z >= 0 && z < NZ
+            && ez_on_pmc) {
+        int material = ID[IDX4D_ID(2,x_ID,y_ID,z_ID)];
+        for (int pole = 0; pole < MAXPOLES; pole++) {
+            int state = IDX4D_T(pole,x,y,z);
+            Tz[state] = GPRMAX_CSUB(Tz[state], GPRMAX_CRMUL(
+                updatecoeffsdispersive[IDX2D_MATDISP(material,2+pole*3)],
+                Ez[IDX3D_FIELDS(x,y,z)]));
+        }
+    }
+"""
+    ),
+}
+
+
+def nondispersive_substitutions():
+    """Placeholders used by the shared PMC body without ADE state."""
+
+    return {
+        "DISP_EX": "",
+        "DISP_EY": "",
+        "DISP_EZ": "",
+        "PHI_EX": "",
+        "PHI_EY": "",
+        "PHI_EZ": "",
+    }
+
+
+def dispersive_substitutions(real):
+    """Placeholders used by the shared PMC body with ADE state."""
+
+    return {
+        "DISP_EX": _DISPERSION_SNIPPET.substitute(REAL=real, T="Tx", E="Ex"),
+        "DISP_EY": _DISPERSION_SNIPPET.substitute(REAL=real, T="Ty", E="Ey"),
+        "DISP_EZ": _DISPERSION_SNIPPET.substitute(REAL=real, T="Tz", E="Ez"),
+        "PHI_EX": "- updatecoeffsE[IDX2D_MAT(material,4)] * phi",
+        "PHI_EY": "- updatecoeffsE[IDX2D_MAT(material,4)] * phi",
+        "PHI_EZ": "- updatecoeffsE[IDX2D_MAT(material,4)] * phi",
+    }

--- a/gprMax/cuda_opencl/knl_virtual_waveguide.py
+++ b/gprMax/cuda_opencl/knl_virtual_waveguide.py
@@ -1,0 +1,270 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""Device-resident aperture coupling for auxiliary virtual waveguides."""
+
+from string import Template
+
+
+def _args(name, backend, *, electric):
+    prefix = {"cuda": "__global__ void", "opencl": "", "metal": "kernel void"}[backend]
+    integer = "device const int&" if backend == "metal" else "int"
+    real_const = {
+        "cuda": "const $REAL* __restrict__",
+        "opencl": "__global const $REAL* restrict",
+        "metal": "device const $REAL*",
+    }[backend]
+    real = {"cuda": "$REAL*", "opencl": "__global $REAL*", "metal": "device $REAL*"}[backend]
+    uint_const = {
+        "cuda": "const unsigned int* __restrict__",
+        "opencl": "__global const uint* restrict",
+        "metal": "device const uint*",
+    }[backend]
+    values = [
+        f"{integer} NPOINTS",
+        f"{integer} normal_axis",
+        f"{integer} direction_sign",
+        f"{integer} u0",
+        f"{integer} v0",
+        f"{integer} u1",
+        f"{integer} v1",
+        f"{integer} plane_index",
+        f"{integer} aux_nx",
+        f"{integer} aux_ny",
+        f"{integer} aux_nz",
+    ]
+    if electric:
+        values.extend((f"{real_const} aux_coeffs", f"{uint_const} aux_ID"))
+        names = (
+            "main_Ex",
+            "main_Ey",
+            "main_Ez",
+            "main_Hx",
+            "main_Hy",
+            "main_Hz",
+            "aux_Ex",
+            "aux_Ey",
+            "aux_Ez",
+            "aux_Hx",
+            "aux_Hy",
+            "aux_Hz",
+        )
+    else:
+        names = ("main_Hx", "main_Hy", "main_Hz", "aux_Hx", "aux_Hy", "aux_Hz")
+    values.extend(f"{real} {value}" for value in names)
+    suffix = ", uint i [[thread_position_in_grid]]" if backend == "metal" else ""
+    if backend == "opencl":
+        return Template(",\n            ".join(values))
+    return Template(f"{prefix} {name}(" + ",\n            ".join(values) + suffix + ")")
+
+
+couple_magnetic = {
+    "args_cuda": _args("couple_virtual_waveguide_magnetic", "cuda", electric=False),
+    "args_opencl": _args("couple_virtual_waveguide_magnetic", "opencl", electric=False),
+    "args_metal": _args("couple_virtual_waveguide_magnetic", "metal", electric=False),
+    "func": Template(
+        """
+    $CUDA_IDX
+    if (i < NPOINTS) {
+        int nu = u1 - u0;
+        int nv = v1 - v0;
+        int stride_v = nv + 1;
+        int u = i / stride_v;
+        int v = i - u * stride_v;
+        int aperture = direction_sign < 0 ? 0 :
+            (normal_axis == 0 ? aux_nx : (normal_axis == 1 ? aux_ny : aux_nz));
+        int aux_index;
+        int main_index;
+        if (u < nu && v < nv) {
+            if (normal_axis == 0) {
+                aux_index = aperture * (aux_ny + 1) * (aux_nz + 1) + u * (aux_nz + 1) + v;
+                main_index = IDX3D_FIELDS(plane_index,u0+u,v0+v);
+                aux_Hx[aux_index] = main_Hx[main_index];
+            }
+            else if (normal_axis == 1) {
+                aux_index = u * (aux_ny + 1) * (aux_nz + 1) + aperture * (aux_nz + 1) + v;
+                main_index = IDX3D_FIELDS(u0+u,plane_index,v0+v);
+                aux_Hy[aux_index] = main_Hy[main_index];
+            }
+            else {
+                aux_index = u * (aux_ny + 1) * (aux_nz + 1) + v * (aux_nz + 1) + aperture;
+                main_index = IDX3D_FIELDS(u0+u,v0+v,plane_index);
+                aux_Hz[aux_index] = main_Hz[main_index];
+            }
+        }
+    }
+"""
+    ),
+}
+
+
+clear_rear_magnetic = {
+    "args_cuda": _args("clear_virtual_waveguide_rear_magnetic", "cuda", electric=False),
+    "args_opencl": _args("clear_virtual_waveguide_rear_magnetic", "opencl", electric=False),
+    "args_metal": _args("clear_virtual_waveguide_rear_magnetic", "metal", electric=False),
+    "func": Template(
+        """
+    $CUDA_IDX
+    if (i < NPOINTS) {
+        int x = i / ($NY_FIELDS * $NZ_FIELDS);
+        int remainder = i - x * $NY_FIELDS * $NZ_FIELDS;
+        int y = remainder / $NZ_FIELDS;
+        int z = remainder - y * $NZ_FIELDS;
+        bool rear, tangent_plane;
+        if (normal_axis == 0) {
+            rear = direction_sign < 0 ? x >= plane_index : x < plane_index;
+            tangent_plane = direction_sign < 0 ? x < $NX_FIELDS - 1 : true;
+            if (rear) {
+                if ((direction_sign > 0 || x > plane_index) && y >= u0 && y < u1 && z >= v0 && z < v1) main_Hx[i] = 0;
+                if (tangent_plane && y >= u0 && y <= u1 && z >= v0 && z < v1) main_Hy[i] = 0;
+                if (tangent_plane && y >= u0 && y < u1 && z >= v0 && z <= v1) main_Hz[i] = 0;
+            }
+        }
+        else if (normal_axis == 1) {
+            rear = direction_sign < 0 ? y >= plane_index : y < plane_index;
+            tangent_plane = direction_sign < 0 ? y < $NY_FIELDS - 1 : true;
+            if (rear) {
+                if ((direction_sign > 0 || y > plane_index) && x >= u0 && x < u1 && z >= v0 && z < v1) main_Hy[i] = 0;
+                if (tangent_plane && x >= u0 && x <= u1 && z >= v0 && z < v1) main_Hx[i] = 0;
+                if (tangent_plane && x >= u0 && x < u1 && z >= v0 && z <= v1) main_Hz[i] = 0;
+            }
+        }
+        else {
+            rear = direction_sign < 0 ? z >= plane_index : z < plane_index;
+            tangent_plane = direction_sign < 0 ? z < $NZ_FIELDS - 1 : true;
+            if (rear) {
+                if ((direction_sign > 0 || z > plane_index) && x >= u0 && x < u1 && y >= v0 && y < v1) main_Hz[i] = 0;
+                if (tangent_plane && x >= u0 && x <= u1 && y >= v0 && y < v1) main_Hx[i] = 0;
+                if (tangent_plane && x >= u0 && x < u1 && y >= v0 && y <= v1) main_Hy[i] = 0;
+            }
+        }
+    }
+"""
+    ),
+}
+
+
+couple_electric = {
+    "args_cuda": _args("couple_virtual_waveguide_electric", "cuda", electric=True),
+    "args_opencl": _args("couple_virtual_waveguide_electric", "opencl", electric=True),
+    "args_metal": _args("couple_virtual_waveguide_electric", "metal", electric=True),
+    "func": Template(
+        """
+    $CUDA_IDX
+    if (i < NPOINTS) {
+        int nu = u1 - u0;
+        int nv = v1 - v0;
+        int stride_v = nv + 1;
+        int u = i / stride_v;
+        int v = i - u * stride_v;
+        int aperture = direction_sign < 0 ? 0 :
+            (normal_axis == 0 ? aux_nx : (normal_axis == 1 ? aux_ny : aux_nz));
+        int inside = direction_sign < 0 ? 0 : aperture - 1;
+        int aidx = 0, midx = 0, material;
+        $REAL cross_field;
+
+        if (normal_axis == 0) {
+            if (u < nu && v > 0 && v < nv) {
+                aidx = aperture*(aux_ny+1)*(aux_nz+1)+u*(aux_nz+1)+v;
+                material = aux_ID[1*(aux_nx+1)*(aux_ny+1)*(aux_nz+1)+aidx];
+                cross_field = direction_sign < 0
+                    ? aux_Hz[u*(aux_nz+1)+v] - main_Hz[IDX3D_FIELDS(plane_index-1,u0+u,v0+v)]
+                    : main_Hz[IDX3D_FIELDS(plane_index,u0+u,v0+v)] - aux_Hz[inside*(aux_ny+1)*(aux_nz+1)+u*(aux_nz+1)+v];
+                aux_Ey[aidx] = aux_coeffs[IDX2D_MAT(material,0)]*aux_Ey[aidx]
+                    + aux_coeffs[IDX2D_MAT(material,3)]*(aux_Hx[aidx]-aux_Hx[aidx-1])
+                    - aux_coeffs[IDX2D_MAT(material,1)]*cross_field;
+            }
+            if (u > 0 && u < nu && v < nv) {
+                aidx = aperture*(aux_ny+1)*(aux_nz+1)+u*(aux_nz+1)+v;
+                material = aux_ID[2*(aux_nx+1)*(aux_ny+1)*(aux_nz+1)+aidx];
+                cross_field = direction_sign < 0
+                    ? aux_Hy[u*(aux_nz+1)+v] - main_Hy[IDX3D_FIELDS(plane_index-1,u0+u,v0+v)]
+                    : main_Hy[IDX3D_FIELDS(plane_index,u0+u,v0+v)] - aux_Hy[inside*(aux_ny+1)*(aux_nz+1)+u*(aux_nz+1)+v];
+                aux_Ez[aidx] = aux_coeffs[IDX2D_MAT(material,0)]*aux_Ez[aidx]
+                    + aux_coeffs[IDX2D_MAT(material,1)]*cross_field
+                    - aux_coeffs[IDX2D_MAT(material,2)]*(aux_Hx[aidx]-aux_Hx[aidx-(aux_nz+1)]);
+            }
+            if (u < nu && v <= nv) {
+                aidx=aperture*(aux_ny+1)*(aux_nz+1)+u*(aux_nz+1)+v;
+                main_Ey[IDX3D_FIELDS(plane_index,u0+u,v0+v)]=aux_Ey[aidx];
+            }
+            if (u <= nu && v < nv) {
+                aidx=aperture*(aux_ny+1)*(aux_nz+1)+u*(aux_nz+1)+v;
+                main_Ez[IDX3D_FIELDS(plane_index,u0+u,v0+v)]=aux_Ez[aidx];
+            }
+            aidx=(direction_sign<0?0:inside)*(aux_ny+1)*(aux_nz+1)+u*(aux_nz+1)+v;
+            midx=IDX3D_FIELDS(direction_sign<0?plane_index:plane_index-1,u0+u,v0+v);
+            main_Ex[midx]=aux_Ex[aidx];
+        }
+        else if (normal_axis == 1) {
+            if (u < nu && v > 0 && v < nv) {
+                aidx=u*(aux_ny+1)*(aux_nz+1)+aperture*(aux_nz+1)+v;
+                material=aux_ID[aidx];
+                cross_field=direction_sign<0
+                    ? aux_Hz[u*(aux_ny+1)*(aux_nz+1)+v]-main_Hz[IDX3D_FIELDS(u0+u,plane_index-1,v0+v)]
+                    : main_Hz[IDX3D_FIELDS(u0+u,plane_index,v0+v)]-aux_Hz[u*(aux_ny+1)*(aux_nz+1)+inside*(aux_nz+1)+v];
+                aux_Ex[aidx]=aux_coeffs[IDX2D_MAT(material,0)]*aux_Ex[aidx]
+                    +aux_coeffs[IDX2D_MAT(material,2)]*cross_field
+                    -aux_coeffs[IDX2D_MAT(material,3)]*(aux_Hy[aidx]-aux_Hy[aidx-1]);
+            }
+            if (u > 0 && u < nu && v < nv) {
+                aidx=u*(aux_ny+1)*(aux_nz+1)+aperture*(aux_nz+1)+v;
+                material=aux_ID[2*(aux_nx+1)*(aux_ny+1)*(aux_nz+1)+aidx];
+                cross_field=direction_sign<0
+                    ? aux_Hx[u*(aux_ny+1)*(aux_nz+1)+v]-main_Hx[IDX3D_FIELDS(u0+u,plane_index-1,v0+v)]
+                    : main_Hx[IDX3D_FIELDS(u0+u,plane_index,v0+v)]-aux_Hx[u*(aux_ny+1)*(aux_nz+1)+inside*(aux_nz+1)+v];
+                aux_Ez[aidx]=aux_coeffs[IDX2D_MAT(material,0)]*aux_Ez[aidx]
+                    +aux_coeffs[IDX2D_MAT(material,1)]*(aux_Hy[aidx]-aux_Hy[aidx-(aux_ny+1)*(aux_nz+1)])
+                    -aux_coeffs[IDX2D_MAT(material,2)]*cross_field;
+            }
+            if(u<nu&&v<=nv){aidx=u*(aux_ny+1)*(aux_nz+1)+aperture*(aux_nz+1)+v;main_Ex[IDX3D_FIELDS(u0+u,plane_index,v0+v)]=aux_Ex[aidx];}
+            if(u<=nu&&v<nv){aidx=u*(aux_ny+1)*(aux_nz+1)+aperture*(aux_nz+1)+v;main_Ez[IDX3D_FIELDS(u0+u,plane_index,v0+v)]=aux_Ez[aidx];}
+            aidx=u*(aux_ny+1)*(aux_nz+1)+(direction_sign<0?0:inside)*(aux_nz+1)+v;
+            main_Ey[IDX3D_FIELDS(u0+u,direction_sign<0?plane_index:plane_index-1,v0+v)]=aux_Ey[aidx];
+        }
+        else {
+            if(u<nu&&v>0&&v<nv){
+                aidx=u*(aux_ny+1)*(aux_nz+1)+v*(aux_nz+1)+aperture;material=aux_ID[aidx];
+                cross_field=direction_sign<0?aux_Hy[u*(aux_ny+1)*(aux_nz+1)+v*(aux_nz+1)]-main_Hy[IDX3D_FIELDS(u0+u,v0+v,plane_index-1)]:main_Hy[IDX3D_FIELDS(u0+u,v0+v,plane_index)]-aux_Hy[u*(aux_ny+1)*(aux_nz+1)+v*(aux_nz+1)+inside];
+                aux_Ex[aidx]=aux_coeffs[IDX2D_MAT(material,0)]*aux_Ex[aidx]+aux_coeffs[IDX2D_MAT(material,2)]*(aux_Hz[aidx]-aux_Hz[aidx-(aux_nz+1)])-aux_coeffs[IDX2D_MAT(material,3)]*cross_field;
+            }
+            if(u>0&&u<nu&&v<nv){
+                aidx=u*(aux_ny+1)*(aux_nz+1)+v*(aux_nz+1)+aperture;material=aux_ID[(aux_nx+1)*(aux_ny+1)*(aux_nz+1)+aidx];
+                cross_field=direction_sign<0?aux_Hx[u*(aux_ny+1)*(aux_nz+1)+v*(aux_nz+1)]-main_Hx[IDX3D_FIELDS(u0+u,v0+v,plane_index-1)]:main_Hx[IDX3D_FIELDS(u0+u,v0+v,plane_index)]-aux_Hx[u*(aux_ny+1)*(aux_nz+1)+v*(aux_nz+1)+inside];
+                aux_Ey[aidx]=aux_coeffs[IDX2D_MAT(material,0)]*aux_Ey[aidx]+aux_coeffs[IDX2D_MAT(material,3)]*cross_field-aux_coeffs[IDX2D_MAT(material,1)]*(aux_Hz[aidx]-aux_Hz[aidx-(aux_ny+1)*(aux_nz+1)]);
+            }
+            if(u<nu&&v<=nv){aidx=u*(aux_ny+1)*(aux_nz+1)+v*(aux_nz+1)+aperture;main_Ex[IDX3D_FIELDS(u0+u,v0+v,plane_index)]=aux_Ex[aidx];}
+            if(u<=nu&&v<nv){aidx=u*(aux_ny+1)*(aux_nz+1)+v*(aux_nz+1)+aperture;main_Ey[IDX3D_FIELDS(u0+u,v0+v,plane_index)]=aux_Ey[aidx];}
+            aidx=u*(aux_ny+1)*(aux_nz+1)+v*(aux_nz+1)+(direction_sign<0?0:inside);
+            main_Ez[IDX3D_FIELDS(u0+u,v0+v,direction_sign<0?plane_index:plane_index-1)]=aux_Ez[aidx];
+        }
+    }
+"""
+    ),
+}
+
+
+clear_rear_electric = {
+    "args_cuda": _args("clear_virtual_waveguide_rear_electric", "cuda", electric=False),
+    "args_opencl": _args("clear_virtual_waveguide_rear_electric", "opencl", electric=False),
+    "args_metal": _args("clear_virtual_waveguide_rear_electric", "metal", electric=False),
+    "func": Template(
+        """
+    $CUDA_IDX
+    if(i<NPOINTS){
+        int x=i/($NY_FIELDS*$NZ_FIELDS);int r=i-x*$NY_FIELDS*$NZ_FIELDS;int y=r/$NZ_FIELDS;int z=r-y*$NZ_FIELDS;bool rear;
+        if(normal_axis==0){rear=direction_sign<0?x>plane_index:x<plane_index;if(rear){if((direction_sign<0||x<plane_index-1)&&y>=u0&&y<=u1&&z>=v0&&z<=v1)main_Hx[i]=0;if(y>=u0&&y<u1&&z>=v0&&z<=v1)main_Hy[i]=0;if(y>=u0&&y<=u1&&z>=v0&&z<v1)main_Hz[i]=0;}}
+        else if(normal_axis==1){rear=direction_sign<0?y>plane_index:y<plane_index;if(rear){if((direction_sign<0||y<plane_index-1)&&x>=u0&&x<=u1&&z>=v0&&z<=v1)main_Hy[i]=0;if(x>=u0&&x<u1&&z>=v0&&z<=v1)main_Hx[i]=0;if(x>=u0&&x<=u1&&z>=v0&&z<v1)main_Hz[i]=0;}}
+        else{rear=direction_sign<0?z>plane_index:z<plane_index;if(rear){if((direction_sign<0||z<plane_index-1)&&x>=u0&&x<=u1&&y>=v0&&y<=v1)main_Hz[i]=0;if(x>=u0&&x<u1&&y>=v0&&y<=v1)main_Hx[i]=0;if(x>=u0&&x<=u1&&y>=v0&&y<v1)main_Hy[i]=0;}}
+    }
+"""
+    ),
+}

--- a/gprMax/eigenmode_device.py
+++ b/gprMax/eigenmode_device.py
@@ -1,0 +1,233 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""Backend-neutral packing for device-resident eigenmode operations."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from gprMax import config
+from gprMax.eigenmode_ports import DFT_PHASE_REANCHOR_INTERVAL, _dft_phase_at_time
+
+
+def _padded_components(components, nu, nv, dtype):
+    result = np.zeros((3, nu + 1, nv + 1), dtype=dtype)
+    for component, values in enumerate(components):
+        values = np.asarray(values, dtype=dtype)
+        if values.ndim != 2 or values.shape[0] > nu + 1 or values.shape[1] > nv + 1:
+            raise ValueError(
+                "Eigenmode source profile shape does not fit its transverse aperture: "
+                f"component {component} has shape {values.shape}, maximum is "
+                f"{(nu + 1, nv + 1)}."
+            )
+        result[component, : values.shape[0], : values.shape[1]] = values
+    return result
+
+
+def eigenmode_source_profiles(source):
+    """Return packed E/H profile bases used by one modal source."""
+
+    dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
+    nu, nv = np.asarray(source.transverse_stop) - np.asarray(source.transverse_start)
+    if source.broadband_e_envelopes is None:
+        electric = [_padded_components(source.modal_e_real, nu, nv, dtype)]
+        magnetic = [_padded_components(source.modal_h_real, nu, nv, dtype)]
+    else:
+        electric = []
+        magnetic = []
+        for quadrature, fields in enumerate(
+            (source.broadband_modal_e_real, source.broadband_modal_e_imag)
+        ):
+            for anchor in range(source.broadband_e_envelopes.shape[0]):
+                electric.append(_padded_components(fields[anchor], nu, nv, dtype))
+        for quadrature, fields in enumerate(
+            (source.broadband_modal_h_real, source.broadband_modal_h_imag)
+        ):
+            for anchor in range(source.broadband_h_envelopes.shape[0]):
+                magnetic.append(_padded_components(fields[anchor], nu, nv, dtype))
+    return np.ascontiguousarray(electric), np.ascontiguousarray(magnetic)
+
+
+def eigenmode_source_envelopes(source, grid, iteration, magnetic):
+    """Yield ``(basis, envelope)`` pairs active at one FDTD update."""
+
+    envelopes = source.broadband_e_envelopes if magnetic else source.broadband_h_envelopes
+    if envelopes is not None:
+        if iteration >= envelopes.shape[2]:
+            return
+        anchor_count = envelopes.shape[0]
+        for quadrature in range(2):
+            for anchor in range(anchor_count):
+                value = float(envelopes[anchor, quadrature, iteration])
+                if value != 0:
+                    yield quadrature * anchor_count + anchor, value
+        return
+
+    time = iteration * grid.dt
+    if not magnetic:
+        time += source._magnetic_modal_time_offset(grid)
+    if source._source_is_active(time):
+        yield 0, float(source._waveform_value(time, grid))
+
+
+def upload_device_arrays(arrays, backend, *, queue=None, dev=None):
+    """Upload named contiguous arrays using the selected backend."""
+
+    if backend == "cuda":
+        import pycuda.gpuarray as gpuarray
+
+        return {
+            name: gpuarray.to_gpu(np.ascontiguousarray(array)) for name, array in arrays.items()
+        }
+    if backend == "opencl":
+        import pyopencl.array as clarray
+
+        return {
+            name: clarray.to_device(queue, np.ascontiguousarray(array))
+            for name, array in arrays.items()
+        }
+    if backend == "metal":
+        return {
+            name: dev.newBufferWithBytes_length_options_(
+                np.ascontiguousarray(array).tobytes(), array.nbytes, 0
+            )
+            for name, array in arrays.items()
+        }
+    raise ValueError(f"Unknown device backend {backend!r}.")
+
+
+def prepare_device_eigenmode_source(source, backend, *, queue=None, dev=None):
+    electric, magnetic = eigenmode_source_profiles(source)
+    if max(electric.size, magnetic.size) > np.iinfo(np.int32).max:
+        raise ValueError("Eigenmode source profiles exceed the signed 32-bit index range.")
+    uploaded = upload_device_arrays(
+        {"electric": electric, "magnetic": magnetic},
+        backend,
+        queue=queue,
+        dev=dev,
+    )
+    source.device_electric_profiles = uploaded["electric"]
+    source.device_magnetic_profiles = uploaded["magnetic"]
+
+
+def prepare_device_eigenmode_monitor(monitor, backend, *, queue=None, dev=None):
+    """Upload one monitor's modal bases, phases, and DFT accumulators."""
+
+    dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
+    complex_arrays = {
+        "electric_phase": monitor.electric_phase,
+        "magnetic_phase": monitor.magnetic_phase,
+        "phase_step": monitor.phase_step,
+        "conj_eu": monitor.conj_eu,
+        "conj_ev": monitor.conj_ev,
+        "conj_hu": monitor.conj_hu,
+        "conj_hv": monitor.conj_hv,
+        "electric_dft": monitor.electric_dft,
+        "magnetic_dft": monitor.magnetic_dft,
+    }
+    if max(np.asarray(values).size for values in complex_arrays.values()) > np.iinfo(np.int32).max:
+        raise ValueError("Eigenmode monitor arrays exceed the signed 32-bit index range.")
+    arrays = {}
+    for name, values in complex_arrays.items():
+        arrays[f"{name}_real"] = np.ascontiguousarray(np.real(values), dtype=dtype)
+        arrays[f"{name}_imag"] = np.ascontiguousarray(np.imag(values), dtype=dtype)
+    monitor.device_arrays = upload_device_arrays(arrays, backend, queue=queue, dev=dev)
+    if backend == "metal":
+        monitor.device_parameters = np.zeros(
+            1,
+            dtype=np.dtype(
+                [
+                    ("NF", np.int32),
+                    ("NM", np.int32),
+                    ("normal_axis", np.int32),
+                    ("direction_sign", np.int32),
+                    ("magnetic_side", np.int32),
+                    ("u0", np.int32),
+                    ("v0", np.int32),
+                    ("u1", np.int32),
+                    ("v1", np.int32),
+                    ("plane_index", np.int32),
+                    ("dt", dtype),
+                    ("measure", dtype),
+                    ("handedness", np.int32),
+                ],
+                align=True,
+            ),
+        )
+        if monitor.device_parameters.nbytes != 52:
+            raise RuntimeError("Unexpected Metal eigenmode-parameter structure layout.")
+
+
+def _device_array_to_host(value, backend, shape, dtype):
+    if backend in ("cuda", "opencl"):
+        return value.get().reshape(shape)
+    nbytes = int(np.prod(shape)) * np.dtype(dtype).itemsize
+    return np.frombuffer(value.contents().as_buffer(nbytes), dtype=dtype).reshape(shape).copy()
+
+
+def finalise_device_eigenmode_monitors(monitors, backend):
+    """Copy only completed modal DFTs back to their monitor objects."""
+
+    dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
+    for monitor in monitors:
+        arrays = monitor.device_arrays
+        shape = monitor.electric_dft.shape
+        electric = _device_array_to_host(
+            arrays["electric_dft_real"], backend, shape, dtype
+        ) + 1j * _device_array_to_host(arrays["electric_dft_imag"], backend, shape, dtype)
+        magnetic = _device_array_to_host(
+            arrays["magnetic_dft_real"], backend, shape, dtype
+        ) + 1j * _device_array_to_host(arrays["magnetic_dft_imag"], backend, shape, dtype)
+        np.copyto(monitor.electric_dft, electric, casting="same_kind")
+        np.copyto(monitor.magnetic_dft, magnetic, casting="same_kind")
+
+
+def _replace_device_array(array, values, backend):
+    values = np.ascontiguousarray(values)
+    if backend in ("cuda", "opencl"):
+        array.set(values)
+        return
+    view = np.frombuffer(array.contents().as_buffer(values.nbytes), dtype=values.dtype).reshape(
+        values.shape
+    )
+    np.copyto(view, values)
+
+
+def reanchor_device_eigenmode_monitor(monitor, grid, backend):
+    """Periodically reset recursively advanced device DFT phases exactly."""
+
+    if monitor._next_iteration % DFT_PHASE_REANCHOR_INTERVAL:
+        return
+    dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
+    electric = _dft_phase_at_time(
+        monitor.frequency,
+        monitor._next_iteration * grid.dt,
+        monitor.electric_phase.dtype,
+    )
+    magnetic = _dft_phase_at_time(
+        monitor.frequency,
+        (monitor._next_iteration + 0.5) * grid.dt,
+        monitor.magnetic_phase.dtype,
+    )
+    arrays = monitor.device_arrays
+    _replace_device_array(
+        arrays["electric_phase_real"], np.asarray(electric.real, dtype=dtype), backend
+    )
+    _replace_device_array(
+        arrays["electric_phase_imag"], np.asarray(electric.imag, dtype=dtype), backend
+    )
+    _replace_device_array(
+        arrays["magnetic_phase_real"], np.asarray(magnetic.real, dtype=dtype), backend
+    )
+    _replace_device_array(
+        arrays["magnetic_phase_imag"], np.asarray(magnetic.imag, dtype=dtype), backend
+    )

--- a/gprMax/grid/metal_grid.py
+++ b/gprMax/grid/metal_grid.py
@@ -25,6 +25,33 @@ from gprMax.grid.fdtd_grid import FDTDGrid
 from gprMax.pml import MetalPML
 
 
+class MetalBufferView:
+    """Byte-offset view into a shared Metal buffer."""
+
+    def __init__(self, buffer, offset=0):
+        self.buffer = buffer
+        self.offset = int(offset)
+
+
+class MetalArray(MetalBufferView):
+    """Minimal first-axis slicing used by the plane-wave kernels."""
+
+    def __init__(self, buffer, shape, dtype):
+        super().__init__(buffer, 0)
+        self.shape = tuple(shape)
+        self.dtype = np.dtype(dtype)
+
+    def __getitem__(self, index):
+        if not isinstance(index, (int, np.integer)):
+            raise TypeError("Metal device arrays support integer first-axis views only")
+        if index < 0:
+            index += self.shape[0]
+        if index < 0 or index >= self.shape[0]:
+            raise IndexError(index)
+        stride = int(np.prod(self.shape[1:])) * self.dtype.itemsize
+        return MetalBufferView(self.buffer, index * stride)
+
+
 class MetalGrid(FDTDGrid):
     """Additional grid methods for solving on compute device using Apple Metal."""
 
@@ -133,3 +160,60 @@ class MetalGrid(FDTDGrid):
         self.updatecoeffsH_dev = dev.newBufferWithBytes_length_options_(self.updatecoeffsH,
                                                                         self.updatecoeffsH.nbytes,
                                                                         self.storage)
+
+    def htod_mat_coeff_arrays(self, _queue=None):
+        """OpenCL-compatible alias used by shared plane-wave orchestration."""
+
+        from gprMax import config
+
+        self.htod_material_arrays(config.get_model_config().device["dev"])
+
+    def htod_planewave_arrays(self, dpw, _queue=None):
+        """Upload all auxiliary plane-wave arrays as offset-capable buffers."""
+
+        from gprMax import config
+
+        dev = config.get_model_config().device["dev"]
+
+        def upload(values):
+            values = np.ascontiguousarray(values)
+            buffer = dev.newBufferWithBytes_length_options_(
+                values, values.nbytes, self.storage
+            )
+            return MetalArray(buffer, values.shape, values.dtype)
+
+        for name in (
+            "E_fields", "H_fields", "Ix", "Iy", "Iz", "pml_rhx",
+            "pml_rhy", "pml_rhz", "pml_rex", "pml_rey", "pml_rez",
+        ):
+            setattr(dpw, f"{name}_dev", upload(getattr(dpw, name)))
+
+        real = dpw.E_fields.dtype
+        source_e = np.asarray(
+            dpw.waveformvalues_wholedt * dpw.projections[None, :3, None],
+            dtype=real,
+            order="C",
+        )
+        source_h = np.asarray(
+            dpw.waveformvalues_halfdt * dpw.projections[None, 3:, None],
+            dtype=real,
+            order="C",
+        )
+        if source_e.size > np.iinfo(np.int32).max:
+            raise ValueError("Plane-wave source arrays exceed the signed 32-bit index range.")
+        dpw.source_e_dev = upload(source_e)
+        dpw.source_h_dev = upload(source_h)
+
+        if dpw.axial != 0:
+            for name in (
+                "E_fields_s", "H_fields_s", "Ix_s", "Iy_s", "Iz_s",
+                "Ix0", "Iy0", "Iz0", "pml_rhx0", "pml_rhy0",
+                "pml_rhz0", "pml_rex0", "pml_rey0", "pml_rez0", "ID",
+            ):
+                setattr(dpw, f"{name}_dev", upload(getattr(dpw, name)))
+        if dpw.dispersive:
+            for name in ("Px", "Py", "Pz"):
+                setattr(dpw, f"{name}_dev", upload(getattr(dpw, name)))
+            if dpw.axial != 0:
+                for name in ("Px_s", "Py_s", "Pz_s"):
+                    setattr(dpw, f"{name}_dev", upload(getattr(dpw, name)))

--- a/gprMax/model.py
+++ b/gprMax/model.py
@@ -583,17 +583,12 @@ class Model:
             # own flag rather than the global one.
 
     def _check_accelerator_symmetry_boundaries(self, grids: Sequence[FDTDGrid]):
-        """Reject accelerator PMC after material dispersion is resolved."""
-        solver = config.sim_config.general["solver"]
-        maxpoles = config.get_model_config().materials["maxpoles"]
-        has_pmc = any("pmc" in grid.symmetry_boundaries.values() for grid in grids)
+        """Reserved parity check after material dispersion is resolved."""
 
-        if solver in ("cuda", "opencl", "metal") and maxpoles > 0 and has_pmc:
-            raise ValueError(
-                "Dispersive PMC symmetry boundaries currently require the CPU "
-                "solver. PEC and nondispersive PMC symmetry are supported by "
-                "CUDA, OpenCL, and Apple Metal."
-            )
+        # All local backends now implement both phases of the dispersive PMC
+        # ADE update. Keep this hook because MPI symmetry remains deliberately
+        # rejected by the command builder and future backends may need an
+        # explicit capability check here.
 
     def _check_memory_requirements(self, grids: Sequence[FDTDGrid]):
         # Check memory requirements to build model/scene (different to memory

--- a/gprMax/network_ports.py
+++ b/gprMax/network_ports.py
@@ -397,3 +397,155 @@ class RationalNetworkTerminal:
         self.voltage[iteration + 1] = -self.dl * field[self.xcoord, self.ycoord, self.zcoord]
         self.network_current[iteration] = current
         self.generator_voltage[iteration] = self.waveform_half[iteration]
+
+
+def rational_network_host_arrays(terminals, grid) -> dict[str, np.ndarray]:
+    """Pack independent rational terminals into backend-neutral arrays.
+
+    One device work-item owns one terminal and advances all of its pole
+    states serially. Complex recurrence coefficients are split into real and
+    imaginary arrays so the identical kernel body works on CUDA, OpenCL, and
+    Metal without relying on backend-specific complex ABIs.
+    """
+
+    count = len(terminals)
+    real_dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
+    total_poles = sum(len(terminal.model.poles) for terminal in terminals)
+    if total_poles > np.iinfo(np.int32).max:
+        raise ValueError("rational-network pole state exceeds the signed 32-bit index range")
+    largest_terminal_stride = max(grid.iterations + 1, 7)
+    if count * largest_terminal_stride > np.iinfo(np.int32).max:
+        raise ValueError("rational-network histories exceed the signed 32-bit index range")
+
+    # x, y, z, polarisation, pole offset, pole count
+    info = np.zeros((count, 6), dtype=np.int32)
+    # dl, area, source coefficient, denominator, alpha, G, C
+    params = np.zeros((count, 7), dtype=real_dtype)
+    waveform_whole = np.zeros((count, grid.iterations + 1), dtype=real_dtype)
+    waveform_half = np.zeros((count, grid.iterations), dtype=real_dtype)
+    voltage = np.zeros((count, grid.iterations + 1), dtype=real_dtype)
+    current = np.zeros((count, grid.iterations), dtype=real_dtype)
+
+    # Device APIs do not consistently accept zero-byte buffers. A pole-free
+    # resistor/capacitor therefore carries one unused scalar allocation.
+    pole_storage = max(total_poles, 1)
+    coefficient_names = (
+        "exp_half",
+        "coeff_half_new",
+        "coeff_half_old",
+        "exp_full",
+        "coeff_full_new",
+        "coeff_full_old",
+    )
+    coefficients = {
+        f"{name}_{part}": np.zeros(pole_storage, dtype=real_dtype)
+        for name in coefficient_names
+        for part in ("real", "imag")
+    }
+    state_real = np.zeros(pole_storage, dtype=real_dtype)
+    state_imag = np.zeros(pole_storage, dtype=real_dtype)
+
+    offset = 0
+    polarisation_index = {"x": 0, "y": 1, "z": 2}
+    for index, terminal in enumerate(terminals):
+        pole_count = len(terminal.model.poles)
+        info[index] = (
+            terminal.xcoord,
+            terminal.ycoord,
+            terminal.zcoord,
+            polarisation_index[terminal.polarisation],
+            offset,
+            pole_count,
+        )
+        params[index] = (
+            terminal.dl,
+            terminal.area,
+            terminal.source_coefficient,
+            terminal.denominator,
+            terminal.alpha,
+            terminal.model.conductance,
+            terminal.model.capacitance,
+        )
+        waveform_whole[index] = terminal.waveform_whole
+        waveform_half[index] = terminal.waveform_half
+        voltage[index] = terminal.voltage
+        current[index] = terminal.network_current
+        if pole_count:
+            section = slice(offset, offset + pole_count)
+            for name in coefficient_names:
+                values = np.asarray(getattr(terminal, name))
+                coefficients[f"{name}_real"][section] = np.real(values)
+                coefficients[f"{name}_imag"][section] = np.imag(values)
+            state_real[section] = np.real(terminal.states)
+            state_imag[section] = np.imag(terminal.states)
+        offset += pole_count
+
+    return {
+        "info": info,
+        "params": params,
+        "waveform_whole": waveform_whole,
+        "waveform_half": waveform_half,
+        "voltage": voltage,
+        "current": current,
+        **coefficients,
+        "state_real": state_real,
+        "state_imag": state_imag,
+    }
+
+
+def htod_rational_network_arrays(terminals, grid, queue=None):
+    """Copy packed rational-network arrays to the active compute device."""
+
+    arrays = rational_network_host_arrays(terminals, grid)
+    solver = config.sim_config.general["solver"]
+    if solver == "cuda":
+        import pycuda.gpuarray as gpuarray
+
+        return {name: gpuarray.to_gpu(array) for name, array in arrays.items()}
+    if solver == "opencl":
+        import pyopencl.array as clarray
+
+        return {name: clarray.to_device(queue, array) for name, array in arrays.items()}
+    if solver == "metal":
+        dev = config.get_model_config().device["dev"]
+        return {
+            name: dev.newBufferWithBytes_length_options_(array.tobytes(), array.nbytes, 0)
+            for name, array in arrays.items()
+        }
+    raise ValueError(f"Unknown device solver {solver!r} for rational-network arrays.")
+
+
+def dtoh_rational_network_outputs(voltage, current, grid) -> None:
+    """Copy device terminal histories into their runtime terminal objects."""
+
+    voltage_shape = (len(grid.networkterminals), grid.iterations + 1)
+    current_shape = (len(grid.networkterminals), grid.iterations)
+    if config.sim_config.general["solver"] == "metal":
+        dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
+
+        def metal_array(buffer, shape):
+            nbytes = int(np.prod(shape)) * dtype.itemsize
+            if buffer.length() != nbytes:
+                raise ValueError(
+                    "Rational-network Metal output buffer has the wrong size: "
+                    f"expected {nbytes} bytes, got {buffer.length()}."
+                )
+            return (
+                np.frombuffer(buffer.contents().as_buffer(nbytes), dtype=dtype)
+                .reshape(shape)
+                .copy()
+            )
+
+        voltage = metal_array(voltage, voltage_shape)
+        current = metal_array(current, current_shape)
+
+    if voltage.shape != voltage_shape or current.shape != current_shape:
+        raise ValueError(
+            "Rational-network device output shape does not match the grid: "
+            f"expected {voltage_shape} and {current_shape}, got "
+            f"{voltage.shape} and {current.shape}."
+        )
+    for index, terminal in enumerate(grid.networkterminals):
+        np.copyto(terminal.voltage, voltage[index], casting="same_kind")
+        np.copyto(terminal.network_current, current[index], casting="same_kind")
+        np.copyto(terminal.generator_voltage, terminal.waveform_half, casting="same_kind")

--- a/gprMax/ntff/device.py
+++ b/gprMax/ntff/device.py
@@ -26,6 +26,7 @@ import numpy as np
 import numpy.typing as npt
 
 from gprMax.cuda_opencl.knl_ntff import (
+    build_equivalent_current_time_kernel_source,
     build_ntff_kernel_source,
     build_time_domain_ntff_kernel_source,
 )
@@ -42,13 +43,21 @@ def _is_time_domain_monitor(monitor) -> bool:
     return hasattr(monitor, "load_device_component_output")
 
 
+def _is_equivalent_current_time_monitor(monitor) -> bool:
+    return hasattr(monitor, "load_device_far_field_output")
+
+
 def configure_ntff_monitors(grid, *, allow_time_domain: bool = False) -> None:
     """Perform backend-independent material validation before time stepping."""
 
     for monitor in grid.ntff_monitors:
         if _is_time_domain_monitor(monitor) and not allow_time_domain:
             raise ValueError("advanced-time KSIR requires a time-domain-capable device collector")
-        if not (_is_frequency_monitor(monitor) or _is_time_domain_monitor(monitor)):
+        if not (
+            _is_frequency_monitor(monitor)
+            or _is_time_domain_monitor(monitor)
+            or _is_equivalent_current_time_monitor(monitor)
+        ):
             raise TypeError("unrecognised NTFF monitor type")
         monitor.validate_materials(grid.ID, grid.IDlookup)
         configure_background = getattr(monitor, "configure_background", None)
@@ -508,8 +517,240 @@ class CUDATimeDomainKSIRCollector:
         return record.device["output"].get()
 
 
+@dataclass
+class _EquivalentCurrentTimeRecord:
+    monitor: object
+    npatches: int
+    ndirections: int
+    output_length: int
+    max_samples: int
+    device: Dict[str, object]
+    electric_observed: int = 0
+    magnetic_observed: int = 0
+
+
+class _EquivalentCurrentTimeCollector:
+    """Backend-neutral orchestration for the 1997 Love-current transform."""
+
+    _threads = 128
+
+    def _initialise_equivalent_records(self, backend: str) -> None:
+        self.records: List[_EquivalentCurrentTimeRecord] = []
+        limits = np.iinfo(np.int32)
+        for monitor in self.monitors:
+            if monitor.device_backend != backend:
+                raise ValueError(
+                    f"{backend} equivalent-current monitor is not configured for {backend}"
+                )
+            if monitor.real_dtype != self.real_dtype:
+                raise ValueError("equivalent-current monitor dtype does not match field dtype")
+            max_samples = max(
+                stencil.shape[0]
+                for component in ELECTRIC_COMPONENTS + MAGNETIC_COMPONENTS
+                for _, stencil in monitor._stencils[component]
+            )
+            record = _EquivalentCurrentTimeRecord(
+                monitor=monitor,
+                npatches=int(monitor.npatches),
+                ndirections=int(monitor.directions.shape[0]),
+                output_length=int(monitor._raw_length),
+                max_samples=int(max_samples),
+                device={},
+            )
+            sizes = (
+                record.npatches,
+                record.ndirections,
+                record.output_length,
+                record.npatches * record.ndirections,
+                record.ndirections * record.output_length,
+            )
+            if any(size > limits.max for size in sizes):
+                raise ValueError("equivalent-current time arrays exceed device int32 indexing")
+            metadata = self._equivalent_metadata(record)
+            self._allocate_equivalent(record, metadata)
+            self.records.append(record)
+
+    @staticmethod
+    def _packed_component_stencil(monitor, component: str, max_samples: int):
+        counts = np.zeros(monitor.npatches, dtype=np.int32)
+        indices = np.zeros((monitor.npatches, max_samples), dtype=np.int32)
+        limits = np.iinfo(np.int32)
+        for patch_indices, stencil in monitor._stencils[component]:
+            if np.any(stencil < limits.min) or np.any(stencil > limits.max):
+                raise ValueError("equivalent-current stencil exceeds device int32 indexing")
+            counts[patch_indices] = stencil.shape[0]
+            indices[patch_indices, : stencil.shape[0]] = stencil.T.astype(np.int32)
+        return counts, indices.ravel()
+
+    def _equivalent_metadata(self, record: _EquivalentCurrentTimeRecord):
+        monitor = record.monitor
+        result = {
+            "normals": np.ascontiguousarray(monitor.normals, dtype=self.real_dtype),
+            "area_weights": np.ascontiguousarray(
+                monitor.area_weights, dtype=self.real_dtype
+            ),
+            "electric_theta_basis": np.ascontiguousarray(
+                monitor.phi_basis, dtype=self.real_dtype
+            ),
+            "electric_phi_basis": np.ascontiguousarray(
+                -monitor.theta_basis, dtype=self.real_dtype
+            ),
+            "magnetic_theta_basis": np.ascontiguousarray(
+                monitor.theta_basis, dtype=self.real_dtype
+            ),
+            "magnetic_phi_basis": np.ascontiguousarray(
+                monitor.phi_basis, dtype=self.real_dtype
+            ),
+        }
+        for kind, components in (
+            ("electric", ELECTRIC_COMPONENTS),
+            ("magnetic", MAGNETIC_COMPONENTS),
+        ):
+            for axis, component in zip("xyz", components):
+                count, stencil = self._packed_component_stencil(
+                    monitor, component, record.max_samples
+                )
+                result[f"{kind}_count_{axis}"] = count
+                result[f"{kind}_stencil_{axis}"] = stencil
+        for kind, offset in (("electric", 0.5), ("magnetic", 0.0)):
+            integer_delay, fraction = monitor._delay_maps[offset]
+            if np.any(integer_delay < np.iinfo(np.int32).min) or np.any(
+                integer_delay > np.iinfo(np.int32).max
+            ):
+                raise ValueError("equivalent-current delay exceeds device int32 indexing")
+            result[f"{kind}_integer_delay"] = np.ascontiguousarray(
+                integer_delay.ravel(), dtype=np.int32
+            )
+            result[f"{kind}_fractional_delay"] = np.ascontiguousarray(
+                fraction.ravel(), dtype=self.real_dtype
+            )
+        return result
+
+    def _allocate_equivalent(self, record, metadata) -> None:
+        raise NotImplementedError
+
+    def _gather_equivalent(self, record, kind, target, scale) -> None:
+        raise NotImplementedError
+
+    def _deposit_equivalent(self, record, kind, sample_index, current, previous) -> None:
+        raise NotImplementedError
+
+    def _download_equivalent(self, record, name):
+        raise NotImplementedError
+
+    def _observe_equivalent(self, iteration: int, kind: str) -> None:
+        counter_name = f"{kind}_observed"
+        scale_name = "impedance" if kind == "magnetic" else None
+        for record in self.records:
+            expected = getattr(record, counter_name)
+            if iteration != expected:
+                raise ValueError(
+                    f"expected device equivalent-current {kind} iteration "
+                    f"{expected}, received {iteration}"
+                )
+            slot = iteration % 2
+            current = record.device[f"{kind}_current_{slot}"]
+            scale = record.monitor.impedance if scale_name else -1.0
+            self._gather_equivalent(record, kind, current, scale)
+            if iteration > 0:
+                previous = record.device[f"{kind}_current_{1 - slot}"]
+                sample_index = iteration if kind == "magnetic" else iteration - 1
+                self._deposit_equivalent(
+                    record, kind, sample_index, current, previous
+                )
+            setattr(record, counter_name, expected + 1)
+
+    def observe_electric(self, iteration: int) -> None:
+        self._observe_equivalent(iteration, "electric")
+
+    def observe_magnetic(self, iteration: int) -> None:
+        self._observe_equivalent(iteration, "magnetic")
+
+    def finalise(self) -> None:
+        for record in self.records:
+            if (
+                record.electric_observed != record.monitor.iterations
+                or record.magnetic_observed != record.monitor.iterations
+            ):
+                raise RuntimeError("equivalent-current device monitor missed time samples")
+            shape = (record.ndirections, record.output_length)
+            theta = self._download_equivalent(record, "output_theta").reshape(shape)
+            phi = self._download_equivalent(record, "output_phi").reshape(shape)
+            record.monitor.load_device_far_field_output(theta, phi)
+            record.monitor.finalise()
+
+
+class CUDAEquivalentCurrentTimeCollector(_EquivalentCurrentTimeCollector):
+    """Device-resident 1997 Love-current transform on CUDA."""
+
+    def __init__(self, updates, monitors):
+        self.updates = updates
+        self.grid = updates.grid
+        self.monitors = list(monitors)
+        self.real_dtype = np.dtype(self.grid.Ex.dtype)
+        self.real_scalar = self.real_dtype.type
+        self.gpuarray = self.grid.gpuarray
+        source = build_equivalent_current_time_kernel_source(
+            updates.ntff_c_real, "cuda"
+        )
+        module = updates.source_module(
+            source, options=getattr(updates, "ntff_compiler_options", None)
+        )
+        self.gather_kernel = module.get_function("gather_equivalent_current_time")
+        self.deposit_kernel = module.get_function("deposit_equivalent_current_time")
+        self._initialise_equivalent_records("cuda")
+
+    def _allocate_equivalent(self, record, metadata) -> None:
+        for name, values in metadata.items():
+            record.device[name] = self.gpuarray.to_gpu(values)
+        for kind in ("electric", "magnetic"):
+            for slot in range(2):
+                record.device[f"{kind}_current_{slot}"] = self.gpuarray.empty(
+                    record.npatches * 3, self.real_dtype
+                )
+        for name in ("output_theta", "output_phi"):
+            record.device[name] = self.gpuarray.zeros(
+                record.ndirections * record.output_length, self.real_dtype
+            )
+
+    def _gather_equivalent(self, record, kind, target, scale) -> None:
+        d = record.device
+        fields = tuple(getattr(self.grid, f"{component}_dev") for component in (
+            ELECTRIC_COMPONENTS if kind == "electric" else MAGNETIC_COMPONENTS
+        ))
+        self.gather_kernel(
+            np.int32(record.npatches), np.int32(record.max_samples),
+            d[f"{kind}_count_x"].gpudata, d[f"{kind}_count_y"].gpudata,
+            d[f"{kind}_count_z"].gpudata, d[f"{kind}_stencil_x"].gpudata,
+            d[f"{kind}_stencil_y"].gpudata, d[f"{kind}_stencil_z"].gpudata,
+            d["normals"].gpudata, self.real_scalar(scale),
+            fields[0].gpudata, fields[1].gpudata, fields[2].gpudata,
+            target.gpudata, block=(self._threads, 1, 1),
+            grid=((record.npatches + self._threads - 1) // self._threads, 1, 1),
+        )
+
+    def _deposit_equivalent(self, record, kind, sample_index, current, previous) -> None:
+        d = record.device
+        self.deposit_kernel(
+            np.int32(record.ndirections), np.int32(record.npatches),
+            np.int32(record.output_length), np.int32(sample_index),
+            np.int32(record.monitor._time_origin_step),
+            self.real_scalar(1 / record.monitor.dt), current.gpudata,
+            previous.gpudata, d[f"{kind}_theta_basis"].gpudata,
+            d[f"{kind}_phi_basis"].gpudata,
+            d[f"{kind}_integer_delay"].gpudata,
+            d[f"{kind}_fractional_delay"].gpudata,
+            d["area_weights"].gpudata, d["output_theta"].gpudata,
+            d["output_phi"].gpudata, block=(self._threads, 1, 1),
+            grid=((record.ndirections + self._threads - 1) // self._threads, 1, 1),
+        )
+
+    def _download_equivalent(self, record, name):
+        return record.device[name].get()
+
+
 class CUDACombinedKSIRCollector:
-    """Dispatch frequency-domain and advanced-time monitors on CUDA."""
+    """Dispatch all NTFF monitors on CUDA."""
 
     def __init__(self, updates):
         configure_ntff_monitors(updates.grid, allow_time_domain=True)
@@ -519,6 +760,11 @@ class CUDACombinedKSIRCollector:
         time_monitors = [
             monitor for monitor in updates.grid.ntff_monitors if _is_time_domain_monitor(monitor)
         ]
+        equivalent_time_monitors = [
+            monitor
+            for monitor in updates.grid.ntff_monitors
+            if _is_equivalent_current_time_monitor(monitor)
+        ]
         self.frequency = (
             CUDAKSIRCollector(updates, frequency_monitors, configure=False)
             if frequency_monitors
@@ -527,24 +773,35 @@ class CUDACombinedKSIRCollector:
         self.time_domain = (
             CUDATimeDomainKSIRCollector(updates, time_monitors) if time_monitors else None
         )
+        self.equivalent_time = (
+            CUDAEquivalentCurrentTimeCollector(updates, equivalent_time_monitors)
+            if equivalent_time_monitors
+            else None
+        )
 
     def observe_electric(self, iteration: int) -> None:
         if self.frequency is not None:
             self.frequency.observe_electric(iteration)
         if self.time_domain is not None:
             self.time_domain.observe_electric(iteration)
+        if self.equivalent_time is not None:
+            self.equivalent_time.observe_electric(iteration)
 
     def observe_magnetic(self, iteration: int) -> None:
         if self.frequency is not None:
             self.frequency.observe_magnetic(iteration)
         if self.time_domain is not None:
             self.time_domain.observe_magnetic(iteration)
+        if self.equivalent_time is not None:
+            self.equivalent_time.observe_magnetic(iteration)
 
     def finalise(self) -> None:
         if self.frequency is not None:
             self.frequency.finalise()
         if self.time_domain is not None:
             self.time_domain.finalise()
+        if self.equivalent_time is not None:
+            self.equivalent_time.finalise()
 
 
 class OpenCLKSIRCollector(_DeviceKSIRCollector):
@@ -720,8 +977,76 @@ class OpenCLTimeDomainKSIRCollector(CUDATimeDomainKSIRCollector):
         return record.device["output"].get(queue=self.queue)
 
 
+class OpenCLEquivalentCurrentTimeCollector(_EquivalentCurrentTimeCollector):
+    """Device-resident 1997 Love-current transform on OpenCL."""
+
+    def __init__(self, updates, monitors):
+        self.updates = updates
+        self.grid = updates.grid
+        self.monitors = list(monitors)
+        self.real_dtype = np.dtype(self.grid.Ex.dtype)
+        self.real_scalar = self.real_dtype.type
+        self.clarray = self.grid.clarray
+        self.queue = updates.queue
+        source = build_equivalent_current_time_kernel_source(
+            updates.ntff_c_real, "opencl"
+        )
+        options = getattr(updates, "ntff_compiler_options", None)
+        program = updates.cl.Program(updates.ctx, source).build(options=options)
+        self.gather_kernel = program.gather_equivalent_current_time
+        self.deposit_kernel = program.deposit_equivalent_current_time
+        self._initialise_equivalent_records("opencl")
+
+    def _allocate_equivalent(self, record, metadata) -> None:
+        for name, values in metadata.items():
+            record.device[name] = self.clarray.to_device(self.queue, values)
+        for kind in ("electric", "magnetic"):
+            for slot in range(2):
+                record.device[f"{kind}_current_{slot}"] = self.clarray.empty(
+                    self.queue, record.npatches * 3, self.real_dtype
+                )
+        for name in ("output_theta", "output_phi"):
+            record.device[name] = self.clarray.zeros(
+                self.queue,
+                record.ndirections * record.output_length,
+                self.real_dtype,
+            )
+
+    def _gather_equivalent(self, record, kind, target, scale) -> None:
+        d = record.device
+        fields = tuple(getattr(self.grid, f"{component}_dev") for component in (
+            ELECTRIC_COMPONENTS if kind == "electric" else MAGNETIC_COMPONENTS
+        ))
+        self.gather_kernel(
+            self.queue, (record.npatches,), None,
+            np.int32(record.npatches), np.int32(record.max_samples),
+            d[f"{kind}_count_x"].data, d[f"{kind}_count_y"].data,
+            d[f"{kind}_count_z"].data, d[f"{kind}_stencil_x"].data,
+            d[f"{kind}_stencil_y"].data, d[f"{kind}_stencil_z"].data,
+            d["normals"].data, self.real_scalar(scale), fields[0].data,
+            fields[1].data, fields[2].data, target.data,
+        )
+
+    def _deposit_equivalent(self, record, kind, sample_index, current, previous) -> None:
+        d = record.device
+        self.deposit_kernel(
+            self.queue, (record.ndirections,), None,
+            np.int32(record.ndirections), np.int32(record.npatches),
+            np.int32(record.output_length), np.int32(sample_index),
+            np.int32(record.monitor._time_origin_step),
+            self.real_scalar(1 / record.monitor.dt), current.data, previous.data,
+            d[f"{kind}_theta_basis"].data, d[f"{kind}_phi_basis"].data,
+            d[f"{kind}_integer_delay"].data,
+            d[f"{kind}_fractional_delay"].data, d["area_weights"].data,
+            d["output_theta"].data, d["output_phi"].data,
+        )
+
+    def _download_equivalent(self, record, name):
+        return record.device[name].get(queue=self.queue)
+
+
 class OpenCLCombinedKSIRCollector:
-    """Dispatch frequency-domain and advanced-time monitors on OpenCL."""
+    """Dispatch all NTFF monitors on OpenCL."""
 
     def __init__(self, updates):
         configure_ntff_monitors(updates.grid, allow_time_domain=True)
@@ -731,6 +1056,11 @@ class OpenCLCombinedKSIRCollector:
         time_monitors = [
             monitor for monitor in updates.grid.ntff_monitors if _is_time_domain_monitor(monitor)
         ]
+        equivalent_time_monitors = [
+            monitor
+            for monitor in updates.grid.ntff_monitors
+            if _is_equivalent_current_time_monitor(monitor)
+        ]
         self.frequency = (
             OpenCLKSIRCollector(updates, frequency_monitors, configure=False)
             if frequency_monitors
@@ -739,24 +1069,35 @@ class OpenCLCombinedKSIRCollector:
         self.time_domain = (
             OpenCLTimeDomainKSIRCollector(updates, time_monitors) if time_monitors else None
         )
+        self.equivalent_time = (
+            OpenCLEquivalentCurrentTimeCollector(updates, equivalent_time_monitors)
+            if equivalent_time_monitors
+            else None
+        )
 
     def observe_electric(self, iteration: int) -> None:
         if self.frequency is not None:
             self.frequency.observe_electric(iteration)
         if self.time_domain is not None:
             self.time_domain.observe_electric(iteration)
+        if self.equivalent_time is not None:
+            self.equivalent_time.observe_electric(iteration)
 
     def observe_magnetic(self, iteration: int) -> None:
         if self.frequency is not None:
             self.frequency.observe_magnetic(iteration)
         if self.time_domain is not None:
             self.time_domain.observe_magnetic(iteration)
+        if self.equivalent_time is not None:
+            self.equivalent_time.observe_magnetic(iteration)
 
     def finalise(self) -> None:
         if self.frequency is not None:
             self.frequency.finalise()
         if self.time_domain is not None:
             self.time_domain.finalise()
+        if self.equivalent_time is not None:
+            self.equivalent_time.finalise()
 
 
 class MetalKSIRCollector(_DeviceKSIRCollector):
@@ -812,7 +1153,10 @@ class MetalKSIRCollector(_DeviceKSIRCollector):
             record.device["outside_imag"],
         )
         for index, buffer in enumerate(buffers):
-            encoder.setBuffer_offset_atIndex_(buffer, 0, index)
+            if hasattr(buffer, "buffer") and hasattr(buffer, "offset"):
+                encoder.setBuffer_offset_atIndex_(buffer.buffer, buffer.offset, index)
+            else:
+                encoder.setBuffer_offset_atIndex_(buffer, 0, index)
         encoder.dispatchThreads_threadsPerThreadgroup_(
             self.metal.MTLSizeMake(record.total, 1, 1),
             self.metal.MTLSizeMake(
@@ -992,8 +1336,129 @@ class MetalTimeDomainKSIRCollector(CUDATimeDomainKSIRCollector):
         ).copy()
 
 
+class MetalEquivalentCurrentTimeCollector(_EquivalentCurrentTimeCollector):
+    """Device-resident 1997 Love-current transform on Apple Metal."""
+
+    def __init__(self, updates, monitors):
+        self.updates = updates
+        self.grid = updates.grid
+        self.monitors = list(monitors)
+        self.real_dtype = np.dtype(self.grid.Ex.dtype)
+        self.real_scalar = self.real_dtype.type
+        self.dev = updates.dev
+        self.queue = updates.cmdqueue
+        self.metal = updates.metal
+        self.storage = getattr(self.grid, "storage", 0)
+        source = build_equivalent_current_time_kernel_source(
+            updates.ntff_c_real, "metal"
+        )
+        library, error = self.dev.newLibraryWithSource_options_error_(
+            source, updates.opts, None
+        )
+        if library is None:
+            raise RuntimeError(f"Failed to compile Metal equivalent-current NTFF: {error}")
+        gather = library.newFunctionWithName_("gather_equivalent_current_time")
+        deposit = library.newFunctionWithName_("deposit_equivalent_current_time")
+        self.gather_pipeline = self.dev.newComputePipelineStateWithFunction_error_(
+            gather, None
+        )[0]
+        self.deposit_pipeline = self.dev.newComputePipelineStateWithFunction_error_(
+            deposit, None
+        )[0]
+        self._initialise_equivalent_records("metal")
+
+    def _buffer(self, values):
+        contiguous = np.ascontiguousarray(values)
+        return self.dev.newBufferWithBytes_length_options_(
+            contiguous, contiguous.nbytes, self.storage
+        )
+
+    @staticmethod
+    def _set_scalar(encoder, index, value):
+        scalar = np.asarray(value)
+        encoder.setBytes_length_atIndex_(scalar.tobytes(), scalar.nbytes, index)
+
+    def _finish(self, command, encoder, pipeline, count):
+        encoder.dispatchThreads_threadsPerThreadgroup_(
+            self.metal.MTLSizeMake(int(count), 1, 1),
+            self.metal.MTLSizeMake(
+                min(int(count), pipeline.maxTotalThreadsPerThreadgroup()), 1, 1
+            ),
+        )
+        encoder.endEncoding()
+        command.commit()
+        command.waitUntilCompleted()
+
+    def _allocate_equivalent(self, record, metadata) -> None:
+        for name, values in metadata.items():
+            record.device[name] = self._buffer(values)
+        empty = np.empty(record.npatches * 3, dtype=self.real_dtype)
+        for kind in ("electric", "magnetic"):
+            for slot in range(2):
+                record.device[f"{kind}_current_{slot}"] = self._buffer(empty)
+        zeros = np.zeros(
+            record.ndirections * record.output_length, dtype=self.real_dtype
+        )
+        record.device["output_theta"] = self._buffer(zeros)
+        record.device["output_phi"] = self._buffer(zeros)
+
+    def _gather_equivalent(self, record, kind, target, scale) -> None:
+        d = record.device
+        fields = tuple(getattr(self.grid, f"{component}_dev") for component in (
+            ELECTRIC_COMPONENTS if kind == "electric" else MAGNETIC_COMPONENTS
+        ))
+        command = self.queue.commandBuffer()
+        encoder = command.computeCommandEncoder()
+        encoder.setComputePipelineState_(self.gather_pipeline)
+        self._set_scalar(encoder, 0, np.int32(record.npatches))
+        self._set_scalar(encoder, 1, np.int32(record.max_samples))
+        for index, buffer in enumerate(
+            (
+                d[f"{kind}_count_x"], d[f"{kind}_count_y"],
+                d[f"{kind}_count_z"], d[f"{kind}_stencil_x"],
+                d[f"{kind}_stencil_y"], d[f"{kind}_stencil_z"], d["normals"],
+            ),
+            start=2,
+        ):
+            encoder.setBuffer_offset_atIndex_(buffer, 0, index)
+        self._set_scalar(encoder, 9, self.real_scalar(scale))
+        for index, buffer in enumerate((*fields, target), start=10):
+            encoder.setBuffer_offset_atIndex_(buffer, 0, index)
+        self._finish(command, encoder, self.gather_pipeline, record.npatches)
+
+    def _deposit_equivalent(self, record, kind, sample_index, current, previous) -> None:
+        d = record.device
+        command = self.queue.commandBuffer()
+        encoder = command.computeCommandEncoder()
+        encoder.setComputePipelineState_(self.deposit_pipeline)
+        scalars = (
+            np.int32(record.ndirections), np.int32(record.npatches),
+            np.int32(record.output_length), np.int32(sample_index),
+            np.int32(record.monitor._time_origin_step),
+            self.real_scalar(1 / record.monitor.dt),
+        )
+        for index, value in enumerate(scalars):
+            self._set_scalar(encoder, index, value)
+        buffers = (
+            current, previous, d[f"{kind}_theta_basis"],
+            d[f"{kind}_phi_basis"], d[f"{kind}_integer_delay"],
+            d[f"{kind}_fractional_delay"], d["area_weights"],
+            d["output_theta"], d["output_phi"],
+        )
+        for index, buffer in enumerate(buffers, start=6):
+            encoder.setBuffer_offset_atIndex_(buffer, 0, index)
+        self._finish(command, encoder, self.deposit_pipeline, record.ndirections)
+
+    def _download_equivalent(self, record, name):
+        count = record.ndirections * record.output_length
+        nbytes = count * self.real_dtype.itemsize
+        return np.frombuffer(
+            record.device[name].contents().as_buffer(nbytes), dtype=self.real_dtype
+        ).copy()
+
+
 class MetalCombinedKSIRCollector:
-    """Dispatch frequency-domain and advanced-time monitors on Metal."""
+    """Dispatch all NTFF monitors on Metal."""
 
     def __init__(self, updates):
         configure_ntff_monitors(updates.grid, allow_time_domain=True)
@@ -1003,6 +1468,11 @@ class MetalCombinedKSIRCollector:
         time_monitors = [
             monitor for monitor in updates.grid.ntff_monitors if _is_time_domain_monitor(monitor)
         ]
+        equivalent_time_monitors = [
+            monitor
+            for monitor in updates.grid.ntff_monitors
+            if _is_equivalent_current_time_monitor(monitor)
+        ]
         self.frequency = (
             MetalKSIRCollector(updates, frequency_monitors, configure=False)
             if frequency_monitors
@@ -1011,21 +1481,32 @@ class MetalCombinedKSIRCollector:
         self.time_domain = (
             MetalTimeDomainKSIRCollector(updates, time_monitors) if time_monitors else None
         )
+        self.equivalent_time = (
+            MetalEquivalentCurrentTimeCollector(updates, equivalent_time_monitors)
+            if equivalent_time_monitors
+            else None
+        )
 
     def observe_electric(self, iteration: int) -> None:
         if self.frequency is not None:
             self.frequency.observe_electric(iteration)
         if self.time_domain is not None:
             self.time_domain.observe_electric(iteration)
+        if self.equivalent_time is not None:
+            self.equivalent_time.observe_electric(iteration)
 
     def observe_magnetic(self, iteration: int) -> None:
         if self.frequency is not None:
             self.frequency.observe_magnetic(iteration)
         if self.time_domain is not None:
             self.time_domain.observe_magnetic(iteration)
+        if self.equivalent_time is not None:
+            self.equivalent_time.observe_magnetic(iteration)
 
     def finalise(self) -> None:
         if self.frequency is not None:
             self.frequency.finalise()
         if self.time_domain is not None:
             self.time_domain.finalise()
+        if self.equivalent_time is not None:
+            self.equivalent_time.finalise()

--- a/gprMax/ntff/equivalent_current_time.py
+++ b/gprMax/ntff/equivalent_current_time.py
@@ -91,6 +91,7 @@ class EquivalentCurrentTimeMonitor:
         wave_speed,
         impedance,
         nthreads=1,
+        device_backend=None,
     ):
         self.name = name
         self.lower = np.asarray(lower, dtype=np.int64)
@@ -106,12 +107,18 @@ class EquivalentCurrentTimeMonitor:
         self.origin = np.asarray(origin, dtype=self.real_dtype)
         self.allow_external_sources = False
         self.managed_output = True
-        self.device_backend = None
+        if device_backend not in (None, "cuda", "opencl", "metal"):
+            raise ValueError("device_backend must be None, 'cuda', 'opencl', or 'metal'")
+        self.device_backend = device_backend
         self.collection_backend = (
-            "cython_openmp"
-            if _gather_equivalent_current_component is not None
-            and _deposit_equivalent_current_time is not None
-            else "numpy_fallback"
+            f"{device_backend}_device"
+            if device_backend is not None
+            else (
+                "cython_openmp"
+                if _gather_equivalent_current_component is not None
+                and _deposit_equivalent_current_time is not None
+                else "numpy_fallback"
+            )
         )
         if self.lower.shape != (3,) or self.upper.shape != (3,):
             raise ValueError("equivalent-current bounds must have shape (3,)")
@@ -177,10 +184,12 @@ class EquivalentCurrentTimeMonitor:
         self._time_origin_step = int(np.floor(np.min(shift))) - 2
         last_step = self.iterations - 1 + int(np.ceil(np.max(shift))) + 2
         self._raw_length = last_step - self._time_origin_step + 1
-        self._theta_output = np.zeros(
-            (self.directions.shape[0], self._raw_length), dtype=self.real_dtype
+        self._theta_output = (
+            np.zeros((self.directions.shape[0], self._raw_length), dtype=self.real_dtype)
+            if device_backend is None
+            else None
         )
-        self._phi_output = np.zeros_like(self._theta_output)
+        self._phi_output = None if self._theta_output is None else np.zeros_like(self._theta_output)
         self._complete_start_step = int(np.ceil(np.max(shift) + 1))
         self._complete_stop_step = int(np.floor(np.min(shift) + self.iterations - 1))
         if self._complete_stop_step < self._complete_start_step:
@@ -203,6 +212,11 @@ class EquivalentCurrentTimeMonitor:
         return self._result
 
     def _build_stencils(self):
+        # Surface coordinates and Yee offsets are stored in the configured
+        # field precision. A fixed 1e-9 tolerance is tighter than one ULP for
+        # typical single-precision grid coordinates and can reject an exactly
+        # aligned surface after division by ``spacing``.
+        alignment_tolerance = max(1e-9, 32 * np.finfo(self.real_dtype).eps)
         result = {}
         for component in ELECTRIC_COMPONENTS + MAGNETIC_COMPONENTS:
             component_axis = "xyz".index(component[1].lower())
@@ -217,9 +231,16 @@ class EquivalentCurrentTimeMonitor:
                 for axis in range(3):
                     sample_index = target[:, axis] / self.spacing[axis] - offset[axis]
                     nearest = np.rint(sample_index)
-                    if np.allclose(sample_index, nearest, rtol=0, atol=1e-9):
+                    if np.allclose(
+                        sample_index, nearest, rtol=0, atol=alignment_tolerance
+                    ):
                         shifts_by_axis.append((0.0,))
-                    elif np.allclose(np.abs(sample_index - nearest), 0.5, rtol=0, atol=1e-9):
+                    elif np.allclose(
+                        np.abs(sample_index - nearest),
+                        0.5,
+                        rtol=0,
+                        atol=alignment_tolerance,
+                    ):
                         shifts_by_axis.append((-0.5, 0.5))
                     else:
                         raise RuntimeError(f"cannot form symmetric {component} stencil")
@@ -228,7 +249,12 @@ class EquivalentCurrentTimeMonitor:
                     position = target + np.asarray(shifts) * self.spacing
                     indices_float = position / self.spacing - offset
                     indices = np.rint(indices_float).astype(np.int64)
-                    if not np.allclose(indices_float, indices, rtol=0, atol=1e-9):
+                    if not np.allclose(
+                        indices_float,
+                        indices,
+                        rtol=0,
+                        atol=alignment_tolerance,
+                    ):
                         raise RuntimeError(f"{component} stencil is not on Yee samples")
                     if np.any(indices < 0) or np.any(
                         indices >= np.asarray(self.field_shape)[np.newaxis, :]
@@ -330,6 +356,8 @@ class EquivalentCurrentTimeMonitor:
         return self.surface_material_id
 
     def observe_electric(self, iteration, Ex, Ey, Ez):
+        if self.device_backend is not None:
+            raise RuntimeError("device equivalent-current monitors are observed by the backend")
         if iteration != self._next_electric:
             raise ValueError(f"expected electric iteration {self._next_electric}, got {iteration}")
         electric = self._gather_vector(ELECTRIC_COMPONENTS, (Ex, Ey, Ez))
@@ -347,6 +375,8 @@ class EquivalentCurrentTimeMonitor:
         self._next_electric += 1
 
     def observe_magnetic(self, iteration, Hx, Hy, Hz):
+        if self.device_backend is not None:
+            raise RuntimeError("device equivalent-current monitors are observed by the backend")
         if iteration != self._next_magnetic:
             raise ValueError(f"expected magnetic iteration {self._next_magnetic}, got {iteration}")
         magnetic = self._gather_vector(MAGNETIC_COMPONENTS, (Hx, Hy, Hz))
@@ -363,11 +393,31 @@ class EquivalentCurrentTimeMonitor:
         self._previous_magnetic = electric_current
         self._next_magnetic += 1
 
+    def load_device_far_field_output(self, theta_output, phi_output):
+        """Install completed device traces before normal finalisation."""
+
+        if self.device_backend is None:
+            raise RuntimeError("CPU equivalent-current monitors cannot load device output")
+        expected = (self.directions.shape[0], self._raw_length)
+        theta_output = np.asarray(theta_output, dtype=self.real_dtype)
+        phi_output = np.asarray(phi_output, dtype=self.real_dtype)
+        if theta_output.shape != expected or phi_output.shape != expected:
+            raise ValueError(
+                "equivalent-current device output has the wrong shape: "
+                f"expected {expected}, got {theta_output.shape} and {phi_output.shape}"
+            )
+        self._theta_output = np.ascontiguousarray(theta_output)
+        self._phi_output = np.ascontiguousarray(phi_output)
+        self._next_electric = self.iterations
+        self._next_magnetic = self.iterations
+
     def finalise(self):
         if self._finalised:
             return
         if self._next_electric != self.iterations or self._next_magnetic != self.iterations:
             raise RuntimeError("equivalent-current monitor did not receive every time step")
+        if self._theta_output is None or self._phi_output is None:
+            raise RuntimeError("equivalent-current device output was not loaded")
         start = self._complete_start_step - self._time_origin_step
         stop = self._complete_stop_step - self._time_origin_step + 1
         scale = -1 / (4 * np.pi * self.wave_speed)

--- a/gprMax/ntff/interface.py
+++ b/gprMax/ntff/interface.py
@@ -1447,7 +1447,7 @@ class NTFFCompiledOutputs:
             group.attrs["range_normalized"] = True
             group.attrs["normalization"] = "r * field at reduced time t - r/c"
             group.attrs["interpolation"] = "linear"
-            group.attrs["solver"] = "cpu"
+            group.attrs["solver"] = monitor.device_backend or "cpu"
             group.attrs["collection_backend"] = monitor.collection_backend
             group.attrs["outputs"] = np.asarray(spec.outputs, dtype="S20")
             group.attrs["terminal_decay_threshold"] = result.terminal_decay_threshold
@@ -1715,12 +1715,6 @@ def compile_ntff_outputs(model, grid) -> Optional[NTFFCompiledOutputs]:
         )
     if config.get_model_config().mode != "3D":
         raise ValueError("the reusable NTFF interface currently supports only 3-D models")
-    if time_far_requests and config.sim_config.general["solver"] != "cpu":
-        raise ValueError(
-            "the 1997 equivalent-current time-domain transform currently supports "
-            "the CPU solver; device-resident kernels are the next implementation stage"
-        )
-
     for transform in transform_specs.values():
         if transform.surface_id not in surface_specs:
             raise ValueError(
@@ -2016,6 +2010,11 @@ def compile_ntff_outputs(model, grid) -> Optional[NTFFCompiledOutputs]:
             wave_speed=wave_speed,
             impedance=impedance,
             nthreads=config.get_model_config().ompthreads,
+            device_backend=(
+                config.sim_config.general["solver"]
+                if config.sim_config.general["solver"] in ("cuda", "opencl", "metal")
+                else None
+            ),
         )
         monitor.surfaces = compiled.surfaces
         monitor.closure = compiled.closure

--- a/gprMax/solvers.py
+++ b/gprMax/solvers.py
@@ -72,11 +72,9 @@ class Solver:
             self.updates.update_magnetic()
             self.updates.update_magnetic_pml()
             self.updates.update_magnetic_sources(iteration)
-            if isinstance(self.updates, CPUUpdates):
-                self.updates.update_eigenmode_sources_magnetic(iteration)
+            self.updates.update_eigenmode_sources_magnetic(iteration)
             self.updates.update_plane_waves_magnetic(iteration)
-            if isinstance(self.updates, CPUUpdates):
-                self.updates.observe_eigenmode_ports(iteration)
+            self.updates.observe_eigenmode_ports(iteration)
 
             if isinstance(self.updates, MPIUpdates):
                 self.updates.halo_swap_magnetic()
@@ -95,8 +93,7 @@ class Solver:
 
             self.updates.update_electric_pml()
             self.updates.update_electric_sources(iteration)
-            if isinstance(self.updates, CPUUpdates):
-                self.updates.update_eigenmode_sources_electric(iteration)
+            self.updates.update_eigenmode_sources_electric(iteration)
             self.updates.update_plane_waves_electric(iteration)
 
             # TODO: Increment iteration here if add Model to Solver

--- a/gprMax/sources.py
+++ b/gprMax/sources.py
@@ -2730,6 +2730,22 @@ def dtoh_transmission_line_outputs(Vtotal, Itotal, G):
     """Copy device terminal histories into their transmission-line objects."""
 
     expected = (len(G.transmissionlines), G.iterations + 1)
+    general = getattr(config.sim_config, "general", {})
+    if general.get("solver") == "metal":
+        dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
+        nbytes = int(np.prod(expected)) * dtype.itemsize
+
+        def metal_array(buffer):
+            if buffer.length() != nbytes:
+                raise ValueError(
+                    "Transmission-line Metal output buffer has the wrong size: "
+                    f"expected {nbytes} bytes, got {buffer.length()}."
+                )
+            return np.frombuffer(
+                buffer.contents().as_buffer(nbytes), dtype=dtype
+            ).reshape(expected).copy()
+
+        Vtotal, Itotal = metal_array(Vtotal), metal_array(Itotal)
     if Vtotal.shape != expected or Itotal.shape != expected:
         raise ValueError(
             "Transmission-line device output shape does not match the grid: "

--- a/gprMax/updates/cuda_updates.py
+++ b/gprMax/updates/cuda_updates.py
@@ -26,17 +26,28 @@ from jinja2 import Environment, PackageLoader
 
 from gprMax import config
 from gprMax.cuda_opencl import (
+    knl_eigenmode,
     knl_fields_updates,
     knl_magnetic_frill_source,
     knl_planewave_updates,
+    knl_rational_network,
     knl_snapshots,
     knl_source_updates,
     knl_store_outputs,
     knl_symmetry_boundaries,
     knl_tfsf_injection,
     knl_transmission_line,
+    knl_virtual_waveguide,
+)
+from gprMax.eigenmode_device import (
+    eigenmode_source_envelopes,
+    finalise_device_eigenmode_monitors,
+    prepare_device_eigenmode_monitor,
+    prepare_device_eigenmode_source,
+    reanchor_device_eigenmode_monitor,
 )
 from gprMax.grid.cuda_grid import CUDAGrid
+from gprMax.network_ports import dtoh_rational_network_outputs, htod_rational_network_arrays
 from gprMax.ntff.device import CUDACombinedKSIRCollector
 from gprMax.receivers import dtoh_rx_array, htod_rx_arrays, requested_current_outputs
 from gprMax.snapshots import (
@@ -63,7 +74,7 @@ logger = logging.getLogger(__name__)
 class CUDAUpdates(Updates[CUDAGrid]):
     """Defines update functions for GPU-based (CUDA) solver."""
 
-    def __init__(self, G: CUDAGrid):
+    def __init__(self, G: CUDAGrid, shared=None):
         """
         Args:
             G: CUDAGrid class describing a grid in a model.
@@ -75,9 +86,15 @@ class CUDAUpdates(Updates[CUDAGrid]):
         self.source_module = getattr(import_module("pycuda.compiler"), "SourceModule")
         self.drv.init()
 
-        # Create device handle and context on specific GPU device (and make it current context)
-        self.dev = config.get_model_config().device["dev"]
-        self.ctx = self.dev.make_context()
+        # Auxiliary virtual guides must share the parent's CUDA context so a
+        # coupling kernel can address both grids without per-step transfers.
+        self._owns_context = shared is None
+        if shared is None:
+            self.dev = config.get_model_config().device["dev"]
+            self.ctx = self.dev.make_context()
+        else:
+            self.dev = shared.dev
+            self.ctx = shared.ctx
 
         # Set common substitutions for use in kernels
         # Substitutions in function arguments
@@ -90,6 +107,7 @@ class CUDAUpdates(Updates[CUDAGrid]):
             "REAL": config.sim_config.dtypes["C_float_or_double"],
             "CUDA_IDX": "int i = blockIdx.x * blockDim.x + threadIdx.x;",
             "TFSF_IDX": "int t = blockIdx.x * blockDim.x + threadIdx.x;",
+            "METAL_DFT_PARAMETERS": "",
             "NX_FIELDS": self.grid.nx + 1,
             "NY_FIELDS": self.grid.ny + 1,
             "NZ_FIELDS": self.grid.nz + 1,
@@ -120,17 +138,27 @@ class CUDAUpdates(Updates[CUDAGrid]):
             self._set_src_knls()
         if self.grid.transmissionlines:
             self._set_transmission_line_knls()
+        if self.grid.networkterminals:
+            self._set_rational_network_knl()
         if self.grid.magneticfrillsources:
             self._set_magnetic_frill_knls()
         if self.grid.snapshots:
             self._set_snapshot_knl()
         if self.grid.discreteplanewaves:
             self._set_planewave_knls()
+        if self.grid.eigenmodesources:
+            self._set_eigenmode_source_knls()
+        if self.grid.eigenmodeports:
+            self._set_eigenmode_monitor_knl()
         self.ntff_collector = None
         if self.grid.ntff_monitors:
             self.ntff_c_real = config.sim_config.dtypes["C_float_or_double"]
             self.ntff_compiler_options = config.sim_config.devices["nvcc_opts"]
             self.ntff_collector = CUDACombinedKSIRCollector(self)
+        if self.grid.virtual_waveguides:
+            self._set_virtual_waveguide_knls()
+        for guide in self.grid.virtual_waveguides:
+            guide.initialise_device(self)
 
     def _build_knl(self, knl_func, subs_name_args, subs_func):
         """Builds a CUDA kernel from templates: 1) function name and args;
@@ -257,15 +285,47 @@ class CUDAUpdates(Updates[CUDAGrid]):
             self.grid.htod_dispersive_arrays()
 
     def _set_symmetry_boundary_knl(self):
-        """Build the nondispersive PMC ghost-image boundary kernel."""
+        """Build normal or dispersive PMC ghost-image boundary kernels."""
+        substitutions = dict(self.subs_func)
+        substitutions.update(knl_symmetry_boundaries.nondispersive_substitutions())
         source = self._build_knl(
             knl_symmetry_boundaries.update_electric_pmc,
             self.subs_name_args,
-            self.subs_func,
+            substitutions,
         )
         module = self.source_module(source, options=config.sim_config.devices["nvcc_opts"])
         self.update_electric_pmc_dev = module.get_function("update_electric_pmc")
         self._copy_mat_coeffs(module, module)
+        if config.get_model_config().materials["maxpoles"] > 0:
+            substitutions = dict(self.subs_func)
+            substitutions.update(
+                knl_symmetry_boundaries.dispersive_substitutions(
+                    config.sim_config.dtypes["C_float_or_double"]
+                )
+            )
+            source = self._build_knl(
+                knl_symmetry_boundaries.update_electric_pmc_dispersive,
+                self.subs_name_args,
+                substitutions,
+            )
+            module_a = self.source_module(
+                source, options=config.sim_config.devices["nvcc_opts"]
+            )
+            self.update_electric_pmc_dispersive_dev = module_a.get_function(
+                "update_electric_pmc_dispersive"
+            )
+            self._copy_mat_coeffs(module_a, module_a)
+            source = self._build_knl(
+                knl_symmetry_boundaries.update_electric_pmc_dispersive_b,
+                self.subs_name_args,
+                self.subs_func,
+            )
+            module_b = self.source_module(
+                source, options=config.sim_config.devices["nvcc_opts"]
+            )
+            self.update_electric_pmc_dispersive_b_dev = module_b.get_function(
+                "update_electric_pmc_dispersive_b"
+            )
 
     def _pmc_flags(self):
         boundaries = self.grid.symmetry_boundaries
@@ -428,6 +488,104 @@ class CUDAUpdates(Updates[CUDAGrid]):
             "update_transmission_line_electric"
         )
 
+    def _set_eigenmode_source_knls(self):
+        """Upload modal bases and compile device TF/SF source kernels."""
+
+        if not hasattr(self.grid, "updatecoeffsE_dev"):
+            self.grid.htod_mat_coeff_arrays()
+        for source in self.grid.eigenmodesources:
+            prepare_device_eigenmode_source(source, "cuda")
+        self.eigenmode_tpb = (128, 1, 1)
+        magnetic = self._build_knl(
+            knl_eigenmode.update_eigenmode_magnetic,
+            self.subs_name_args,
+            self.subs_func,
+        )
+        module = self.source_module(magnetic, options=config.sim_config.devices["nvcc_opts"])
+        self.update_eigenmode_magnetic_dev = module.get_function("update_eigenmode_magnetic")
+        electric = self._build_knl(
+            knl_eigenmode.update_eigenmode_electric,
+            self.subs_name_args,
+            self.subs_func,
+        )
+        module = self.source_module(electric, options=config.sim_config.devices["nvcc_opts"])
+        self.update_eigenmode_electric_dev = module.get_function("update_eigenmode_electric")
+
+    def _set_eigenmode_monitor_knl(self):
+        """Upload modal projection bases and compile the DFT kernel."""
+
+        for monitor in self.grid.eigenmodeports:
+            prepare_device_eigenmode_monitor(monitor, "cuda")
+        source = self._build_knl(
+            knl_eigenmode.accumulate_eigenmode_dft,
+            self.subs_name_args,
+            self.subs_func,
+        )
+        module = self.source_module(source, options=config.sim_config.devices["nvcc_opts"])
+        self.accumulate_eigenmode_dft_dev = module.get_function("accumulate_eigenmode_dft")
+
+    def _set_virtual_waveguide_knls(self):
+        """Compile aperture coupling kernels for auxiliary device grids."""
+
+        self.virtual_tpb = (128, 1, 1)
+        for specification, attribute, name in (
+            (
+                knl_virtual_waveguide.couple_magnetic,
+                "couple_virtual_magnetic_dev",
+                "couple_virtual_waveguide_magnetic",
+            ),
+            (
+                knl_virtual_waveguide.clear_rear_magnetic,
+                "clear_virtual_magnetic_dev",
+                "clear_virtual_waveguide_rear_magnetic",
+            ),
+            (
+                knl_virtual_waveguide.couple_electric,
+                "couple_virtual_electric_dev",
+                "couple_virtual_waveguide_electric",
+            ),
+            (
+                knl_virtual_waveguide.clear_rear_electric,
+                "clear_virtual_electric_dev",
+                "clear_virtual_waveguide_rear_electric",
+            ),
+        ):
+            source = self._build_knl(specification, self.subs_name_args, self.subs_func)
+            module = self.source_module(source, options=config.sim_config.devices["nvcc_opts"])
+            setattr(self, attribute, module.get_function(name))
+
+    def _set_rational_network_knl(self):
+        """Initialise sparse device-resident rational-network terminals."""
+
+        arrays = htod_rational_network_arrays(self.grid.networkterminals, self.grid)
+        for name, array in arrays.items():
+            setattr(self, f"rn_{name}_dev", array)
+
+        self.rn_tpb = (32, 1, 1)
+        self.rn_bpg = (
+            int(np.ceil(len(self.grid.networkterminals) / self.rn_tpb[0])),
+            1,
+            1,
+        )
+        substitutions = dict(self.subs_func)
+        substitutions.update(
+            {
+                "NY_RNINFO": 6,
+                "NY_RNPARAMS": 7,
+                "NY_RNWAVEWHOLE": self.grid.iterations + 1,
+                "NY_RNWAVEHALF": self.grid.iterations,
+                "NY_RNVOLTAGE": self.grid.iterations + 1,
+                "NY_RNCURRENT": self.grid.iterations,
+            }
+        )
+        source = self._build_knl(
+            knl_rational_network.update_rational_network,
+            self.subs_name_args,
+            substitutions,
+        )
+        module = self.source_module(source, options=config.sim_config.devices["nvcc_opts"])
+        self.update_rational_network_dev = module.get_function("update_rational_network")
+
     def _set_magnetic_frill_knls(self):
         """Initialise device-resident magnetic-frill sources and their kernel.
 
@@ -510,7 +668,6 @@ class CUDAUpdates(Updates[CUDAGrid]):
         self.grid.htod_mat_coeff_arrays()
 
         for dpw in self.grid.discreteplanewaves:
-
             # Upload all 1D DPW arrays to GPU
             self.grid.htod_planewave_arrays(dpw)
 
@@ -553,7 +710,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
             if dpw.dispersive:
                 bld = self._build_knl(
                     knl_planewave_updates.update_1d_electric_dispersive_A,
-                    self.subs_name_args, subs_pw
+                    self.subs_name_args,
+                    subs_pw,
                 )
                 knl = self.source_module(bld, options=config.sim_config.devices["nvcc_opts"])
                 dpw.update_1d_electric_dispersive_A_dev = knl.get_function(
@@ -562,7 +720,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                 bld = self._build_knl(
                     knl_planewave_updates.update_1d_electric_dispersive_B,
-                    self.subs_name_args, subs_pw
+                    self.subs_name_args,
+                    subs_pw,
                 )
                 knl = self.source_module(bld, options=config.sim_config.devices["nvcc_opts"])
                 dpw.update_1d_electric_dispersive_B_dev = knl.get_function(
@@ -587,10 +746,10 @@ class CUDAUpdates(Updates[CUDAGrid]):
             # Axial kernels (only if dpw.axial != 0)
             # updatecoeffsH/E passed as pointer args - no constant memory, no 64KB limit
             if dpw.axial != 0:
-
                 bld = self._build_knl(
                     knl_planewave_updates.update_1d_magnetic_axial_source,
-                    self.subs_name_args, subs_pw
+                    self.subs_name_args,
+                    subs_pw,
                 )
                 knl = self.source_module(bld, options=config.sim_config.devices["nvcc_opts"])
                 dpw.update_1d_magnetic_axial_source_dev = knl.get_function(
@@ -599,7 +758,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                 bld = self._build_knl(
                     knl_planewave_updates.update_1d_magnetic_axial_source_pml,
-                    self.subs_name_args, subs_pw
+                    self.subs_name_args,
+                    subs_pw,
                 )
                 knl = self.source_module(bld, options=config.sim_config.devices["nvcc_opts"])
                 dpw.update_1d_magnetic_axial_source_pml_dev = knl.get_function(
@@ -608,7 +768,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                 bld = self._build_knl(
                     knl_planewave_updates.update_1d_magnetic_axial_inject,
-                    self.subs_name_args, subs_pw
+                    self.subs_name_args,
+                    subs_pw,
                 )
                 knl = self.source_module(bld, options=config.sim_config.devices["nvcc_opts"])
                 dpw.update_1d_magnetic_axial_inject_dev = knl.get_function(
@@ -617,7 +778,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                 bld = self._build_knl(
                     knl_planewave_updates.update_1d_magnetic_axial_main,
-                    self.subs_name_args, subs_pw
+                    self.subs_name_args,
+                    subs_pw,
                 )
                 knl = self.source_module(bld, options=config.sim_config.devices["nvcc_opts"])
                 dpw.update_1d_magnetic_axial_main_dev = knl.get_function(
@@ -626,7 +788,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                 bld = self._build_knl(
                     knl_planewave_updates.update_1d_magnetic_axial_main_pml_end,
-                    self.subs_name_args, subs_pw
+                    self.subs_name_args,
+                    subs_pw,
                 )
                 knl = self.source_module(bld, options=config.sim_config.devices["nvcc_opts"])
                 dpw.update_1d_magnetic_axial_main_pml_end_dev = knl.get_function(
@@ -635,7 +798,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                 bld = self._build_knl(
                     knl_planewave_updates.update_1d_magnetic_axial_main_pml_start,
-                    self.subs_name_args, subs_pw
+                    self.subs_name_args,
+                    subs_pw,
                 )
                 knl = self.source_module(bld, options=config.sim_config.devices["nvcc_opts"])
                 dpw.update_1d_magnetic_axial_main_pml_start_dev = knl.get_function(
@@ -644,7 +808,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                 bld = self._build_knl(
                     knl_planewave_updates.update_1d_electric_axial_source,
-                    self.subs_name_args, subs_pw
+                    self.subs_name_args,
+                    subs_pw,
                 )
                 knl = self.source_module(bld, options=config.sim_config.devices["nvcc_opts"])
                 dpw.update_1d_electric_axial_source_dev = knl.get_function(
@@ -653,7 +818,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                 bld = self._build_knl(
                     knl_planewave_updates.update_1d_electric_axial_source_pml,
-                    self.subs_name_args, subs_pw
+                    self.subs_name_args,
+                    subs_pw,
                 )
                 knl = self.source_module(bld, options=config.sim_config.devices["nvcc_opts"])
                 dpw.update_1d_electric_axial_source_pml_dev = knl.get_function(
@@ -662,7 +828,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                 bld = self._build_knl(
                     knl_planewave_updates.update_1d_electric_axial_inject,
-                    self.subs_name_args, subs_pw
+                    self.subs_name_args,
+                    subs_pw,
                 )
                 knl = self.source_module(bld, options=config.sim_config.devices["nvcc_opts"])
                 dpw.update_1d_electric_axial_inject_dev = knl.get_function(
@@ -671,7 +838,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                 bld = self._build_knl(
                     knl_planewave_updates.update_1d_electric_axial_main,
-                    self.subs_name_args, subs_pw
+                    self.subs_name_args,
+                    subs_pw,
                 )
                 knl = self.source_module(bld, options=config.sim_config.devices["nvcc_opts"])
                 dpw.update_1d_electric_axial_main_dev = knl.get_function(
@@ -680,7 +848,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                 bld = self._build_knl(
                     knl_planewave_updates.update_1d_electric_axial_main_pml_end,
-                    self.subs_name_args, subs_pw
+                    self.subs_name_args,
+                    subs_pw,
                 )
                 knl = self.source_module(bld, options=config.sim_config.devices["nvcc_opts"])
                 dpw.update_1d_electric_axial_main_pml_end_dev = knl.get_function(
@@ -689,7 +858,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                 bld = self._build_knl(
                     knl_planewave_updates.update_1d_electric_axial_main_pml_start,
-                    self.subs_name_args, subs_pw
+                    self.subs_name_args,
+                    subs_pw,
                 )
                 knl = self.source_module(bld, options=config.sim_config.devices["nvcc_opts"])
                 dpw.update_1d_electric_axial_main_pml_start_dev = knl.get_function(
@@ -700,7 +870,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 if dpw.dispersive:
                     bld = self._build_knl(
                         knl_planewave_updates.update_1d_electric_dispersive_axial_source,
-                        self.subs_name_args, subs_pw
+                        self.subs_name_args,
+                        subs_pw,
                     )
                     knl = self.source_module(bld, options=config.sim_config.devices["nvcc_opts"])
                     dpw.update_1d_electric_dispersive_axial_source_dev = knl.get_function(
@@ -709,7 +880,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                     bld = self._build_knl(
                         knl_planewave_updates.update_1d_electric_dispersive_axial_source_T,
-                        self.subs_name_args, subs_pw
+                        self.subs_name_args,
+                        subs_pw,
                     )
                     knl = self.source_module(bld, options=config.sim_config.devices["nvcc_opts"])
                     dpw.update_1d_electric_dispersive_axial_source_T_dev = knl.get_function(
@@ -718,7 +890,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                     bld = self._build_knl(
                         knl_planewave_updates.update_1d_electric_dispersive_axial_main,
-                        self.subs_name_args, subs_pw
+                        self.subs_name_args,
+                        subs_pw,
                     )
                     knl = self.source_module(bld, options=config.sim_config.devices["nvcc_opts"])
                     dpw.update_1d_electric_dispersive_axial_main_dev = knl.get_function(
@@ -727,7 +900,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                     bld = self._build_knl(
                         knl_planewave_updates.update_1d_electric_dispersive_axial_main_T,
-                        self.subs_name_args, subs_pw
+                        self.subs_name_args,
+                        subs_pw,
                     )
                     knl = self.source_module(bld, options=config.sim_config.devices["nvcc_opts"])
                     dpw.update_1d_electric_dispersive_axial_main_T_dev = knl.get_function(
@@ -819,30 +993,41 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 continue
 
             # coef_H_1 and coef_H_2 depend on face axis
-            if idx < 2:   # x faces — use DBx (col 1)
-                c1 = REAL(mat[1]); c2 = REAL(mat[1])
-            elif idx < 4: # y faces — use DBy (col 2)
-                c1 = REAL(mat[2]); c2 = REAL(mat[2])
-            else:         # z faces — use DBz (col 3)
-                c1 = REAL(mat[3]); c2 = REAL(mat[3])
+            if idx < 2:  # x faces — use DBx (col 1)
+                c1 = REAL(mat[1])
+                c2 = REAL(mat[1])
+            elif idx < 4:  # y faces — use DBy (col 2)
+                c1 = REAL(mat[2])
+                c2 = REAL(mat[2])
+            else:  # z faces — use DBz (col 3)
+                c1 = REAL(mat[3])
+                c2 = REAL(mat[3])
 
             face_dev(
                 np.int32(self.grid.ny + 1),
                 np.int32(self.grid.nz + 1),
                 np.int32(NY_F),
                 np.int32(NZ_F),
-                np.int32(x_s), np.int32(x_e),
-                np.int32(y_s), np.int32(y_e),
-                np.int32(z_s), np.int32(z_e),
-                np.int32(m[0]), np.int32(m[1]), np.int32(m[2]),
-                np.int32(origin[0]), np.int32(origin[1]), np.int32(origin[2]),
-                c1, c2,
+                np.int32(x_s),
+                np.int32(x_e),
+                np.int32(y_s),
+                np.int32(y_e),
+                np.int32(z_s),
+                np.int32(z_e),
+                np.int32(m[0]),
+                np.int32(m[1]),
+                np.int32(m[2]),
+                np.int32(origin[0]),
+                np.int32(origin[1]),
+                np.int32(origin[2]),
+                c1,
+                c2,
                 self.grid.Hx_dev,
                 self.grid.Hy_dev,
                 self.grid.Hz_dev,
-                dpw.E_fields_dev[0],   # E_x row
-                dpw.E_fields_dev[1],   # E_y row
-                dpw.E_fields_dev[2],   # E_z row
+                dpw.E_fields_dev[0],  # E_x row
+                dpw.E_fields_dev[1],  # E_y row
+                dpw.E_fields_dev[2],  # E_z row
                 block=(256, 1, 1),
                 grid=(int(np.ceil(face_size / 256)), 1, 1),
             )
@@ -888,30 +1073,41 @@ class CUDAUpdates(Updates[CUDAGrid]):
             if face_size == 0:
                 continue
 
-            if idx < 2:   # x faces — use CBx (col 1)
-                c1 = REAL(mat[1]); c2 = REAL(mat[1])
-            elif idx < 4: # y faces — use CBy (col 2)
-                c1 = REAL(mat[2]); c2 = REAL(mat[2])
-            else:         # z faces — use CBz (col 3)
-                c1 = REAL(mat[3]); c2 = REAL(mat[3])
+            if idx < 2:  # x faces — use CBx (col 1)
+                c1 = REAL(mat[1])
+                c2 = REAL(mat[1])
+            elif idx < 4:  # y faces — use CBy (col 2)
+                c1 = REAL(mat[2])
+                c2 = REAL(mat[2])
+            else:  # z faces — use CBz (col 3)
+                c1 = REAL(mat[3])
+                c2 = REAL(mat[3])
 
             face_dev(
                 np.int32(self.grid.ny + 1),
                 np.int32(self.grid.nz + 1),
                 np.int32(NY_F),
                 np.int32(NZ_F),
-                np.int32(x_s), np.int32(x_e),
-                np.int32(y_s), np.int32(y_e),
-                np.int32(z_s), np.int32(z_e),
-                np.int32(m[0]), np.int32(m[1]), np.int32(m[2]),
-                np.int32(origin[0]), np.int32(origin[1]), np.int32(origin[2]),
-                c1, c2,
+                np.int32(x_s),
+                np.int32(x_e),
+                np.int32(y_s),
+                np.int32(y_e),
+                np.int32(z_s),
+                np.int32(z_e),
+                np.int32(m[0]),
+                np.int32(m[1]),
+                np.int32(m[2]),
+                np.int32(origin[0]),
+                np.int32(origin[1]),
+                np.int32(origin[2]),
+                c1,
+                c2,
                 self.grid.Ex_dev,
                 self.grid.Ey_dev,
                 self.grid.Ez_dev,
-                dpw.H_fields_dev[0],   # H_x row
-                dpw.H_fields_dev[1],   # H_y row
-                dpw.H_fields_dev[2],   # H_z row
+                dpw.H_fields_dev[0],  # H_x row
+                dpw.H_fields_dev[1],  # H_y row
+                dpw.H_fields_dev[2],  # H_z row
                 block=(256, 1, 1),
                 grid=(int(np.ceil(face_size / 256)), 1, 1),
             )
@@ -960,18 +1156,27 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 np.int32(self.grid.nz + 1),
                 np.int32(NY_F),
                 np.int32(NZ_F),
-                np.int32(x_s), np.int32(x_e),
-                np.int32(y_s), np.int32(y_e),
-                np.int32(z_s), np.int32(z_e),
-                np.int32(m[0]), np.int32(m[1]), np.int32(m[2]),
-                np.int32(origin[0]), np.int32(origin[1]), np.int32(origin[2]),
+                np.int32(x_s),
+                np.int32(x_e),
+                np.int32(y_s),
+                np.int32(y_e),
+                np.int32(z_s),
+                np.int32(z_e),
+                np.int32(m[0]),
+                np.int32(m[1]),
+                np.int32(m[2]),
+                np.int32(origin[0]),
+                np.int32(origin[1]),
+                np.int32(origin[2]),
                 np.int32(dpw.origin_axial),
                 self.grid.Hx_dev,
                 self.grid.Hy_dev,
                 self.grid.Hz_dev,
-                dpw.E_fields_dev[0],   # E_x row (main 1D grid, matches Cython applyTFSFMagnetic_axial)
-                dpw.E_fields_dev[1],   # E_y row
-                dpw.E_fields_dev[2],   # E_z row
+                dpw.E_fields_dev[
+                    0
+                ],  # E_x row (main 1D grid, matches Cython applyTFSFMagnetic_axial)
+                dpw.E_fields_dev[1],  # E_y row
+                dpw.E_fields_dev[2],  # E_z row
                 self.grid.ID_dev,
                 # updatecoeffsH is read from constant memory (populated by _copy_mat_coeffs)
                 block=(256, 1, 1),
@@ -1022,18 +1227,27 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 np.int32(self.grid.nz + 1),
                 np.int32(NY_F),
                 np.int32(NZ_F),
-                np.int32(x_s), np.int32(x_e),
-                np.int32(y_s), np.int32(y_e),
-                np.int32(z_s), np.int32(z_e),
-                np.int32(m[0]), np.int32(m[1]), np.int32(m[2]),
-                np.int32(origin[0]), np.int32(origin[1]), np.int32(origin[2]),
+                np.int32(x_s),
+                np.int32(x_e),
+                np.int32(y_s),
+                np.int32(y_e),
+                np.int32(z_s),
+                np.int32(z_e),
+                np.int32(m[0]),
+                np.int32(m[1]),
+                np.int32(m[2]),
+                np.int32(origin[0]),
+                np.int32(origin[1]),
+                np.int32(origin[2]),
                 np.int32(dpw.origin_axial),
                 self.grid.Ex_dev,
                 self.grid.Ey_dev,
                 self.grid.Ez_dev,
-                dpw.H_fields_dev[0],   # H_x row (main 1D grid, matches Cython applyTFSFElectric_axial)
-                dpw.H_fields_dev[1],   # H_y row
-                dpw.H_fields_dev[2],   # H_z row
+                dpw.H_fields_dev[
+                    0
+                ],  # H_x row (main 1D grid, matches Cython applyTFSFElectric_axial)
+                dpw.H_fields_dev[1],  # H_y row
+                dpw.H_fields_dev[2],  # H_z row
                 self.grid.ID_dev,
                 # updatecoeffsE is read from constant memory (populated by _copy_mat_coeffs)
                 block=(256, 1, 1),
@@ -1183,6 +1397,63 @@ class CUDAUpdates(Updates[CUDAGrid]):
         if collector is not None:
             collector.observe_magnetic(iteration)
 
+    def observe_eigenmode_ports(self, iteration):
+        """Project modal port fields and accumulate DFTs on CUDA."""
+
+        real = config.sim_config.dtypes["float_or_double"]
+        for monitor in self.grid.eigenmodeports:
+            if iteration != monitor._next_iteration:
+                raise RuntimeError(
+                    f"expected eigenmode DFT iteration {monitor._next_iteration}, "
+                    f"received {iteration}"
+                )
+            owner = monitor.owner
+            arrays = monitor.device_arrays
+            nf, nm = monitor.electric_dft.shape
+            self.accumulate_eigenmode_dft_dev(
+                np.int32(nf),
+                np.int32(nm),
+                np.int32(owner.normal_axis),
+                np.int32(1 if owner.direction == "+" else -1),
+                np.int32(monitor.magnetic_side),
+                np.int32(owner.transverse_start[0]),
+                np.int32(owner.transverse_start[1]),
+                np.int32(owner.transverse_stop[0]),
+                np.int32(owner.transverse_stop[1]),
+                np.int32(owner.plane_index),
+                real(self.grid.dt),
+                real(monitor.measure),
+                np.int32(monitor.handedness),
+                arrays["electric_phase_real"].gpudata,
+                arrays["electric_phase_imag"].gpudata,
+                arrays["magnetic_phase_real"].gpudata,
+                arrays["magnetic_phase_imag"].gpudata,
+                arrays["phase_step_real"].gpudata,
+                arrays["phase_step_imag"].gpudata,
+                arrays["conj_eu_real"].gpudata,
+                arrays["conj_eu_imag"].gpudata,
+                arrays["conj_ev_real"].gpudata,
+                arrays["conj_ev_imag"].gpudata,
+                arrays["conj_hu_real"].gpudata,
+                arrays["conj_hu_imag"].gpudata,
+                arrays["conj_hv_real"].gpudata,
+                arrays["conj_hv_imag"].gpudata,
+                arrays["electric_dft_real"].gpudata,
+                arrays["electric_dft_imag"].gpudata,
+                arrays["magnetic_dft_real"].gpudata,
+                arrays["magnetic_dft_imag"].gpudata,
+                self.grid.Ex_dev.gpudata,
+                self.grid.Ey_dev.gpudata,
+                self.grid.Ez_dev.gpudata,
+                self.grid.Hx_dev.gpudata,
+                self.grid.Hy_dev.gpudata,
+                self.grid.Hz_dev.gpudata,
+                block=(128, 1, 1),
+                grid=(int(np.ceil(nf / 128)), 1, 1),
+            )
+            monitor._next_iteration += 1
+            reanchor_device_eigenmode_monitor(monitor, self.grid, "cuda")
+
     def update_magnetic_pml(self):
         """Updates magnetic field components with the PML correction."""
         for pml in self.grid.pmls["slabs"]:
@@ -1250,6 +1521,156 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 grid=self.frill_bpg,
             )
 
+    def _launch_eigenmode_source(self, source, iteration, magnetic):
+        nu, nv = np.asarray(source.transverse_stop) - np.asarray(source.transverse_start)
+        npoints = int((nu + 1) * (nv + 1))
+        block = self.eigenmode_tpb
+        launch_grid = (int(np.ceil(npoints / block[0])), 1, 1)
+        kernel = (
+            self.update_eigenmode_magnetic_dev if magnetic else self.update_eigenmode_electric_dev
+        )
+        profiles = source.device_electric_profiles if magnetic else source.device_magnetic_profiles
+        fields = (
+            (self.grid.Hx_dev, self.grid.Hy_dev, self.grid.Hz_dev)
+            if magnetic
+            else (self.grid.Ex_dev, self.grid.Ey_dev, self.grid.Ez_dev)
+        )
+        coefficients = self.grid.updatecoeffsH_dev if magnetic else self.grid.updatecoeffsE_dev
+        real = config.sim_config.dtypes["float_or_double"]
+        for basis, envelope in eigenmode_source_envelopes(source, self.grid, iteration, magnetic):
+            kernel(
+                np.int32(npoints),
+                np.int32(source.normal_axis),
+                np.int32(1 if source.direction == "+" else -1),
+                np.int32(source.transverse_start[0]),
+                np.int32(source.transverse_start[1]),
+                np.int32(source.transverse_stop[0]),
+                np.int32(source.transverse_stop[1]),
+                np.int32(source.plane_index),
+                np.int32(basis),
+                real(envelope),
+                profiles.gpudata,
+                coefficients.gpudata,
+                self.grid.ID_dev.gpudata,
+                *(field.gpudata for field in fields),
+                block=block,
+                grid=launch_grid,
+            )
+
+    def update_eigenmode_sources_magnetic(self, iteration):
+        for source in self.grid.eigenmodesources:
+            self._launch_eigenmode_source(source, iteration, True)
+        for guide in self.grid.virtual_waveguides:
+            self._update_virtual_waveguide_magnetic(guide, iteration)
+
+    def update_eigenmode_sources_electric(self, iteration):
+        for source in self.grid.eigenmodesources:
+            self._launch_eigenmode_source(source, iteration, False)
+        for guide in self.grid.virtual_waveguides:
+            self._update_virtual_waveguide_electric(guide, iteration)
+
+    def _virtual_scalars(self, guide, npoints):
+        aux = guide.aux_grid
+        return (
+            np.int32(npoints),
+            np.int32(guide.normal_axis),
+            np.int32(guide.direction_sign),
+            np.int32(guide.u0),
+            np.int32(guide.v0),
+            np.int32(guide.u1),
+            np.int32(guide.v1),
+            np.int32(guide.plane_index),
+            np.int32(aux.nx),
+            np.int32(aux.ny),
+            np.int32(aux.nz),
+        )
+
+    def _virtual_launch(self, kernel, npoints, *arguments):
+        kernel(
+            *arguments,
+            block=self.virtual_tpb,
+            grid=(int(np.ceil(npoints / self.virtual_tpb[0])), 1, 1),
+        )
+
+    def _update_virtual_waveguide_magnetic(self, guide, iteration):
+        child = guide.aux_updates
+        child.update_magnetic()
+        child.update_magnetic_pml()
+        child.update_eigenmode_sources_magnetic(iteration)
+        nface = (guide.nu + 1) * (guide.nv + 1)
+        main_h = tuple(
+            field.gpudata for field in (self.grid.Hx_dev, self.grid.Hy_dev, self.grid.Hz_dev)
+        )
+        aux_h = tuple(
+            field.gpudata
+            for field in (guide.aux_grid.Hx_dev, guide.aux_grid.Hy_dev, guide.aux_grid.Hz_dev)
+        )
+        self._virtual_launch(
+            self.couple_virtual_magnetic_dev,
+            nface,
+            *self._virtual_scalars(guide, nface),
+            *main_h,
+            *aux_h,
+        )
+        nmain = self.grid.Ex.size
+        self._virtual_launch(
+            self.clear_virtual_magnetic_dev,
+            nmain,
+            *self._virtual_scalars(guide, nmain),
+            *main_h,
+            *aux_h,
+        )
+
+    def _update_virtual_waveguide_electric(self, guide, iteration):
+        child = guide.aux_updates
+        child.update_electric_a()
+        child.update_electric_pml()
+        child.update_eigenmode_sources_electric(iteration)
+        child.update_electric_b()
+        nface = (guide.nu + 1) * (guide.nv + 1)
+        main_fields = tuple(
+            field.gpudata
+            for field in (
+                self.grid.Ex_dev,
+                self.grid.Ey_dev,
+                self.grid.Ez_dev,
+                self.grid.Hx_dev,
+                self.grid.Hy_dev,
+                self.grid.Hz_dev,
+            )
+        )
+        aux_fields = tuple(
+            field.gpudata
+            for field in (
+                guide.aux_grid.Ex_dev,
+                guide.aux_grid.Ey_dev,
+                guide.aux_grid.Ez_dev,
+                guide.aux_grid.Hx_dev,
+                guide.aux_grid.Hy_dev,
+                guide.aux_grid.Hz_dev,
+            )
+        )
+        self._virtual_launch(
+            self.couple_virtual_electric_dev,
+            nface,
+            *self._virtual_scalars(guide, nface),
+            guide.aux_grid.updatecoeffsE_dev.gpudata,
+            guide.aux_grid.ID_dev.gpudata,
+            *main_fields,
+            *aux_fields,
+        )
+        nmain = self.grid.Ex.size
+        self._virtual_launch(
+            self.clear_virtual_electric_dev,
+            nmain,
+            *self._virtual_scalars(guide, nmain),
+            *(field.gpudata for field in (self.grid.Ex_dev, self.grid.Ey_dev, self.grid.Ez_dev)),
+            *(
+                field.gpudata
+                for field in (guide.aux_grid.Ex_dev, guide.aux_grid.Ey_dev, guide.aux_grid.Ez_dev)
+            ),
+        )
+
     def update_electric_a(self):
         """Updates electric field components."""
         # All materials are non-dispersive so do standard update.
@@ -1293,15 +1714,36 @@ class CUDAUpdates(Updates[CUDAGrid]):
             )
 
     def update_symmetry_boundaries_electric(self):
-        """Apply the nondispersive PMC ghost-image correction on CUDA."""
+        """Apply the PMC ghost-image correction on CUDA."""
         if "pmc" not in self.grid.symmetry_boundaries.values():
             return
-
-        self.update_electric_pmc_dev(
+        dispersive = config.get_model_config().materials["maxpoles"] > 0
+        kernel = (
+            self.update_electric_pmc_dispersive_dev
+            if dispersive
+            else self.update_electric_pmc_dev
+        )
+        leading = [
             np.int32(self.grid.nx),
             np.int32(self.grid.ny),
             np.int32(self.grid.nz),
+        ]
+        if dispersive:
+            leading.append(np.int32(config.get_model_config().materials["maxpoles"]))
+        arguments = [
+            *leading,
             *self._pmc_flags(),
+        ]
+        if dispersive:
+            arguments.extend(
+                [
+                    self.grid.updatecoeffsdispersive_dev.gpudata,
+                    self.grid.Tx_dev.gpudata,
+                    self.grid.Ty_dev.gpudata,
+                    self.grid.Tz_dev.gpudata,
+                ]
+            )
+        arguments.extend([
             self.grid.ID_dev.gpudata,
             self.grid.Ex_dev.gpudata,
             self.grid.Ey_dev.gpudata,
@@ -1309,8 +1751,28 @@ class CUDAUpdates(Updates[CUDAGrid]):
             self.grid.Hx_dev.gpudata,
             self.grid.Hy_dev.gpudata,
             self.grid.Hz_dev.gpudata,
+        ])
+        kernel(
+            *arguments,
             block=self.grid.tpb,
             grid=self.grid.bpg,
+        )
+
+    def update_symmetry_boundaries_electric_b(self):
+        """Complete the dispersive PMC ADE update on CUDA."""
+        if (
+            "pmc" not in self.grid.symmetry_boundaries.values()
+            or config.get_model_config().materials["maxpoles"] == 0
+        ):
+            return
+        self.update_electric_pmc_dispersive_b_dev(
+            np.int32(self.grid.nx), np.int32(self.grid.ny), np.int32(self.grid.nz),
+            np.int32(config.get_model_config().materials["maxpoles"]),
+            *self._pmc_flags(), self.grid.updatecoeffsdispersive_dev.gpudata,
+            self.grid.Tx_dev.gpudata, self.grid.Ty_dev.gpudata,
+            self.grid.Tz_dev.gpudata, self.grid.ID_dev.gpudata,
+            self.grid.Ex_dev.gpudata, self.grid.Ey_dev.gpudata,
+            self.grid.Ez_dev.gpudata, block=self.grid.tpb, grid=self.grid.bpg,
         )
 
     def update_electric_pml(self):
@@ -1381,7 +1843,6 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 grid=(round32(len(self.grid.hertziandipoles)), 1, 1),
             )
 
-
     def update_plane_waves_magnetic(self, iteration):
         """Updates 1D DPW auxiliary grid H fields and applies TF/SF
         corrections to 3D H field arrays at all 6 faces.
@@ -1393,9 +1854,9 @@ class CUDAUpdates(Updates[CUDAGrid]):
         REAL = config.sim_config.dtypes["float_or_double"]
 
         for dpw in self.grid.discreteplanewaves:
-            n  = np.int32(dpw.length)
-            p  = np.int32(dpw.pml_length)
-            M  = np.int32(dpw.m[3])
+            n = np.int32(dpw.length)
+            p = np.int32(dpw.pml_length)
+            M = np.int32(dpw.m[3])
             mx = np.int32(dpw.m[0])
             my = np.int32(dpw.m[1])
             mz = np.int32(dpw.m[2])
@@ -1403,8 +1864,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
             dy = REAL(self.grid.dy)
             dz = REAL(self.grid.dz)
 
-            bulk_size  = int(np.ceil((dpw.length - 2 * dpw.m[3]) / 256))
-            pml_size   = int(np.ceil(dpw.pml_length / 256))
+            bulk_size = int(np.ceil((dpw.length - 2 * dpw.m[3]) / 256))
+            pml_size = int(np.ceil(dpw.pml_length / 256))
 
             # Source injection into the first M samples of the 1D grid. The
             # projected waveform remains device-resident for the full solve.
@@ -1426,7 +1887,7 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 #  Standard (homogeneous) magnetic 1D update
                 # Get background material coefficients
                 mat = self.grid.updatecoeffsH[dpw.material.numID]
-                DA  = REAL(mat[0])
+                DA = REAL(mat[0])
                 DBx = REAL(mat[1])
                 DBy = REAL(mat[2])
                 DBz = REAL(mat[3])
@@ -1446,12 +1907,26 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 # where xy=DBy(col2), xz=DBz(col3), yx=DBx(col1), yz=DBz(col3),
                 #       zx=DBx(col1), zy=DBy(col2)  per plane_wave.pyx
                 dpw.update_1d_magnetic_dev(
-                    n, M, mx, my, mz,
-                    DA,  DBy, DBz,   # coef_H_xt, coef_H_xy, coef_H_xz
-                    DA,  DBx, DBz,   # coef_H_yt, coef_H_yx, coef_H_yz
-                    DA,  DBx, DBy,   # coef_H_zt, coef_H_zx, coef_H_zy
-                    Hx_ptr, Hy_ptr, Hz_ptr,
-                    Ex_ptr, Ey_ptr, Ez_ptr,
+                    n,
+                    M,
+                    mx,
+                    my,
+                    mz,
+                    DA,
+                    DBy,
+                    DBz,  # coef_H_xt, coef_H_xy, coef_H_xz
+                    DA,
+                    DBx,
+                    DBz,  # coef_H_yt, coef_H_yx, coef_H_yz
+                    DA,
+                    DBx,
+                    DBy,  # coef_H_zt, coef_H_zx, coef_H_zy
+                    Hx_ptr,
+                    Hy_ptr,
+                    Hz_ptr,
+                    Ex_ptr,
+                    Ey_ptr,
+                    Ez_ptr,
                     block=(256, 1, 1),
                     grid=(bulk_size, 1, 1),
                 )
@@ -1465,15 +1940,28 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 # Coeff rows: RA=row0, RB=row1, RC=row2, RD=row3 of rcHx/rcHy/rcHz
                 if pml_size > 0:
                     dpw.update_1d_magnetic_pml_dev(
-                        n, p, M, mx, my, mz, srcm, dx, dy, dz,
-                        Hx_ptr, Hy_ptr, Hz_ptr,
-                        Ex_ptr, Ey_ptr, Ez_ptr,
-                        dpw.Ix_dev[3],   # Ixmzy
-                        dpw.Ix_dev[2],   # Ixmyz
-                        dpw.Iy_dev[3],   # Iymzx
-                        dpw.Iy_dev[2],   # Iymxz
-                        dpw.Iz_dev[3],   # Izmyx
-                        dpw.Iz_dev[2],   # Izmxy
+                        n,
+                        p,
+                        M,
+                        mx,
+                        my,
+                        mz,
+                        srcm,
+                        dx,
+                        dy,
+                        dz,
+                        Hx_ptr,
+                        Hy_ptr,
+                        Hz_ptr,
+                        Ex_ptr,
+                        Ey_ptr,
+                        Ez_ptr,
+                        dpw.Ix_dev[3],  # Ixmzy
+                        dpw.Ix_dev[2],  # Ixmyz
+                        dpw.Iy_dev[3],  # Iymzx
+                        dpw.Iy_dev[2],  # Iymxz
+                        dpw.Iz_dev[3],  # Izmyx
+                        dpw.Iz_dev[2],  # Izmxy
                         dpw.pml_rhx_dev[0],  # RAHx
                         dpw.pml_rhx_dev[1],  # RBHx
                         dpw.pml_rhx_dev[2],  # RCHx
@@ -1513,9 +2001,17 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 # Launch 1: Update source grid bulk
                 if bulk_size > 0:
                     dpw.update_1d_magnetic_axial_source_dev(
-                        n, M, mx, my, mz,
-                        Hx_s, Hy_s, Hz_s,
-                        Ex_s, Ey_s, Ez_s,
+                        n,
+                        M,
+                        mx,
+                        my,
+                        mz,
+                        Hx_s,
+                        Hy_s,
+                        Hz_s,
+                        Ex_s,
+                        Ey_s,
+                        Ez_s,
                         dpw.ID_dev,
                         self.grid.updatecoeffsH_dev,
                         self.grid.updatecoeffsE_dev,
@@ -1531,15 +2027,27 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 # Coeff rows: RA=0, RB=1, RC=2, RD=3 of pml_rhx0/pml_rhy0/pml_rhz0
                 if pml_size > 0:
                     dpw.update_1d_magnetic_axial_source_pml_dev(
-                        n, p, M, mx, my, mz, dx, dy, dz,
-                        Hx_s, Hy_s, Hz_s,
-                        Ex_s, Ey_s, Ez_s,
-                        dpw.Ix_s_dev[3],   # Ixmzy_s
-                        dpw.Ix_s_dev[2],   # Ixmyz_s
-                        dpw.Iy_s_dev[3],   # Iymzx_s
-                        dpw.Iy_s_dev[2],   # Iymxz_s
-                        dpw.Iz_s_dev[3],   # Izmyx_s
-                        dpw.Iz_s_dev[2],   # Izmxy_s
+                        n,
+                        p,
+                        M,
+                        mx,
+                        my,
+                        mz,
+                        dx,
+                        dy,
+                        dz,
+                        Hx_s,
+                        Hy_s,
+                        Hz_s,
+                        Ex_s,
+                        Ey_s,
+                        Ez_s,
+                        dpw.Ix_s_dev[3],  # Ixmzy_s
+                        dpw.Ix_s_dev[2],  # Ixmyz_s
+                        dpw.Iy_s_dev[3],  # Iymzx_s
+                        dpw.Iy_s_dev[2],  # Iymxz_s
+                        dpw.Iz_s_dev[3],  # Izmyx_s
+                        dpw.Iz_s_dev[2],  # Izmxy_s
                         dpw.pml_rhx0_dev[0],  # RAHx0
                         dpw.pml_rhx0_dev[1],  # RBHx0
                         dpw.pml_rhx0_dev[2],  # RCHx0
@@ -1561,9 +2069,17 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                 # Launch 2-Inject source into main grid at src-2
                 dpw.update_1d_magnetic_axial_inject_dev(
-                    n, np.int32(dpw.origin_axial), mx, my, mz,
-                    Hx_m, Hy_m, Hz_m,
-                    Ex_s, Ey_s, Ez_s,
+                    n,
+                    np.int32(dpw.origin_axial),
+                    mx,
+                    my,
+                    mz,
+                    Hx_m,
+                    Hy_m,
+                    Hz_m,
+                    Ex_s,
+                    Ey_s,
+                    Ez_s,
                     dpw.ID_dev,
                     self.grid.updatecoeffsH_dev,
                     self.grid.updatecoeffsE_dev,
@@ -1574,12 +2090,22 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 # Launch 3- Update main grid bulk
                 # Range [M-1, N-M) gives size N - 2M + 1 (includes origin point)
                 main_bulk_threads = dpw.length - 2 * dpw.m[3] + 1
-                main_bulk_size = int(np.ceil(main_bulk_threads / 256)) if main_bulk_threads > 0 else 0
+                main_bulk_size = (
+                    int(np.ceil(main_bulk_threads / 256)) if main_bulk_threads > 0 else 0
+                )
                 if main_bulk_size > 0:
                     dpw.update_1d_magnetic_axial_main_dev(
-                        n, M, mx, my, mz,
-                        Hx_m, Hy_m, Hz_m,
-                        Ex_m, Ey_m, Ez_m,
+                        n,
+                        M,
+                        mx,
+                        my,
+                        mz,
+                        Hx_m,
+                        Hy_m,
+                        Hz_m,
+                        Ex_m,
+                        Ey_m,
+                        Ez_m,
                         dpw.ID_dev,
                         self.grid.updatecoeffsH_dev,
                         self.grid.updatecoeffsE_dev,
@@ -1591,21 +2117,39 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 # Main PML integrals at rows 2,3 of Ix/Iy/Iz; coeffs at rows 0-3 of pml_rh*
                 if pml_size > 0:
                     dpw.update_1d_magnetic_axial_main_pml_end_dev(
-                        n, p, M, mx, my, mz, dx, dy, dz,
-                        Hx_m, Hy_m, Hz_m,
-                        Ex_m, Ey_m, Ez_m,
-                        dpw.Ix_dev[3],   # Ixmzy
-                        dpw.Ix_dev[2],   # Ixmyz
-                        dpw.Iy_dev[3],   # Iymzx
-                        dpw.Iy_dev[2],   # Iymxz
-                        dpw.Iz_dev[3],   # Izmyx
-                        dpw.Iz_dev[2],   # Izmxy
-                        dpw.pml_rhx_dev[0], dpw.pml_rhx_dev[1],
-                        dpw.pml_rhx_dev[2], dpw.pml_rhx_dev[3],
-                        dpw.pml_rhy_dev[0], dpw.pml_rhy_dev[1],
-                        dpw.pml_rhy_dev[2], dpw.pml_rhy_dev[3],
-                        dpw.pml_rhz_dev[0], dpw.pml_rhz_dev[1],
-                        dpw.pml_rhz_dev[2], dpw.pml_rhz_dev[3],
+                        n,
+                        p,
+                        M,
+                        mx,
+                        my,
+                        mz,
+                        dx,
+                        dy,
+                        dz,
+                        Hx_m,
+                        Hy_m,
+                        Hz_m,
+                        Ex_m,
+                        Ey_m,
+                        Ez_m,
+                        dpw.Ix_dev[3],  # Ixmzy
+                        dpw.Ix_dev[2],  # Ixmyz
+                        dpw.Iy_dev[3],  # Iymzx
+                        dpw.Iy_dev[2],  # Iymxz
+                        dpw.Iz_dev[3],  # Izmyx
+                        dpw.Iz_dev[2],  # Izmxy
+                        dpw.pml_rhx_dev[0],
+                        dpw.pml_rhx_dev[1],
+                        dpw.pml_rhx_dev[2],
+                        dpw.pml_rhx_dev[3],
+                        dpw.pml_rhy_dev[0],
+                        dpw.pml_rhy_dev[1],
+                        dpw.pml_rhy_dev[2],
+                        dpw.pml_rhy_dev[3],
+                        dpw.pml_rhz_dev[0],
+                        dpw.pml_rhz_dev[1],
+                        dpw.pml_rhz_dev[2],
+                        dpw.pml_rhz_dev[3],
                         dpw.ID_dev,
                         self.grid.updatecoeffsH_dev,
                         self.grid.updatecoeffsE_dev,
@@ -1617,21 +2161,38 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 # Uses Ix0/Iy0/Iz0 (separate from main Ix/Iy/Iz) and pml_rh*0 (source coeffs reused)
                 if pml_size > 0:
                     dpw.update_1d_magnetic_axial_main_pml_start_dev(
-                        n, p, mx, my, mz, dx, dy, dz,
-                        Hx_m, Hy_m, Hz_m,
-                        Ex_m, Ey_m, Ez_m,
-                        dpw.Ix0_dev[3],   # Ixmzy0
-                        dpw.Ix0_dev[2],   # Ixmyz0
-                        dpw.Iy0_dev[3],   # Iymzx0
-                        dpw.Iy0_dev[2],   # Iymxz0
-                        dpw.Iz0_dev[3],   # Izmyx0
-                        dpw.Iz0_dev[2],   # Izmxy0
-                        dpw.pml_rhx0_dev[0], dpw.pml_rhx0_dev[1],
-                        dpw.pml_rhx0_dev[2], dpw.pml_rhx0_dev[3],
-                        dpw.pml_rhy0_dev[0], dpw.pml_rhy0_dev[1],
-                        dpw.pml_rhy0_dev[2], dpw.pml_rhy0_dev[3],
-                        dpw.pml_rhz0_dev[0], dpw.pml_rhz0_dev[1],
-                        dpw.pml_rhz0_dev[2], dpw.pml_rhz0_dev[3],
+                        n,
+                        p,
+                        mx,
+                        my,
+                        mz,
+                        dx,
+                        dy,
+                        dz,
+                        Hx_m,
+                        Hy_m,
+                        Hz_m,
+                        Ex_m,
+                        Ey_m,
+                        Ez_m,
+                        dpw.Ix0_dev[3],  # Ixmzy0
+                        dpw.Ix0_dev[2],  # Ixmyz0
+                        dpw.Iy0_dev[3],  # Iymzx0
+                        dpw.Iy0_dev[2],  # Iymxz0
+                        dpw.Iz0_dev[3],  # Izmyx0
+                        dpw.Iz0_dev[2],  # Izmxy0
+                        dpw.pml_rhx0_dev[0],
+                        dpw.pml_rhx0_dev[1],
+                        dpw.pml_rhx0_dev[2],
+                        dpw.pml_rhx0_dev[3],
+                        dpw.pml_rhy0_dev[0],
+                        dpw.pml_rhy0_dev[1],
+                        dpw.pml_rhy0_dev[2],
+                        dpw.pml_rhy0_dev[3],
+                        dpw.pml_rhz0_dev[0],
+                        dpw.pml_rhz0_dev[1],
+                        dpw.pml_rhz0_dev[2],
+                        dpw.pml_rhz0_dev[3],
                         dpw.ID_dev,
                         self.grid.updatecoeffsH_dev,
                         self.grid.updatecoeffsE_dev,
@@ -1653,9 +2214,9 @@ class CUDAUpdates(Updates[CUDAGrid]):
         REAL = config.sim_config.dtypes["float_or_double"]
 
         for dpw in self.grid.discreteplanewaves:
-            n  = np.int32(dpw.length)
-            p  = np.int32(dpw.pml_length)
-            M  = np.int32(dpw.m[3])
+            n = np.int32(dpw.length)
+            p = np.int32(dpw.pml_length)
+            M = np.int32(dpw.m[3])
             mx = np.int32(dpw.m[0])
             my = np.int32(dpw.m[1])
             mz = np.int32(dpw.m[2])
@@ -1663,8 +2224,8 @@ class CUDAUpdates(Updates[CUDAGrid]):
             dy = REAL(self.grid.dy)
             dz = REAL(self.grid.dz)
 
-            bulk_size  = int(np.ceil((dpw.length - 2 * dpw.m[3]) / 256))
-            pml_size   = int(np.ceil(dpw.pml_length / 256))
+            bulk_size = int(np.ceil((dpw.length - 2 * dpw.m[3]) / 256))
+            pml_size = int(np.ceil(dpw.pml_length / 256))
 
             # Source injection into the first M samples of the 1D grid. The
             # projected waveform remains device-resident for the full solve.
@@ -1685,7 +2246,7 @@ class CUDAUpdates(Updates[CUDAGrid]):
             if dpw.axial == 0:
                 #  Standard (homogeneous) electric 1D update
                 mat = self.grid.updatecoeffsE[dpw.material.numID]
-                CA  = REAL(mat[0])
+                CA = REAL(mat[0])
                 CBx = REAL(mat[1])
                 CBy = REAL(mat[2])
                 CBz = REAL(mat[3])
@@ -1705,12 +2266,26 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 # timestep (double update -> compounding amplitude error).
                 if not dpw.dispersive:
                     dpw.update_1d_electric_dev(
-                        n, M, mx, my, mz,
-                        CA,  CBy, CBz,   # coef_E_xt, coef_E_xy, coef_E_xz
-                        CA,  CBx, CBz,   # coef_E_yt, coef_E_yx, coef_E_yz
-                        CA,  CBx, CBy,   # coef_E_zt, coef_E_zx, coef_E_zy
-                        Ex_ptr, Ey_ptr, Ez_ptr,
-                        Hx_ptr, Hy_ptr, Hz_ptr,
+                        n,
+                        M,
+                        mx,
+                        my,
+                        mz,
+                        CA,
+                        CBy,
+                        CBz,  # coef_E_xt, coef_E_xy, coef_E_xz
+                        CA,
+                        CBx,
+                        CBz,  # coef_E_yt, coef_E_yx, coef_E_yz
+                        CA,
+                        CBx,
+                        CBy,  # coef_E_zt, coef_E_zx, coef_E_zy
+                        Ex_ptr,
+                        Ey_ptr,
+                        Ez_ptr,
+                        Hx_ptr,
+                        Hy_ptr,
+                        Hz_ptr,
                         block=(256, 1, 1),
                         grid=(bulk_size, 1, 1),
                     )
@@ -1724,15 +2299,28 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 # launches its own PML pass.
                 if pml_size > 0 and not dpw.dispersive:
                     dpw.update_1d_electric_pml_dev(
-                        n, p, M, mx, my, mz, srce, dx, dy, dz,
-                        Ex_ptr, Ey_ptr, Ez_ptr,
-                        Hx_ptr, Hy_ptr, Hz_ptr,
-                        dpw.Ix_dev[1],   # Jxmzy
-                        dpw.Ix_dev[0],   # Jxmyz
-                        dpw.Iy_dev[1],   # Jymzx
-                        dpw.Iy_dev[0],   # Jymxz
-                        dpw.Iz_dev[1],   # Jzmyx
-                        dpw.Iz_dev[0],   # Jzmxy
+                        n,
+                        p,
+                        M,
+                        mx,
+                        my,
+                        mz,
+                        srce,
+                        dx,
+                        dy,
+                        dz,
+                        Ex_ptr,
+                        Ey_ptr,
+                        Ez_ptr,
+                        Hx_ptr,
+                        Hy_ptr,
+                        Hz_ptr,
+                        dpw.Ix_dev[1],  # Jxmzy
+                        dpw.Ix_dev[0],  # Jxmyz
+                        dpw.Iy_dev[1],  # Jymzx
+                        dpw.Iy_dev[0],  # Jymxz
+                        dpw.Iz_dev[1],  # Jzmyx
+                        dpw.Iz_dev[0],  # Jzmxy
                         dpw.pml_rex_dev[0],  # RAEx
                         dpw.pml_rex_dev[1],  # RBEx
                         dpw.pml_rex_dev[2],  # RCEx
@@ -1756,10 +2344,10 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 # Part B: final T subtraction (after PML, uses post-PML E values).
                 if dpw.dispersive:
                     mat = self.grid.updatecoeffsE[dpw.material.numID]
-                    CA   = REAL(mat[0])
-                    CBx  = REAL(mat[1])
-                    CBy  = REAL(mat[2])
-                    CBz  = REAL(mat[3])
+                    CA = REAL(mat[0])
+                    CBx = REAL(mat[1])
+                    CBy = REAL(mat[2])
+                    CBz = REAL(mat[3])
                     srce = REAL(mat[4])
                     num_poles = np.int32(config.get_model_config().materials["maxpoles"])
 
@@ -1776,40 +2364,83 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                     if bulk_size > 0:
                         dpw.update_1d_electric_dispersive_A_dev(
-                            n, M, mx, my, mz, num_poles,
-                            CA, CBx, CBy, CBz, srce,
+                            n,
+                            M,
+                            mx,
+                            my,
+                            mz,
+                            num_poles,
+                            CA,
+                            CBx,
+                            CBy,
+                            CBz,
+                            srce,
                             coef_D_ptr,
-                            dpw.Px_dev, dpw.Py_dev, dpw.Pz_dev,
-                            Ex_ptr, Ey_ptr, Ez_ptr,
-                            Hx_ptr, Hy_ptr, Hz_ptr,
+                            dpw.Px_dev,
+                            dpw.Py_dev,
+                            dpw.Pz_dev,
+                            Ex_ptr,
+                            Ey_ptr,
+                            Ez_ptr,
+                            Hx_ptr,
+                            Hy_ptr,
+                            Hz_ptr,
                             block=(256, 1, 1),
                             grid=(bulk_size, 1, 1),
                         )
 
                     if pml_size > 0:
                         dpw.update_1d_electric_pml_dev(
-                            n, p, M, mx, my, mz, srce, dx, dy, dz,
-                            Ex_ptr, Ey_ptr, Ez_ptr,
-                            Hx_ptr, Hy_ptr, Hz_ptr,
-                            dpw.Ix_dev[1], dpw.Ix_dev[0],
-                            dpw.Iy_dev[1], dpw.Iy_dev[0],
-                            dpw.Iz_dev[1], dpw.Iz_dev[0],
-                            dpw.pml_rex_dev[0], dpw.pml_rex_dev[1],
-                            dpw.pml_rex_dev[2], dpw.pml_rex_dev[3],
-                            dpw.pml_rey_dev[0], dpw.pml_rey_dev[1],
-                            dpw.pml_rey_dev[2], dpw.pml_rey_dev[3],
-                            dpw.pml_rez_dev[0], dpw.pml_rez_dev[1],
-                            dpw.pml_rez_dev[2], dpw.pml_rez_dev[3],
+                            n,
+                            p,
+                            M,
+                            mx,
+                            my,
+                            mz,
+                            srce,
+                            dx,
+                            dy,
+                            dz,
+                            Ex_ptr,
+                            Ey_ptr,
+                            Ez_ptr,
+                            Hx_ptr,
+                            Hy_ptr,
+                            Hz_ptr,
+                            dpw.Ix_dev[1],
+                            dpw.Ix_dev[0],
+                            dpw.Iy_dev[1],
+                            dpw.Iy_dev[0],
+                            dpw.Iz_dev[1],
+                            dpw.Iz_dev[0],
+                            dpw.pml_rex_dev[0],
+                            dpw.pml_rex_dev[1],
+                            dpw.pml_rex_dev[2],
+                            dpw.pml_rex_dev[3],
+                            dpw.pml_rey_dev[0],
+                            dpw.pml_rey_dev[1],
+                            dpw.pml_rey_dev[2],
+                            dpw.pml_rey_dev[3],
+                            dpw.pml_rez_dev[0],
+                            dpw.pml_rez_dev[1],
+                            dpw.pml_rez_dev[2],
+                            dpw.pml_rez_dev[3],
                             block=(256, 1, 1),
                             grid=(pml_size, 1, 1),
                         )
 
                     if bulk_size > 0:
                         dpw.update_1d_electric_dispersive_B_dev(
-                            n, M, num_poles,
+                            n,
+                            M,
+                            num_poles,
                             coef_D_ptr,
-                            dpw.Px_dev, dpw.Py_dev, dpw.Pz_dev,
-                            Ex_ptr, Ey_ptr, Ez_ptr,
+                            dpw.Px_dev,
+                            dpw.Py_dev,
+                            dpw.Pz_dev,
+                            Ex_ptr,
+                            Ey_ptr,
+                            Ez_ptr,
                             block=(256, 1, 1),
                             grid=(bulk_size, 1, 1),
                         )
@@ -1837,9 +2468,17 @@ class CUDAUpdates(Updates[CUDAGrid]):
                     # Launch 1: Source grid bulk
                     if bulk_size > 0:
                         dpw.update_1d_electric_axial_source_dev(
-                            n, M, mx, my, mz,
-                            Ex_s, Ey_s, Ez_s,
-                            Hx_s, Hy_s, Hz_s,
+                            n,
+                            M,
+                            mx,
+                            my,
+                            mz,
+                            Ex_s,
+                            Ey_s,
+                            Ez_s,
+                            Hx_s,
+                            Hy_s,
+                            Hz_s,
                             dpw.ID_dev,
                             self.grid.updatecoeffsH_dev,
                             self.grid.updatecoeffsE_dev,
@@ -1853,21 +2492,39 @@ class CUDAUpdates(Updates[CUDAGrid]):
                     # Kernel param order: Jxmzy_s..Jzmxy_s pairs with E PML naming.
                     if pml_size > 0:
                         dpw.update_1d_electric_axial_source_pml_dev(
-                            n, p, M, mx, my, mz, dx, dy, dz,
-                            Ex_s, Ey_s, Ez_s,
-                            Hx_s, Hy_s, Hz_s,
-                            dpw.Ix_s_dev[1],   # Ixjzy_s
-                            dpw.Ix_s_dev[0],   # Ixjyz_s
-                            dpw.Iy_s_dev[1],   # Iyjzx_s
-                            dpw.Iy_s_dev[0],   # Iyjxz_s
-                            dpw.Iz_s_dev[1],   # Izjyx_s
-                            dpw.Iz_s_dev[0],   # Izjxy_s
-                            dpw.pml_rex0_dev[0], dpw.pml_rex0_dev[1],
-                            dpw.pml_rex0_dev[2], dpw.pml_rex0_dev[3],
-                            dpw.pml_rey0_dev[0], dpw.pml_rey0_dev[1],
-                            dpw.pml_rey0_dev[2], dpw.pml_rey0_dev[3],
-                            dpw.pml_rez0_dev[0], dpw.pml_rez0_dev[1],
-                            dpw.pml_rez0_dev[2], dpw.pml_rez0_dev[3],
+                            n,
+                            p,
+                            M,
+                            mx,
+                            my,
+                            mz,
+                            dx,
+                            dy,
+                            dz,
+                            Ex_s,
+                            Ey_s,
+                            Ez_s,
+                            Hx_s,
+                            Hy_s,
+                            Hz_s,
+                            dpw.Ix_s_dev[1],  # Ixjzy_s
+                            dpw.Ix_s_dev[0],  # Ixjyz_s
+                            dpw.Iy_s_dev[1],  # Iyjzx_s
+                            dpw.Iy_s_dev[0],  # Iyjxz_s
+                            dpw.Iz_s_dev[1],  # Izjyx_s
+                            dpw.Iz_s_dev[0],  # Izjxy_s
+                            dpw.pml_rex0_dev[0],
+                            dpw.pml_rex0_dev[1],
+                            dpw.pml_rex0_dev[2],
+                            dpw.pml_rex0_dev[3],
+                            dpw.pml_rey0_dev[0],
+                            dpw.pml_rey0_dev[1],
+                            dpw.pml_rey0_dev[2],
+                            dpw.pml_rey0_dev[3],
+                            dpw.pml_rez0_dev[0],
+                            dpw.pml_rez0_dev[1],
+                            dpw.pml_rez0_dev[2],
+                            dpw.pml_rez0_dev[3],
                             dpw.ID_dev,
                             self.grid.updatecoeffsH_dev,
                             self.grid.updatecoeffsE_dev,
@@ -1877,9 +2534,17 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                     # Launch 2- Inject source into main grid at src-1
                     dpw.update_1d_electric_axial_inject_dev(
-                        n, np.int32(dpw.origin_axial), mx, my, mz,
-                        Ex_m, Ey_m, Ez_m,
-                        Hx_s, Hy_s, Hz_s,
+                        n,
+                        np.int32(dpw.origin_axial),
+                        mx,
+                        my,
+                        mz,
+                        Ex_m,
+                        Ey_m,
+                        Ez_m,
+                        Hx_s,
+                        Hy_s,
+                        Hz_s,
                         dpw.ID_dev,
                         self.grid.updatecoeffsH_dev,
                         self.grid.updatecoeffsE_dev,
@@ -1890,12 +2555,22 @@ class CUDAUpdates(Updates[CUDAGrid]):
                     # Launch 3- Main grid bulk
                     # Electric main range is [M, N-M) - size N - 2M (no -1, unlike magnetic)
                     main_bulk_threads = dpw.length - 2 * dpw.m[3]
-                    main_bulk_size = int(np.ceil(main_bulk_threads / 256)) if main_bulk_threads > 0 else 0
+                    main_bulk_size = (
+                        int(np.ceil(main_bulk_threads / 256)) if main_bulk_threads > 0 else 0
+                    )
                     if main_bulk_size > 0:
                         dpw.update_1d_electric_axial_main_dev(
-                            n, M, mx, my, mz,
-                            Ex_m, Ey_m, Ez_m,
-                            Hx_m, Hy_m, Hz_m,
+                            n,
+                            M,
+                            mx,
+                            my,
+                            mz,
+                            Ex_m,
+                            Ey_m,
+                            Ez_m,
+                            Hx_m,
+                            Hy_m,
+                            Hz_m,
                             dpw.ID_dev,
                             self.grid.updatecoeffsH_dev,
                             self.grid.updatecoeffsE_dev,
@@ -1906,21 +2581,39 @@ class CUDAUpdates(Updates[CUDAGrid]):
                     # Main grid PML end
                     if pml_size > 0:
                         dpw.update_1d_electric_axial_main_pml_end_dev(
-                            n, p, M, mx, my, mz, dx, dy, dz,
-                            Ex_m, Ey_m, Ez_m,
-                            Hx_m, Hy_m, Hz_m,
-                            dpw.Ix_dev[1],   # Ixjzy
-                            dpw.Ix_dev[0],   # Ixjyz
-                            dpw.Iy_dev[1],   # Iyjzx
-                            dpw.Iy_dev[0],   # Iyjxz
-                            dpw.Iz_dev[1],   # Izjyx
-                            dpw.Iz_dev[0],   # Izjxy
-                            dpw.pml_rex_dev[0], dpw.pml_rex_dev[1],
-                            dpw.pml_rex_dev[2], dpw.pml_rex_dev[3],
-                            dpw.pml_rey_dev[0], dpw.pml_rey_dev[1],
-                            dpw.pml_rey_dev[2], dpw.pml_rey_dev[3],
-                            dpw.pml_rez_dev[0], dpw.pml_rez_dev[1],
-                            dpw.pml_rez_dev[2], dpw.pml_rez_dev[3],
+                            n,
+                            p,
+                            M,
+                            mx,
+                            my,
+                            mz,
+                            dx,
+                            dy,
+                            dz,
+                            Ex_m,
+                            Ey_m,
+                            Ez_m,
+                            Hx_m,
+                            Hy_m,
+                            Hz_m,
+                            dpw.Ix_dev[1],  # Ixjzy
+                            dpw.Ix_dev[0],  # Ixjyz
+                            dpw.Iy_dev[1],  # Iyjzx
+                            dpw.Iy_dev[0],  # Iyjxz
+                            dpw.Iz_dev[1],  # Izjyx
+                            dpw.Iz_dev[0],  # Izjxy
+                            dpw.pml_rex_dev[0],
+                            dpw.pml_rex_dev[1],
+                            dpw.pml_rex_dev[2],
+                            dpw.pml_rex_dev[3],
+                            dpw.pml_rey_dev[0],
+                            dpw.pml_rey_dev[1],
+                            dpw.pml_rey_dev[2],
+                            dpw.pml_rey_dev[3],
+                            dpw.pml_rez_dev[0],
+                            dpw.pml_rez_dev[1],
+                            dpw.pml_rez_dev[2],
+                            dpw.pml_rez_dev[3],
                             dpw.ID_dev,
                             self.grid.updatecoeffsH_dev,
                             self.grid.updatecoeffsE_dev,
@@ -1931,21 +2624,38 @@ class CUDAUpdates(Updates[CUDAGrid]):
                     # Main grid PML start
                     if pml_size > 0:
                         dpw.update_1d_electric_axial_main_pml_start_dev(
-                            n, p, mx, my, mz, dx, dy, dz,
-                            Ex_m, Ey_m, Ez_m,
-                            Hx_m, Hy_m, Hz_m,
-                            dpw.Ix0_dev[1],   # Ixjzy0
-                            dpw.Ix0_dev[0],   # Ixjyz0
-                            dpw.Iy0_dev[1],   # Iyjzx0
-                            dpw.Iy0_dev[0],   # Iyjxz0
-                            dpw.Iz0_dev[1],   # Izjyx0
-                            dpw.Iz0_dev[0],   # Izjxy0
-                            dpw.pml_rex0_dev[0], dpw.pml_rex0_dev[1],
-                            dpw.pml_rex0_dev[2], dpw.pml_rex0_dev[3],
-                            dpw.pml_rey0_dev[0], dpw.pml_rey0_dev[1],
-                            dpw.pml_rey0_dev[2], dpw.pml_rey0_dev[3],
-                            dpw.pml_rez0_dev[0], dpw.pml_rez0_dev[1],
-                            dpw.pml_rez0_dev[2], dpw.pml_rez0_dev[3],
+                            n,
+                            p,
+                            mx,
+                            my,
+                            mz,
+                            dx,
+                            dy,
+                            dz,
+                            Ex_m,
+                            Ey_m,
+                            Ez_m,
+                            Hx_m,
+                            Hy_m,
+                            Hz_m,
+                            dpw.Ix0_dev[1],  # Ixjzy0
+                            dpw.Ix0_dev[0],  # Ixjyz0
+                            dpw.Iy0_dev[1],  # Iyjzx0
+                            dpw.Iy0_dev[0],  # Iyjxz0
+                            dpw.Iz0_dev[1],  # Izjyx0
+                            dpw.Iz0_dev[0],  # Izjxy0
+                            dpw.pml_rex0_dev[0],
+                            dpw.pml_rex0_dev[1],
+                            dpw.pml_rex0_dev[2],
+                            dpw.pml_rex0_dev[3],
+                            dpw.pml_rey0_dev[0],
+                            dpw.pml_rey0_dev[1],
+                            dpw.pml_rey0_dev[2],
+                            dpw.pml_rey0_dev[3],
+                            dpw.pml_rez0_dev[0],
+                            dpw.pml_rez0_dev[1],
+                            dpw.pml_rez0_dev[2],
+                            dpw.pml_rez0_dev[3],
                             dpw.ID_dev,
                             self.grid.updatecoeffsH_dev,
                             self.grid.updatecoeffsE_dev,
@@ -1964,10 +2674,21 @@ class CUDAUpdates(Updates[CUDAGrid]):
                     # Source grid dispersive bulk
                     if bulk_size > 0:
                         dpw.update_1d_electric_dispersive_axial_source_dev(
-                            n, M, mx, my, mz, num_poles,
-                            dpw.Px_s_dev, dpw.Py_s_dev, dpw.Pz_s_dev,
-                            Ex_s, Ey_s, Ez_s,
-                            Hx_s, Hy_s, Hz_s,
+                            n,
+                            M,
+                            mx,
+                            my,
+                            mz,
+                            num_poles,
+                            dpw.Px_s_dev,
+                            dpw.Py_s_dev,
+                            dpw.Pz_s_dev,
+                            Ex_s,
+                            Ey_s,
+                            Ez_s,
+                            Hx_s,
+                            Hy_s,
+                            Hz_s,
                             dpw.ID_dev,
                             self.grid.updatecoeffsE_dev,
                             matD,
@@ -1978,18 +2699,39 @@ class CUDAUpdates(Updates[CUDAGrid]):
                     # Source grid PML (reuse non-dispersive — same PML math)
                     if pml_size > 0:
                         dpw.update_1d_electric_axial_source_pml_dev(
-                            n, p, M, mx, my, mz, dx, dy, dz,
-                            Ex_s, Ey_s, Ez_s,
-                            Hx_s, Hy_s, Hz_s,
-                            dpw.Ix_s_dev[1], dpw.Ix_s_dev[0],
-                            dpw.Iy_s_dev[1], dpw.Iy_s_dev[0],
-                            dpw.Iz_s_dev[1], dpw.Iz_s_dev[0],
-                            dpw.pml_rex0_dev[0], dpw.pml_rex0_dev[1],
-                            dpw.pml_rex0_dev[2], dpw.pml_rex0_dev[3],
-                            dpw.pml_rey0_dev[0], dpw.pml_rey0_dev[1],
-                            dpw.pml_rey0_dev[2], dpw.pml_rey0_dev[3],
-                            dpw.pml_rez0_dev[0], dpw.pml_rez0_dev[1],
-                            dpw.pml_rez0_dev[2], dpw.pml_rez0_dev[3],
+                            n,
+                            p,
+                            M,
+                            mx,
+                            my,
+                            mz,
+                            dx,
+                            dy,
+                            dz,
+                            Ex_s,
+                            Ey_s,
+                            Ez_s,
+                            Hx_s,
+                            Hy_s,
+                            Hz_s,
+                            dpw.Ix_s_dev[1],
+                            dpw.Ix_s_dev[0],
+                            dpw.Iy_s_dev[1],
+                            dpw.Iy_s_dev[0],
+                            dpw.Iz_s_dev[1],
+                            dpw.Iz_s_dev[0],
+                            dpw.pml_rex0_dev[0],
+                            dpw.pml_rex0_dev[1],
+                            dpw.pml_rex0_dev[2],
+                            dpw.pml_rex0_dev[3],
+                            dpw.pml_rey0_dev[0],
+                            dpw.pml_rey0_dev[1],
+                            dpw.pml_rey0_dev[2],
+                            dpw.pml_rey0_dev[3],
+                            dpw.pml_rez0_dev[0],
+                            dpw.pml_rez0_dev[1],
+                            dpw.pml_rez0_dev[2],
+                            dpw.pml_rez0_dev[3],
                             dpw.ID_dev,
                             self.grid.updatecoeffsH_dev,
                             self.grid.updatecoeffsE_dev,
@@ -2000,9 +2742,15 @@ class CUDAUpdates(Updates[CUDAGrid]):
                     # Source grid final T subtraction
                     if bulk_size > 0:
                         dpw.update_1d_electric_dispersive_axial_source_T_dev(
-                            n, M, num_poles,
-                            dpw.Px_s_dev, dpw.Py_s_dev, dpw.Pz_s_dev,
-                            Ex_s, Ey_s, Ez_s,
+                            n,
+                            M,
+                            num_poles,
+                            dpw.Px_s_dev,
+                            dpw.Py_s_dev,
+                            dpw.Pz_s_dev,
+                            Ex_s,
+                            Ey_s,
+                            Ez_s,
                             dpw.ID_dev,
                             matD,
                             block=(256, 1, 1),
@@ -2011,9 +2759,17 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                     # Inject source into main grid at src-1 (reuse non-dispersive inject)
                     dpw.update_1d_electric_axial_inject_dev(
-                        n, np.int32(dpw.origin_axial), mx, my, mz,
-                        Ex_m, Ey_m, Ez_m,
-                        Hx_s, Hy_s, Hz_s,
+                        n,
+                        np.int32(dpw.origin_axial),
+                        mx,
+                        my,
+                        mz,
+                        Ex_m,
+                        Ey_m,
+                        Ez_m,
+                        Hx_s,
+                        Hy_s,
+                        Hz_s,
                         dpw.ID_dev,
                         self.grid.updatecoeffsH_dev,
                         self.grid.updatecoeffsE_dev,
@@ -2023,13 +2779,26 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                     # Main grid dispersive bulk
                     main_bulk_threads = dpw.length - 2 * dpw.m[3]
-                    main_bulk_size = int(np.ceil(main_bulk_threads / 256)) if main_bulk_threads > 0 else 0
+                    main_bulk_size = (
+                        int(np.ceil(main_bulk_threads / 256)) if main_bulk_threads > 0 else 0
+                    )
                     if main_bulk_size > 0:
                         dpw.update_1d_electric_dispersive_axial_main_dev(
-                            n, M, mx, my, mz, num_poles,
-                            dpw.Px_dev, dpw.Py_dev, dpw.Pz_dev,
-                            Ex_m, Ey_m, Ez_m,
-                            Hx_m, Hy_m, Hz_m,
+                            n,
+                            M,
+                            mx,
+                            my,
+                            mz,
+                            num_poles,
+                            dpw.Px_dev,
+                            dpw.Py_dev,
+                            dpw.Pz_dev,
+                            Ex_m,
+                            Ey_m,
+                            Ez_m,
+                            Hx_m,
+                            Hy_m,
+                            Hz_m,
                             dpw.ID_dev,
                             self.grid.updatecoeffsE_dev,
                             matD,
@@ -2040,18 +2809,39 @@ class CUDAUpdates(Updates[CUDAGrid]):
                     # Main grid PML end (reuse non-dispersive)
                     if pml_size > 0:
                         dpw.update_1d_electric_axial_main_pml_end_dev(
-                            n, p, M, mx, my, mz, dx, dy, dz,
-                            Ex_m, Ey_m, Ez_m,
-                            Hx_m, Hy_m, Hz_m,
-                            dpw.Ix_dev[1], dpw.Ix_dev[0],
-                            dpw.Iy_dev[1], dpw.Iy_dev[0],
-                            dpw.Iz_dev[1], dpw.Iz_dev[0],
-                            dpw.pml_rex_dev[0], dpw.pml_rex_dev[1],
-                            dpw.pml_rex_dev[2], dpw.pml_rex_dev[3],
-                            dpw.pml_rey_dev[0], dpw.pml_rey_dev[1],
-                            dpw.pml_rey_dev[2], dpw.pml_rey_dev[3],
-                            dpw.pml_rez_dev[0], dpw.pml_rez_dev[1],
-                            dpw.pml_rez_dev[2], dpw.pml_rez_dev[3],
+                            n,
+                            p,
+                            M,
+                            mx,
+                            my,
+                            mz,
+                            dx,
+                            dy,
+                            dz,
+                            Ex_m,
+                            Ey_m,
+                            Ez_m,
+                            Hx_m,
+                            Hy_m,
+                            Hz_m,
+                            dpw.Ix_dev[1],
+                            dpw.Ix_dev[0],
+                            dpw.Iy_dev[1],
+                            dpw.Iy_dev[0],
+                            dpw.Iz_dev[1],
+                            dpw.Iz_dev[0],
+                            dpw.pml_rex_dev[0],
+                            dpw.pml_rex_dev[1],
+                            dpw.pml_rex_dev[2],
+                            dpw.pml_rex_dev[3],
+                            dpw.pml_rey_dev[0],
+                            dpw.pml_rey_dev[1],
+                            dpw.pml_rey_dev[2],
+                            dpw.pml_rey_dev[3],
+                            dpw.pml_rez_dev[0],
+                            dpw.pml_rez_dev[1],
+                            dpw.pml_rez_dev[2],
+                            dpw.pml_rez_dev[3],
                             dpw.ID_dev,
                             self.grid.updatecoeffsH_dev,
                             self.grid.updatecoeffsE_dev,
@@ -2061,18 +2851,38 @@ class CUDAUpdates(Updates[CUDAGrid]):
 
                         # Main grid PML start (reuse non-dispersive)
                         dpw.update_1d_electric_axial_main_pml_start_dev(
-                            n, p, mx, my, mz, dx, dy, dz,
-                            Ex_m, Ey_m, Ez_m,
-                            Hx_m, Hy_m, Hz_m,
-                            dpw.Ix0_dev[1], dpw.Ix0_dev[0],
-                            dpw.Iy0_dev[1], dpw.Iy0_dev[0],
-                            dpw.Iz0_dev[1], dpw.Iz0_dev[0],
-                            dpw.pml_rex0_dev[0], dpw.pml_rex0_dev[1],
-                            dpw.pml_rex0_dev[2], dpw.pml_rex0_dev[3],
-                            dpw.pml_rey0_dev[0], dpw.pml_rey0_dev[1],
-                            dpw.pml_rey0_dev[2], dpw.pml_rey0_dev[3],
-                            dpw.pml_rez0_dev[0], dpw.pml_rez0_dev[1],
-                            dpw.pml_rez0_dev[2], dpw.pml_rez0_dev[3],
+                            n,
+                            p,
+                            mx,
+                            my,
+                            mz,
+                            dx,
+                            dy,
+                            dz,
+                            Ex_m,
+                            Ey_m,
+                            Ez_m,
+                            Hx_m,
+                            Hy_m,
+                            Hz_m,
+                            dpw.Ix0_dev[1],
+                            dpw.Ix0_dev[0],
+                            dpw.Iy0_dev[1],
+                            dpw.Iy0_dev[0],
+                            dpw.Iz0_dev[1],
+                            dpw.Iz0_dev[0],
+                            dpw.pml_rex0_dev[0],
+                            dpw.pml_rex0_dev[1],
+                            dpw.pml_rex0_dev[2],
+                            dpw.pml_rex0_dev[3],
+                            dpw.pml_rey0_dev[0],
+                            dpw.pml_rey0_dev[1],
+                            dpw.pml_rey0_dev[2],
+                            dpw.pml_rey0_dev[3],
+                            dpw.pml_rez0_dev[0],
+                            dpw.pml_rez0_dev[1],
+                            dpw.pml_rez0_dev[2],
+                            dpw.pml_rez0_dev[3],
                             dpw.ID_dev,
                             self.grid.updatecoeffsH_dev,
                             self.grid.updatecoeffsE_dev,
@@ -2083,9 +2893,15 @@ class CUDAUpdates(Updates[CUDAGrid]):
                     # Main grid final T subtraction
                     if main_bulk_size > 0:
                         dpw.update_1d_electric_dispersive_axial_main_T_dev(
-                            n, M, num_poles,
-                            dpw.Px_dev, dpw.Py_dev, dpw.Pz_dev,
-                            Ex_m, Ey_m, Ez_m,
+                            n,
+                            M,
+                            num_poles,
+                            dpw.Px_dev,
+                            dpw.Py_dev,
+                            dpw.Pz_dev,
+                            Ex_m,
+                            Ey_m,
+                            Ez_m,
                             dpw.ID_dev,
                             matD,
                             block=(256, 1, 1),
@@ -2119,6 +2935,42 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 grid=self.grid.bpg,
             )
 
+    def update_network_terminals(self, iteration):
+        """Apply sparse rational-network corrections entirely on CUDA."""
+
+        if not self.grid.networkterminals:
+            return
+        self.update_rational_network_dev(
+            np.int32(len(self.grid.networkterminals)),
+            np.int32(iteration),
+            config.sim_config.dtypes["float_or_double"](self.grid.dt),
+            self.rn_info_dev.gpudata,
+            self.rn_params_dev.gpudata,
+            self.rn_waveform_whole_dev.gpudata,
+            self.rn_waveform_half_dev.gpudata,
+            self.rn_voltage_dev.gpudata,
+            self.rn_current_dev.gpudata,
+            self.rn_exp_half_real_dev.gpudata,
+            self.rn_exp_half_imag_dev.gpudata,
+            self.rn_coeff_half_new_real_dev.gpudata,
+            self.rn_coeff_half_new_imag_dev.gpudata,
+            self.rn_coeff_half_old_real_dev.gpudata,
+            self.rn_coeff_half_old_imag_dev.gpudata,
+            self.rn_exp_full_real_dev.gpudata,
+            self.rn_exp_full_imag_dev.gpudata,
+            self.rn_coeff_full_new_real_dev.gpudata,
+            self.rn_coeff_full_new_imag_dev.gpudata,
+            self.rn_coeff_full_old_real_dev.gpudata,
+            self.rn_coeff_full_old_imag_dev.gpudata,
+            self.rn_state_real_dev.gpudata,
+            self.rn_state_imag_dev.gpudata,
+            self.grid.Ex_dev.gpudata,
+            self.grid.Ey_dev.gpudata,
+            self.grid.Ez_dev.gpudata,
+            block=self.rn_tpb,
+            grid=self.rn_bpg,
+        )
+
     def time_start(self):
         """Starts event timers used to calculate solving time for model."""
         self.iterstart = self.drv.Event()
@@ -2151,16 +3003,22 @@ class CUDAUpdates(Updates[CUDAGrid]):
         if collector is not None:
             collector.finalise()
 
+        if getattr(self.grid, "eigenmodeports", ()):
+            finalise_device_eigenmode_monitors(self.grid.eigenmodeports, "cuda")
+
         # Copy output from receivers array back to correct receiver objects
         if self.grid.rxs:
             currents = self.rxcurrents_dev.get() if self.nrxcurrent else None
-            dtoh_rx_array(
-                self.rxs_dev.get(), self.rxcoords_dev.get(), self.grid, currents
-            )
+            dtoh_rx_array(self.rxs_dev.get(), self.rxcoords_dev.get(), self.grid, currents)
 
         if self.grid.transmissionlines:
             dtoh_transmission_line_outputs(
                 self.tl_Vtotal_dev.get(), self.tl_Itotal_dev.get(), self.grid
+            )
+
+        if getattr(self.grid, "networkterminals", ()):
+            dtoh_rational_network_outputs(
+                self.rn_voltage_dev.get(), self.rn_current_dev.get(), self.grid
             )
 
         if self.grid.magneticfrillsources:
@@ -2188,5 +3046,6 @@ class CUDAUpdates(Updates[CUDAGrid]):
     def cleanup(self):
         """Cleanup GPU context."""
         # Remove context from top of stack and clear
-        self.ctx.pop()
-        self.ctx = None
+        if self._owns_context:
+            self.ctx.pop()
+            self.ctx = None

--- a/gprMax/updates/metal_plane_waves.py
+++ b/gprMax/updates/metal_plane_waves.py
@@ -1,0 +1,107 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""Metal launch adapter for the shared discrete-plane-wave kernels."""
+
+import numpy as np
+
+from gprMax import config
+from gprMax.grid.metal_grid import MetalBufferView
+from gprMax.updates.opencl_updates import OpenCLUpdates
+
+
+class _MetalElementwiseKernel:
+    """Small callable matching the PyOpenCL ElementwiseKernel launch API."""
+
+    def __init__(self, owner, pipeline):
+        self.owner = owner
+        self.pipeline = pipeline
+
+    @staticmethod
+    def _buffer_and_offset(value):
+        if isinstance(value, MetalBufferView):
+            return value.buffer, value.offset
+        if hasattr(value, "contents") and hasattr(value, "length"):
+            return value, 0
+        return None
+
+    def __call__(self, *arguments, range=None):
+        if range is None:
+            raise ValueError("Metal elementwise kernels require an explicit range")
+        count = int(range.stop) - int(range.start or 0)
+        if count <= 0:
+            return
+        command = self.owner.cmdqueue.commandBuffer()
+        encoder = command.computeCommandEncoder()
+        encoder.setComputePipelineState_(self.pipeline)
+        for index, argument in enumerate(arguments):
+            view = self._buffer_and_offset(argument)
+            if view is not None:
+                encoder.setBuffer_offset_atIndex_(view[0], view[1], index)
+            else:
+                scalar = np.asarray(argument)
+                encoder.setBytes_length_atIndex_(
+                    scalar.tobytes(), scalar.dtype.itemsize, index
+                )
+        encoder.dispatchThreads_threadsPerThreadgroup_(
+            self.owner.metal.MTLSizeMake(count, 1, 1),
+            self.owner.metal.MTLSizeMake(
+                min(count, self.pipeline.maxTotalThreadsPerThreadgroup()), 1, 1
+            ),
+        )
+        encoder.endEncoding()
+        command.commit()
+        command.waitUntilCompleted()
+
+
+class MetalPlaneWaveController(OpenCLUpdates):
+    """Reuse backend-neutral OpenCL plane-wave sequencing with Metal launches."""
+
+    def __init__(self, updates):
+        # Deliberately do not call OpenCLUpdates.__init__. Its plane-wave
+        # orchestration is backend-neutral once arrays and elementwise
+        # launches expose the small interfaces provided here.
+        self.grid = updates.grid
+        self.dev = updates.dev
+        self.cmdqueue = updates.cmdqueue
+        self.queue = updates.cmdqueue
+        self.metal = updates.metal
+        self.opts = updates.opts
+        self.knl_common = updates.knl_common
+        self._planewave_kernel_cache = {}
+        self._set_planewave_knls()
+
+    def _planewave_kernel(self, specification, name):
+        try:
+            return self._planewave_kernel_cache[name]
+        except KeyError:
+            pass
+        c_real = config.sim_config.dtypes["C_float_or_double"]
+        declaration = specification["args_metal"].substitute(
+            {
+                "REAL": c_real,
+                "COMPLEX": config.get_model_config().materials["dispersiveCdtype"],
+            }
+        )
+        body = specification["func"].substitute(
+            {"CUDA_IDX": "", "TFSF_IDX": "int t = i;", "REAL": c_real}
+        )
+        source = f"{self.knl_common}\n{declaration}{{\n{body}}}\n"
+        library, error = self.dev.newLibraryWithSource_options_error_(
+            source, self.opts, None
+        )
+        if library is None:
+            raise RuntimeError(f"Failed to compile Metal plane-wave kernel {name}: {error}")
+        function = library.newFunctionWithName_(name)
+        pipeline = self.dev.newComputePipelineStateWithFunction_error_(function, None)[0]
+        kernel = _MetalElementwiseKernel(self, pipeline)
+        self._planewave_kernel_cache[name] = kernel
+        return kernel

--- a/gprMax/updates/metal_updates.py
+++ b/gprMax/updates/metal_updates.py
@@ -25,13 +25,25 @@ from jinja2 import Environment, PackageLoader
 
 from gprMax import config
 from gprMax.cuda_opencl import (
+    knl_eigenmode,
     knl_fields_updates,
     knl_magnetic_frill_source,
+    knl_rational_network,
     knl_snapshots,
     knl_source_updates,
     knl_store_outputs,
     knl_symmetry_boundaries,
+    knl_transmission_line,
+    knl_virtual_waveguide,
 )
+from gprMax.eigenmode_device import (
+    eigenmode_source_envelopes,
+    finalise_device_eigenmode_monitors,
+    prepare_device_eigenmode_monitor,
+    prepare_device_eigenmode_source,
+    reanchor_device_eigenmode_monitor,
+)
+from gprMax.network_ports import dtoh_rational_network_outputs, htod_rational_network_arrays
 from gprMax.ntff.device import MetalCombinedKSIRCollector
 from gprMax.receivers import dtoh_rx_array, htod_rx_arrays, requested_current_outputs
 from gprMax.snapshots import (
@@ -43,10 +55,13 @@ from gprMax.snapshots import (
 )
 from gprMax.sources import (
     MAGNETIC_FRILL_MAX_TERMS,
+    dtoh_transmission_line_outputs,
     dtoh_magnetic_frill_source_outputs,
     htod_magnetic_frill_source_arrays,
     htod_src_arrays,
+    htod_transmission_line_arrays,
 )
+from gprMax.updates.metal_plane_waves import MetalPlaneWaveController
 from gprMax.utilities.utilities import round32
 
 logger = logging.getLogger(__name__)
@@ -55,7 +70,7 @@ logger = logging.getLogger(__name__)
 class MetalUpdates:
     """Defines update functions for Apple Metal-based solver."""
 
-    def __init__(self, G):
+    def __init__(self, G, shared=None):
         """
         Args:
             G: OpenCLGrid class describing a grid in a model.
@@ -66,9 +81,14 @@ class MetalUpdates:
         self.metal = import_module("Metal")
         self.opts = self.metal.MTLCompileOptions.new()
 
-        # Select device and create command queue
-        self.dev = config.get_model_config().device["dev"]
-        self.cmdqueue = self.dev.newCommandQueue()
+        # Auxiliary virtual guides share the parent's device and command
+        # queue so their fields can be coupled without host transfers.
+        if shared is None:
+            self.dev = config.get_model_config().device["dev"]
+            self.cmdqueue = self.dev.newCommandQueue()
+        else:
+            self.dev = shared.dev
+            self.cmdqueue = shared.cmdqueue
 
         # Set common substitutions for use in kernels
         # Substitutions in function arguments
@@ -80,6 +100,21 @@ class MetalUpdates:
         self.subs_func = {
             "REAL": config.sim_config.dtypes["C_float_or_double"],
             "CUDA_IDX": "",
+            "METAL_DFT_PARAMETERS": """
+                int NF = parameters.NF;
+                int NM = parameters.NM;
+                int normal_axis = parameters.normal_axis;
+                int direction_sign = parameters.direction_sign;
+                int magnetic_side = parameters.magnetic_side;
+                int u0 = parameters.u0;
+                int v0 = parameters.v0;
+                int u1 = parameters.u1;
+                int v1 = parameters.v1;
+                int plane_index = parameters.plane_index;
+                float dt = parameters.dt;
+                float measure = parameters.measure;
+                int handedness = parameters.handedness;
+            """,
             "NX_FIELDS": self.grid.nx + 1,
             "NY_FIELDS": self.grid.ny + 1,
             "NZ_FIELDS": self.grid.nz + 1,
@@ -106,20 +141,31 @@ class MetalUpdates:
             self._set_pml_knls()
         if self.grid.rxs:
             self._set_rx_knl()
-        if (
-            self.grid.voltagesources
-            + self.grid.hertziandipoles
-            + self.grid.magneticdipoles
-        ):
+        if self.grid.voltagesources + self.grid.hertziandipoles + self.grid.magneticdipoles:
             self._set_src_knls()
+        if getattr(self.grid, "transmissionlines", ()):
+            self._set_transmission_line_knls()
         if self.grid.magneticfrillsources:
             self._set_magnetic_frill_knl()
+        if self.grid.networkterminals:
+            self._set_rational_network_knl()
+        if self.grid.eigenmodesources:
+            self._set_eigenmode_source_knls()
+        if self.grid.eigenmodeports:
+            self._set_eigenmode_monitor_knl()
         if self.grid.snapshots:
             self._set_snapshot_knl()
+        self.planewave_controller = None
+        if self.grid.discreteplanewaves:
+            self.planewave_controller = MetalPlaneWaveController(self)
         self.ntff_collector = None
         if self.grid.ntff_monitors:
             self.ntff_c_real = config.sim_config.dtypes["C_float_or_double"]
             self.ntff_collector = MetalCombinedKSIRCollector(self)
+        if self.grid.virtual_waveguides:
+            self._set_virtual_waveguide_knls()
+        for guide in self.grid.virtual_waveguides:
+            guide.initialise_device(self)
 
     def _build_knl(self, knl_func, subs_name_args, subs_func):
         """Builds an Apple Metal kernel from templates: 1) function name and args;
@@ -142,6 +188,20 @@ class MetalUpdates:
         knl = self.knl_common + "\n" + name_plus_args + "{" + func_body + "}"
 
         return knl
+
+    def _compile_pipeline(self, specification, function_name, substitutions=None):
+        """Compile one templated Metal kernel and return its pipeline state."""
+
+        source = self._build_knl(
+            specification,
+            self.subs_name_args,
+            substitutions or self.subs_func,
+        )
+        library, error = self.dev.newLibraryWithSource_options_error_(source, self.opts, None)
+        if library is None:
+            raise RuntimeError(f"Failed to compile Metal {function_name} kernel: {error}")
+        function = library.newFunctionWithName_(function_name)
+        return self.dev.newComputePipelineStateWithFunction_error_(function, None)[0]
 
     def _set_macros(self):
         """Common macros to be used in kernels."""
@@ -237,34 +297,22 @@ class MetalUpdates:
                 self.subs_name_args,
                 self.subs_func,
             )
-            lib, _ = self.dev.newLibraryWithSource_options_error_(
-                bld, self.opts, None
-            )
-            self.dispersive_update_a_dev = lib.newFunctionWithName_(
-                "update_electric_dispersive_A"
-            )
-            self.pso_dispersive_a = (
-                self.dev.newComputePipelineStateWithFunction_error_(
-                    self.dispersive_update_a_dev, None
-                )[0]
-            )
+            lib, _ = self.dev.newLibraryWithSource_options_error_(bld, self.opts, None)
+            self.dispersive_update_a_dev = lib.newFunctionWithName_("update_electric_dispersive_A")
+            self.pso_dispersive_a = self.dev.newComputePipelineStateWithFunction_error_(
+                self.dispersive_update_a_dev, None
+            )[0]
 
             bld = self._build_knl(
                 knl_fields_updates.update_electric_dispersive_B,
                 self.subs_name_args,
                 self.subs_func,
             )
-            lib, _ = self.dev.newLibraryWithSource_options_error_(
-                bld, self.opts, None
-            )
-            self.dispersive_update_b_dev = lib.newFunctionWithName_(
-                "update_electric_dispersive_B"
-            )
-            self.pso_dispersive_b = (
-                self.dev.newComputePipelineStateWithFunction_error_(
-                    self.dispersive_update_b_dev, None
-                )[0]
-            )
+            lib, _ = self.dev.newLibraryWithSource_options_error_(bld, self.opts, None)
+            self.dispersive_update_b_dev = lib.newFunctionWithName_("update_electric_dispersive_B")
+            self.pso_dispersive_b = self.dev.newComputePipelineStateWithFunction_error_(
+                self.dispersive_update_b_dev, None
+            )[0]
 
             # Tx/Ty/Tz + updatecoeffsdispersive host arrays already exist by
             # this point (allocated during grid.build(), same as for every
@@ -288,19 +336,69 @@ class MetalUpdates:
         self.grid.htod_material_arrays(self.dev)
 
     def _set_symmetry_boundary_knl(self):
-        """Build the nondispersive PMC ghost-image boundary kernel."""
+        """Build normal or dispersive PMC ghost-image boundary kernels."""
+        substitutions = dict(self.subs_func)
+        substitutions.update(knl_symmetry_boundaries.nondispersive_substitutions())
         source = self._build_knl(
             knl_symmetry_boundaries.update_electric_pmc,
             self.subs_name_args,
-            self.subs_func,
+            substitutions,
         )
         library, error = self.dev.newLibraryWithSource_options_error_(source, self.opts, None)
         if library is None:
             raise RuntimeError(f"Failed to compile Metal PMC kernel: {error}")
         function = library.newFunctionWithName_("update_electric_pmc")
-        self.pso_electric_pmc = self.dev.newComputePipelineStateWithFunction_error_(
-            function, None
-        )[0]
+        self.pso_electric_pmc = self.dev.newComputePipelineStateWithFunction_error_(function, None)[
+            0
+        ]
+        if config.get_model_config().materials["maxpoles"] > 0:
+            substitutions = dict(self.subs_func)
+            substitutions.update(
+                knl_symmetry_boundaries.dispersive_substitutions(
+                    config.sim_config.dtypes["C_float_or_double"]
+                )
+            )
+            self.pso_electric_pmc_dispersive = self._compile_pipeline(
+                knl_symmetry_boundaries.update_electric_pmc_dispersive,
+                "update_electric_pmc_dispersive",
+                substitutions,
+            )
+            self.pso_electric_pmc_dispersive_b = self._compile_pipeline(
+                knl_symmetry_boundaries.update_electric_pmc_dispersive_b,
+                "update_electric_pmc_dispersive_b",
+                self.subs_func,
+            )
+
+    def _set_transmission_line_knls(self):
+        """Initialise device-resident transmission lines on Metal."""
+
+        arrays = htod_transmission_line_arrays(self.grid.transmissionlines, self.grid)
+        for name, array in arrays.items():
+            setattr(self, f"tl_{name}_dev", array)
+        real = config.sim_config.dtypes["float_or_double"]
+        line = self.grid.transmissionlines[0]
+        self.tl_line_coefficient = real(config.c * self.grid.dt / line.dl)
+        self.tl_abc_coefficient = real(
+            (config.c * self.grid.dt - line.dl) / (config.c * self.grid.dt + line.dl)
+        )
+        substitutions = dict(self.subs_func)
+        substitutions.update(
+            {
+                "NY_TLINFO": 10,
+                "NY_TLWAVES": self.grid.iterations + 1,
+                "NY_TLOUTPUTS": self.grid.iterations + 1,
+            }
+        )
+        self.pso_transmission_line_magnetic = self._compile_pipeline(
+            knl_transmission_line.update_transmission_line_magnetic,
+            "update_transmission_line_magnetic",
+            substitutions,
+        )
+        self.pso_transmission_line_electric = self._compile_pipeline(
+            knl_transmission_line.update_transmission_line_electric,
+            "update_transmission_line_electric",
+            substitutions,
+        )
 
     def _pmc_flags(self):
         boundaries = self.grid.symmetry_boundaries
@@ -332,9 +430,7 @@ class MetalUpdates:
             subs_name_args_pml["FUNC"] = func_name
             bld = self._build_knl(knl_electric_name, subs_name_args_pml, self.subs_func)
 
-            lib, error = self.dev.newLibraryWithSource_options_error_(
-                bld, self.opts, None
-            )
+            lib, error = self.dev.newLibraryWithSource_options_error_(bld, self.opts, None)
             if lib is None:
                 logger.debug(f"Electric PML kernel compilation failed: {error}")
                 raise RuntimeError(f"Failed to compile electric PML kernel: {error}")
@@ -349,9 +445,7 @@ class MetalUpdates:
             subs_name_args_pml["FUNC"] = func_name
             bld = self._build_knl(knl_magnetic_name, subs_name_args_pml, self.subs_func)
 
-            lib, error = self.dev.newLibraryWithSource_options_error_(
-                bld, self.opts, None
-            )
+            lib, error = self.dev.newLibraryWithSource_options_error_(bld, self.opts, None)
             if lib is None:
                 logger.debug(f"Magnetic PML kernel compilation failed: {error}")
                 raise RuntimeError(f"Failed to compile magnetic PML kernel: {error}")
@@ -382,9 +476,7 @@ class MetalUpdates:
             }
         )
 
-        bld = self._build_knl(
-            knl_store_outputs.store_outputs, self.subs_name_args, self.subs_func
-        )
+        bld = self._build_knl(knl_store_outputs.store_outputs, self.subs_name_args, self.subs_func)
         lib, _ = self.dev.newLibraryWithSource_options_error_(bld, self.opts, None)
         self.store_outputs_dev = lib.newFunctionWithName_("store_outputs")
         self.pso_store_outputs = self.dev.newComputePipelineStateWithFunction_error_(
@@ -397,14 +489,10 @@ class MetalUpdates:
                 self.subs_func,
             )
             lib, _ = self.dev.newLibraryWithSource_options_error_(bld, self.opts, None)
-            self.store_current_outputs_dev = lib.newFunctionWithName_(
-                "store_current_outputs"
-            )
-            self.pso_store_current_outputs = (
-                self.dev.newComputePipelineStateWithFunction_error_(
-                    self.store_current_outputs_dev, None
-                )[0]
-            )
+            self.store_current_outputs_dev = lib.newFunctionWithName_("store_current_outputs")
+            self.pso_store_current_outputs = self.dev.newComputePipelineStateWithFunction_error_(
+                self.store_current_outputs_dev, None
+            )[0]
 
         # No self.grid.set_thread_group_size() call here - store_outputs()'s
         # own dispatch always computes its thread-group size directly from
@@ -431,14 +519,10 @@ class MetalUpdates:
                 self.subs_func,
             )
             lib, _ = self.dev.newLibraryWithSource_options_error_(bld, self.opts, None)
-            self.update_hertzian_dipole_dev = lib.newFunctionWithName_(
-                "update_hertzian_dipole"
-            )
-            self.pso_hertzian_dipole = (
-                self.dev.newComputePipelineStateWithFunction_error_(
-                    self.update_hertzian_dipole_dev, None
-                )[0]
-            )
+            self.update_hertzian_dipole_dev = lib.newFunctionWithName_("update_hertzian_dipole")
+            self.pso_hertzian_dipole = self.dev.newComputePipelineStateWithFunction_error_(
+                self.update_hertzian_dipole_dev, None
+            )[0]
 
         if self.grid.magneticdipoles:
             (
@@ -453,14 +537,10 @@ class MetalUpdates:
                 self.subs_func,
             )
             lib, _ = self.dev.newLibraryWithSource_options_error_(bld, self.opts, None)
-            self.update_magnetic_dipole_dev = lib.newFunctionWithName_(
-                "update_magnetic_dipole"
-            )
-            self.pso_magnetic_dipole = (
-                self.dev.newComputePipelineStateWithFunction_error_(
-                    self.update_magnetic_dipole_dev, None
-                )[0]
-            )
+            self.update_magnetic_dipole_dev = lib.newFunctionWithName_("update_magnetic_dipole")
+            self.pso_magnetic_dipole = self.dev.newComputePipelineStateWithFunction_error_(
+                self.update_magnetic_dipole_dev, None
+            )[0]
 
         if self.grid.voltagesources:
             (
@@ -475,21 +555,15 @@ class MetalUpdates:
                 self.subs_func,
             )
             lib, _ = self.dev.newLibraryWithSource_options_error_(bld, self.opts, None)
-            self.update_voltage_source_dev = lib.newFunctionWithName_(
-                "update_voltage_source"
-            )
-            self.pso_voltage_source = (
-                self.dev.newComputePipelineStateWithFunction_error_(
-                    self.update_voltage_source_dev, None
-                )[0]
-            )
+            self.update_voltage_source_dev = lib.newFunctionWithName_("update_voltage_source")
+            self.pso_voltage_source = self.dev.newComputePipelineStateWithFunction_error_(
+                self.update_voltage_source_dev, None
+            )[0]
 
     def _set_magnetic_frill_knl(self):
         """Initialise corrected device-resident magnetic-frill sources."""
 
-        arrays = htod_magnetic_frill_source_arrays(
-            self.grid.magneticfrillsources, self.grid
-        )
+        arrays = htod_magnetic_frill_source_arrays(self.grid.magneticfrillsources, self.grid)
         for name, array in arrays.items():
             setattr(self, f"frill_{name}_dev", array)
 
@@ -509,15 +583,87 @@ class MetalUpdates:
             self.subs_name_args,
             substitutions,
         )
-        library, error = self.dev.newLibraryWithSource_options_error_(
-            source, self.opts, None
-        )
+        library, error = self.dev.newLibraryWithSource_options_error_(source, self.opts, None)
         if library is None:
             raise RuntimeError(f"Failed to compile Metal magnetic-frill kernel: {error}")
         function = library.newFunctionWithName_("update_magnetic_frill_source")
         self.pso_magnetic_frill = self.dev.newComputePipelineStateWithFunction_error_(
             function, None
         )[0]
+
+    def _set_rational_network_knl(self):
+        """Initialise sparse device-resident rational-network terminals."""
+
+        arrays = htod_rational_network_arrays(self.grid.networkterminals, self.grid)
+        for name, array in arrays.items():
+            setattr(self, f"rn_{name}_dev", array)
+        substitutions = dict(self.subs_func)
+        substitutions.update(
+            {
+                "NY_RNINFO": 6,
+                "NY_RNPARAMS": 7,
+                "NY_RNWAVEWHOLE": self.grid.iterations + 1,
+                "NY_RNWAVEHALF": self.grid.iterations,
+                "NY_RNVOLTAGE": self.grid.iterations + 1,
+                "NY_RNCURRENT": self.grid.iterations,
+            }
+        )
+        source = self._build_knl(
+            knl_rational_network.update_rational_network,
+            self.subs_name_args,
+            substitutions,
+        )
+        library, error = self.dev.newLibraryWithSource_options_error_(source, self.opts, None)
+        if library is None:
+            raise RuntimeError(f"Failed to compile Metal rational-network kernel: {error}")
+        function = library.newFunctionWithName_("update_rational_network")
+        self.pso_rational_network = self.dev.newComputePipelineStateWithFunction_error_(
+            function, None
+        )[0]
+
+    def _set_eigenmode_source_knls(self):
+        """Upload modal bases and compile device TF/SF source kernels."""
+
+        for source in self.grid.eigenmodesources:
+            prepare_device_eigenmode_source(source, "metal", dev=self.dev)
+        self.pso_eigenmode_magnetic = self._compile_pipeline(
+            knl_eigenmode.update_eigenmode_magnetic,
+            "update_eigenmode_magnetic",
+        )
+        self.pso_eigenmode_electric = self._compile_pipeline(
+            knl_eigenmode.update_eigenmode_electric,
+            "update_eigenmode_electric",
+        )
+
+    def _set_eigenmode_monitor_knl(self):
+        """Upload modal projection bases and compile the DFT kernel."""
+
+        for monitor in self.grid.eigenmodeports:
+            prepare_device_eigenmode_monitor(monitor, "metal", dev=self.dev)
+        self.pso_eigenmode_dft = self._compile_pipeline(
+            knl_eigenmode.accumulate_eigenmode_dft,
+            "accumulate_eigenmode_dft",
+        )
+
+    def _set_virtual_waveguide_knls(self):
+        """Compile auxiliary-grid aperture coupling kernels."""
+
+        self.pso_virtual_magnetic = self._compile_pipeline(
+            knl_virtual_waveguide.couple_magnetic,
+            "couple_virtual_waveguide_magnetic",
+        )
+        self.pso_virtual_clear_magnetic = self._compile_pipeline(
+            knl_virtual_waveguide.clear_rear_magnetic,
+            "clear_virtual_waveguide_rear_magnetic",
+        )
+        self.pso_virtual_electric = self._compile_pipeline(
+            knl_virtual_waveguide.couple_electric,
+            "couple_virtual_waveguide_electric",
+        )
+        self.pso_virtual_clear_electric = self._compile_pipeline(
+            knl_virtual_waveguide.clear_rear_electric,
+            "clear_virtual_waveguide_rear_electric",
+        )
 
     def _set_snapshot_knl(self):
         """Snapshots - initialises arrays on compute device, prepares kernel and
@@ -540,16 +686,12 @@ class MetalUpdates:
                 "NZ_SNAPS": Snapshot.nz_max,
             }
         )
-        bld = self._build_knl(
-            knl_snapshots.store_snapshot, self.subs_name_args, subs_func_snap
-        )
+        bld = self._build_knl(knl_snapshots.store_snapshot, self.subs_name_args, subs_func_snap)
         lib, _ = self.dev.newLibraryWithSource_options_error_(bld, self.opts, None)
         self.update_store_snapshot_dev = lib.newFunctionWithName_("store_snapshot")
-        self.pso_store_snapshot = (
-            self.dev.newComputePipelineStateWithFunction_error_(
-                self.update_store_snapshot_dev, None
-            )[0]
-        )
+        self.pso_store_snapshot = self.dev.newComputePipelineStateWithFunction_error_(
+            self.update_store_snapshot_dev, None
+        )[0]
 
     def _metal_snapshot_buffers_to_numpy(self):
         """Converts the six device-resident snapshot buffers into host numpy
@@ -557,9 +699,7 @@ class MetalUpdates:
         with - MTLBuffer has no .get() (that's the CUDA/OpenCL array API);
         Metal buffers are read back via .contents().as_buffer(size)."""
         numsnaps = (
-            1
-            if config.get_model_config().device["snapsgpu2cpu"]
-            else len(self.grid.snapshots)
+            1 if config.get_model_config().device["snapsgpu2cpu"] else len(self.grid.snapshots)
         )
         shape = (numsnaps, Snapshot.nx_max, Snapshot.ny_max, Snapshot.nz_max)
         dtype = config.sim_config.dtypes["float_or_double"]
@@ -567,9 +707,7 @@ class MetalUpdates:
 
         def _to_numpy(buf):
             return (
-                np.frombuffer(buf.contents().as_buffer(nbytes), dtype=dtype)
-                .reshape(shape)
-                .copy()
+                np.frombuffer(buf.contents().as_buffer(nbytes), dtype=dtype).reshape(shape).copy()
             )
 
         return (
@@ -589,12 +727,8 @@ class MetalUpdates:
         """
         if self.grid.rxs:
             self.cmdbuffer_store_outputs = self.cmdqueue.commandBuffer()
-            self.cmpencoder_store_outputs = (
-                self.cmdbuffer_store_outputs.computeCommandEncoder()
-            )
-            self.cmpencoder_store_outputs.setComputePipelineState_(
-                self.pso_store_outputs
-            )
+            self.cmpencoder_store_outputs = self.cmdbuffer_store_outputs.computeCommandEncoder()
+            self.cmpencoder_store_outputs.setComputePipelineState_(self.pso_store_outputs)
 
             # Set buffer arguments for the kernel
             # NRX (number of receivers)
@@ -607,37 +741,21 @@ class MetalUpdates:
             iteration_buffer = self.dev.newBufferWithBytes_length_options_(
                 np.int32(iteration).tobytes(), 4, 0
             )
-            self.cmpencoder_store_outputs.setBuffer_offset_atIndex_(
-                iteration_buffer, 0, 1
-            )
+            self.cmpencoder_store_outputs.setBuffer_offset_atIndex_(iteration_buffer, 0, 1)
 
             # rxcoords - receiver coordinates
-            self.cmpencoder_store_outputs.setBuffer_offset_atIndex_(
-                self.rxcoords_dev, 0, 2
-            )
+            self.cmpencoder_store_outputs.setBuffer_offset_atIndex_(self.rxcoords_dev, 0, 2)
 
             # rxs - receiver data storage array
             self.cmpencoder_store_outputs.setBuffer_offset_atIndex_(self.rxs_dev, 0, 3)
 
             # Field component buffers (Ex, Ey, Ez, Hx, Hy, Hz)
-            self.cmpencoder_store_outputs.setBuffer_offset_atIndex_(
-                self.grid.Ex_dev, 0, 4
-            )
-            self.cmpencoder_store_outputs.setBuffer_offset_atIndex_(
-                self.grid.Ey_dev, 0, 5
-            )
-            self.cmpencoder_store_outputs.setBuffer_offset_atIndex_(
-                self.grid.Ez_dev, 0, 6
-            )
-            self.cmpencoder_store_outputs.setBuffer_offset_atIndex_(
-                self.grid.Hx_dev, 0, 7
-            )
-            self.cmpencoder_store_outputs.setBuffer_offset_atIndex_(
-                self.grid.Hy_dev, 0, 8
-            )
-            self.cmpencoder_store_outputs.setBuffer_offset_atIndex_(
-                self.grid.Hz_dev, 0, 9
-            )
+            self.cmpencoder_store_outputs.setBuffer_offset_atIndex_(self.grid.Ex_dev, 0, 4)
+            self.cmpencoder_store_outputs.setBuffer_offset_atIndex_(self.grid.Ey_dev, 0, 5)
+            self.cmpencoder_store_outputs.setBuffer_offset_atIndex_(self.grid.Ez_dev, 0, 6)
+            self.cmpencoder_store_outputs.setBuffer_offset_atIndex_(self.grid.Hx_dev, 0, 7)
+            self.cmpencoder_store_outputs.setBuffer_offset_atIndex_(self.grid.Hy_dev, 0, 8)
+            self.cmpencoder_store_outputs.setBuffer_offset_atIndex_(self.grid.Hz_dev, 0, 9)
 
             self.cmpencoder_store_outputs.dispatchThreads_threadsPerThreadgroup_(
                 self.metal.MTLSizeMake(round32(len(self.grid.rxs)), 1, 1),
@@ -755,9 +873,7 @@ class MetalUpdates:
                 cmdbuffer_snap.waitUntilCompleted()
 
                 if config.get_model_config().device["snapsgpu2cpu"]:
-                    dtoh_snapshot_array(
-                        *self._metal_snapshot_buffers_to_numpy(), 0, snap
-                    )
+                    dtoh_snapshot_array(*self._metal_snapshot_buffers_to_numpy(), 0, snap)
 
     def observe_ntff_electric(self, iteration):
         """Collect electric frequency- and time-domain KSIR data on Metal."""
@@ -772,6 +888,219 @@ class MetalUpdates:
         collector = getattr(self, "ntff_collector", None)
         if collector is not None:
             collector.observe_magnetic(iteration)
+
+    def _dispatch_1d(self, pipeline, scalars, buffers, npoints):
+        """Bind and execute one bounds-checked one-dimensional Metal kernel."""
+
+        command = self.cmdqueue.commandBuffer()
+        encoder = command.computeCommandEncoder()
+        encoder.setComputePipelineState_(pipeline)
+        for index, value in enumerate(scalars):
+            encoder.setBytes_length_atIndex_(value.tobytes(), value.nbytes, index)
+        for index, buffer in enumerate(buffers, start=len(scalars)):
+            encoder.setBuffer_offset_atIndex_(buffer, 0, index)
+        encoder.dispatchThreads_threadsPerThreadgroup_(
+            self.metal.MTLSizeMake(int(npoints), 1, 1),
+            self.metal.MTLSizeMake(pipeline.maxTotalThreadsPerThreadgroup(), 1, 1),
+        )
+        encoder.endEncoding()
+        command.commit()
+        command.waitUntilCompleted()
+
+    def observe_eigenmode_ports(self, iteration):
+        """Project modal port fields and accumulate DFTs on Metal."""
+
+        real = config.sim_config.dtypes["float_or_double"]
+        for monitor in self.grid.eigenmodeports:
+            if iteration != monitor._next_iteration:
+                raise RuntimeError(
+                    f"expected eigenmode DFT iteration {monitor._next_iteration}, "
+                    f"received {iteration}"
+                )
+            owner = monitor.owner
+            arrays = monitor.device_arrays
+            nf, nm = monitor.electric_dft.shape
+            parameters = monitor.device_parameters
+            parameters[0] = (
+                nf,
+                nm,
+                owner.normal_axis,
+                1 if owner.direction == "+" else -1,
+                monitor.magnetic_side,
+                owner.transverse_start[0],
+                owner.transverse_start[1],
+                owner.transverse_stop[0],
+                owner.transverse_stop[1],
+                owner.plane_index,
+                self.grid.dt,
+                monitor.measure,
+                monitor.handedness,
+            )
+            buffers = (
+                arrays["electric_phase_real"],
+                arrays["electric_phase_imag"],
+                arrays["magnetic_phase_real"],
+                arrays["magnetic_phase_imag"],
+                arrays["phase_step_real"],
+                arrays["phase_step_imag"],
+                arrays["conj_eu_real"],
+                arrays["conj_eu_imag"],
+                arrays["conj_ev_real"],
+                arrays["conj_ev_imag"],
+                arrays["conj_hu_real"],
+                arrays["conj_hu_imag"],
+                arrays["conj_hv_real"],
+                arrays["conj_hv_imag"],
+                arrays["electric_dft_real"],
+                arrays["electric_dft_imag"],
+                arrays["magnetic_dft_real"],
+                arrays["magnetic_dft_imag"],
+                self.grid.Ex_dev,
+                self.grid.Ey_dev,
+                self.grid.Ez_dev,
+                self.grid.Hx_dev,
+                self.grid.Hy_dev,
+                self.grid.Hz_dev,
+            )
+            self._dispatch_1d(self.pso_eigenmode_dft, (parameters,), buffers, nf)
+            monitor._next_iteration += 1
+            reanchor_device_eigenmode_monitor(monitor, self.grid, "metal")
+
+    def _launch_eigenmode_source(self, source, iteration, magnetic):
+        nu, nv = np.asarray(source.transverse_stop) - np.asarray(source.transverse_start)
+        npoints = int((nu + 1) * (nv + 1))
+        pipeline = self.pso_eigenmode_magnetic if magnetic else self.pso_eigenmode_electric
+        profiles = source.device_electric_profiles if magnetic else source.device_magnetic_profiles
+        coefficients = self.grid.updatecoeffsH_dev if magnetic else self.grid.updatecoeffsE_dev
+        fields = (
+            (self.grid.Hx_dev, self.grid.Hy_dev, self.grid.Hz_dev)
+            if magnetic
+            else (self.grid.Ex_dev, self.grid.Ey_dev, self.grid.Ez_dev)
+        )
+        real = config.sim_config.dtypes["float_or_double"]
+        for basis, envelope in eigenmode_source_envelopes(source, self.grid, iteration, magnetic):
+            scalars = (
+                np.int32(npoints),
+                np.int32(source.normal_axis),
+                np.int32(1 if source.direction == "+" else -1),
+                np.int32(source.transverse_start[0]),
+                np.int32(source.transverse_start[1]),
+                np.int32(source.transverse_stop[0]),
+                np.int32(source.transverse_stop[1]),
+                np.int32(source.plane_index),
+                np.int32(basis),
+                real(envelope),
+            )
+            self._dispatch_1d(
+                pipeline,
+                scalars,
+                (profiles, coefficients, self.grid.ID_dev, *fields),
+                npoints,
+            )
+
+    def update_eigenmode_sources_magnetic(self, iteration):
+        for source in self.grid.eigenmodesources:
+            self._launch_eigenmode_source(source, iteration, True)
+        for guide in self.grid.virtual_waveguides:
+            self._update_virtual_waveguide_magnetic(guide, iteration)
+
+    def update_eigenmode_sources_electric(self, iteration):
+        for source in self.grid.eigenmodesources:
+            self._launch_eigenmode_source(source, iteration, False)
+        for guide in self.grid.virtual_waveguides:
+            self._update_virtual_waveguide_electric(guide, iteration)
+
+    @staticmethod
+    def _virtual_scalars(guide, npoints):
+        aux = guide.aux_grid
+        return (
+            np.int32(npoints),
+            np.int32(guide.normal_axis),
+            np.int32(guide.direction_sign),
+            np.int32(guide.u0),
+            np.int32(guide.v0),
+            np.int32(guide.u1),
+            np.int32(guide.v1),
+            np.int32(guide.plane_index),
+            np.int32(aux.nx),
+            np.int32(aux.ny),
+            np.int32(aux.nz),
+        )
+
+    def _update_virtual_waveguide_magnetic(self, guide, iteration):
+        child = guide.aux_updates
+        child.update_magnetic()
+        child.update_magnetic_pml()
+        child.update_eigenmode_sources_magnetic(iteration)
+        nface = (guide.nu + 1) * (guide.nv + 1)
+        main_h = (self.grid.Hx_dev, self.grid.Hy_dev, self.grid.Hz_dev)
+        aux_h = (
+            guide.aux_grid.Hx_dev,
+            guide.aux_grid.Hy_dev,
+            guide.aux_grid.Hz_dev,
+        )
+        self._dispatch_1d(
+            self.pso_virtual_magnetic,
+            self._virtual_scalars(guide, nface),
+            (*main_h, *aux_h),
+            nface,
+        )
+        nmain = self.grid.Ex.size
+        self._dispatch_1d(
+            self.pso_virtual_clear_magnetic,
+            self._virtual_scalars(guide, nmain),
+            (*main_h, *aux_h),
+            nmain,
+        )
+
+    def _update_virtual_waveguide_electric(self, guide, iteration):
+        child = guide.aux_updates
+        child.update_electric_a()
+        child.update_electric_pml()
+        child.update_eigenmode_sources_electric(iteration)
+        child.update_electric_b()
+        nface = (guide.nu + 1) * (guide.nv + 1)
+        main_fields = (
+            self.grid.Ex_dev,
+            self.grid.Ey_dev,
+            self.grid.Ez_dev,
+            self.grid.Hx_dev,
+            self.grid.Hy_dev,
+            self.grid.Hz_dev,
+        )
+        aux_fields = (
+            guide.aux_grid.Ex_dev,
+            guide.aux_grid.Ey_dev,
+            guide.aux_grid.Ez_dev,
+            guide.aux_grid.Hx_dev,
+            guide.aux_grid.Hy_dev,
+            guide.aux_grid.Hz_dev,
+        )
+        self._dispatch_1d(
+            self.pso_virtual_electric,
+            self._virtual_scalars(guide, nface),
+            (
+                guide.aux_grid.updatecoeffsE_dev,
+                guide.aux_grid.ID_dev,
+                *main_fields,
+                *aux_fields,
+            ),
+            nface,
+        )
+        nmain = self.grid.Ex.size
+        self._dispatch_1d(
+            self.pso_virtual_clear_electric,
+            self._virtual_scalars(guide, nmain),
+            (
+                self.grid.Ex_dev,
+                self.grid.Ey_dev,
+                self.grid.Ez_dev,
+                guide.aux_grid.Ex_dev,
+                guide.aux_grid.Ey_dev,
+                guide.aux_grid.Ez_dev,
+            ),
+            nmain,
+        )
 
     def update_magnetic(self):
         """Updates magnetic field components."""
@@ -799,9 +1128,7 @@ class MetalUpdates:
         self.cmpencoderH.setBuffer_offset_atIndex_(self.grid.Ey_dev, 0, 8)
         self.cmpencoderH.setBuffer_offset_atIndex_(self.grid.Ez_dev, 0, 9)
 
-        self.cmpencoderH.dispatchThreads_threadsPerThreadgroup_(
-            self.grid.tptg, self.grid.tgs
-        )
+        self.cmpencoderH.dispatchThreads_threadsPerThreadgroup_(self.grid.tptg, self.grid.tgs)
         self.cmpencoderH.endEncoding()
         self.cmdbufferH.commit()
         self.cmdbufferH.waitUntilCompleted()
@@ -813,6 +1140,24 @@ class MetalUpdates:
 
     def update_magnetic_sources(self, iteration):
         """Updates magnetic field components from sources."""
+        if getattr(self.grid, "transmissionlines", ()):
+            real = config.sim_config.dtypes["float_or_double"]
+            self._dispatch_1d(
+                self.pso_transmission_line_magnetic,
+                (
+                    np.int32(len(self.grid.transmissionlines)), np.int32(iteration),
+                    real(self.grid.dx), real(self.grid.dy), real(self.grid.dz),
+                    self.tl_line_coefficient,
+                ),
+                (
+                    self.tl_info_dev, self.tl_resistance_dev,
+                    self.tl_waveform_half_dev, self.tl_voltage_dev,
+                    self.tl_current_dev, self.tl_Vtotal_dev, self.tl_Itotal_dev,
+                    self.grid.Hx_dev, self.grid.Hy_dev, self.grid.Hz_dev,
+                ),
+                len(self.grid.transmissionlines),
+            )
+
         if self.grid.magneticdipoles:
             real_dtype = config.sim_config.dtypes["float_or_double"]
             real_nbytes = np.dtype(real_dtype).itemsize
@@ -850,15 +1195,9 @@ class MetalUpdates:
             cmpencoder_magnetic.setBuffer_offset_atIndex_(dz_buffer, 0, 4)
 
             # Set source info and waveform buffers
-            cmpencoder_magnetic.setBuffer_offset_atIndex_(
-                self.srcinfo1_magnetic_dev, 0, 5
-            )
-            cmpencoder_magnetic.setBuffer_offset_atIndex_(
-                self.srcinfo2_magnetic_dev, 0, 6
-            )
-            cmpencoder_magnetic.setBuffer_offset_atIndex_(
-                self.srcwaves_magnetic_dev, 0, 7
-            )
+            cmpencoder_magnetic.setBuffer_offset_atIndex_(self.srcinfo1_magnetic_dev, 0, 5)
+            cmpencoder_magnetic.setBuffer_offset_atIndex_(self.srcinfo2_magnetic_dev, 0, 6)
+            cmpencoder_magnetic.setBuffer_offset_atIndex_(self.srcwaves_magnetic_dev, 0, 7)
 
             # Set ID and field buffers
             cmpencoder_magnetic.setBuffer_offset_atIndex_(self.grid.ID_dev, 0, 8)
@@ -913,6 +1252,61 @@ class MetalUpdates:
             cmdbuffer.commit()
             cmdbuffer.waitUntilCompleted()
 
+    def update_plane_waves_magnetic(self, iteration):
+        """Advance Metal auxiliary plane waves and apply magnetic TF/SF corrections."""
+
+        if self.planewave_controller is not None:
+            self.planewave_controller.update_plane_waves_magnetic(iteration)
+
+    def update_network_terminals(self, iteration):
+        """Apply sparse rational-network corrections entirely on Metal."""
+
+        if not self.grid.networkterminals:
+            return
+        command = self.cmdqueue.commandBuffer()
+        encoder = command.computeCommandEncoder()
+        encoder.setComputePipelineState_(self.pso_rational_network)
+        terminal_count = np.int32(len(self.grid.networkterminals))
+        iteration_value = np.int32(iteration)
+        dt_value = config.sim_config.dtypes["float_or_double"](self.grid.dt)
+        encoder.setBytes_length_atIndex_(terminal_count.tobytes(), 4, 0)
+        encoder.setBytes_length_atIndex_(iteration_value.tobytes(), 4, 1)
+        encoder.setBytes_length_atIndex_(dt_value.tobytes(), dt_value.nbytes, 2)
+        buffers = (
+            self.rn_info_dev,
+            self.rn_params_dev,
+            self.rn_waveform_whole_dev,
+            self.rn_waveform_half_dev,
+            self.rn_voltage_dev,
+            self.rn_current_dev,
+            self.rn_exp_half_real_dev,
+            self.rn_exp_half_imag_dev,
+            self.rn_coeff_half_new_real_dev,
+            self.rn_coeff_half_new_imag_dev,
+            self.rn_coeff_half_old_real_dev,
+            self.rn_coeff_half_old_imag_dev,
+            self.rn_exp_full_real_dev,
+            self.rn_exp_full_imag_dev,
+            self.rn_coeff_full_new_real_dev,
+            self.rn_coeff_full_new_imag_dev,
+            self.rn_coeff_full_old_real_dev,
+            self.rn_coeff_full_old_imag_dev,
+            self.rn_state_real_dev,
+            self.rn_state_imag_dev,
+            self.grid.Ex_dev,
+            self.grid.Ey_dev,
+            self.grid.Ez_dev,
+        )
+        for index, buffer in enumerate(buffers, start=3):
+            encoder.setBuffer_offset_atIndex_(buffer, 0, index)
+        encoder.dispatchThreads_threadsPerThreadgroup_(
+            self.metal.MTLSizeMake(int(terminal_count), 1, 1),
+            self.metal.MTLSizeMake(self.pso_rational_network.maxTotalThreadsPerThreadgroup(), 1, 1),
+        )
+        encoder.endEncoding()
+        command.commit()
+        command.waitUntilCompleted()
+
     def update_electric_a(self):
         """Updates electric field components."""
 
@@ -947,9 +1341,7 @@ class MetalUpdates:
             self.cmpencoderE.setBuffer_offset_atIndex_(self.grid.Hy_dev, 0, 8)
             self.cmpencoderE.setBuffer_offset_atIndex_(self.grid.Hz_dev, 0, 9)
 
-            self.cmpencoderE.dispatchThreads_threadsPerThreadgroup_(
-                self.grid.tptg, self.grid.tgs
-            )
+            self.cmpencoderE.dispatchThreads_threadsPerThreadgroup_(self.grid.tptg, self.grid.tgs)
 
             self.cmpencoderE.endEncoding()
             self.cmdbufferE.commit()
@@ -976,9 +1368,7 @@ class MetalUpdates:
             # update_electric_dispersive_A's args_metal signature exactly:
             # NX, NY, NZ, MAXPOLES, updatecoeffsdispersive, Tx, Ty, Tz, ID,
             # Ex, Ey, Ez, Hx, Hy, Hz (indices 0-14).
-            cmpencoder.setBuffer_offset_atIndex_(
-                self.grid.updatecoeffsdispersive_dev, 0, 4
-            )
+            cmpencoder.setBuffer_offset_atIndex_(self.grid.updatecoeffsdispersive_dev, 0, 4)
             cmpencoder.setBuffer_offset_atIndex_(self.grid.Tx_dev, 0, 5)
             cmpencoder.setBuffer_offset_atIndex_(self.grid.Ty_dev, 0, 6)
             cmpencoder.setBuffer_offset_atIndex_(self.grid.Tz_dev, 0, 7)
@@ -998,9 +1388,7 @@ class MetalUpdates:
             # exactly the class of bug fixed in _set_rx_knl() above.
             cmpencoder.dispatchThreads_threadsPerThreadgroup_(
                 self.grid.tptg,
-                self.metal.MTLSizeMake(
-                    self.pso_dispersive_a.maxTotalThreadsPerThreadgroup(), 1, 1
-                ),
+                self.metal.MTLSizeMake(self.pso_dispersive_a.maxTotalThreadsPerThreadgroup(), 1, 1),
             )
 
             cmpencoder.endEncoding()
@@ -1008,23 +1396,37 @@ class MetalUpdates:
             cmdbuffer.waitUntilCompleted()
 
     def update_symmetry_boundaries_electric(self):
-        """Apply the nondispersive PMC ghost-image correction on Metal."""
+        """Apply the PMC ghost-image correction on Metal."""
         if "pmc" not in self.grid.symmetry_boundaries.values():
             return
-
+        dispersive = config.get_model_config().materials["maxpoles"] > 0
+        pipeline = (
+            self.pso_electric_pmc_dispersive if dispersive else self.pso_electric_pmc
+        )
         command = self.cmdqueue.commandBuffer()
         encoder = command.computeCommandEncoder()
-        encoder.setComputePipelineState_(self.pso_electric_pmc)
-        scalars = (
+        encoder.setComputePipelineState_(pipeline)
+        scalars = [
             np.int32(self.grid.nx),
             np.int32(self.grid.ny),
             np.int32(self.grid.nz),
-            *self._pmc_flags(),
-        )
+        ]
+        if dispersive:
+            scalars.append(np.int32(config.get_model_config().materials["maxpoles"]))
+        scalars.extend(self._pmc_flags())
         for index, value in enumerate(scalars):
             encoder.setBytes_length_atIndex_(value.tobytes(), 4, index)
-
-        buffers = (
+        buffers = []
+        if dispersive:
+            buffers.extend(
+                [
+                    self.grid.updatecoeffsdispersive_dev,
+                    self.grid.Tx_dev,
+                    self.grid.Ty_dev,
+                    self.grid.Tz_dev,
+                ]
+            )
+        buffers.extend([
             self.grid.ID_dev,
             self.grid.Ex_dev,
             self.grid.Ey_dev,
@@ -1032,15 +1434,13 @@ class MetalUpdates:
             self.grid.Hx_dev,
             self.grid.Hy_dev,
             self.grid.Hz_dev,
-        )
-        for index, buffer in enumerate(buffers, start=9):
+        ])
+        for index, buffer in enumerate(buffers, start=len(scalars)):
             encoder.setBuffer_offset_atIndex_(buffer, 0, index)
 
         encoder.dispatchThreads_threadsPerThreadgroup_(
             self.grid.tptg,
-            self.metal.MTLSizeMake(
-                self.pso_electric_pmc.maxTotalThreadsPerThreadgroup(), 1, 1
-            ),
+            self.metal.MTLSizeMake(pipeline.maxTotalThreadsPerThreadgroup(), 1, 1),
         )
         encoder.endEncoding()
         command.commit()
@@ -1097,15 +1497,9 @@ class MetalUpdates:
             cmpencoder_voltage.setBuffer_offset_atIndex_(dz_buffer, 0, 4)
 
             # Set source info and waveform buffers
-            cmpencoder_voltage.setBuffer_offset_atIndex_(
-                self.srcinfo1_voltage_dev, 0, 5
-            )
-            cmpencoder_voltage.setBuffer_offset_atIndex_(
-                self.srcinfo2_voltage_dev, 0, 6
-            )
-            cmpencoder_voltage.setBuffer_offset_atIndex_(
-                self.srcwaves_voltage_dev, 0, 7
-            )
+            cmpencoder_voltage.setBuffer_offset_atIndex_(self.srcinfo1_voltage_dev, 0, 5)
+            cmpencoder_voltage.setBuffer_offset_atIndex_(self.srcinfo2_voltage_dev, 0, 6)
+            cmpencoder_voltage.setBuffer_offset_atIndex_(self.srcwaves_voltage_dev, 0, 7)
 
             # Set ID and field buffers
             cmpencoder_voltage.setBuffer_offset_atIndex_(self.grid.ID_dev, 0, 8)
@@ -1123,6 +1517,34 @@ class MetalUpdates:
             cmpencoder_voltage.endEncoding()
             cmdbuffer_voltage.commit()
             cmdbuffer_voltage.waitUntilCompleted()
+
+        if getattr(self.grid, "transmissionlines", ()):
+            real = config.sim_config.dtypes["float_or_double"]
+            self._dispatch_1d(
+                self.pso_transmission_line_electric,
+                (
+                    np.int32(len(self.grid.transmissionlines)),
+                    np.int32(iteration),
+                    real(self.grid.dx),
+                    real(self.grid.dy),
+                    real(self.grid.dz),
+                    self.tl_line_coefficient,
+                    self.tl_abc_coefficient,
+                ),
+                (
+                    self.tl_info_dev,
+                    self.tl_resistance_dev,
+                    self.tl_waveform_whole_dev,
+                    self.tl_voltage_dev,
+                    self.tl_current_dev,
+                    self.tl_abcv0_dev,
+                    self.tl_abcv1_dev,
+                    self.grid.Ex_dev,
+                    self.grid.Ey_dev,
+                    self.grid.Ez_dev,
+                ),
+                len(self.grid.transmissionlines),
+            )
 
         if self.grid.hertziandipoles:
             real_dtype = config.sim_config.dtypes["float_or_double"]
@@ -1171,15 +1593,9 @@ class MetalUpdates:
             cmpencoder_hertzian.setBuffer_offset_atIndex_(dz_buffer, 0, 4)
 
             # Set source info and waveform buffers
-            cmpencoder_hertzian.setBuffer_offset_atIndex_(
-                self.srcinfo1_hertzian_dev, 0, 5
-            )
-            cmpencoder_hertzian.setBuffer_offset_atIndex_(
-                self.srcinfo2_hertzian_dev, 0, 6
-            )
-            cmpencoder_hertzian.setBuffer_offset_atIndex_(
-                self.srcwaves_hertzian_dev, 0, 7
-            )
+            cmpencoder_hertzian.setBuffer_offset_atIndex_(self.srcinfo1_hertzian_dev, 0, 5)
+            cmpencoder_hertzian.setBuffer_offset_atIndex_(self.srcinfo2_hertzian_dev, 0, 6)
+            cmpencoder_hertzian.setBuffer_offset_atIndex_(self.srcwaves_hertzian_dev, 0, 7)
 
             # Set ID and field buffers
             cmpencoder_hertzian.setBuffer_offset_atIndex_(self.grid.ID_dev, 0, 8)
@@ -1202,9 +1618,7 @@ class MetalUpdates:
             # Optional debug: Check source fields briefly for first iteration
             if iteration == 1:
                 try:
-                    total_elements = (
-                        (self.grid.nx + 1) * (self.grid.ny + 1) * (self.grid.nz + 1)
-                    )
+                    total_elements = (self.grid.nx + 1) * (self.grid.ny + 1) * (self.grid.nz + 1)
                     buffer_size = total_elements * 4
                     ex_buffer = self.grid.Ex_dev.contents().as_buffer(buffer_size)
                     ex_array = np.frombuffer(ex_buffer, dtype=np.float32)
@@ -1219,6 +1633,12 @@ class MetalUpdates:
                     logger.exception(f"Error checking fields after source kernel: {e}")
 
         self.grid.iteration += 1
+
+    def update_plane_waves_electric(self, iteration):
+        """Advance Metal auxiliary plane waves and apply electric TF/SF corrections."""
+
+        if self.planewave_controller is not None:
+            self.planewave_controller.update_plane_waves_electric(iteration)
 
     def update_electric_b(self):
         """If there are any dispersive materials do 2nd part of dispersive
@@ -1246,9 +1666,7 @@ class MetalUpdates:
             # update_electric_dispersive_B's args_metal signature exactly:
             # NX, NY, NZ, MAXPOLES, updatecoeffsdispersive, Tx, Ty, Tz, ID,
             # Ex, Ey, Ez (indices 0-11 - no H components, unlike phase A).
-            cmpencoder.setBuffer_offset_atIndex_(
-                self.grid.updatecoeffsdispersive_dev, 0, 4
-            )
+            cmpencoder.setBuffer_offset_atIndex_(self.grid.updatecoeffsdispersive_dev, 0, 4)
             cmpencoder.setBuffer_offset_atIndex_(self.grid.Tx_dev, 0, 5)
             cmpencoder.setBuffer_offset_atIndex_(self.grid.Ty_dev, 0, 6)
             cmpencoder.setBuffer_offset_atIndex_(self.grid.Tz_dev, 0, 7)
@@ -1259,9 +1677,7 @@ class MetalUpdates:
 
             cmpencoder.dispatchThreads_threadsPerThreadgroup_(
                 self.grid.tptg,
-                self.metal.MTLSizeMake(
-                    self.pso_dispersive_b.maxTotalThreadsPerThreadgroup(), 1, 1
-                ),
+                self.metal.MTLSizeMake(self.pso_dispersive_b.maxTotalThreadsPerThreadgroup(), 1, 1),
             )
 
             cmpencoder.endEncoding()
@@ -1269,9 +1685,37 @@ class MetalUpdates:
             cmdbuffer.waitUntilCompleted()
 
     def update_symmetry_boundaries_electric_b(self):
-        """No-op because dispersive PMC symmetry is rejected for Metal."""
-
-        pass
+        """Complete the dispersive PMC ADE update on Metal."""
+        if (
+            "pmc" not in self.grid.symmetry_boundaries.values()
+            or config.get_model_config().materials["maxpoles"] == 0
+        ):
+            return
+        command = self.cmdqueue.commandBuffer()
+        encoder = command.computeCommandEncoder()
+        pipeline = self.pso_electric_pmc_dispersive_b
+        encoder.setComputePipelineState_(pipeline)
+        scalars = (
+            np.int32(self.grid.nx), np.int32(self.grid.ny), np.int32(self.grid.nz),
+            np.int32(config.get_model_config().materials["maxpoles"]),
+            *self._pmc_flags(),
+        )
+        for index, value in enumerate(scalars):
+            encoder.setBytes_length_atIndex_(value.tobytes(), 4, index)
+        buffers = (
+            self.grid.updatecoeffsdispersive_dev, self.grid.Tx_dev,
+            self.grid.Ty_dev, self.grid.Tz_dev, self.grid.ID_dev,
+            self.grid.Ex_dev, self.grid.Ey_dev, self.grid.Ez_dev,
+        )
+        for index, buffer in enumerate(buffers, start=len(scalars)):
+            encoder.setBuffer_offset_atIndex_(buffer, 0, index)
+        encoder.dispatchThreads_threadsPerThreadgroup_(
+            self.grid.tptg,
+            self.metal.MTLSizeMake(pipeline.maxTotalThreadsPerThreadgroup(), 1, 1),
+        )
+        encoder.endEncoding()
+        command.commit()
+        command.waitUntilCompleted()
 
     def time_start(self):
         """Starts event timers used to calculate solving time for model."""
@@ -1314,6 +1758,17 @@ class MetalUpdates:
                 self.frill_Itot_dev,
                 self.grid,
             )
+
+        if getattr(self.grid, "transmissionlines", ()):
+            dtoh_transmission_line_outputs(
+                self.tl_Vtotal_dev, self.tl_Itotal_dev, self.grid
+            )
+
+        if getattr(self.grid, "networkterminals", ()):
+            dtoh_rational_network_outputs(self.rn_voltage_dev, self.rn_current_dev, self.grid)
+
+        if getattr(self.grid, "eigenmodeports", ()):
+            finalise_device_eigenmode_monitors(self.grid.eigenmodeports, "metal")
 
         # Copy data from any snapshots back to correct snapshot objects
         if self.grid.snapshots and not config.get_model_config().device["snapsgpu2cpu"]:

--- a/gprMax/updates/opencl_updates.py
+++ b/gprMax/updates/opencl_updates.py
@@ -25,17 +25,28 @@ from jinja2 import Environment, PackageLoader
 
 from gprMax import config
 from gprMax.cuda_opencl import (
+    knl_eigenmode,
     knl_fields_updates,
     knl_magnetic_frill_source,
     knl_planewave_updates,
+    knl_rational_network,
     knl_snapshots,
     knl_source_updates,
     knl_store_outputs,
     knl_symmetry_boundaries,
     knl_tfsf_injection,
     knl_transmission_line,
+    knl_virtual_waveguide,
+)
+from gprMax.eigenmode_device import (
+    eigenmode_source_envelopes,
+    finalise_device_eigenmode_monitors,
+    prepare_device_eigenmode_monitor,
+    prepare_device_eigenmode_source,
+    reanchor_device_eigenmode_monitor,
 )
 from gprMax.grid.opencl_grid import OpenCLGrid
+from gprMax.network_ports import dtoh_rational_network_outputs, htod_rational_network_arrays
 from gprMax.ntff.device import OpenCLCombinedKSIRCollector
 from gprMax.receivers import dtoh_rx_array, htod_rx_arrays, requested_current_outputs
 from gprMax.snapshots import (
@@ -61,7 +72,7 @@ logger = logging.getLogger(__name__)
 class OpenCLUpdates(Updates[OpenCLGrid]):
     """Defines update functions for OpenCL-based solver."""
 
-    def __init__(self, G: OpenCLGrid):
+    def __init__(self, G: OpenCLGrid, shared=None):
         """
         Args:
             G: OpenCLGrid class describing a grid in a model.
@@ -73,11 +84,17 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
         self.elwiseknl = getattr(import_module("pyopencl.elementwise"), "ElementwiseKernel")
 
         # Select device, create context and command queue
-        self.dev = config.get_model_config().device["dev"]
-        self.ctx = self.cl.Context(devices=[self.dev])
-        self.queue = self.cl.CommandQueue(
-            self.ctx, properties=self.cl.command_queue_properties.PROFILING_ENABLE
-        )
+        if shared is None:
+            self.dev = config.get_model_config().device["dev"]
+            self.ctx = self.cl.Context(devices=[self.dev])
+            self.queue = self.cl.CommandQueue(
+                self.ctx,
+                properties=self.cl.command_queue_properties.PROFILING_ENABLE,
+            )
+        else:
+            self.dev = shared.dev
+            self.ctx = shared.ctx
+            self.queue = shared.queue
 
         # Enviroment for templating kernels
         self.env = Environment(loader=PackageLoader("gprMax", "cuda_opencl"))
@@ -101,17 +118,27 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
             self._set_src_knls()
         if self.grid.transmissionlines:
             self._set_transmission_line_knls()
+        if self.grid.networkterminals:
+            self._set_rational_network_knl()
         if self.grid.magneticfrillsources:
             self._set_magnetic_frill_knl()
         if self.grid.snapshots:
             self._set_snapshot_knl()
         if self.grid.discreteplanewaves:
             self._set_planewave_knls()
+        if self.grid.eigenmodesources:
+            self._set_eigenmode_source_knls()
+        if self.grid.eigenmodeports:
+            self._set_eigenmode_monitor_knl()
         self.ntff_collector = None
         if self.grid.ntff_monitors:
             self.ntff_c_real = config.sim_config.dtypes["C_float_or_double"]
             self.ntff_compiler_options = config.sim_config.devices["compiler_opts"]
             self.ntff_collector = OpenCLCombinedKSIRCollector(self)
+        if self.grid.virtual_waveguides:
+            self._set_virtual_waveguide_knls()
+        for guide in self.grid.virtual_waveguides:
+            guide.initialise_device(self)
 
     def _set_macros(self):
         """Common macros to be used in kernels."""
@@ -250,7 +277,7 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
             self.grid.htod_dispersive_arrays(self.queue)
 
     def _set_symmetry_boundary_knl(self):
-        """Build the nondispersive PMC ghost-image boundary kernel."""
+        """Build normal or dispersive PMC ghost-image boundary kernels."""
         substitutions = {
             "CUDA_IDX": "",
             "REAL": config.sim_config.dtypes["C_float_or_double"],
@@ -261,6 +288,7 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
             "NY_ID": self.grid.ID.shape[2],
             "NZ_ID": self.grid.ID.shape[3],
         }
+        substitutions.update(knl_symmetry_boundaries.nondispersive_substitutions())
         self.update_electric_pmc_dev = self.elwiseknl(
             self.ctx,
             knl_symmetry_boundaries.update_electric_pmc["args_opencl"].substitute(
@@ -271,6 +299,41 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
             preamble=self.knl_common,
             options=config.sim_config.devices["compiler_opts"],
         )
+        if config.get_model_config().materials["maxpoles"] > 0:
+            dispersive = dict(substitutions)
+            dispersive.update(
+                knl_symmetry_boundaries.dispersive_substitutions(
+                    config.sim_config.dtypes["C_float_or_double"]
+                )
+            )
+            arguments = {
+                "REAL": config.sim_config.dtypes["C_float_or_double"],
+                "COMPLEX": config.get_model_config().materials["dispersiveCdtype"],
+            }
+            self.update_electric_pmc_dispersive_dev = self.elwiseknl(
+                self.ctx,
+                knl_symmetry_boundaries.update_electric_pmc_dispersive[
+                    "args_opencl"
+                ].substitute(arguments),
+                knl_symmetry_boundaries.update_electric_pmc_dispersive["func"].substitute(
+                    dispersive
+                ),
+                "update_electric_pmc_dispersive",
+                preamble=self.knl_common,
+                options=config.sim_config.devices["compiler_opts"],
+            )
+            self.update_electric_pmc_dispersive_b_dev = self.elwiseknl(
+                self.ctx,
+                knl_symmetry_boundaries.update_electric_pmc_dispersive_b[
+                    "args_opencl"
+                ].substitute(arguments),
+                knl_symmetry_boundaries.update_electric_pmc_dispersive_b["func"].substitute(
+                    substitutions
+                ),
+                "update_electric_pmc_dispersive_b",
+                preamble=self.knl_common,
+                options=config.sim_config.devices["compiler_opts"],
+            )
 
     def _pmc_flags(self):
         boundaries = self.grid.symmetry_boundaries
@@ -497,6 +560,130 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
                 substitutions
             ),
             "update_transmission_line_electric",
+            preamble=self.knl_common,
+            options=config.sim_config.devices["compiler_opts"],
+        )
+
+    def _set_eigenmode_source_knls(self):
+        """Upload modal bases and compile device TF/SF source kernels."""
+
+        if not hasattr(self.grid, "updatecoeffsE_dev"):
+            self.grid.htod_mat_coeff_arrays(self.queue)
+        for source in self.grid.eigenmodesources:
+            prepare_device_eigenmode_source(source, "opencl", queue=self.queue)
+        arguments = {"REAL": config.sim_config.dtypes["C_float_or_double"]}
+        substitutions = {
+            "CUDA_IDX": "",
+            "REAL": config.sim_config.dtypes["C_float_or_double"],
+        }
+        self.update_eigenmode_magnetic_dev = self.elwiseknl(
+            self.ctx,
+            knl_eigenmode.update_eigenmode_magnetic["args_opencl"].substitute(arguments),
+            knl_eigenmode.update_eigenmode_magnetic["func"].substitute(substitutions),
+            "update_eigenmode_magnetic",
+            preamble=self.knl_common,
+            options=config.sim_config.devices["compiler_opts"],
+        )
+        self.update_eigenmode_electric_dev = self.elwiseknl(
+            self.ctx,
+            knl_eigenmode.update_eigenmode_electric["args_opencl"].substitute(arguments),
+            knl_eigenmode.update_eigenmode_electric["func"].substitute(substitutions),
+            "update_eigenmode_electric",
+            preamble=self.knl_common,
+            options=config.sim_config.devices["compiler_opts"],
+        )
+
+    def _set_eigenmode_monitor_knl(self):
+        """Upload modal projection bases and compile the DFT kernel."""
+
+        for monitor in self.grid.eigenmodeports:
+            prepare_device_eigenmode_monitor(monitor, "opencl", queue=self.queue)
+        self.accumulate_eigenmode_dft_dev = self.elwiseknl(
+            self.ctx,
+            knl_eigenmode.accumulate_eigenmode_dft["args_opencl"].substitute(
+                {"REAL": config.sim_config.dtypes["C_float_or_double"]}
+            ),
+            knl_eigenmode.accumulate_eigenmode_dft["func"].substitute(
+                {
+                    "CUDA_IDX": "",
+                    "METAL_DFT_PARAMETERS": "",
+                    "REAL": config.sim_config.dtypes["C_float_or_double"],
+                }
+            ),
+            "accumulate_eigenmode_dft",
+            preamble=self.knl_common,
+            options=config.sim_config.devices["compiler_opts"],
+        )
+
+    def _set_virtual_waveguide_knls(self):
+        """Compile aperture coupling kernels for auxiliary device grids."""
+
+        arguments = {"REAL": config.sim_config.dtypes["C_float_or_double"]}
+        substitutions = {
+            "CUDA_IDX": "",
+            "REAL": config.sim_config.dtypes["C_float_or_double"],
+            "NX_FIELDS": self.grid.nx + 1,
+            "NY_FIELDS": self.grid.ny + 1,
+            "NZ_FIELDS": self.grid.nz + 1,
+        }
+        for specification, attribute, name in (
+            (
+                knl_virtual_waveguide.couple_magnetic,
+                "couple_virtual_magnetic_dev",
+                "couple_virtual_waveguide_magnetic",
+            ),
+            (
+                knl_virtual_waveguide.clear_rear_magnetic,
+                "clear_virtual_magnetic_dev",
+                "clear_virtual_waveguide_rear_magnetic",
+            ),
+            (
+                knl_virtual_waveguide.couple_electric,
+                "couple_virtual_electric_dev",
+                "couple_virtual_waveguide_electric",
+            ),
+            (
+                knl_virtual_waveguide.clear_rear_electric,
+                "clear_virtual_electric_dev",
+                "clear_virtual_waveguide_rear_electric",
+            ),
+        ):
+            setattr(
+                self,
+                attribute,
+                self.elwiseknl(
+                    self.ctx,
+                    specification["args_opencl"].substitute(arguments),
+                    specification["func"].substitute(substitutions),
+                    name,
+                    preamble=self.knl_common,
+                    options=config.sim_config.devices["compiler_opts"],
+                ),
+            )
+
+    def _set_rational_network_knl(self):
+        """Initialise sparse device-resident rational-network terminals."""
+
+        arrays = htod_rational_network_arrays(self.grid.networkterminals, self.grid, self.queue)
+        for name, array in arrays.items():
+            setattr(self, f"rn_{name}_dev", array)
+        substitutions = {
+            "CUDA_IDX": "",
+            "REAL": config.sim_config.dtypes["C_float_or_double"],
+            "NY_RNINFO": 6,
+            "NY_RNPARAMS": 7,
+            "NY_RNWAVEWHOLE": self.grid.iterations + 1,
+            "NY_RNWAVEHALF": self.grid.iterations,
+            "NY_RNVOLTAGE": self.grid.iterations + 1,
+            "NY_RNCURRENT": self.grid.iterations,
+        }
+        self.update_rational_network_dev = self.elwiseknl(
+            self.ctx,
+            knl_rational_network.update_rational_network["args_opencl"].substitute(
+                {"REAL": config.sim_config.dtypes["C_float_or_double"]}
+            ),
+            knl_rational_network.update_rational_network["func"].substitute(substitutions),
+            "update_rational_network",
             preamble=self.knl_common,
             options=config.sim_config.devices["compiler_opts"],
         )
@@ -1545,6 +1732,62 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
         if collector is not None:
             collector.observe_magnetic(iteration)
 
+    def observe_eigenmode_ports(self, iteration):
+        """Project modal port fields and accumulate DFTs on OpenCL."""
+
+        real = config.sim_config.dtypes["float_or_double"]
+        for monitor in self.grid.eigenmodeports:
+            if iteration != monitor._next_iteration:
+                raise RuntimeError(
+                    f"expected eigenmode DFT iteration {monitor._next_iteration}, "
+                    f"received {iteration}"
+                )
+            owner = monitor.owner
+            arrays = monitor.device_arrays
+            nf, nm = monitor.electric_dft.shape
+            self.accumulate_eigenmode_dft_dev(
+                np.int32(nf),
+                np.int32(nm),
+                np.int32(owner.normal_axis),
+                np.int32(1 if owner.direction == "+" else -1),
+                np.int32(monitor.magnetic_side),
+                np.int32(owner.transverse_start[0]),
+                np.int32(owner.transverse_start[1]),
+                np.int32(owner.transverse_stop[0]),
+                np.int32(owner.transverse_stop[1]),
+                np.int32(owner.plane_index),
+                real(self.grid.dt),
+                real(monitor.measure),
+                np.int32(monitor.handedness),
+                arrays["electric_phase_real"],
+                arrays["electric_phase_imag"],
+                arrays["magnetic_phase_real"],
+                arrays["magnetic_phase_imag"],
+                arrays["phase_step_real"],
+                arrays["phase_step_imag"],
+                arrays["conj_eu_real"],
+                arrays["conj_eu_imag"],
+                arrays["conj_ev_real"],
+                arrays["conj_ev_imag"],
+                arrays["conj_hu_real"],
+                arrays["conj_hu_imag"],
+                arrays["conj_hv_real"],
+                arrays["conj_hv_imag"],
+                arrays["electric_dft_real"],
+                arrays["electric_dft_imag"],
+                arrays["magnetic_dft_real"],
+                arrays["magnetic_dft_imag"],
+                self.grid.Ex_dev,
+                self.grid.Ey_dev,
+                self.grid.Ez_dev,
+                self.grid.Hx_dev,
+                self.grid.Hy_dev,
+                self.grid.Hz_dev,
+                range=slice(0, nf),
+            )
+            monitor._next_iteration += 1
+            reanchor_device_eigenmode_monitor(monitor, self.grid, "opencl")
+
     def update_magnetic_pml(self):
         """Updates magnetic field components with the PML correction."""
         for pml in self.grid.pmls["slabs"]:
@@ -1620,6 +1863,144 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
                     self.grid.Hz_dev,
                 )
 
+    def _launch_eigenmode_source(self, source, iteration, magnetic):
+        nu, nv = np.asarray(source.transverse_stop) - np.asarray(source.transverse_start)
+        npoints = int((nu + 1) * (nv + 1))
+        kernel = (
+            self.update_eigenmode_magnetic_dev if magnetic else self.update_eigenmode_electric_dev
+        )
+        profiles = source.device_electric_profiles if magnetic else source.device_magnetic_profiles
+        fields = (
+            (self.grid.Hx_dev, self.grid.Hy_dev, self.grid.Hz_dev)
+            if magnetic
+            else (self.grid.Ex_dev, self.grid.Ey_dev, self.grid.Ez_dev)
+        )
+        coefficients = self.grid.updatecoeffsH_dev if magnetic else self.grid.updatecoeffsE_dev
+        real = config.sim_config.dtypes["float_or_double"]
+        for basis, envelope in eigenmode_source_envelopes(source, self.grid, iteration, magnetic):
+            kernel(
+                np.int32(npoints),
+                np.int32(source.normal_axis),
+                np.int32(1 if source.direction == "+" else -1),
+                np.int32(source.transverse_start[0]),
+                np.int32(source.transverse_start[1]),
+                np.int32(source.transverse_stop[0]),
+                np.int32(source.transverse_stop[1]),
+                np.int32(source.plane_index),
+                np.int32(basis),
+                real(envelope),
+                profiles,
+                coefficients,
+                self.grid.ID_dev,
+                *fields,
+                range=slice(0, npoints),
+            )
+
+    def update_eigenmode_sources_magnetic(self, iteration):
+        for source in self.grid.eigenmodesources:
+            self._launch_eigenmode_source(source, iteration, True)
+        for guide in self.grid.virtual_waveguides:
+            self._update_virtual_waveguide_magnetic(guide, iteration)
+
+    def update_eigenmode_sources_electric(self, iteration):
+        for source in self.grid.eigenmodesources:
+            self._launch_eigenmode_source(source, iteration, False)
+        for guide in self.grid.virtual_waveguides:
+            self._update_virtual_waveguide_electric(guide, iteration)
+
+    def _virtual_scalars(self, guide, npoints):
+        aux = guide.aux_grid
+        return (
+            np.int32(npoints),
+            np.int32(guide.normal_axis),
+            np.int32(guide.direction_sign),
+            np.int32(guide.u0),
+            np.int32(guide.v0),
+            np.int32(guide.u1),
+            np.int32(guide.v1),
+            np.int32(guide.plane_index),
+            np.int32(aux.nx),
+            np.int32(aux.ny),
+            np.int32(aux.nz),
+        )
+
+    @staticmethod
+    def _virtual_launch(kernel, npoints, *arguments):
+        kernel(*arguments, range=slice(0, npoints))
+
+    def _update_virtual_waveguide_magnetic(self, guide, iteration):
+        child = guide.aux_updates
+        child.update_magnetic()
+        child.update_magnetic_pml()
+        child.update_eigenmode_sources_magnetic(iteration)
+        nface = (guide.nu + 1) * (guide.nv + 1)
+        main_h = (self.grid.Hx_dev, self.grid.Hy_dev, self.grid.Hz_dev)
+        aux_h = (
+            guide.aux_grid.Hx_dev,
+            guide.aux_grid.Hy_dev,
+            guide.aux_grid.Hz_dev,
+        )
+        self._virtual_launch(
+            self.couple_virtual_magnetic_dev,
+            nface,
+            *self._virtual_scalars(guide, nface),
+            *main_h,
+            *aux_h,
+        )
+        nmain = self.grid.Ex.size
+        self._virtual_launch(
+            self.clear_virtual_magnetic_dev,
+            nmain,
+            *self._virtual_scalars(guide, nmain),
+            *main_h,
+            *aux_h,
+        )
+
+    def _update_virtual_waveguide_electric(self, guide, iteration):
+        child = guide.aux_updates
+        child.update_electric_a()
+        child.update_electric_pml()
+        child.update_eigenmode_sources_electric(iteration)
+        child.update_electric_b()
+        nface = (guide.nu + 1) * (guide.nv + 1)
+        main_fields = (
+            self.grid.Ex_dev,
+            self.grid.Ey_dev,
+            self.grid.Ez_dev,
+            self.grid.Hx_dev,
+            self.grid.Hy_dev,
+            self.grid.Hz_dev,
+        )
+        aux_fields = (
+            guide.aux_grid.Ex_dev,
+            guide.aux_grid.Ey_dev,
+            guide.aux_grid.Ez_dev,
+            guide.aux_grid.Hx_dev,
+            guide.aux_grid.Hy_dev,
+            guide.aux_grid.Hz_dev,
+        )
+        self._virtual_launch(
+            self.couple_virtual_electric_dev,
+            nface,
+            *self._virtual_scalars(guide, nface),
+            guide.aux_grid.updatecoeffsE_dev,
+            guide.aux_grid.ID_dev,
+            *main_fields,
+            *aux_fields,
+        )
+        nmain = self.grid.Ex.size
+        self._virtual_launch(
+            self.clear_virtual_electric_dev,
+            nmain,
+            *self._virtual_scalars(guide, nmain),
+            self.grid.Ex_dev,
+            self.grid.Ey_dev,
+            self.grid.Ez_dev,
+            guide.aux_grid.Ex_dev,
+            guide.aux_grid.Ey_dev,
+            guide.aux_grid.Ez_dev,
+        )
+
     def update_electric_a(self):
         """Updates electric field components."""
         # All materials are non-dispersive so do standard update.
@@ -1659,15 +2040,44 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
             )
 
     def update_symmetry_boundaries_electric(self):
-        """Apply the nondispersive PMC ghost-image correction on OpenCL."""
+        """Apply the PMC ghost-image correction on OpenCL."""
         if "pmc" not in self.grid.symmetry_boundaries.values():
             return
-
-        self.update_electric_pmc_dev(
+        dispersive = config.get_model_config().materials["maxpoles"] > 0
+        kernel = (
+            self.update_electric_pmc_dispersive_dev
+            if dispersive
+            else self.update_electric_pmc_dev
+        )
+        leading = [
             np.int32(self.grid.nx),
             np.int32(self.grid.ny),
             np.int32(self.grid.nz),
+        ]
+        if dispersive:
+            leading.append(np.int32(config.get_model_config().materials["maxpoles"]))
+        arguments = [
+            *leading,
             *self._pmc_flags(),
+        ]
+        if dispersive:
+            arguments.extend(
+                [
+                    self.grid.ID_dev,
+                    self.grid.Ex_dev,
+                    self.grid.Ey_dev,
+                    self.grid.Ez_dev,
+                    self.grid.Hx_dev,
+                    self.grid.Hy_dev,
+                    self.grid.Hz_dev,
+                    self.grid.updatecoeffsdispersive_dev,
+                    self.grid.Tx_dev,
+                    self.grid.Ty_dev,
+                    self.grid.Tz_dev,
+                ]
+            )
+        else:
+            arguments.extend([
             self.grid.ID_dev,
             self.grid.Ex_dev,
             self.grid.Ey_dev,
@@ -1675,6 +2085,23 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
             self.grid.Hx_dev,
             self.grid.Hy_dev,
             self.grid.Hz_dev,
+            ])
+        kernel(*arguments)
+
+    def update_symmetry_boundaries_electric_b(self):
+        """Complete the dispersive PMC ADE update on OpenCL."""
+        if (
+            "pmc" not in self.grid.symmetry_boundaries.values()
+            or config.get_model_config().materials["maxpoles"] == 0
+        ):
+            return
+        self.update_electric_pmc_dispersive_b_dev(
+            np.int32(self.grid.nx), np.int32(self.grid.ny), np.int32(self.grid.nz),
+            np.int32(config.get_model_config().materials["maxpoles"]),
+            *self._pmc_flags(), self.grid.ID_dev, self.grid.Ex_dev,
+            self.grid.Ey_dev, self.grid.Ez_dev,
+            self.grid.updatecoeffsdispersive_dev, self.grid.Tx_dev,
+            self.grid.Ty_dev, self.grid.Tz_dev,
         )
 
     def update_electric_pml(self):
@@ -1763,6 +2190,41 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
                 self.grid.Tz_dev,
             )
 
+    def update_network_terminals(self, iteration):
+        """Apply sparse rational-network corrections entirely on OpenCL."""
+
+        if not self.grid.networkterminals:
+            return
+        self.update_rational_network_dev(
+            np.int32(len(self.grid.networkterminals)),
+            np.int32(iteration),
+            config.sim_config.dtypes["float_or_double"](self.grid.dt),
+            self.rn_info_dev,
+            self.rn_params_dev,
+            self.rn_waveform_whole_dev,
+            self.rn_waveform_half_dev,
+            self.rn_voltage_dev,
+            self.rn_current_dev,
+            self.rn_exp_half_real_dev,
+            self.rn_exp_half_imag_dev,
+            self.rn_coeff_half_new_real_dev,
+            self.rn_coeff_half_new_imag_dev,
+            self.rn_coeff_half_old_real_dev,
+            self.rn_coeff_half_old_imag_dev,
+            self.rn_exp_full_real_dev,
+            self.rn_exp_full_imag_dev,
+            self.rn_coeff_full_new_real_dev,
+            self.rn_coeff_full_new_imag_dev,
+            self.rn_coeff_full_old_real_dev,
+            self.rn_coeff_full_old_imag_dev,
+            self.rn_state_real_dev,
+            self.rn_state_imag_dev,
+            self.grid.Ex_dev,
+            self.grid.Ey_dev,
+            self.grid.Ez_dev,
+            range=slice(0, len(self.grid.networkterminals)),
+        )
+
     def time_start(self):
         """Starts event timers used to calculate solving time for model."""
         self.event_marker1 = self.cl.enqueue_marker(self.queue)
@@ -1792,6 +2254,9 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
         if collector is not None:
             collector.finalise()
 
+        if getattr(self.grid, "eigenmodeports", ()):
+            finalise_device_eigenmode_monitors(self.grid.eigenmodeports, "opencl")
+
         # Copy output from receivers array back to correct receiver objects
         if self.grid.rxs:
             currents = self.rxcurrents_dev.get() if self.nrxcurrent else None
@@ -1808,6 +2273,11 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
         if self.grid.transmissionlines:
             dtoh_transmission_line_outputs(
                 self.tl_Vtotal_dev.get(), self.tl_Itotal_dev.get(), self.grid
+            )
+
+        if getattr(self.grid, "networkterminals", ()):
+            dtoh_rational_network_outputs(
+                self.rn_voltage_dev.get(), self.rn_current_dev.get(), self.grid
             )
 
         # Copy data from any snapshots back to correct snapshot objects

--- a/gprMax/updates/updates.py
+++ b/gprMax/updates/updates.py
@@ -112,6 +112,21 @@ class Updates(Generic[GridType], ABC):
 
         pass
 
+    def update_eigenmode_sources_magnetic(self, iteration: int) -> None:
+        """Apply modal magnetic TF/SF corrections and virtual-guide coupling."""
+
+        pass
+
+    def update_eigenmode_sources_electric(self, iteration: int) -> None:
+        """Apply modal electric TF/SF corrections and virtual-guide coupling."""
+
+        pass
+
+    def observe_eigenmode_ports(self, iteration: int) -> None:
+        """Accumulate modal port DFTs."""
+
+        pass
+
     def update_network_terminals(self, iteration: int) -> None:
         """Apply sparse rational-network corrections to electric edges."""
 

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -421,8 +421,8 @@ class NetworkTerminal(GridUserObject):
         self.ID = id
 
     def build(self, grid: FDTDGrid):
-        if config.sim_config.general["solver"] != "cpu" or config.sim_config.mpi:
-            raise ValueError(f"{self.params_str()} currently supports only the non-MPI CPU solver")
+        if config.sim_config.mpi:
+            raise ValueError(f"{self.params_str()} does not yet support the MPI solver")
         if config.get_model_config().mode != "3D":
             raise ValueError(f"{self.params_str()} currently supports only 3-D models")
         if config.sim_config.args.geometry_fixed:
@@ -1149,15 +1149,6 @@ class TransmissionLine(RotatableMixin, GridUserObject):
             self._log(grid, transmission_line, *position)
 
     def _validate_parameters(self, grid: FDTDGrid):
-        # Metal uses the same kernel template, but its host buffer/launch
-        # lifecycle has not yet been enabled and verified.
-        if config.sim_config.general["solver"] == "metal":
-            raise ValueError(
-                f"{self.params_str()} cannot currently be used "
-                "with the Metal-based solver. Consider "
-                "using a #voltage_source instead."
-            )
-
         # A transmission line is a 3D-only source: its internal 1D line
         # model uses a "magic time step" (TransmissionLineUser.dl =
         # sqrt(3) * c * dt) derived from the 3D Courant condition. In 2D
@@ -1569,14 +1560,6 @@ class DiscretePlaneWaveAngles(GridUserObject):
         except KeyError:
             precompute = True
 
-        # Discrete plane waves are not yet available on Apple Metal.
-        if config.sim_config.general["solver"] == "metal":
-            logger.exception(
-                f"{self.params_str()} cannot currently be used "
-                + "with the Apple Metal-based solver. "
-            )
-            raise ValueError
-
         # Check if there is a waveformID in the waveforms list
         if not any(x.ID == waveform_id for x in grid.waveforms):
             logger.exception(
@@ -1744,14 +1727,6 @@ class DiscretePlaneWaveVector(GridUserObject):
         except KeyError:
             precompute = True
 
-        # Discrete plane waves are not yet available on Apple Metal.
-        if config.sim_config.general["solver"] == "metal":
-            logger.exception(
-                f"{self.params_str()} cannot currently be used "
-                + "with the Apple Metal-based solver. "
-            )
-            raise ValueError
-
         # Check if there is a waveformID in the waveforms list
         if not any(x.ID == waveform_id for x in grid.waveforms):
             logger.exception(
@@ -1906,14 +1881,6 @@ class DiscretePlaneWaveAxial(GridUserObject):
             precompute = self.kwargs["precompute"]
         except KeyError:
             precompute = True
-
-        # Discrete plane waves are not yet available on Apple Metal.
-        if config.sim_config.general["solver"] == "metal":
-            logger.exception(
-                f"{self.params_str()} cannot currently be used "
-                + "with the Apple Metal-based solver. "
-            )
-            raise ValueError
 
         # Check if there is a waveformID in the waveforms list
         if not any(x.ID == waveform_id for x in grid.waveforms):
@@ -2092,10 +2059,6 @@ class EigenmodePort(GridUserObject):
             raise ValueError(f"{self.params_str()} currently supports only the main grid.")
         if grid.eigenmodeband is None:
             raise ValueError(f"{self.params_str()} requires one preceding EigenmodeBand.")
-        if config.sim_config.general["solver"] in ("cuda", "opencl", "metal"):
-            raise ValueError(
-                f"{self.params_str()} cannot currently be used with CUDA, OpenCL, or Metal."
-            )
         if config.sim_config.mpi:
             raise ValueError(f"{self.params_str()} cannot currently be used with MPI.")
         try:
@@ -2224,10 +2187,6 @@ class VirtualWaveguide(GridUserObject):
     def build(self, grid: FDTDGrid):
         if isinstance(grid, SubGridBaseGrid):
             raise ValueError(f"{self.params_str()} currently supports only the main grid.")
-        if config.sim_config.general["solver"] in ("cuda", "opencl", "metal"):
-            raise ValueError(
-                f"{self.params_str()} cannot currently be used with CUDA, OpenCL, or Metal."
-            )
         if config.sim_config.mpi:
             raise ValueError(f"{self.params_str()} cannot currently be used with MPI.")
 
@@ -2509,12 +2468,6 @@ class _EigenmodeSourceBuilder(GridUserObject):
         if plot_fields is not None:
             plot_fields = bool(plot_fields)
 
-        if config.sim_config.general["solver"] in ["cuda", "opencl", "metal"]:
-            logger.exception(
-                f"{self.params_str()} cannot currently be used with the CUDA, OpenCL, or Apple Metal solver."
-            )
-            raise ValueError
-
         # MPI decomposes the grid across ranks, but the source plane's
         # bounds/plane-index validation below and the FDFD cross-section
         # extraction in EigenmodeSource.grid_init() both assume a single,
@@ -2742,10 +2695,6 @@ class _EigenmodeReceiverBuilder(GridUserObject):
         if plot_fields is not None and not isinstance(plot_fields, (bool, np.bool_)):
             raise ValueError(f"{self.params_str()} plot_fields must be True, False, or None.")
 
-        if config.sim_config.general["solver"] in ["cuda", "opencl", "metal"]:
-            raise ValueError(
-                f"{self.params_str()} cannot currently be used with the CUDA, OpenCL, or Apple Metal solver."
-            )
         if config.sim_config.mpi:
             raise ValueError(f"{self.params_str()} cannot currently be used with MPI.")
         if normal not in ("x", "y", "z") or direction not in ("+", "-"):
@@ -3997,8 +3946,8 @@ class SymmetryBoundary(GridUserObject):
     material during grid construction. A PMC boundary uses an image-theory
     ghost-node update for the on-wall tangential electric fields.
 
-    Nondispersive PMC boundaries are supported by the CPU, CUDA, OpenCL, and
-    Metal solvers. Dispersive PMC boundaries are currently CPU-only.
+    PEC and PMC boundaries, including PMC boundaries in dispersive models, are
+    supported by the CPU, CUDA, OpenCL, and Metal solvers.
     Symmetry boundaries are not supported in 2D mode, with MPI, or on a
     subgrid, although they may be used on the main grid of a model that
     contains subgrids.

--- a/gprMax/user_objects/cmds_output.py
+++ b/gprMax/user_objects/cmds_output.py
@@ -311,8 +311,8 @@ class NetworkPort(OutputUserObject):
         return self._monitor.result
 
     def build(self, model: Model, grid: FDTDGrid):
-        if config.sim_config.general["solver"] != "cpu" or config.sim_config.mpi:
-            raise ValueError(f"{self.params_str()} currently supports only the non-MPI CPU solver.")
+        if config.sim_config.mpi:
+            raise ValueError(f"{self.params_str()} does not yet support the MPI solver.")
         if config.sim_config.args.geometry_fixed:
             raise ValueError(f"{self.params_str()} does not support geometry-fixed runs.")
         if config.get_model_config().mode != "3D":

--- a/gprMax/virtual_waveguide.py
+++ b/gprMax/virtual_waveguide.py
@@ -22,7 +22,6 @@ from gprMax.cython.virtual_waveguide import (
     couple_virtual_waveguide_electric,
     couple_virtual_waveguide_magnetic,
 )
-from gprMax.grid.fdtd_grid import FDTDGrid
 from gprMax.updates.cpu_updates import CPUUpdates
 
 logger = logging.getLogger(__name__)
@@ -47,7 +46,11 @@ class VirtualWaveguide:
         self._validate()
         self.aux_grid = self._build_auxiliary_grid()
         self.aux_source = self._build_auxiliary_source()
-        self.aux_updates = CPUUpdates(self.aux_grid)
+        if self.aux_source is not None:
+            self.aux_grid.eigenmodesources.append(self.aux_source)
+        self.aux_updates = (
+            CPUUpdates(self.aux_grid) if config.sim_config.general["solver"] == "cpu" else None
+        )
 
         # A virtual split makes only the main-domain side of the H plane a
         # valid sampling plane. This is already the source-monitor policy;
@@ -59,11 +62,6 @@ class VirtualWaveguide:
         mode = config.get_model_config().mode
         if mode != "3D":
             raise ValueError("Virtual waveguides currently require a 3D model.")
-        if config.sim_config.general["solver"] != "cpu":
-            raise ValueError(
-                "Virtual waveguides currently require the CPU solver; GPU support "
-                "will follow the eigenmode-port GPU implementation."
-            )
         if config.sim_config.mpi:
             raise ValueError("Virtual waveguides do not yet support MPI.")
         if self.port.invariant_axis is not None:
@@ -86,6 +84,12 @@ class VirtualWaveguide:
                 "A virtual-waveguide cross-section must be at least two cells "
                 "along each transverse axis."
             )
+        int32_max = np.iinfo(np.int32).max
+        main_points = int(np.prod(np.asarray(self.main_grid.size, dtype=object) + 1))
+        auxiliary_size = [self.nu, self.nv, self.spec.length_cells]
+        auxiliary_points = int(np.prod(np.asarray(auxiliary_size, dtype=object) + 1))
+        if max(main_points, auxiliary_points, (self.nu + 1) * (self.nv + 1)) > int32_max:
+            raise ValueError("Virtual-waveguide device indexing exceeds the signed 32-bit range.")
 
         first_ids, second_ids = self._adjacent_component_ids()
         first_solid, second_solid = self._adjacent_solids()
@@ -186,7 +190,7 @@ class VirtualWaveguide:
 
     def _build_auxiliary_grid(self):
         main = self.main_grid
-        aux = FDTDGrid()
+        aux = type(main)()
         aux.name = f"virtual_waveguide_port_{self.spec.port}"
         aux.size[:] = 1
         aux.size[self.normal_axis] = self.spec.length_cells
@@ -242,13 +246,27 @@ class VirtualWaveguide:
         source.port_monitor = None
         return source
 
+    def initialise_device(self, parent_updates):
+        """Create the auxiliary solver in the parent's accelerator context."""
+
+        if self.aux_updates is not None:
+            return
+        self.aux_updates = type(parent_updates)(self.aux_grid, shared=parent_updates)
+        solver = config.sim_config.general["solver"]
+        if not hasattr(self.aux_grid, "updatecoeffsE_dev"):
+            if solver == "cuda":
+                self.aux_grid.htod_mat_coeff_arrays()
+            elif solver == "opencl":
+                self.aux_grid.htod_mat_coeff_arrays(parent_updates.queue)
+            else:
+                self.aux_grid.htod_material_arrays(parent_updates.dev)
+
     def update_magnetic(self, iteration):
         """Advance auxiliary H, apply modal injection, and join the aperture."""
 
         self.aux_updates.update_magnetic()
         self.aux_updates.update_magnetic_pml()
-        if self.aux_source is not None:
-            self.aux_source.update_eigenmode_magnetic(iteration, self.aux_grid)
+        self.aux_updates.update_eigenmode_sources_magnetic(iteration)
         couple_virtual_waveguide_magnetic(
             config.get_model_config().ompthreads,
             self.normal_axis,
@@ -271,8 +289,7 @@ class VirtualWaveguide:
 
         self.aux_updates.update_electric_a()
         self.aux_updates.update_electric_pml()
-        if self.aux_source is not None:
-            self.aux_source.update_eigenmode_electric(iteration, self.aux_grid)
+        self.aux_updates.update_eigenmode_sources_electric(iteration)
         self.aux_updates.update_electric_b()
         couple_virtual_waveguide_electric(
             config.get_model_config().ompthreads,

--- a/tests/cmds_multiuse/test_metal_gpu_restriction_gaps.py
+++ b/tests/cmds_multiuse/test_metal_gpu_restriction_gaps.py
@@ -1,20 +1,7 @@
-"""Regression tests: two GPU-restriction guards in
-gprMax/user_objects/cmds_multiuse.py listed "cuda"/"opencl" but omitted
-"metal" (Codex-reported), even though Metal has no support for either
-feature they gate:
+"""Regression tests for source and receiver parity across local solvers.
 
-1. TransmissionLine._validate_parameters() rejects transmission lines on
-   OpenCL and Metal until their host-side lifecycle is enabled. CUDA has a
-   device-resident implementation.
-2. Rx.build() applies the same allowable-output list to CUDA, OpenCL, and
-   Metal. Device solvers now support packed, requested-only Ix/Iy/Iz output,
-   so the current components must be accepted consistently on all four
-   solvers.
-
-Both are fixed by adding "metal" to the respective solver-name lists.
-Follows the established pattern (see tests/test_receivers_dtoh.py) of
-replacing config.sim_config wholesale to fake a non-CPU solver without
-needing real GPU/Metal hardware present.
+The tests replace ``config.sim_config`` so that command validation can be
+checked without requiring accelerator hardware.
 """
 from types import SimpleNamespace
 
@@ -32,19 +19,8 @@ def _set_solver(monkeypatch, solver):
     config.sim_config.em_consts = {"z0": 376.730313668}
 
 
-def test_transmission_line_rejected_on_unimplemented_metal_solver(monkeypatch):
-    _set_solver(monkeypatch, "metal")
-
-    tl = TransmissionLine(
-        p1=(0.01, 0.01, 0.01), polarisation="x", resistance=50, waveform_id="w"
-    )
-
-    with pytest.raises(ValueError, match="cannot currently be used"):
-        tl._validate_parameters(grid=None)
-
-
-@pytest.mark.parametrize("solver", ["cuda", "opencl"])
-def test_transmission_line_is_allowed_on_implemented_gpu_solvers(monkeypatch, solver):
+@pytest.mark.parametrize("solver", ["cpu", "cuda", "opencl", "metal"])
+def test_transmission_line_is_allowed_on_every_local_solver(monkeypatch, solver):
     _set_solver(monkeypatch, solver)
     monkeypatch.setattr(
         config,

--- a/tests/fdfd_eigenmode_solver/test_virtual_waveguide_device.py
+++ b/tests/fdfd_eigenmode_solver/test_virtual_waveguide_device.py
@@ -1,0 +1,254 @@
+"""Device-kernel and full-solve parity for virtual eigenmode waveguides."""
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import gprMax
+from gprMax.cuda_opencl import knl_eigenmode, knl_virtual_waveguide
+from tests.test_virtual_waveguide_integration import _uniform_waveguide_scene
+
+
+@pytest.mark.parametrize("backend", ["cuda", "opencl", "metal"])
+def test_eigenmode_device_templates_have_complete_substitutions(backend):
+    substitutions = {
+        "CUDA_IDX": "int i = 0;" if backend == "cuda" else "",
+        "METAL_DFT_PARAMETERS": (
+            "int NF = parameters.NF; int NM = parameters.NM;" if backend == "metal" else ""
+        ),
+        "REAL": "double",
+        "NX_FIELDS": 12,
+        "NY_FIELDS": 13,
+        "NZ_FIELDS": 14,
+    }
+    specifications = (
+        knl_eigenmode.update_eigenmode_magnetic,
+        knl_eigenmode.update_eigenmode_electric,
+        knl_eigenmode.accumulate_eigenmode_dft,
+        knl_virtual_waveguide.couple_magnetic,
+        knl_virtual_waveguide.clear_rear_magnetic,
+        knl_virtual_waveguide.couple_electric,
+        knl_virtual_waveguide.clear_rear_electric,
+    )
+    for specification in specifications:
+        arguments = specification[f"args_{backend}"].substitute({"REAL": "double"})
+        body = specification["func"].substitute(substitutions)
+        assert "$" not in arguments
+        assert "$" not in body
+
+
+def _port_results(path, port_number=1):
+    with h5py.File(Path(path).with_suffix(".h5")) as output:
+        port = output[f"eigenmode_ports/port{port_number}"]
+        return {name: port[name][...] for name in ("incident", "outgoing", "S")}
+
+
+def _broadband_virtual_waveguide_scene():
+    """Three-anchor source exercising all device modal-profile bases."""
+
+    scene = _uniform_waveguide_scene(normal_axis=0, direction="+")
+    objects = scene.grid_objects
+
+    time_window = next(
+        obj for obj in scene.single_use_objects if isinstance(obj, gprMax.TimeWindow)
+    )
+    time_window.time = 1.2e-9
+
+    band = next(obj for obj in objects if isinstance(obj, gprMax.EigenmodeBand))
+    band.kwargs.update(fmin=20e9, fmax=24e9, points=17)
+
+    port = next(obj for obj in objects if isinstance(obj, gprMax.EigenmodePort))
+    port.kwargs["anchors"] = (16.9e9, 22e9, 27e9)
+    excitation = next(obj for obj in objects if isinstance(obj, gprMax.EigenmodeExcitation))
+    excitation.kwargs["waveform"] = "auto"
+    return scene
+
+
+def _active_and_passive_virtual_waveguide_scene():
+    """Finite guide segment joined to active and passive auxiliary guides."""
+
+    scene = _uniform_waveguide_scene(normal_axis=0, direction="+")
+    scene.add(
+        gprMax.EigenmodePort(
+            port=2,
+            p1=(0.04, 0.001, 0.001),
+            p2=(0.04, 0.009, 0.011),
+            direction="-",
+            modes=(1,),
+            anchors=(22e9,),
+            plot_fields=False,
+        )
+    )
+    scene.add(
+        gprMax.VirtualWaveguide(
+            port=2,
+            length_cells=18,
+            pml_cells=8,
+            source_clearance_cells=4,
+        )
+    )
+    return scene
+
+
+def _direct_eigenmode_source_scene():
+    """Conventional in-domain TF/SF source without an auxiliary guide."""
+
+    scene = _uniform_waveguide_scene(normal_axis=0, direction="+")
+    scene.grid_objects = [
+        obj for obj in scene.grid_objects if not isinstance(obj, gprMax.VirtualWaveguide)
+    ]
+    return scene
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+@pytest.mark.parametrize("normal_axis", range(3))
+@pytest.mark.parametrize("direction", ["-", "+"])
+@pytest.mark.parametrize("backend", ["cuda", "opencl"])
+def test_device_virtual_waveguide_matches_cpu(tmp_path, request, backend, normal_axis, direction):
+    if backend == "cuda":
+        device_options = {"gpu": [request.getfixturevalue("gpu_device")]}
+    else:
+        device_options = {"opencl": [request.getfixturevalue("opencl_device")]}
+
+    suffix = f"{'xyz'[normal_axis]}{'minus' if direction == '-' else 'plus'}"
+    cpu_path = tmp_path / f"cpu_virtual_{suffix}"
+    device_path = tmp_path / f"{backend}_virtual_{suffix}"
+    gprMax.run(
+        scenes=[_uniform_waveguide_scene(normal_axis, direction)],
+        outputfile=cpu_path,
+        cpu_precision="double",
+        hide_progress_bars=True,
+        log_level=30,
+    )
+    gprMax.run(
+        scenes=[_uniform_waveguide_scene(normal_axis, direction)],
+        outputfile=device_path,
+        gpu_precision="double",
+        hide_progress_bars=True,
+        log_level=30,
+        **device_options,
+    )
+
+    cpu = _port_results(cpu_path)
+    device = _port_results(device_path)
+    incident_scale = max(float(np.max(np.abs(cpu["incident"]))), 1e-20)
+    for name in cpu:
+        assert np.isfinite(device[name]).all()
+        absolute_tolerance = 5e-5 if name == "S" else 5e-5 * incident_scale
+        assert_allclose(
+            device[name],
+            cpu[name],
+            rtol=5e-4,
+            atol=absolute_tolerance,
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+@pytest.mark.parametrize("backend", ["cuda", "opencl"])
+def test_device_virtual_waveguide_broadband_matches_cpu(tmp_path, request, backend):
+    if backend == "cuda":
+        device_options = {"gpu": [request.getfixturevalue("gpu_device")]}
+    else:
+        device_options = {"opencl": [request.getfixturevalue("opencl_device")]}
+
+    cpu_path = tmp_path / "cpu_virtual_broadband"
+    device_path = tmp_path / f"{backend}_virtual_broadband"
+    gprMax.run(
+        scenes=[_broadband_virtual_waveguide_scene()],
+        outputfile=cpu_path,
+        cpu_precision="double",
+        hide_progress_bars=True,
+        log_level=30,
+    )
+    gprMax.run(
+        scenes=[_broadband_virtual_waveguide_scene()],
+        outputfile=device_path,
+        gpu_precision="double",
+        hide_progress_bars=True,
+        log_level=30,
+        **device_options,
+    )
+
+    cpu = _port_results(cpu_path)
+    device = _port_results(device_path)
+    incident_scale = max(float(np.max(np.abs(cpu["incident"]))), 1e-20)
+    for name in cpu:
+        absolute_tolerance = 5e-5 if name == "S" else 5e-5 * incident_scale
+        assert_allclose(device[name], cpu[name], rtol=5e-4, atol=absolute_tolerance)
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+@pytest.mark.parametrize("backend", ["cuda", "opencl"])
+def test_device_passive_virtual_waveguide_matches_cpu(tmp_path, request, backend):
+    if backend == "cuda":
+        device_options = {"gpu": [request.getfixturevalue("gpu_device")]}
+    else:
+        device_options = {"opencl": [request.getfixturevalue("opencl_device")]}
+
+    cpu_path = tmp_path / "cpu_virtual_passive"
+    device_path = tmp_path / f"{backend}_virtual_passive"
+    run_options = {
+        "hide_progress_bars": True,
+        "log_level": 30,
+    }
+    gprMax.run(
+        scenes=[_active_and_passive_virtual_waveguide_scene()],
+        outputfile=cpu_path,
+        cpu_precision="double",
+        **run_options,
+    )
+    gprMax.run(
+        scenes=[_active_and_passive_virtual_waveguide_scene()],
+        outputfile=device_path,
+        gpu_precision="double",
+        **device_options,
+        **run_options,
+    )
+
+    for port_number in (1, 2):
+        cpu = _port_results(cpu_path, port_number)
+        device = _port_results(device_path, port_number)
+        incident_scale = max(float(np.max(np.abs(cpu["incident"]))), 1e-20)
+        for name in cpu:
+            absolute_tolerance = 5e-5 if name == "S" else 5e-5 * incident_scale
+            assert_allclose(device[name], cpu[name], rtol=5e-4, atol=absolute_tolerance)
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+@pytest.mark.parametrize("backend", ["cuda", "opencl"])
+def test_device_direct_eigenmode_source_matches_cpu(tmp_path, request, backend):
+    if backend == "cuda":
+        device_options = {"gpu": [request.getfixturevalue("gpu_device")]}
+    else:
+        device_options = {"opencl": [request.getfixturevalue("opencl_device")]}
+
+    cpu_path = tmp_path / "cpu_direct_eigenmode"
+    device_path = tmp_path / f"{backend}_direct_eigenmode"
+    run_options = {"hide_progress_bars": True, "log_level": 30}
+    gprMax.run(
+        scenes=[_direct_eigenmode_source_scene()],
+        outputfile=cpu_path,
+        cpu_precision="double",
+        **run_options,
+    )
+    gprMax.run(
+        scenes=[_direct_eigenmode_source_scene()],
+        outputfile=device_path,
+        gpu_precision="double",
+        **device_options,
+        **run_options,
+    )
+
+    cpu = _port_results(cpu_path)
+    device = _port_results(device_path)
+    incident_scale = max(float(np.max(np.abs(cpu["incident"]))), 1e-20)
+    for name in cpu:
+        absolute_tolerance = 5e-5 if name == "S" else 5e-5 * incident_scale
+        assert_allclose(device[name], cpu[name], rtol=5e-4, atol=absolute_tolerance)

--- a/tests/ntff/test_cuda_reusable_interface.py
+++ b/tests/ntff/test_cuda_reusable_interface.py
@@ -132,6 +132,80 @@ def _equivalent_current_scene():
     return scene, transform, far_field
 
 
+def _equivalent_current_time_scene():
+    dl = 0.004
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(0.08, 0.08, 0.08)))
+    scene.add(gprMax.TimeWindow(time=3e-10))
+    scene.add(gprMax.PMLThickness(thickness=3))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
+    scene.add(
+        gprMax.HertzianDipole(
+            polarisation="z", p1=(0.04, 0.04, 0.04), waveform_id="pulse"
+        )
+    )
+    scene.add(
+        gprMax.NTFFSurface(
+            p1=(0.028, 0.028, 0.028),
+            p2=(0.052, 0.052, 0.052),
+            id="surface",
+        )
+    )
+    far_field = gprMax.NTFFTimeFarField(
+        (0, 30, 90, 150, 180),
+        (0, 0, 0, 0, 0),
+        "surface",
+        id="transient",
+        outputs=("Etheta", "Ephi"),
+    )
+    scene.add(far_field)
+    return scene, far_field
+
+
+@pytest.mark.skipif(not HAS_CUDA, reason="No CUDA device/pycuda available")
+@pytest.mark.parametrize(
+    "precision,rtol",
+    [("single", 3e-4), ("double", 2e-11)],
+)
+def test_cuda_equivalent_current_time_far_fields_match_cpu(
+    tmp_path, gpu_device, precision, rtol
+):
+    cpu_scene, cpu_far = _equivalent_current_time_scene()
+    cuda_scene, cuda_far = _equivalent_current_time_scene()
+    gprMax.run(
+        scenes=[cpu_scene],
+        outputfile=tmp_path / f"equivalent_time_cpu_{precision}",
+        hide_progress_bars=True,
+        cpu_precision=precision,
+    )
+    gprMax.run(
+        scenes=[cuda_scene],
+        outputfile=tmp_path / f"equivalent_time_cuda_{precision}",
+        hide_progress_bars=True,
+        gpu=[gpu_device],
+        gpu_precision=precision,
+    )
+
+    assert_allclose(cuda_far.result.times, cpu_far.result.times, rtol=0, atol=0)
+    field_scale = max(
+        np.max(np.abs(cpu_far.result.fields[component]))
+        for component in ("Etheta", "Ephi")
+    )
+    assert field_scale > 0
+    for component in ("Etheta", "Ephi"):
+        expected = cpu_far.result.fields[component]
+        assert_allclose(
+            cuda_far.result.fields[component],
+            expected,
+            rtol=rtol,
+            # The cross-polarised component is analytically zero for this
+            # axis-aligned dipole. Scale absolute round-off against the
+            # physical co-polar field rather than numerical cancellation.
+            atol=rtol * field_scale,
+        )
+
+
 def _plane_wave_rcs_scene():
     dl = 0.004
     scene = gprMax.Scene()

--- a/tests/ntff/test_device_collection.py
+++ b/tests/ntff/test_device_collection.py
@@ -7,6 +7,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 from gprMax.cuda_opencl.knl_ntff import (
+    build_equivalent_current_time_kernel_source,
     build_ntff_kernel_source,
     build_time_domain_ntff_kernel_source,
 )
@@ -258,6 +259,26 @@ def test_backend_kernel_sources_use_configured_real_type(backend, c_real, marker
     assert f"const {c_real}*" in source
     assert "inside_real[i] +=" in source
     assert "complex" not in source.lower()
+
+
+@pytest.mark.parametrize(
+    "backend,c_real,marker",
+    [
+        ("cuda", "float", "blockIdx.x"),
+        ("opencl", "double", "cl_khr_fp64"),
+        ("metal", "float", "thread_position_in_grid"),
+    ],
+)
+def test_equivalent_current_time_kernel_sources_are_backend_complete(
+    backend, c_real, marker
+):
+    source = build_equivalent_current_time_kernel_source(c_real, backend)
+
+    assert marker in source
+    assert "gather_equivalent_current_time" in source
+    assert "deposit_equivalent_current_time" in source
+    assert "current[patch * 3]" in source
+    assert "inverse_dt" in source
 
 
 @pytest.mark.parametrize(

--- a/tests/ports/test_rational_network_device.py
+++ b/tests/ports/test_rational_network_device.py
@@ -1,0 +1,169 @@
+"""End-to-end CPU/GPU parity for sparse rational-network terminals."""
+
+import h5py
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import gprMax
+from gprMax.cuda_opencl import knl_rational_network
+
+
+def _scene():
+    dl = 2e-3
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(0.024, 0.02, 0.02)))
+    scene.add(gprMax.PMLThickness(thickness=2))
+    scene.add(gprMax.TimeWindow(time=4e-10))
+    scene.add(gprMax.OMPThreads(1))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
+
+    resistance = 25.0
+    inductance = 2e-9
+    capacitance = 0.5e-12
+    alpha = -resistance / (2 * inductance)
+    beta = np.sqrt(1 / (inductance * capacitance) - alpha**2)
+    pole = alpha + 1j * beta
+    residue = pole / (inductance * (pole - np.conj(pole)))
+    scene.add(
+        gprMax.RationalNetwork(
+            id="series_rlc",
+            poles=(pole, np.conj(pole)),
+            residues=(residue, np.conj(residue)),
+        )
+    )
+    scene.add(
+        gprMax.NetworkTerminal(
+            p1=(0.012, 0.01, 0.01),
+            polarisation="z",
+            network_id="series_rlc",
+            id="feed",
+        )
+    )
+    scene.add(gprMax.NetworkExcitation("feed", "pulse"))
+    scene.add(gprMax.NetworkPort("feed", reference_impedance=50, spectrum_limit="nyquist"))
+
+    real_pole = -2 * np.pi * 8e9
+    scene.add(
+        gprMax.RationalNetwork(
+            id="real_pole",
+            conductance=1 / 100,
+            capacitance=0.2e-12,
+            poles=(real_pole,),
+            residues=(-real_pole / 100,),
+        )
+    )
+    scene.add(
+        gprMax.NetworkTerminal(
+            p1=(0.01, 0.008, 0.008),
+            polarisation="x",
+            network_id="real_pole",
+            id="feed_x",
+        )
+    )
+    scene.add(gprMax.NetworkExcitation("feed_x", "pulse"))
+    scene.add(gprMax.NetworkPort("feed_x", reference_impedance=50, spectrum_limit="nyquist"))
+
+    scene.add(gprMax.RationalNetwork(id="rc", conductance=1 / 50, capacitance=0.3e-12))
+    scene.add(
+        gprMax.NetworkTerminal(
+            p1=(0.014, 0.012, 0.01),
+            polarisation="y",
+            network_id="rc",
+            id="feed_y",
+        )
+    )
+    scene.add(gprMax.NetworkExcitation("feed_y", "pulse"))
+    scene.add(gprMax.NetworkPort("feed_y", reference_impedance=50, spectrum_limit="nyquist"))
+    scene.add(gprMax.Rx(p1=(0.014, 0.01, 0.01), id="field"))
+    return scene
+
+
+@pytest.mark.parametrize("backend", ["cuda", "opencl", "metal"])
+def test_rational_network_template_substitutions_are_complete(backend):
+    specification = knl_rational_network.update_rational_network
+    arguments = specification[f"args_{backend}"].substitute({"REAL": "double"})
+    body = specification["func"].substitute(
+        {
+            "CUDA_IDX": "int i = 0;" if backend == "cuda" else "",
+            "REAL": "double",
+            "NY_RNINFO": 6,
+            "NY_RNPARAMS": 7,
+            "NY_RNWAVEWHOLE": 8,
+            "NY_RNWAVEHALF": 7,
+            "NY_RNVOLTAGE": 8,
+            "NY_RNCURRENT": 7,
+        }
+    )
+    assert "$" not in arguments
+    assert "$" not in body
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+@pytest.mark.parametrize("backend", ["cuda", "opencl"])
+@pytest.mark.parametrize("precision", ["single", "double"])
+def test_device_rational_network_matches_cpu(tmp_path, request, backend, precision):
+    if backend == "cuda":
+        device_options = {"gpu": [request.getfixturevalue("gpu_device")]}
+    else:
+        device_options = {"opencl": [request.getfixturevalue("opencl_device")]}
+
+    cpu_path = tmp_path / f"cpu_network_{precision}"
+    device_path = tmp_path / f"{backend}_network_{precision}"
+    gprMax.run(
+        scenes=[_scene()],
+        n=1,
+        outputfile=cpu_path,
+        hide_progress_bars=True,
+        cpu_precision=precision,
+    )
+    gprMax.run(
+        scenes=[_scene()],
+        n=1,
+        outputfile=device_path,
+        hide_progress_bars=True,
+        gpu_precision=precision,
+        **device_options,
+    )
+
+    paths = (
+        "ports/feed/Vtotal",
+        "ports/feed/Inetwork",
+        "ports/feed/S11",
+        "ports/feed/Zin",
+        "ports/feed_x/Vtotal",
+        "ports/feed_x/Inetwork",
+        "ports/feed_x/S11",
+        "ports/feed_x/Zin",
+        "ports/feed_y/Vtotal",
+        "ports/feed_y/Inetwork",
+        "ports/feed_y/S11",
+        "ports/feed_y/Zin",
+        "rxs/rx1/Ez",
+    )
+    with h5py.File(str(cpu_path) + ".h5", "r") as output:
+        cpu = {path: output[path][:] for path in paths}
+        valid = {
+            name: output[f"ports/{name}/valid_S11"][:].astype(bool)
+            for name in ("feed", "feed_x", "feed_y")
+        }
+    with h5py.File(str(device_path) + ".h5", "r") as output:
+        device = {path: output[path][:] for path in paths}
+        for name in valid:
+            valid[name] &= output[f"ports/{name}/valid_S11"][:].astype(bool)
+
+    assert all(selector.any() for selector in valid.values())
+    tolerance = 4e-5 if precision == "single" else 5e-8
+    for path in paths:
+        port_name = path.split("/")[1] if path.startswith("ports/") else None
+        selector = valid[port_name] if path.endswith(("S11", "Zin")) else slice(None)
+        scale = max(float(np.max(np.abs(cpu[path][selector]))), 1e-12)
+        assert np.isfinite(device[path][selector]).all()
+        assert_allclose(
+            device[path][selector],
+            cpu[path][selector],
+            rtol=tolerance,
+            atol=tolerance * scale,
+        )

--- a/tests/test_transmission_line_device.py
+++ b/tests/test_transmission_line_device.py
@@ -12,6 +12,7 @@ from gprMax.sources import (
     dtoh_transmission_line_outputs,
     transmission_line_host_arrays,
 )
+from gprMax.updates.metal_updates import MetalUpdates
 
 
 def _line(polarisation="z", coord=(2, 3, 4)):
@@ -132,3 +133,82 @@ def test_transmission_line_template_substitutions_are_complete(backend, kernel):
 
     assert "$" not in arguments
     assert "$" not in body
+
+
+def test_metal_transmission_line_dispatch_preserves_kernel_contract(
+    float64_config,
+):
+    calls = []
+    updates = MetalUpdates.__new__(MetalUpdates)
+    updates._dispatch_1d = lambda pipeline, scalars, buffers, count: calls.append(
+        (pipeline, scalars, buffers, count)
+    )
+    updates.pso_transmission_line_magnetic = "magnetic_pipeline"
+    updates.pso_transmission_line_electric = "electric_pipeline"
+    updates.tl_line_coefficient = np.float64(0.25)
+    updates.tl_abc_coefficient = np.float64(-0.5)
+    for name in (
+        "info",
+        "resistance",
+        "waveform_half",
+        "waveform_whole",
+        "voltage",
+        "current",
+        "abcv0",
+        "abcv1",
+        "Vtotal",
+        "Itotal",
+    ):
+        setattr(updates, f"tl_{name}_dev", name)
+    updates.grid = SimpleNamespace(
+        transmissionlines=[object()],
+        magneticdipoles=[],
+        magneticfrillsources=[],
+        voltagesources=[],
+        hertziandipoles=[],
+        dx=0.001,
+        dy=0.002,
+        dz=0.003,
+        Hx_dev="Hx",
+        Hy_dev="Hy",
+        Hz_dev="Hz",
+        Ex_dev="Ex",
+        Ey_dev="Ey",
+        Ez_dev="Ez",
+        iteration=0,
+    )
+
+    updates.update_magnetic_sources(iteration=3)
+    updates.update_electric_sources(iteration=3)
+
+    assert [call[0] for call in calls] == [
+        "magnetic_pipeline",
+        "electric_pipeline",
+    ]
+    assert len(calls[0][1]) == 6
+    assert calls[0][2] == (
+        "info",
+        "resistance",
+        "waveform_half",
+        "voltage",
+        "current",
+        "Vtotal",
+        "Itotal",
+        "Hx",
+        "Hy",
+        "Hz",
+    )
+    assert len(calls[1][1]) == 7
+    assert calls[1][2] == (
+        "info",
+        "resistance",
+        "waveform_whole",
+        "voltage",
+        "current",
+        "abcv0",
+        "abcv1",
+        "Ex",
+        "Ey",
+        "Ez",
+    )
+    assert calls[0][3] == calls[1][3] == 1

--- a/tests/updates/test_gpu_symmetry_boundaries.py
+++ b/tests/updates/test_gpu_symmetry_boundaries.py
@@ -6,7 +6,13 @@ import numpy as np
 import pytest
 
 from gprMax import config
-from gprMax.cuda_opencl.knl_symmetry_boundaries import update_electric_pmc
+from gprMax.cuda_opencl.knl_symmetry_boundaries import (
+    dispersive_substitutions,
+    nondispersive_substitutions,
+    update_electric_pmc,
+    update_electric_pmc_dispersive,
+    update_electric_pmc_dispersive_b,
+)
 from gprMax.model import Model
 from gprMax.updates.cuda_updates import CUDAUpdates
 from gprMax.updates.metal_updates import MetalUpdates
@@ -24,7 +30,7 @@ from gprMax.user_objects.cmds_multiuse import SymmetryBoundary
 )
 def test_pmc_kernel_templates_cover_faces_and_edges(backend, marker):
     declaration = update_electric_pmc[f"args_{backend}"].substitute(REAL="float")
-    body = update_electric_pmc["func"].substitute(
+    substitutions = dict(
         REAL="float",
         CUDA_IDX=(
             "int i = blockIdx.x * blockDim.x + threadIdx.x;"
@@ -38,6 +44,8 @@ def test_pmc_kernel_templates_cover_faces_and_edges(backend, marker):
         NY_ID=6,
         NZ_ID=7,
     )
+    substitutions.update(nondispersive_substitutions())
+    body = update_electric_pmc["func"].substitute(substitutions)
 
     source = declaration + body
     assert marker in source
@@ -47,6 +55,42 @@ def test_pmc_kernel_templates_cover_faces_and_edges(backend, marker):
     assert "PMC_X0" in source and "PMC_XMAX" in source
     assert "PMC_Y0" in source and "PMC_YMAX" in source
     assert "PMC_Z0" in source and "PMC_ZMAX" in source
+
+
+@pytest.mark.parametrize("backend", ["cuda", "opencl", "metal"])
+def test_dispersive_pmc_templates_include_two_phase_ade_update(backend):
+    arguments = {"REAL": "float", "COMPLEX": "float"}
+    substitutions = {
+        "REAL": "float",
+        "CUDA_IDX": (
+            "int i = blockIdx.x * blockDim.x + threadIdx.x;"
+            if backend == "cuda"
+            else ""
+        ),
+        "NX_FIELDS": 5,
+        "NY_FIELDS": 6,
+        "NZ_FIELDS": 7,
+        "NX_ID": 5,
+        "NY_ID": 6,
+        "NZ_ID": 7,
+        "NX_T": 5,
+        "NY_T": 6,
+        "NZ_T": 7,
+    }
+    phase_a = dict(substitutions)
+    phase_a.update(dispersive_substitutions("float"))
+    source_a = update_electric_pmc_dispersive[f"args_{backend}"].substitute(
+        arguments
+    ) + update_electric_pmc_dispersive["func"].substitute(phase_a)
+    source_b = update_electric_pmc_dispersive_b[f"args_{backend}"].substitute(
+        arguments
+    ) + update_electric_pmc_dispersive_b["func"].substitute(substitutions)
+
+    assert "MAXPOLES" in source_a and "MAXPOLES" in source_b
+    assert "GPRMAX_CREAL" in source_a
+    assert "GPRMAX_CADD" in source_a
+    assert "GPRMAX_CSUB" in source_b
+    assert "$DISP_" not in source_a and "$PHI_" not in source_a
 
 
 def _command_grid():
@@ -85,7 +129,7 @@ def test_nondispersive_gpu_symmetry_command_is_accepted(
 
 
 @pytest.mark.parametrize("solver", ["cuda", "opencl", "metal"])
-def test_dispersive_gpu_pmc_is_rejected_after_material_resolution(
+def test_dispersive_gpu_pmc_is_accepted_after_material_resolution(
     monkeypatch, solver
 ):
     monkeypatch.setattr(
@@ -102,8 +146,8 @@ def test_dispersive_gpu_pmc_is_rejected_after_material_resolution(
     grid = _command_grid()
     SymmetryBoundary(face="x0", type="pmc").build(grid)
 
-    with pytest.raises(ValueError, match="Dispersive PMC"):
-        Model.__new__(Model)._check_accelerator_symmetry_boundaries([grid])
+    Model.__new__(Model)._check_accelerator_symmetry_boundaries([grid])
+    assert grid.symmetry_boundaries == {"x0": "pmc"}
 
 
 class _FakeCUDAArray:
@@ -127,7 +171,12 @@ def _dispatch_grid():
     )
 
 
-def test_cuda_pmc_dispatch_uses_canonical_face_flag_order():
+def test_cuda_pmc_dispatch_uses_canonical_face_flag_order(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "get_model_config",
+        lambda: SimpleNamespace(materials={"maxpoles": 0}),
+    )
     updates = CUDAUpdates.__new__(CUDAUpdates)
     updates.grid = _dispatch_grid()
     calls = []
@@ -152,7 +201,12 @@ def test_cuda_pmc_dispatch_uses_canonical_face_flag_order():
     assert kwargs == {"block": (64, 1, 1), "grid": (2, 1, 1)}
 
 
-def test_opencl_pmc_dispatch_uses_device_arrays():
+def test_opencl_pmc_dispatch_uses_device_arrays(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "get_model_config",
+        lambda: SimpleNamespace(materials={"maxpoles": 0}),
+    )
     updates = OpenCLUpdates.__new__(OpenCLUpdates)
     updates.grid = _dispatch_grid()
     calls = []
@@ -190,6 +244,11 @@ def test_opencl_pmc_kernel_builder_substitutes_real_type(monkeypatch):
             dtypes={"C_float_or_double": "float"},
             devices={"compiler_opts": []},
         ),
+    )
+    monkeypatch.setattr(
+        config,
+        "get_model_config",
+        lambda: SimpleNamespace(materials={"maxpoles": 0}),
     )
 
     updates._set_symmetry_boundary_knl()
@@ -241,7 +300,12 @@ class _FakeMetalCommand:
         self.waited = True
 
 
-def test_metal_pmc_dispatch_uses_expected_scalar_and_buffer_slots():
+def test_metal_pmc_dispatch_uses_expected_scalar_and_buffer_slots(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "get_model_config",
+        lambda: SimpleNamespace(materials={"maxpoles": 0}),
+    )
     updates = MetalUpdates.__new__(MetalUpdates)
     updates.grid = _dispatch_grid()
     updates.grid.tptg = "threads"

--- a/tests/updates/test_opencl_plane_wave_solve.py
+++ b/tests/updates/test_opencl_plane_wave_solve.py
@@ -203,6 +203,71 @@ def _multiple_windowed_scene():
     return scene
 
 
+def _equivalent_current_time_scene():
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(0.004,) * 3))
+    scene.add(gprMax.Domain(p1=(0.08,) * 3))
+    scene.add(gprMax.TimeWindow(time=3e-10))
+    scene.add(gprMax.PMLThickness(thickness=3))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
+    scene.add(
+        gprMax.HertzianDipole(
+            polarisation="z", p1=(0.04,) * 3, waveform_id="pulse"
+        )
+    )
+    scene.add(
+        gprMax.NTFFSurface(
+            p1=(0.028,) * 3,
+            p2=(0.052,) * 3,
+            id="surface",
+        )
+    )
+    far_field = gprMax.NTFFTimeFarField(
+        (0, 30, 90, 150, 180),
+        (0, 0, 0, 0, 0),
+        "surface",
+        id="transient",
+        outputs=("Etheta", "Ephi"),
+    )
+    scene.add(far_field)
+    return scene, far_field
+
+
+@pytest.mark.parametrize("precision,rtol", [("single", 3e-4), ("double", 2e-11)])
+def test_opencl_equivalent_current_time_matches_cpu(
+    tmp_path, opencl_device, precision, rtol
+):
+    cpu_scene, cpu_far = _equivalent_current_time_scene()
+    opencl_scene, opencl_far = _equivalent_current_time_scene()
+    gprMax.run(
+        scenes=[cpu_scene],
+        outputfile=tmp_path / f"equivalent_time_cpu_{precision}",
+        hide_progress_bars=True,
+        cpu_precision=precision,
+    )
+    gprMax.run(
+        scenes=[opencl_scene],
+        outputfile=tmp_path / f"equivalent_time_opencl_{precision}",
+        hide_progress_bars=True,
+        opencl=[opencl_device],
+        gpu_precision=precision,
+    )
+
+    assert_allclose(opencl_far.result.times, cpu_far.result.times, rtol=0, atol=0)
+    scale = max(
+        np.max(np.abs(cpu_far.result.fields[component]))
+        for component in ("Etheta", "Ephi")
+    )
+    assert scale > 0
+    for component in ("Etheta", "Ephi"):
+        assert_allclose(
+            opencl_far.result.fields[component],
+            cpu_far.result.fields[component],
+            rtol=rtol,
+            atol=rtol * scale,
+        )
+
+
 @pytest.mark.parametrize(
     "name,scene_factory",
     [

--- a/tests/updates/test_plane_wave_kernel_templates.py
+++ b/tests/updates/test_plane_wave_kernel_templates.py
@@ -1,7 +1,22 @@
 """Backend-neutral plane-wave and OpenCL NTFF kernel-source regressions."""
 
+from types import SimpleNamespace
+
+import numpy as np
+
 from gprMax.cuda_opencl import knl_planewave_updates, knl_tfsf_injection
 from gprMax.cuda_opencl.knl_ntff import build_ntff_kernel_source
+from gprMax.grid.metal_grid import MetalBufferView
+from gprMax.updates.metal_plane_waves import _MetalElementwiseKernel
+
+
+def _plane_wave_kernel_specs(module):
+    return [
+        value
+        for value in vars(module).values()
+        if isinstance(value, dict)
+        and {"args_metal", "func"}.issubset(value)
+    ]
 
 
 def test_tfsf_kernels_use_backend_index_substitution():
@@ -39,6 +54,84 @@ def test_axial_opencl_kernels_receive_material_coefficients():
         arguments = getattr(knl_planewave_updates, name)["args_opencl"].template
         assert "matH" in arguments
         assert "matE" in arguments
+
+
+def test_all_plane_wave_templates_render_for_metal():
+    specs = _plane_wave_kernel_specs(knl_planewave_updates)
+    specs += (
+        knl_tfsf_injection.STANDARD_H_KERNELS
+        + knl_tfsf_injection.STANDARD_E_KERNELS
+        + knl_tfsf_injection.AXIAL_H_KERNELS
+        + knl_tfsf_injection.AXIAL_E_KERNELS
+    )
+
+    assert len(specs) > 24
+    for specification in specs:
+        declaration = specification["args_metal"].substitute(
+            {"REAL": "float", "COMPLEX": "metal::complex<float>"}
+        )
+        body = specification["func"].substitute(
+            {"CUDA_IDX": "", "TFSF_IDX": "int t = i;", "REAL": "float"}
+        )
+
+        assert "$" not in declaration
+        assert "$" not in body
+        assert "thread_position_in_grid" in declaration
+        assert "blockIdx" not in body
+
+
+class _FakeEncoder:
+    def __init__(self):
+        self.buffers = {}
+        self.scalars = {}
+        self.dispatched = None
+
+    def setComputePipelineState_(self, pipeline):
+        self.pipeline = pipeline
+
+    def setBuffer_offset_atIndex_(self, buffer, offset, index):
+        self.buffers[index] = (buffer, offset)
+
+    def setBytes_length_atIndex_(self, value, length, index):
+        self.scalars[index] = (bytes(value), length)
+
+    def dispatchThreads_threadsPerThreadgroup_(self, threads, group):
+        self.dispatched = (threads, group)
+
+    def endEncoding(self):
+        pass
+
+
+class _FakeCommand:
+    def __init__(self):
+        self.encoder = _FakeEncoder()
+
+    def computeCommandEncoder(self):
+        return self.encoder
+
+    def commit(self):
+        pass
+
+    def waitUntilCompleted(self):
+        pass
+
+
+def test_metal_plane_wave_adapter_preserves_buffer_offsets_and_scalar_types():
+    command = _FakeCommand()
+    owner = SimpleNamespace(
+        cmdqueue=SimpleNamespace(commandBuffer=lambda: command),
+        metal=SimpleNamespace(MTLSizeMake=lambda x, y, z: (x, y, z)),
+    )
+    pipeline = SimpleNamespace(maxTotalThreadsPerThreadgroup=lambda: 64)
+    kernel = _MetalElementwiseKernel(owner, pipeline)
+    raw_buffer = SimpleNamespace(contents=lambda: None, length=lambda: 128)
+    view = MetalBufferView(raw_buffer, 24)
+
+    kernel(np.int32(7), view, range=slice(0, 13))
+
+    assert command.encoder.scalars[0][1] == np.dtype(np.int32).itemsize
+    assert command.encoder.buffers[1] == (raw_buffer, 24)
+    assert command.encoder.dispatched == ((13, 1, 1), (13, 1, 1))
 
 
 def test_opencl_ntff_source_accepts_offset_field_views():

--- a/tests/updates/test_symmetry_boundary_solve_loop.py
+++ b/tests/updates/test_symmetry_boundary_solve_loop.py
@@ -10,8 +10,127 @@ fields at a nearby receiver - not NaN, and not a degenerate all-zero result
 a trap this project has hit before with too-short time windows).
 """
 import numpy as np
+import h5py
+import pytest
+from numpy.testing import assert_allclose
 
 import gprMax
+
+
+def _dispersive_pmc_scene(kind):
+    dl = 1e-3
+    scene = gprMax.Scene()
+    scene.add(gprMax.OMPThreads(n=1))
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(0.02, 0.02, 0.02)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=2e-10))
+    scene.add(gprMax.SymmetryBoundary(face="x0", type="pmc"))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=1.5e10, id="w"))
+    scene.add(gprMax.Material(er=3, se=0.001, mr=1, sm=0, id="medium"))
+    if kind == "debye":
+        scene.add(
+            gprMax.AddDebyeDispersion(
+                poles=1,
+                er_delta=[2.0],
+                tau=[1e-11],
+                material_ids=["medium"],
+            )
+        )
+    else:
+        scene.add(
+            gprMax.AddLorentzDispersion(
+                poles=1,
+                er_delta=[2.0],
+                omega=[2e10],
+                delta=[5e9],
+                material_ids=["medium"],
+            )
+        )
+    scene.add(
+        gprMax.Box(
+            p1=(0.0, 0.0, 0.0),
+            p2=(0.02, 0.02, 0.02),
+            material_id="medium",
+        )
+    )
+    scene.add(
+        gprMax.HertzianDipole(
+            polarisation="z", p1=(0.0, 0.01, 0.01), waveform_id="w"
+        )
+    )
+    scene.add(gprMax.Rx(p1=(0.01, 0.01, 0.01)))
+    return scene
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+@pytest.mark.parametrize("kind", ["debye", "lorentz"])
+def test_cuda_dispersive_pmc_matches_cpu(tmp_path, gpu_device, kind):
+    outputs = {}
+    for backend in ("cpu", "cuda"):
+        path = tmp_path / f"pmc_{kind}_{backend}"
+        options = (
+            {"gpu": [gpu_device], "gpu_precision": "single"}
+            if backend == "cuda"
+            else {"cpu_precision": "single"}
+        )
+        gprMax.run(
+            scenes=[_dispersive_pmc_scene(kind)],
+            outputfile=path,
+            hide_progress_bars=True,
+            **options,
+        )
+        with h5py.File(path.with_suffix(".h5"), "r") as result:
+            outputs[backend] = {
+                component: result[f"rxs/rx1/{component}"][:]
+                for component in ("Ex", "Ey", "Ez", "Hx", "Hy", "Hz")
+            }
+
+    scale = max(np.max(np.abs(values)) for values in outputs["cpu"].values())
+    assert scale > 0
+    for component in outputs["cpu"]:
+        assert_allclose(
+            outputs["cuda"][component],
+            outputs["cpu"][component],
+            rtol=3e-4,
+            atol=3e-4 * scale,
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+@pytest.mark.parametrize("kind", ["debye", "lorentz"])
+def test_opencl_dispersive_pmc_matches_cpu(tmp_path, opencl_device, kind):
+    outputs = {}
+    for backend in ("cpu", "opencl"):
+        path = tmp_path / f"pmc_{kind}_{backend}"
+        options = (
+            {"opencl": [opencl_device], "gpu_precision": "single"}
+            if backend == "opencl"
+            else {"cpu_precision": "single"}
+        )
+        gprMax.run(
+            scenes=[_dispersive_pmc_scene(kind)],
+            outputfile=path,
+            hide_progress_bars=True,
+            **options,
+        )
+        with h5py.File(path.with_suffix(".h5"), "r") as result:
+            outputs[backend] = {
+                component: result[f"rxs/rx1/{component}"][:]
+                for component in ("Ex", "Ey", "Ez", "Hx", "Hy", "Hz")
+            }
+
+    scale = max(np.max(np.abs(values)) for values in outputs["cpu"].values())
+    assert scale > 0
+    for component in outputs["cpu"]:
+        assert_allclose(
+            outputs["opencl"][component],
+            outputs["cpu"][component],
+            rtol=3e-4,
+            atol=3e-4 * scale,
+        )
 
 
 def test_pmc_symmetry_boundary_solve_produces_finite_propagating_field(tmp_path):


### PR DESCRIPTION
# PR Description
## Summary

Completes CPU/CUDA/OpenCL/Metal parity for local non-subgrid simulations.

- Adds accelerator support for eigenmode sources and monitors, virtual waveguides, and rational-network ports.
- Adds device-resident transient equivalent-current NTFF.
- Supports dispersive PMC symmetry boundaries on accelerators.
- Adds Metal discrete plane waves and transmission lines.
- Keeps iterative state and accumulation on-device.
- Updates documentation and regression coverage.

Subgrids, MPI domain decomposition, and Metal double precision remain outside this scope.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Documentation update

## Testing

- 1,454 unit tests passed
- 21 CUDA integration comparisons passed
- 12 OpenCL comparisons passed
- Metal kernel-template and dispatch tests passed
- Black, isort, and diff checks passed
- Documentation builds successfully, with two unrelated existing citation warnings

## Checklist

- [x] Did pre-commit pass all checks?
- [x] I have performed a self-review.
- [x] I have added comments where needed.
- [x] I have updated the documentation.
- [x] My changes generate no new warnings.
- [x] The PR title describes the changes.