### PR TITLE
Extend feature compatibility for HSG subgrids

### DIFF
--- a/docs/source/eigenmode_port.rst
+++ b/docs/source/eigenmode_port.rst
@@ -332,6 +332,47 @@ enlarge the sampled NTFF faces while keeping them outside the PML, refine the
 mesh, and lengthen the time window. Change only one quantity per run so that a
 shift in S11 or the far field has a clear cause.
 
+Direct eigenmode ports inside an HSG subgrid
+=============================================
+
+The Python API can place a complete direct eigenmode model inside an HSG
+subgrid. Add the ``EigenmodeBand``, every related ``EigenmodePort``, the
+waveform when an explicit waveform is used, and the ``EigenmodeExcitation``
+to the same ``SubGridHSG`` object. With ``autotranslate=True``, port planes are
+still specified in global physical coordinates.
+
+The 2D FDFD problem is not solved on a resampled main-grid slice. gprMax reads
+the final component-resolved material IDs from the selected fine-grid Yee
+plane, including its staggered electric and magnetic component shapes, and
+uses the subgrid's two transverse spatial steps. Consequently, a refined
+subgrid can resolve both the guide cross-section and its modal field profile
+more finely than the surrounding main grid. Source injection and modal
+projection are then evaluated at every fine-grid time step.
+
+The complete modal aperture and its adjacent staggered Yee stencil must lie
+strictly inside the subgrid working region. In particular, the normal
+magnetic-field stencil reaches one plane behind the specified reference
+plane, and transverse staggered components include both aperture endpoints.
+gprMax rejects a placement when any of these samples touches the HSG coupling
+surface or enters the auxiliary/PML region. This avoids solving one modal
+problem while injecting it into a truncated or coupled aperture.
+
+Modal bands and S-parameter normalization are local to their owning grid. A
+set of associated ports therefore cannot be split between the main grid and a
+subgrid, or between separate subgrids. Fine-grid results are written beneath
+``/subgrids/<subgrid ID>/eigenmode_ports/portN`` and use the fine-grid
+``dx_dy_dz`` and ``dt`` metadata. The corresponding CSV filename is suffixed
+with ``_<subgrid ID>_sparameters.csv``.
+
+Direct subgrid eigenmode ports currently use the CPU HSG update cycle and are
+not supported with MPI. A ``VirtualWaveguide`` may be attached to a subgrid
+port. Its aperture is translated onto the fine local Yee grid, while its
+independent auxiliary guide inherits the subgrid's ``dx_dy_dz``, ``dt``,
+material cross-section, update coefficients, and fine iteration count. The
+complete physical aperture and its adjacent staggered stencil must satisfy
+the same strict working-region placement rule as a direct subgrid port.
+
+
 Virtual waveguides for internal matched ports
 ==============================================
 
@@ -379,14 +420,15 @@ The HDF5 file then contains raw incident and outgoing modal spectra, but no
 S-parameters are formed because no incident source spectrum exists for
 normalization.
 
-Virtual waveguides are experimental. They run on the CPU, CUDA, OpenCL, and
-Metal solvers and keep both the auxiliary-grid fields and aperture coupling on
-the selected compute device throughout time stepping. They currently require
+Virtual waveguides are experimental. On the main grid they run on the CPU,
+CUDA, OpenCL, and Metal solvers and keep both the auxiliary-grid fields and
+aperture coupling on the selected compute device throughout time stepping.
+They may also be attached through the Python API to a port owned by an HSG
+subgrid; that path uses the CPU fine-grid update cycle. They currently require
 a 3D internal port plane, a locally uniform and non-dispersive cross-section,
-and at least two cells along each transverse axis. MPI and subgrids are not yet
-supported. Use convergence tests for guide length, PML thickness, source
-clearance, mesh resolution, and NTFF-surface position before using
-quantitative results.
+and at least two cells along each transverse axis. MPI is not supported. Use
+convergence tests for guide length, PML thickness, source clearance, mesh
+resolution, and NTFF-surface position before using quantitative results.
 
 How automatic excitation and frequency anchors work
 ====================================================

--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -410,6 +410,11 @@ material-index geometry for insertion into another model:
         filename='reusable_geometry',
     ))
 
+A geometry view can be added to an HSG subgrid. Its points and VTK origin are
+written in the global model coordinate system, even though its material data
+are sampled from the fine local grid. ``GeometryObjectsWrite`` remains a
+main-grid operation.
+
 In a different scene, the saved geometry can be inserted at a chosen origin:
 
 .. code-block:: python
@@ -562,6 +567,41 @@ band-centre anchor; results for that mode far from it may be inaccurate. The
 candidate frequencies remain common to all automatic ports, while the
 retained masks and fallbacks are resolved independently. See
 :doc:`eigenmode_port` for the complete workflow and outputs.
+
+A direct eigenmode model may also be placed wholly inside one HSG subgrid.
+Add its band, ports, waveform (when one is used), and excitation to that same
+subgrid object. With ``autotranslate=True``, the plane coordinates remain
+global physical coordinates:
+
+.. code-block:: python
+
+    fine_grid.add(gprMax.Waveform(
+        wave_type='contsine', amp=1, freq=22e9, id='fine_wave',
+    ))
+    fine_grid.add(gprMax.EigenmodeBand(
+        id='fine_band', fmin=22e9, fmax=22e9, points=1,
+    ))
+    fine_grid.add(gprMax.EigenmodePort(
+        port=1,
+        p1=(0.045, 0.039, 0.039),
+        p2=(0.045, 0.051, 0.049),
+        direction='+', modes=(1,), anchors=(22e9,),
+    ))
+    fine_grid.add(gprMax.EigenmodeExcitation(
+        port=1, mode=1, waveform='fine_wave',
+    ))
+
+The FDFD solver samples the final component-resolved material slice of the
+fine Yee grid and uses its two transverse spatial steps. Injection and modal
+observation then run at every fine-grid time step. The complete plane and its
+adjacent staggered Yee stencil must lie strictly inside the subgrid working
+region; a plane touching the HSG coupling surface or entering its auxiliary
+or PML region is rejected. Ports cannot be divided between the main grid and
+a subgrid, or between different subgrids. ``VirtualWaveguide`` can be added
+to the same subgrid and referenced to one of its ports. The auxiliary guide
+then inherits the fine grid's spatial and temporal steps, material
+cross-section, update coefficients, and iteration count; it is not resampled
+from the coarse main grid.
 
 Voltage Source
 --------------
@@ -949,6 +989,11 @@ steps are applied between repeated model runs:
         dl=(0.002, 0.002, 0.002), time=2e-9,
         filename='fields_2ns', fileext='.h5', outputs=['Ez', 'Hy'],
     ))
+
+A snapshot can also be added to an HSG subgrid. It is sampled on every fine
+subgrid time step, uses the subgrid's spatial discretisation, and records its
+origin in the global model coordinate system. The requested time or iteration
+is interpreted against the owning subgrid's ``dt`` and iteration count.
 
 Reusable NTFF integration surface
 ---------------------------------
@@ -1367,6 +1412,8 @@ case-specific long-duration testing. The material cross-section must be
 invariant through the slab.
 
 When ``id`` is omitted, gprMax assigns ``internal_pml_1``,
-``internal_pml_2``, and so on. Internal slabs currently support the CPU, CUDA,
-OpenCL, and Metal solvers on the main 3D grid; MPI and subgrids are not yet
-supported.
+``internal_pml_2``, and so on. Internal slabs support the CPU, CUDA, OpenCL,
+and Metal solvers on the main 3D grid. A slab may also be added to an HSG
+subgrid, where it uses the CPU solver and the fine-grid update cycle. A
+subgrid-owned slab must lie wholly within the working region: overlap with its
+HSG coupling or auxiliary-PML regions is rejected. MPI is not supported.

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1648,8 +1648,12 @@ and output definitions.
 
 .. note::
 
-    * Eigenmode commands support the main grid with the CPU, CUDA, OpenCL, and
-      Metal solvers, but not subgrids.
+    * Hash commands define eigenmode ports on the main grid, where the CPU,
+      CUDA, OpenCL, and Metal solvers are supported. Direct eigenmode ports may
+      also be added to an HSG subgrid through the Python API; they then use the
+      fine-grid material slice, spatial step, time step, and CPU update cycle.
+      The complete port stencil must remain strictly inside the subgrid working
+      region. See :doc:`eigenmode_port`.
     * Eigenmode commands currently cannot be used with MPI.
 
 #virtual_waveguide:
@@ -1685,9 +1689,11 @@ but no S-parameters can be normalized without an active port.
 
 The port plane must be internal, locally uniform along the guide axis, and at
 least two cells wide in each transverse direction. The minimum guide length
-is ``i3 + i4 + 3`` cells. Virtual waveguides support 3D, non-dispersive guide
-cross-sections with the CPU, CUDA, OpenCL, and Metal solvers; MPI and subgrids
-are not yet supported.
+is ``i3 + i4 + 3`` cells. Main-grid virtual waveguides support 3D,
+non-dispersive guide cross-sections with the CPU, CUDA, OpenCL, and Metal
+solvers. Through the Python API, a virtual waveguide may instead be attached
+to an HSG-subgrid port; it then inherits that subgrid's fine material slice,
+spatial and temporal steps, and CPU update cycle. MPI is not supported.
 
 Unlike a direct eigenmode source, a virtual-waveguide source lies outside the
 main FDTD domain. A closed equivalent-current or KSIR NTFF surface may
@@ -1921,6 +1927,11 @@ For example to save a snapshot of the electromagnetic fields in the model at a s
 
 .. tip::
     A series of snapshots can be more easily defined using a loop and our :ref:`Python API <input-api>`, see :ref:`outputs-snaps`.
+
+    The Python API can also add a snapshot to an HSG subgrid. Such a snapshot
+    uses the subgrid's finer spatial discretisation and time step, while its
+    file origin remains in the global model coordinate system. The hash
+    command above always defines a main-grid snapshot.
 
 Near-to-far-field transformation commands
 ==========================================
@@ -2717,9 +2728,12 @@ and overlaps with a native PML remain errors because they invalidate the
 current formulation.
 
 An automatically generated internal identifier is reported in the log. The
-feature is currently limited to the main 3D grid and is not available with MPI
-or on subgrids. Orthogonal PML slabs may overlap, as domain PMLs do at edges and
-corners.
+hash command defines a slab on the main 3D grid. With the Python API a slab may
+instead be added to an HSG subgrid, provided the complete slab lies inside its
+working region and does not overlap the HSG coupling or auxiliary-PML regions.
+Subgrid slabs use the CPU solver and the subgrid's finer spatial and temporal
+discretisation. The feature is not available with MPI. Orthogonal PML slabs may
+overlap, as domain PMLs do at edges and corners.
 
 
 #symmetry_boundary:

--- a/docs/source/output.rst
+++ b/docs/source/output.rst
@@ -478,8 +478,11 @@ The frequency dataset and validity mask can be plotted directly:
 Eigenmode-port and S-parameter output
 -------------------------------------
 
-Each explicitly numbered eigenmode source or receiver is stored below
-``/eigenmode_ports/portN``. ``frequency`` contains the direct-DFT bins.
+Each explicitly numbered main-grid eigenmode source or receiver is stored
+below ``/eigenmode_ports/portN``. A direct port owned by an HSG subgrid is
+stored below ``/subgrids/<subgrid ID>/eigenmode_ports/portN`` and uses that
+grid's fine ``dx_dy_dz``, ``dt``, and iteration count. ``frequency`` contains
+the direct-DFT bins.
 ``incident`` and ``outgoing`` have shape ``(nmodes, nfrequencies)``, with
 rows ordered by the one-based ``ModeIndices`` attribute. ``S`` is the outgoing
 coefficient divided by the excited source-mode incident coefficient, so the
@@ -542,7 +545,9 @@ physical mask is also true.
 
 A run with one eigenmode source also writes
 ``<output>_sparameters.csv`` with one row per frequency, destination port,
-and destination mode.
+and destination mode. For a source in a subgrid the filename is
+``<output>_<subgrid ID>_sparameters.csv``. Ports in different owning grids are
+finalised independently and do not form one cross-grid S matrix.
 
 When every eigenmode port has a passive virtual waveguide and no
 ``EigenmodeExcitation`` is defined, the same HDF5 groups contain the raw
@@ -853,7 +858,7 @@ strictly enclose the complete subgrid coupling region.
 Snapshots
 ---------
 
-Snapshot files contain a snapshot of the electromagnetic field values of a specified volume of the model domain at a specified point in time during the simulation. By default, snapshot files use the open source `Visualization ToolKit (VTK) <http://www.vtk.org>`_ format which can be viewed in many free readers, such as `Paraview <http://www.paraview.org>`_. Paraview is an open-source, multi-platform data analysis and visualization application. It is available for Linux, macOS, and Windows. You can optionally output snapshot files using the HDF5 format if desired.
+Snapshot files contain a snapshot of the electromagnetic field values of a specified volume of the model domain at a specified point in time during the simulation. By default, snapshot files use the open source `Visualization ToolKit (VTK) <http://www.vtk.org>`_ format which can be viewed in many free readers, such as `Paraview <http://www.paraview.org>`_. Paraview is an open-source, multi-platform data analysis and visualization application. It is available for Linux, macOS, and Windows. You can optionally output snapshot files using the HDF5 format if desired. HDF5 snapshots include ``origin`` (global x, y, z coordinates), ``dx_dy_dz``, ``nx_ny_nz``, and ``time`` attributes. A snapshot owned by an HSG subgrid is sampled at the fine-grid time step and is still positioned in this global coordinate frame.
 
 .. tip::
     You can take advantage of our Python API to easily create a series of snapshots. For example, to create 30 snapshots starting at time 0.1ns until 3ns in intervals of 0.1ns, use the following code snippet in your input file. Replace ``x, y, z, dl, fn`` accordingly.

--- a/gprMax/fields_outputs.py
+++ b/gprMax/fields_outputs.py
@@ -78,7 +78,8 @@ def write_hdf5_outputfile(outputfile: Path, title: str, model):
         sg_tls = [True for sg in model.subgrids if sg.transmissionlines]
         sg_frills = [True for sg in model.subgrids if sg.magneticfrillsources]
         sg_ports = [True for sg in model.subgrids if sg.port_monitors]
-        if sg_rxs or sg_tls or sg_frills or sg_ports:
+        sg_eigenmode_ports = [True for sg in model.subgrids if sg.eigenmodeports]
+        if sg_rxs or sg_tls or sg_frills or sg_ports or sg_eigenmode_ports:
             for sg in model.subgrids:
                 grp = f.create_group(f"/subgrids/{sg.name}")
                 write_hd5_data(grp, sg, is_subgrid=True)

--- a/gprMax/geometry_outputs/geometry_view_lines.py
+++ b/gprMax/geometry_outputs/geometry_view_lines.py
@@ -67,8 +67,7 @@ class GeometryViewLines(GeometryView[GridType]):
 
         # Add offset to subgrid geometry to correctly locate within main grid
         if isinstance(self.grid, SubGridBaseGrid):
-            offset = [self.grid.i0, self.grid.j0, self.grid.k0]
-            self.points += offset * self.grid.dl * self.grid.ratio
+            self.points += self.grid.local_to_global(np.zeros(3, dtype=np.int32))
 
         nx, ny, nz = self.grid_view.size
         n_lines = (

--- a/gprMax/geometry_outputs/geometry_view_voxels.py
+++ b/gprMax/geometry_outputs/geometry_view_voxels.py
@@ -41,13 +41,7 @@ class GeometryViewVoxels(GeometryView[GridType]):
         self.material_data = self.grid_view.get_solid()
 
         if isinstance(self.grid, SubGridBaseGrid):
-            self.origin = np.array(
-                [
-                    (self.grid.i0 * self.grid.dx * self.grid.ratio),
-                    (self.grid.j0 * self.grid.dy * self.grid.ratio),
-                    (self.grid.k0 * self.grid.dz * self.grid.ratio),
-                ]
-            )
+            self.origin = self.grid.local_to_global(self.grid_view.start)
         else:
             self.origin = self.grid_view.start * self.grid.dl
 

--- a/gprMax/scene.py
+++ b/gprMax/scene.py
@@ -25,6 +25,7 @@ from gprMax.grid.fdtd_grid import FDTDGrid
 from gprMax.materials import create_built_in_materials
 from gprMax.model import Model
 from gprMax.mpi_model import MPIModel
+from gprMax.subgrids.grid import SubGridBaseGrid
 from gprMax.subgrids.user_objects import SubGridBase as SubGridUserBase
 from gprMax.user_objects.cmds_geometry.add_grass import AddGrass
 from gprMax.user_objects.cmds_geometry.add_surface_roughness import AddSurfaceRoughness
@@ -211,9 +212,15 @@ class Scene:
                 faces.append((p1, p2))
 
             for p1, p2 in faces:
+                if isinstance(grid, SubGridBaseGrid):
+                    continuous_p1 = tuple(grid.local_to_global(p1))
+                    continuous_p2 = tuple(grid.local_to_global(p2))
+                else:
+                    continuous_p1 = tuple(np.asarray(grid.dl) * p1)
+                    continuous_p2 = tuple(np.asarray(grid.dl) * p2)
                 Plate(
-                    p1=tuple(np.asarray(grid.dl) * p1),
-                    p2=tuple(np.asarray(grid.dl) * p2),
+                    p1=continuous_p1,
+                    p2=continuous_p2,
                     material_id="pec",
                 ).build(grid)
 
@@ -233,6 +240,7 @@ class Scene:
             self.build_grid_objects(subgrid_object.children_grid, subgrid)
             self.build_output_objects(subgrid_object.children_output, model, subgrid)
             self.process_geometry_objects(subgrid_object.children_geometry, subgrid)
+            self._build_internal_pml_enclosures(subgrid)
 
     def create_internal_objects(self, model: Model):
         """Calls the UserObject.build() function in the correct way - API

--- a/gprMax/snapshots.py
+++ b/gprMax/snapshots.py
@@ -30,6 +30,7 @@ from tqdm import tqdm
 import gprMax.config as config
 from gprMax.geometry_outputs.grid_view import GridType, GridView, MPIGridView
 from gprMax.grid.mpi_grid import MPIGrid
+from gprMax.subgrids.grid import SubGridBaseGrid
 from gprMax.utilities.mpi import Dim, Dir
 from gprMax.vtkhdf_filehandlers.vtk_image_data import VtkImageData
 
@@ -317,7 +318,7 @@ class Snapshot(Generic[GridType]):
             pbar: Progress bar class instance.
         """
 
-        origin = self.grid_view.start * self.grid.dl
+        origin = self._physical_origin()
         spacing = self.grid_view.step * self.grid.dl
 
         with VtkImageData(self.filename, self.grid_view.size, origin, spacing) as f:
@@ -339,12 +340,20 @@ class Snapshot(Generic[GridType]):
             # f.attrs["Title"] = G.title
             f.attrs["nx_ny_nz"] = tuple(self.grid_view.size)
             f.attrs["dx_dy_dz"] = self.grid_view.step * self.grid.dl
+            f.attrs["origin"] = self._physical_origin()
             f.attrs["time"] = self.time * self.grid.dt
 
             for key in ["Ex", "Ey", "Ez", "Hx", "Hy", "Hz"]:
                 if self.outputs[key]:
                     f[key] = self.snapfields[key]
                     pbar.update(n=self.snapfields[key].nbytes)
+
+    def _physical_origin(self):
+        """Return the snapshot origin in the model's global coordinate frame."""
+
+        if isinstance(self.grid, SubGridBaseGrid):
+            return self.grid.local_to_global(self.grid_view.start)
+        return self.grid_view.start * self.grid.dl
 
 
 class MPISnapshot(Snapshot[MPIGrid]):
@@ -605,6 +614,7 @@ class MPISnapshot(Snapshot[MPIGrid]):
             # f.attrs["Title"] = G.title
             f.attrs["nx_ny_nz"] = self.grid_view.global_size
             f.attrs["dx_dy_dz"] = self.grid_view.step * self.grid.dl
+            f.attrs["origin"] = self.grid_view.global_start * self.grid.dl
             f.attrs["time"] = self.time * self.grid.dt
 
             dset_slice = self.grid_view.get_3d_output_slice()

--- a/gprMax/subgrids/updates.py
+++ b/gprMax/subgrids/updates.py
@@ -90,14 +90,19 @@ class SubgridUpdater(CPUUpdates[SubGridBaseGrid]):
         self.iteration = 0
 
     def store_outputs(self):
-        return super().store_outputs(self.iteration)
+        super().store_outputs(self.iteration)
+        super().store_snapshots(self.iteration)
 
     def update_electric_sources(self):
-        super().update_electric_sources(self.iteration)
+        iteration = self.iteration
+        super().update_electric_sources(iteration)
+        super().update_eigenmode_sources_electric(iteration)
         self.iteration += 1
 
     def update_magnetic_sources(self):
-        return super().update_magnetic_sources(self.iteration)
+        super().update_magnetic_sources(self.iteration)
+        super().update_eigenmode_sources_magnetic(self.iteration)
+        super().observe_eigenmode_ports(self.iteration)
 
     def update_network_terminals(self):
         """Update sparse terminals at the fine-grid electric time step."""

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -1999,8 +1999,6 @@ class EigenmodeBand(GridUserObject):
         super().__init__(**kwargs)
 
     def build(self, grid: FDTDGrid):
-        if isinstance(grid, SubGridBaseGrid):
-            raise ValueError(f"{self.params_str()} currently supports only the main grid.")
         if grid.eigenmodeband is not None:
             raise ValueError("Exactly one EigenmodeBand may be defined per grid.")
         try:
@@ -2055,8 +2053,6 @@ class EigenmodePort(GridUserObject):
         super().__init__(**kwargs)
 
     def build(self, grid: FDTDGrid):
-        if isinstance(grid, SubGridBaseGrid):
-            raise ValueError(f"{self.params_str()} currently supports only the main grid.")
         if grid.eigenmodeband is None:
             raise ValueError(f"{self.params_str()} requires one preceding EigenmodeBand.")
         if config.sim_config.mpi:
@@ -2185,8 +2181,6 @@ class VirtualWaveguide(GridUserObject):
         )
 
     def build(self, grid: FDTDGrid):
-        if isinstance(grid, SubGridBaseGrid):
-            raise ValueError(f"{self.params_str()} currently supports only the main grid.")
         if config.sim_config.mpi:
             raise ValueError(f"{self.params_str()} cannot currently be used with MPI.")
 
@@ -2281,8 +2275,6 @@ class EigenmodeExcitation(GridUserObject):
         return kwargs
 
     def build(self, grid: FDTDGrid):
-        if isinstance(grid, SubGridBaseGrid):
-            raise ValueError(f"{self.params_str()} currently supports only the main grid.")
         if grid.eigenmodeexcitation is not None:
             raise ValueError("Only one EigenmodeExcitation may be defined per grid.")
         if grid.eigenmodeband is None:
@@ -2407,6 +2399,74 @@ def build_passive_virtual_eigenmode_ports(grid):
         runtime.fallback_frequency = band.representative_frequency
 
 
+def _discretise_eigenmode_plane(
+    user_object,
+    grid,
+    normal_axis,
+    transverse_axes,
+    full_lower,
+    full_upper,
+):
+    """Map one global-coordinate modal plane onto its owning grid.
+
+    Main-grid coordinates have a zero local origin. HSG coordinates are still
+    supplied in the global model frame, so ``SubgridUserInput`` must translate
+    them past the fine grid's auxiliary padding. A modal plane is deliberately
+    more restricted than ordinary subgrid geometry: every staggered component
+    used by the FDFD slice, TF/SF correction, and modal monitor must remain
+    strictly inside the HSG working region and away from its coupling surface.
+    """
+
+    uip = user_object._create_uip(grid)
+    full_lower = np.asarray(
+        uip.resolve_inf_point(tuple(full_lower), role="lower"),
+        dtype=np.float64,
+    )
+    full_upper = np.asarray(
+        uip.resolve_inf_point(tuple(full_upper), role="upper"),
+        dtype=np.float64,
+    )
+    lower = np.asarray(uip.discretise_point(tuple(full_lower)), dtype=np.int32)
+    upper = np.asarray(uip.discretise_point(tuple(full_upper)), dtype=np.int32)
+    plane_index = int(lower[normal_axis])
+
+    if int(upper[normal_axis]) != plane_index:
+        raise ValueError(
+            f"{user_object.params_str()} modal-plane normal coordinates must map "
+            "to the same grid plane."
+        )
+
+    if isinstance(grid, SubGridBaseGrid):
+        inner = np.asarray(
+            (
+                grid.n_boundary_cells_x,
+                grid.n_boundary_cells_y,
+                grid.n_boundary_cells_z,
+            ),
+            dtype=np.int32,
+        )
+        outer = np.asarray(grid.size, dtype=np.int32) - inner
+
+        # E is sampled/updated on plane_index and H on plane_index or
+        # plane_index - 1. Transverse staggered components include both range
+        # endpoints. Keep this complete stencil off the HSG coupling surface.
+        stencil_lower = lower.copy()
+        stencil_upper = upper.copy()
+        stencil_lower[normal_axis] = plane_index - 1
+        stencil_upper[normal_axis] = plane_index
+        if np.any(stencil_lower <= inner) or np.any(stencil_upper >= outer):
+            working_lower = tuple(grid.local_to_global(inner))
+            working_upper = tuple(grid.local_to_global(outer))
+            raise ValueError(
+                f"{user_object.params_str()} eigenmode plane and its adjacent "
+                "Yee stencil must lie strictly inside the subgrid working region "
+                f"from {working_lower} m to {working_upper} m; it cannot touch "
+                "the HSG coupling surface or enter the auxiliary/PML region."
+            )
+
+    return full_lower, full_upper, lower, upper, plane_index
+
+
 class _EigenmodeSourceBuilder(GridUserObject):
     """Internal builder for the active plane defined by an EigenmodePort."""
 
@@ -2422,9 +2482,6 @@ class _EigenmodeSourceBuilder(GridUserObject):
         super().__init__(**kwargs)
 
     def build(self, grid: FDTDGrid):
-        if isinstance(grid, SubGridBaseGrid):
-            raise ValueError(f"{self.params_str()} currently supports only the main grid.")
-
         try:
             normal = self.kwargs["normal"]
             direction = self.kwargs["direction"]
@@ -2538,26 +2595,17 @@ class _EigenmodeSourceBuilder(GridUserObject):
         full_upper[normal_axis] = w
         full_lower[transverse_axes] = p1
         full_upper[transverse_axes] = p2
-        uip = self._create_uip(grid)
-        full_lower = np.asarray(
-            uip.resolve_inf_point(tuple(full_lower), role="lower"),
-            dtype=np.float64,
-        )
-        full_upper = np.asarray(
-            uip.resolve_inf_point(tuple(full_upper), role="upper"),
-            dtype=np.float64,
+        full_lower, full_upper, lower, upper, plane_index = _discretise_eigenmode_plane(
+            self,
+            grid,
+            normal_axis,
+            transverse_axes,
+            full_lower,
+            full_upper,
         )
         p1 = tuple(full_lower[transverse_axes])
         p2 = tuple(full_upper[transverse_axes])
         w = float(full_lower[normal_axis])
-
-        lower = np.zeros(3, dtype=np.int32)
-        upper = np.zeros(3, dtype=np.int32)
-        plane_index = int(round(w / grid.dl[normal_axis]))
-        lower[transverse_axes[0]] = int(round(p1[0] / grid.dl[transverse_axes[0]]))
-        lower[transverse_axes[1]] = int(round(p1[1] / grid.dl[transverse_axes[1]]))
-        upper[transverse_axes[0]] = int(round(p2[0] / grid.dl[transverse_axes[0]]))
-        upper[transverse_axes[1]] = int(round(p2[1] / grid.dl[transverse_axes[1]]))
 
         if plane_index < 0 or plane_index > grid.size[normal_axis]:
             logger.exception(
@@ -2656,9 +2704,6 @@ class _EigenmodeReceiverBuilder(GridUserObject):
         super().__init__(**kwargs)
 
     def build(self, grid: FDTDGrid):
-        if isinstance(grid, SubGridBaseGrid):
-            raise ValueError(f"{self.params_str()} currently supports only the main grid.")
-
         try:
             normal = self.kwargs["normal"]
             direction = self.kwargs["direction"]
@@ -2730,22 +2775,17 @@ class _EigenmodeReceiverBuilder(GridUserObject):
         full_upper[normal_axis] = w
         full_lower[transverse_axes] = p1
         full_upper[transverse_axes] = p2
-        uip = self._create_uip(grid)
-        full_lower = np.asarray(
-            uip.resolve_inf_point(tuple(full_lower), role="lower"), dtype=np.float64
-        )
-        full_upper = np.asarray(
-            uip.resolve_inf_point(tuple(full_upper), role="upper"), dtype=np.float64
+        full_lower, full_upper, lower, upper, plane_index = _discretise_eigenmode_plane(
+            self,
+            grid,
+            normal_axis,
+            transverse_axes,
+            full_lower,
+            full_upper,
         )
         p1 = tuple(full_lower[transverse_axes])
         p2 = tuple(full_upper[transverse_axes])
         w = float(full_lower[normal_axis])
-        lower = np.zeros(3, dtype=np.int32)
-        upper = np.zeros(3, dtype=np.int32)
-        plane_index = int(round(w / grid.dl[normal_axis]))
-        for position, axis in enumerate(transverse_axes):
-            lower[axis] = int(round(p1[position] / grid.dl[axis]))
-            upper[axis] = int(round(p2[position] / grid.dl[axis]))
 
         if plane_index < 0 or plane_index > grid.size[normal_axis]:
             raise ValueError(f"{self.params_str()} receiver plane is outside the grid.")
@@ -2766,7 +2806,9 @@ class _EigenmodeReceiverBuilder(GridUserObject):
                 f"{self.params_str()} in {domain_mode} mode must span the invariant axis."
             )
 
-        if port_index not in grid.virtual_waveguide_specs:
+        if port_index not in grid.virtual_waveguide_specs and not isinstance(
+            grid, SubGridBaseGrid
+        ):
             axis_name = "xyz"[normal_axis]
             face = f"{axis_name}0" if direction == "+" else f"{axis_name}max"
             pml_thickness = grid.pmls["thickness"][face]
@@ -3814,7 +3856,7 @@ class PMLCFS(GridUserObject):
 
 
 class PMLSlab(GridUserObject):
-    """Place an experimental one-axis RIPML slab inside the main grid.
+    """Place an experimental one-axis RIPML slab inside a grid.
 
     ``p1`` and ``p2`` bound a rectangular region. ``maximum_face`` selects the
     local face at which complex stretching is greatest; the profile reduces
@@ -3825,7 +3867,8 @@ class PMLSlab(GridUserObject):
     faces coincident with the model boundary are omitted. The zero-stretch
     entrance remains open. Set ``build_pec=False`` to provide a custom or
     deliberately open enclosure. Exposed faces are then reported as warnings;
-    incomplete enclosures have no stability guarantee.
+    incomplete enclosures have no stability guarantee. A slab added to an HSG
+    subgrid must lie wholly within its working region.
     """
 
     FACE_TO_DIRECTION = {
@@ -3871,8 +3914,6 @@ class PMLSlab(GridUserObject):
 
         if config.sim_config.mpi:
             raise ValueError(f"{self.params_str()} cannot currently be used with MPI.")
-        if isinstance(grid, SubGridBaseGrid):
-            raise ValueError(f"{self.params_str()} cannot currently be used on a subgrid.")
         if config.get_model_config().mode.startswith("2D"):
             raise ValueError(f"{self.params_str()} cannot currently be used in 2D mode.")
         if maximum_face not in self.FACE_TO_DIRECTION:
@@ -3891,6 +3932,16 @@ class PMLSlab(GridUserObject):
             return
         if not np.all(upper > lower):
             raise ValueError(f"{self.params_str()} must have non-zero extent on all three axes.")
+        if isinstance(grid, SubGridBaseGrid):
+            inner = np.array(
+                [grid.n_boundary_cells_x, grid.n_boundary_cells_y, grid.n_boundary_cells_z]
+            )
+            outer = np.asarray(grid.size) - inner
+            if np.any(lower < inner) or np.any(upper > outer):
+                raise ValueError(
+                    f"{self.params_str()} must lie wholly inside the subgrid working region; "
+                    "it cannot overlap the HSG coupling or auxiliary PML regions."
+                )
 
         axis = "xyz".index(maximum_face[0])
         if upper[axis] - lower[axis] < 2:
@@ -3919,10 +3970,16 @@ class PMLSlab(GridUserObject):
             "build_pec": bool(build_pec),
             "generated_pec_faces": 0,
         }
+        if isinstance(grid, SubGridBaseGrid):
+            continuous_lower = grid.local_to_global(lower)
+            continuous_upper = grid.local_to_global(upper)
+        else:
+            continuous_lower = uip.discrete_to_continuous(lower)
+            continuous_upper = uip.discrete_to_continuous(upper)
         logger.info(
             f"{self.grid_name(grid)}Internal PML slab '{ID}' from "
-            f"{tuple(uip.discrete_to_continuous(lower))}m to "
-            f"{tuple(uip.discrete_to_continuous(upper))}m, with maximum "
+            f"{tuple(continuous_lower)}m to "
+            f"{tuple(continuous_upper)}m, with maximum "
             f"stretching on its {maximum_face} face"
             + (
                 f", using profile '{profile_id}'"

--- a/gprMax/user_objects/cmds_output.py
+++ b/gprMax/user_objects/cmds_output.py
@@ -378,6 +378,10 @@ class Snapshot(OutputUserObject):
                             '.vtkhdf' (default) or '.h5'
         outputs: optional list of outputs for receiver. It can be any
                     selection from Ex, Ey, Ez, Hx, Hy, or Hz.
+
+    A snapshot added to an HSG subgrid uses that grid's spatial and temporal
+    discretisation. Its output origin is expressed in global model
+    coordinates.
     """
 
     @property
@@ -424,9 +428,6 @@ class Snapshot(OutputUserObject):
         return start + step * np.ceil(size / step)
 
     def build(self, model: Model, grid: FDTDGrid):
-        if isinstance(grid, SubGridBaseGrid):
-            raise ValueError(f"{self.params_str()} do not add snapshots to subgrids.")
-
         uip = self._create_uip(grid)
         self.lower_bound = uip.resolve_inf_point(self.lower_bound, role="lower")
         self.upper_bound = uip.resolve_inf_point(self.upper_bound, role="upper")

--- a/gprMax/virtual_waveguide.py
+++ b/gprMax/virtual_waveguide.py
@@ -22,6 +22,8 @@ from gprMax.cython.virtual_waveguide import (
     couple_virtual_waveguide_electric,
     couple_virtual_waveguide_magnetic,
 )
+from gprMax.grid.fdtd_grid import FDTDGrid
+from gprMax.subgrids.grid import SubGridBaseGrid
 from gprMax.updates.cpu_updates import CPUUpdates
 
 logger = logging.getLogger(__name__)
@@ -190,7 +192,12 @@ class VirtualWaveguide:
 
     def _build_auxiliary_grid(self):
         main = self.main_grid
-        aux = type(main)()
+        # An HSG-owned guide follows the fine grid's numerical parameters but
+        # is an independent, ordinary auxiliary Yee grid. Constructing a
+        # second SubGridHSG would incorrectly require an HSG coupling region
+        # and a parent coarse grid around a guide that is deliberately
+        # detached from the physical domain.
+        aux = FDTDGrid() if isinstance(main, SubGridBaseGrid) else type(main)()
         aux.name = f"virtual_waveguide_port_{self.spec.port}"
         aux.size[:] = 1
         aux.size[self.normal_axis] = self.spec.length_cells

--- a/tests/cmds_multiuse/test_eigenmode_subgrid.py
+++ b/tests/cmds_multiuse/test_eigenmode_subgrid.py
@@ -1,17 +1,550 @@
-'''Validation for eigenmode commands placed on HSG subgrids.'''
+"""Fine-grid eigenmode-port validation for HSG subgrids."""
 
+import h5py
+import numpy as np
 import pytest
 
 import gprMax
+import gprMax.model as model_mod
 from gprMax.subgrids.subgrid_hsg import SubGridHSG
 
 
+FREQUENCY = 12e9
+
+
+def _add_modal_commands(
+    owner,
+    *,
+    offset,
+    normal_axis=0,
+    passive_port=False,
+    virtual_waveguide=False,
+):
+    """Add the same non-degenerate 12 by 10 mm aperture after translation."""
+
+    transverse_axes = tuple(axis for axis in range(3) if axis != normal_axis)
+    core_p1 = np.full(3, 0.012)
+    core_p2 = np.full(3, 0.016)
+    core_p1[normal_axis] = 0.006
+    core_p2[normal_axis] = 0.027
+    core_p1[transverse_axes[0]] = 0.013
+    core_p2[transverse_axes[0]] = 0.017
+    owner.add(gprMax.Material(er=4, se=0, mr=1, sm=0, id="core"))
+    owner.add(
+        gprMax.Box(
+            p1=tuple(core_p1 + offset),
+            p2=tuple(core_p2 + offset),
+            material_id="core",
+        )
+    )
+    source_p1 = np.full(3, 0.009)
+    source_p2 = source_p1.copy()
+    source_p1[normal_axis] = 0.015
+    source_p2[normal_axis] = 0.015
+    source_p2[transverse_axes[0]] = 0.021
+    source_p2[transverse_axes[1]] = 0.019
+
+    owner.add(gprMax.Waveform(wave_type="contsine", amp=1, freq=FREQUENCY, id="wave"))
+    owner.add(
+        gprMax.EigenmodeBand(
+            id="band",
+            fmin=FREQUENCY,
+            fmax=FREQUENCY,
+            points=1,
+        )
+    )
+    owner.add(
+        gprMax.EigenmodePort(
+            port=1,
+            p1=tuple(source_p1 + offset),
+            p2=tuple(source_p2 + offset),
+            direction="+",
+            modes=(1,),
+            anchors=(FREQUENCY,),
+            plot_fields=False,
+        )
+    )
+    if passive_port:
+        passive_p1 = source_p1.copy()
+        passive_p2 = source_p2.copy()
+        passive_p1[normal_axis] = 0.024
+        passive_p2[normal_axis] = 0.024
+        owner.add(
+            gprMax.EigenmodePort(
+                port=2,
+                p1=tuple(passive_p1 + offset),
+                p2=tuple(passive_p2 + offset),
+                direction="-",
+                modes=(1,),
+                anchors=(FREQUENCY,),
+                plot_fields=False,
+            )
+        )
+    owner.add(
+        gprMax.EigenmodeExcitation(
+            port=1,
+            mode=1,
+            waveform="wave",
+            plot_waveform=False,
+        )
+    )
+    if virtual_waveguide:
+        owner.add(
+            gprMax.VirtualWaveguide(
+                port=1,
+                length_cells=12,
+                pml_cells=4,
+                source_clearance_cells=3,
+            )
+        )
+
+
+def _uniform_fine_scene(
+    normal_axis=0,
+    *,
+    iterations=None,
+    passive_port=False,
+    virtual_waveguide=False,
+):
+    scene = gprMax.Scene()
+    scene.add(gprMax.Domain(p1=(0.03, 0.03, 0.03)))
+    scene.add(gprMax.Discretisation(p1=(0.001, 0.001, 0.001)))
+    if iterations is None:
+        scene.add(gprMax.TimeWindow(time=5e-10))
+    else:
+        scene.add(gprMax.TimeWindow(iterations=iterations))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.OMPThreads(1))
+    _add_modal_commands(
+        scene,
+        offset=np.zeros(3),
+        normal_axis=normal_axis,
+        passive_port=passive_port,
+        virtual_waveguide=virtual_waveguide,
+    )
+    return scene
+
+
+def _subgrid_scene(
+    *,
+    timewindow=5e-10,
+    iterations=None,
+    normal_axis=0,
+    port_p1=None,
+    port_p2=None,
+    virtual_waveguide=False,
+):
+    scene = gprMax.Scene()
+    scene.add(gprMax.Domain(p1=(0.09, 0.09, 0.09)))
+    scene.add(gprMax.Discretisation(p1=(0.003, 0.003, 0.003)))
+    if iterations is None:
+        scene.add(gprMax.TimeWindow(time=timewindow))
+    else:
+        scene.add(gprMax.TimeWindow(iterations=iterations))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.OMPThreads(1))
+    subgrid = gprMax.SubGridHSG(
+        p1=(0.03, 0.03, 0.03),
+        p2=(0.06, 0.06, 0.06),
+        ratio=3,
+        id="fine_grid",
+    )
+    scene.add(subgrid)
+    if port_p1 is None:
+        _add_modal_commands(
+            subgrid,
+            offset=np.full(3, 0.03),
+            normal_axis=normal_axis,
+            passive_port=True,
+            virtual_waveguide=virtual_waveguide,
+        )
+    else:
+        subgrid.add(
+            gprMax.Waveform(wave_type="contsine", amp=1, freq=FREQUENCY, id="wave")
+        )
+        subgrid.add(
+            gprMax.EigenmodeBand(
+                id="band",
+                fmin=FREQUENCY,
+                fmax=FREQUENCY,
+                points=1,
+            )
+        )
+        subgrid.add(
+            gprMax.EigenmodePort(
+                port=1,
+                p1=port_p1,
+                p2=port_p2,
+                direction="+",
+                modes=(1,),
+                anchors=(FREQUENCY,),
+                plot_fields=False,
+            )
+        )
+        subgrid.add(
+            gprMax.EigenmodeExcitation(
+                port=1,
+                mode=1,
+                waveform="wave",
+                plot_waveform=False,
+            )
+        )
+    return scene, subgrid
+
+
+def _capture_built_grids(monkeypatch, *, uniform_source_stop_iteration=None):
+    captured = []
+    original_build = model_mod.Model.build
+
+    def patched_build(self):
+        original_build(self)
+        if uniform_source_stop_iteration is not None and not self.subgrids:
+            for source in self.G.eigenmodesources:
+                source.stop = uniform_source_stop_iteration * self.G.dt
+            for guide in self.G.virtual_waveguides:
+                if guide.aux_source is not None:
+                    guide.aux_source.stop = uniform_source_stop_iteration * self.G.dt
+        captured.append([self.G, *self.subgrids])
+
+    monkeypatch.setattr(model_mod.Model, "build", patched_build)
+    return captured
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("normal_axis", range(3), ids=("x", "y", "z"))
+def test_subgrid_fdfd_slice_matches_translated_uniform_fine_grid(
+    monkeypatch, tmp_path, normal_axis
+):
+    captured = _capture_built_grids(monkeypatch)
+
+    gprMax.run(
+        scenes=[_uniform_fine_scene(normal_axis)],
+        geometry_only=True,
+        outputfile=tmp_path / "uniform",
+        cpu_precision="double",
+        hide_progress_bars=True,
+    )
+    scene, _ = _subgrid_scene(normal_axis=normal_axis)
+    gprMax.run(
+        scenes=[scene],
+        geometry_only=True,
+        outputfile=tmp_path / "subgrid",
+        subgrid=True,
+        autotranslate=True,
+        cpu_precision="double",
+        hide_progress_bars=True,
+    )
+
+    uniform_grid = captured[0][0]
+    fine_grid = captured[1][1]
+    uniform_source = uniform_grid.eigenmodesources[0]
+    fine_source = fine_grid.eigenmodesources[0]
+
+    np.testing.assert_allclose(fine_grid.dl, uniform_grid.dl)
+    source_start = np.zeros(3, dtype=np.int32)
+    source_start[fine_source.normal_axis] = fine_source.plane_index
+    source_start[list(fine_source.transverse_axes)] = fine_source.transverse_start
+    expected_start = np.full(3, 0.039)
+    expected_start[normal_axis] = 0.045
+    np.testing.assert_allclose(fine_grid.local_to_global(source_start), expected_start)
+    assert fine_source._transverse_cell_shape() == uniform_source._transverse_cell_shape()
+    assert fine_source.complex_neff == pytest.approx(
+        uniform_source.complex_neff,
+        rel=1e-12,
+        abs=1e-12,
+    )
+    for fine_field, uniform_field in zip(
+        (
+            *fine_source.modal_e,
+            *fine_source.modal_h,
+            *fine_source.modal_e_real,
+            *fine_source.modal_h_real,
+        ),
+        (
+            *uniform_source.modal_e,
+            *uniform_source.modal_h,
+            *uniform_source.modal_e_real,
+            *uniform_source.modal_h_real,
+        ),
+    ):
+        np.testing.assert_allclose(fine_field, uniform_field, rtol=1e-11, atol=1e-9)
+
+
 @pytest.mark.parametrize(
-    'command_type',
-    (gprMax.EigenmodeBand, gprMax.EigenmodePort, gprMax.EigenmodeExcitation),
-    ids=('band', 'port', 'excitation'),
+    ("p1", "p2"),
+    (
+        ((0.031, 0.039, 0.039), (0.031, 0.051, 0.051)),
+        ((0.045, 0.030, 0.039), (0.045, 0.051, 0.051)),
+        ((0.045, 0.039, 0.039), (0.045, 0.060, 0.051)),
+    ),
+    ids=("normal-stencil", "lower-transverse", "upper-transverse"),
 )
-def test_eigenmode_command_rejects_subgrid(command_type):
-    subgrid = object.__new__(SubGridHSG)
-    with pytest.raises(ValueError, match='currently supports only the main grid'):
-        command_type().build(subgrid)
+def test_subgrid_eigenmode_plane_cannot_touch_coupling_surface(tmp_path, p1, p2):
+    scene, _ = _subgrid_scene(timewindow=1e-10, port_p1=p1, port_p2=p2)
+
+    with pytest.raises(ValueError, match="must lie strictly inside the subgrid working region"):
+        gprMax.run(
+            scenes=[scene],
+            geometry_only=True,
+            outputfile=tmp_path / "invalid",
+            subgrid=True,
+            autotranslate=True,
+            hide_progress_bars=True,
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("normal_axis", range(3), ids=("x", "y", "z"))
+def test_subgrid_virtual_waveguide_inherits_fine_grid(
+    monkeypatch, tmp_path, normal_axis
+):
+    captured = _capture_built_grids(monkeypatch)
+
+    gprMax.run(
+        scenes=[
+            _uniform_fine_scene(
+                normal_axis,
+                virtual_waveguide=True,
+            )
+        ],
+        geometry_only=True,
+        outputfile=tmp_path / "uniform_virtual",
+        cpu_precision="double",
+        hide_progress_bars=True,
+    )
+    scene, _ = _subgrid_scene(
+        normal_axis=normal_axis,
+        virtual_waveguide=True,
+    )
+    gprMax.run(
+        scenes=[scene],
+        geometry_only=True,
+        outputfile=tmp_path / "subgrid_virtual",
+        subgrid=True,
+        autotranslate=True,
+        cpu_precision="double",
+        hide_progress_bars=True,
+    )
+
+    uniform_grid = captured[0][0]
+    fine_grid = captured[1][1]
+    uniform_guide = uniform_grid.virtual_waveguides[0]
+    fine_guide = fine_grid.virtual_waveguides[0]
+
+    assert fine_guide.main_grid is fine_grid
+    assert type(fine_guide.aux_grid) is type(uniform_guide.aux_grid)
+    np.testing.assert_allclose(fine_guide.aux_grid.dl, fine_grid.dl)
+    assert fine_guide.aux_grid.dt == pytest.approx(fine_grid.dt)
+    assert fine_guide.aux_grid.iterations == fine_grid.iterations
+    np.testing.assert_array_equal(fine_guide.aux_grid.size, uniform_guide.aux_grid.size)
+    np.testing.assert_array_equal(fine_guide.aux_grid.solid, uniform_guide.aux_grid.solid)
+    np.testing.assert_array_equal(fine_guide.aux_grid.ID, uniform_guide.aux_grid.ID)
+    np.testing.assert_allclose(
+        fine_guide.aux_grid.updatecoeffsE,
+        uniform_guide.aux_grid.updatecoeffsE,
+    )
+    np.testing.assert_allclose(
+        fine_guide.aux_grid.updatecoeffsH,
+        uniform_guide.aux_grid.updatecoeffsH,
+    )
+    assert fine_guide.aux_source.plane_index == uniform_guide.aux_source.plane_index
+    for fine_field, uniform_field in zip(
+        (*fine_guide.aux_source.modal_e, *fine_guide.aux_source.modal_h),
+        (*uniform_guide.aux_source.modal_e, *uniform_guide.aux_source.modal_h),
+    ):
+        np.testing.assert_allclose(fine_field, uniform_field, rtol=1e-11, atol=1e-9)
+
+
+@pytest.mark.integration
+def test_subgrid_virtual_waveguide_transient_matches_uniform_fine_grid(
+    monkeypatch, tmp_path
+):
+    captured = _capture_built_grids(monkeypatch, uniform_source_stop_iteration=3)
+    fine_iterations = 6
+    gprMax.run(
+        scenes=[
+            _uniform_fine_scene(
+                iterations=fine_iterations,
+                passive_port=True,
+                virtual_waveguide=True,
+            )
+        ],
+        outputfile=tmp_path / "uniform_virtual_transient",
+        cpu_precision="double",
+        hide_progress_bars=True,
+    )
+    scene, _ = _subgrid_scene(
+        iterations=fine_iterations // 3,
+        virtual_waveguide=True,
+    )
+    gprMax.run(
+        scenes=[scene],
+        outputfile=tmp_path / "subgrid_virtual_transient",
+        subgrid=True,
+        autotranslate=True,
+        cpu_precision="double",
+        hide_progress_bars=True,
+    )
+
+    uniform_guide = captured[0][0].virtual_waveguides[0]
+    fine_guide = captured[1][1].virtual_waveguides[0]
+    for field_name in ("Ex", "Ey", "Ez", "Hx", "Hy", "Hz"):
+        np.testing.assert_allclose(
+            getattr(fine_guide.aux_grid, field_name),
+            getattr(uniform_guide.aux_grid, field_name),
+            rtol=1e-11,
+            atol=1e-12,
+            err_msg=field_name,
+        )
+
+
+@pytest.mark.integration
+def test_subgrid_transient_modal_response_matches_uniform_fine_grid(
+    monkeypatch, tmp_path
+):
+    """Compare identical fine updates before a boundary return can arrive."""
+
+    # An HSG run performs ``ratio`` fine updates per main iteration but all
+    # sources inherit the main grid's last output time. Give the uniform-fine
+    # reference the same source stop time before comparing those updates.
+    captured = _capture_built_grids(monkeypatch, uniform_source_stop_iteration=3)
+    fine_iterations = 6
+    uniform_output = tmp_path / "uniform_transient"
+    subgrid_output = tmp_path / "subgrid_transient"
+    gprMax.run(
+        scenes=[
+            _uniform_fine_scene(
+                iterations=fine_iterations,
+                passive_port=True,
+            )
+        ],
+        outputfile=uniform_output,
+        cpu_precision="double",
+        hide_progress_bars=True,
+    )
+    scene, subgrid_object = _subgrid_scene(iterations=fine_iterations // 3)
+    gprMax.run(
+        scenes=[scene],
+        outputfile=subgrid_output,
+        subgrid=True,
+        autotranslate=True,
+        cpu_precision="double",
+        hide_progress_bars=True,
+    )
+
+    assert subgrid_object.subgrid.iterations == fine_iterations
+    uniform_grid = captured[0][0]
+    fine_grid = captured[1][1]
+    inner = np.asarray(
+        (
+            fine_grid.n_boundary_cells_x,
+            fine_grid.n_boundary_cells_y,
+            fine_grid.n_boundary_cells_z,
+        )
+    )
+    outer = np.asarray(fine_grid.size) - inner
+    cell_slices = tuple(slice(int(start), int(stop)) for start, stop in zip(inner, outer))
+    component_slices = tuple(
+        slice(int(start), int(stop + 1)) for start, stop in zip(inner, outer)
+    )
+    np.testing.assert_array_equal(fine_grid.solid[cell_slices], uniform_grid.solid)
+    np.testing.assert_array_equal(
+        fine_grid.ID[(slice(None), *component_slices)],
+        uniform_grid.ID,
+    )
+    fine_slices = tuple(slice(int(start + 2), int(stop - 1)) for start, stop in zip(inner, outer))
+    uniform_slices = (slice(2, -2),) * 3
+    for field_name, fine_field, uniform_field in zip(
+        ("Ey", "Ez", "Hx", "Hy", "Hz"),
+        (fine_grid.Ey, fine_grid.Ez, fine_grid.Hx, fine_grid.Hy, fine_grid.Hz),
+        (
+            uniform_grid.Ey,
+            uniform_grid.Ez,
+            uniform_grid.Hx,
+            uniform_grid.Hy,
+            uniform_grid.Hz,
+        ),
+    ):
+        np.testing.assert_allclose(
+            fine_field[fine_slices],
+            uniform_field[uniform_slices],
+            rtol=1e-11,
+            atol=1e-12,
+            err_msg=field_name,
+        )
+    with (
+        h5py.File(uniform_output.with_suffix(".h5"), "r") as uniform,
+        h5py.File(subgrid_output.with_suffix(".h5"), "r") as refined,
+    ):
+        for port_name in ("port1", "port2"):
+            uniform_port = uniform[f"eigenmode_ports/{port_name}"]
+            refined_port = refined[f"subgrids/fine_grid/eigenmode_ports/{port_name}"]
+            for dataset in ("incident", "outgoing"):
+                np.testing.assert_allclose(
+                    refined_port[dataset][...],
+                    uniform_port[dataset][...],
+                    rtol=1e-10,
+                    atol=1e-20,
+                )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("virtual_waveguide", (False, True), ids=("direct", "virtual"))
+def test_subgrid_eigenmode_source_runs_and_writes_fine_grid_port(
+    tmp_path, virtual_waveguide
+):
+    scene, subgrid_object = _subgrid_scene(
+        timewindow=5e-10,
+        virtual_waveguide=virtual_waveguide,
+    )
+    variant = "virtual" if virtual_waveguide else "direct"
+    outputfile = tmp_path / f"subgrid_eigenmode_{variant}"
+    gprMax.run(
+        scenes=[scene],
+        outputfile=outputfile,
+        subgrid=True,
+        autotranslate=True,
+        cpu_precision="double",
+        hide_progress_bars=True,
+    )
+    assert (tmp_path / f"subgrid_eigenmode_{variant}_fine_grid_sparameters.csv").is_file()
+
+    with h5py.File(outputfile.with_suffix(".h5"), "r") as output:
+        group = output["subgrids/fine_grid/eigenmode_ports"]
+        assert output["subgrids/fine_grid"].attrs["neigenmodeports"] == 2
+        assert set(group) == {"port1", "port2"}
+        for port in group.values():
+            assert np.all(np.isfinite(port["incident"][...]))
+            assert np.all(np.isfinite(port["outgoing"][...]))
+        assert np.max(np.abs(group["port1/incident"][...])) > 0
+
+    fine_grid = subgrid_object.subgrid
+    assert all(
+        port._next_iteration == fine_grid.iterations for port in fine_grid.eigenmodeports
+    )
+    assert max(
+        float(np.max(np.abs(field)))
+        for field in (
+            fine_grid.Ex,
+            fine_grid.Ey,
+            fine_grid.Ez,
+            fine_grid.Hx,
+            fine_grid.Hy,
+            fine_grid.Hz,
+        )
+    ) > 0
+    if virtual_waveguide:
+        assert len(fine_grid.virtual_waveguides) == 1
+        guide = fine_grid.virtual_waveguides[0]
+        assert guide.aux_grid.iterations == fine_grid.iterations
+        assert max(
+            float(np.max(np.abs(field)))
+            for field in (
+                guide.aux_grid.Ex,
+                guide.aux_grid.Ey,
+                guide.aux_grid.Ez,
+                guide.aux_grid.Hx,
+                guide.aux_grid.Hy,
+                guide.aux_grid.Hz,
+            )
+        ) > 0

--- a/tests/outputs/test_subgrid_geometry_view_origin.py
+++ b/tests/outputs/test_subgrid_geometry_view_origin.py
@@ -1,0 +1,52 @@
+"""Global-coordinate placement of voxel and edge views owned by a subgrid."""
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("output_type", ("n", "f"))
+def test_subgrid_geometry_view_uses_requested_global_origin(tmp_path, output_type):
+    scene = gprMax.Scene()
+    scene.add(gprMax.Domain(p1=(0.09, 0.09, 0.09)))
+    scene.add(gprMax.Discretisation(p1=(0.003, 0.003, 0.003)))
+    scene.add(gprMax.TimeWindow(time=1e-11))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    subgrid = gprMax.SubGridHSG(
+        p1=(0.03, 0.03, 0.03),
+        p2=(0.06, 0.06, 0.06),
+        ratio=3,
+        id="fine_grid",
+    )
+    scene.add(subgrid)
+    subgrid.add(
+        gprMax.GeometryView(
+            p1=(0.041, 0.042, 0.043),
+            p2=(0.048, 0.049, 0.050),
+            dl=(0.001, 0.001, 0.001),
+            filename=f"fine_geometry_{output_type}",
+            output_type=output_type,
+        )
+    )
+
+    gprMax.run(
+        scenes=[scene],
+        geometry_only=True,
+        outputfile=tmp_path / f"geometry_{output_type}",
+        subgrid=True,
+        autotranslate=True,
+        hide_progress_bars=True,
+    )
+
+    filename = tmp_path / f"fine_geometry_{output_type}.vtkhdf"
+    assert filename.exists()
+    with h5py.File(filename, "r") as view:
+        vtk = view["VTKHDF"]
+        if output_type == "n":
+            np.testing.assert_allclose(vtk.attrs["Origin"], (0.041, 0.042, 0.043))
+        else:
+            points = vtk["Points"][...]
+            np.testing.assert_allclose(np.min(points, axis=0), (0.041, 0.042, 0.043))

--- a/tests/subgrids/test_subgrid_snapshots_pml.py
+++ b/tests/subgrids/test_subgrid_snapshots_pml.py
@@ -1,0 +1,182 @@
+"""Field-output and internal-PML coverage for objects owned by an HSG subgrid."""
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+import gprMax.model as model_mod
+
+
+def _subgrid_scene(timewindow=5e-11):
+    scene = gprMax.Scene()
+    scene.add(gprMax.Domain(p1=(0.09, 0.09, 0.09)))
+    scene.add(gprMax.Discretisation(p1=(0.003, 0.003, 0.003)))
+    scene.add(gprMax.TimeWindow(time=timewindow))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.OMPThreads(1))
+    subgrid = gprMax.SubGridHSG(
+        p1=(0.03, 0.03, 0.03),
+        p2=(0.06, 0.06, 0.06),
+        ratio=3,
+        id="fine_grid",
+    )
+    scene.add(subgrid)
+    return scene, subgrid
+
+
+@pytest.mark.integration
+def test_snapshot_runs_at_fine_time_step_and_uses_global_origin(tmp_path):
+    scene, subgrid = _subgrid_scene()
+    subgrid.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
+    subgrid.add(
+        gprMax.HertzianDipole(
+            p1=(0.045, 0.045, 0.045),
+            polarisation="z",
+            waveform_id="pulse",
+        )
+    )
+    subgrid.add(
+        gprMax.Snapshot(
+            p1=(0.042, 0.042, 0.042),
+            p2=(0.049, 0.049, 0.049),
+            dl=(0.001, 0.001, 0.001),
+            filename="subgrid_fields",
+            time=2e-11,
+            fileext=".h5",
+            outputs=["Ez"],
+        )
+    )
+
+    output = tmp_path / "snapshot_model"
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        outputfile=output,
+        subgrid=True,
+        autotranslate=True,
+        hide_progress_bars=True,
+    )
+
+    filename = tmp_path / "snapshot_model_snaps" / "subgrid_fields.h5"
+    assert filename.exists()
+    with h5py.File(filename, "r") as snapshot:
+        np.testing.assert_allclose(snapshot.attrs["origin"], (0.042, 0.042, 0.042))
+        np.testing.assert_allclose(snapshot.attrs["dx_dy_dz"], (0.001, 0.001, 0.001))
+        assert snapshot.attrs["time"] == pytest.approx(2e-11, rel=0.1)
+        assert snapshot["Ez"].shape == (7, 7, 7)
+        assert np.max(np.abs(snapshot["Ez"][...])) > 0
+
+
+def _capture_grids(monkeypatch):
+    captured = []
+    original_build = model_mod.Model.build
+
+    def patched_build(self):
+        original_build(self)
+        captured.append([self.G, *self.subgrids])
+
+    monkeypatch.setattr(model_mod.Model, "build", patched_build)
+    return captured
+
+
+def _add_internal_slab(owner):
+    owner.add(
+        gprMax.PMLSlab(
+            p1=(0.040, 0.040, 0.040),
+            p2=(0.044, 0.050, 0.050),
+            maximum_face="x0",
+            id="fine_load",
+        )
+    )
+
+
+@pytest.mark.integration
+def test_subgrid_internal_pml_matches_uniform_fine_grid_coefficients(monkeypatch, tmp_path):
+    captured = _capture_grids(monkeypatch)
+
+    uniform = gprMax.Scene()
+    uniform.add(gprMax.Domain(p1=(0.09, 0.09, 0.09)))
+    uniform.add(gprMax.Discretisation(p1=(0.001, 0.001, 0.001)))
+    uniform.add(gprMax.TimeWindow(time=1e-11))
+    uniform.add(gprMax.PMLThickness(thickness=0))
+    _add_internal_slab(uniform)
+    gprMax.run(
+        scenes=[uniform],
+        geometry_only=True,
+        outputfile=tmp_path / "uniform",
+        hide_progress_bars=True,
+        cpu_precision="double",
+    )
+
+    subgrid_scene, subgrid = _subgrid_scene(timewindow=1e-11)
+    _add_internal_slab(subgrid)
+    gprMax.run(
+        scenes=[subgrid_scene],
+        geometry_only=True,
+        outputfile=tmp_path / "subgrid",
+        subgrid=True,
+        autotranslate=True,
+        hide_progress_bars=True,
+    )
+
+    uniform_pml = next(pml for pml in captured[0][0].pmls["slabs"] if pml.ID == "fine_load")
+    fine_grid = captured[1][1]
+    subgrid_pml = next(pml for pml in fine_grid.pmls["slabs"] if pml.ID == "fine_load")
+    for name in ("ERA", "ERB", "ERE", "ERF", "HRA", "HRB", "HRE", "HRF"):
+        np.testing.assert_allclose(getattr(subgrid_pml, name), getattr(uniform_pml, name))
+
+    record = fine_grid.pmls["internal_registry"]["fine_load"]
+    assert record["generated_pec_faces"] == 5
+    assert record["enclosure_complete"]
+
+
+def test_subgrid_internal_pml_cannot_overlap_coupling_region(tmp_path):
+    scene, subgrid = _subgrid_scene(timewindow=1e-11)
+    subgrid.add(
+        gprMax.PMLSlab(
+            p1=(0.029, 0.040, 0.040),
+            p2=(0.034, 0.050, 0.050),
+            maximum_face="x0",
+        )
+    )
+
+    with pytest.raises(ValueError, match="wholly inside the subgrid working region"):
+        gprMax.run(
+            scenes=[scene],
+            geometry_only=True,
+            outputfile=tmp_path / "invalid",
+            subgrid=True,
+            autotranslate=True,
+            hide_progress_bars=True,
+        )
+
+
+@pytest.mark.integration
+def test_subgrid_internal_pml_runs_on_every_fine_update(tmp_path):
+    scene, subgrid = _subgrid_scene(timewindow=1e-10)
+    _add_internal_slab(subgrid)
+    subgrid.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=8e9, id="pulse"))
+    subgrid.add(
+        gprMax.HertzianDipole(
+            p1=(0.047, 0.045, 0.045),
+            polarisation="z",
+            waveform_id="pulse",
+        )
+    )
+    subgrid.add(gprMax.Rx(p1=(0.043, 0.045, 0.045), id="inside_load"))
+
+    output = tmp_path / "pml_update"
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        outputfile=output,
+        subgrid=True,
+        autotranslate=True,
+        hide_progress_bars=True,
+    )
+
+    with h5py.File(output.with_suffix(".h5"), "r") as result:
+        ez = result["subgrids/fine_grid/rxs/rx1/Ez"][...]
+        assert np.all(np.isfinite(ez))
+        assert np.max(np.abs(ez)) > 0


### PR DESCRIPTION
## Summary

Extends HSG subgrid support to features that can operate entirely on the fine grid:

- enables snapshots and geometry views with global-coordinate origins and fine-grid spacing/time steps;
- enables internal PML slabs when they remain wholly inside the HSG working region;
- enables direct eigenmode bands, ports, excitation, and modal observation on the fine update cycle;
- enables virtual waveguides attached to subgrid eigenmode ports, inheriting the fine material cross-section, `dl`, `dt`, update coefficients, and iteration count;
- writes eigenmode-only subgrid output under `/subgrids/<id>/eigenmode_ports`;
- rejects modal stencils or PML slabs that touch the HSG coupling surface or auxiliary/PML region;
- documents the supported workflows, output locations, restrictions, and coordinate conventions.

The branch is based on current `devel`, including PR #757's revised eigenmode preparation, cutoff handling, generalized coefficients, and power-wave validity logic.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Validation

- 176 eigenmode tests passed; 18 hardware-dependent GPU tests deselected.
- 24 focused direct/virtual eigenmode subgrid tests passed.
- 19 focused subgrid snapshot, PML, geometry-view, and eigenmode tests passed.
- Sphinx HTML build succeeded; only two pre-existing unused-citation warnings remain.
- `git diff --check` passed.

The transient validation compares a subgrid-owned virtual waveguide with an equivalent uniformly fine model and verifies every auxiliary E/H field after the same fine-grid updates. Construction parity is checked in all three normal orientations.

## Current restrictions

- HSG subgrids use the CPU fine-grid update cycle.
- MPI remains unsupported for eigenmode ports, virtual waveguides, and internal PML slabs.
- Modal apertures and subgrid PML slabs must remain strictly inside the HSG working region.

## Checklist

- [x] I have performed a self-review of the code.
- [x] I have added comments for non-obvious coordinate and auxiliary-grid handling.
- [x] I have made corresponding documentation changes.
- [x] My changes generate no new documentation warnings.
- [x] The PR title is a short description of the changes.
