### PR TITLE
Extend MPI support for local devices and configured precision

### DIFF
--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -654,9 +654,12 @@ convolution treatment of Giannakis and Giannopoulos [GIA2014]_: every pole
 current is evaluated analytically at the electric half-step for a linearly
 varying voltage, rather than estimated by averaging its two integer-time
 values. State is stored only for placed terminals. Independent one-port
-networks are supported in 3-D, non-MPI models on the CPU, CUDA, OpenCL, and
-Metal solvers; terminals inside subgrids currently use the CPU solver. Device
-runs keep the network recurrence and field correction on the compute device
+rational networks are supported in 3-D on the CPU, CUDA, OpenCL, and Metal
+solvers, including domain-decomposed MPI CPU models; terminals inside
+subgrids currently use the CPU solver. An MPI terminal is advanced only on
+the rank that owns its electric edge, and its histories are gathered for port
+post-processing. Device runs keep the network recurrence and field correction
+on the compute device
 and copy the completed histories back after the solve. Coupled multiport
 admittance matrices are reserved for a later extension.
 
@@ -729,8 +732,11 @@ resulting aperture remains sub-cell. For example:
     ))
 
 The corrected formulation is supported by the CPU, CUDA, OpenCL, and Metal
-solvers. It is also supported inside a CPU ``SubGridHSG``. Add the waveform,
-PEC ground plane, thin wire, and magnetic frill to the same subgrid object,
+solvers and by domain-decomposed MPI CPU models. Its four magnetic feed edges
+may cross internal MPI rank boundaries; symmetry-boundary completion is not
+supported with MPI. It is also supported inside a CPU ``SubGridHSG``. Add the
+waveform, PEC ground plane, thin wire, and magnetic frill to the same subgrid
+object,
 using the same global-coordinate convention as other subgrid sources when
 ``autotranslate=True``:
 
@@ -907,6 +913,12 @@ arrays that are stored under ``/ports/feed`` in the model HDF5 file. For a
 hard source, gprMax obtains terminal current from the surrounding magnetic-
 field loop and accounts explicitly for the half-step phase difference from
 the integer-time voltage during transformation.
+
+``RxPort`` also supports domain-decomposed MPI CPU models. The owning rank
+stores the voltage history; hard-source current loops may cross internal rank
+faces because magnetic halos are synchronised before sampling. Histories are
+gathered and transformed once on the coordinator rank, while ``port.result``
+is rebound to that final result for Python API use.
 
 An ``RxPort`` may also be placed inside a ``SubGridHSG``. Add the waveform,
 voltage source, and port to the same subgrid object; the port is then sampled

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -698,8 +698,11 @@ For example, a z-directed wire of radius 0.1 mm is specified by:
 
 The wire may lie on a transverse domain face only when that face is a PMC
 symmetry boundary. A wire and its surrounding magnetic stencil must not touch
-a PML region. Thin wires in 2D models, MPI models, and overlapping sub-cell
-wire junctions are not currently supported. The charge-based end-cap treatment
+a PML region. MPI domain decomposition is supported: each electric edge and
+each member of the surrounding magnetic stencil is constructed on its owning
+rank, including a stencil that crosses an internal rank boundary. Thin wires
+in 2D models and overlapping sub-cell wire junctions are not currently
+supported. The charge-based end-cap treatment
 from [MAK2002]_ is not implemented, so an isolated open end retains the usual
 staircasing/electrically-long end error; the improved straight-section update
 is used up to the final wire edge. No special runtime solver is used: the
@@ -1200,11 +1203,14 @@ discretely identical to a finite-resistance ``#voltage_source`` having the
 same :math:`R`, waveform, position, and polarisation. A zero-resistance hard
 source is not equivalent.
 
-This implementation supports 3-D, non-MPI models on the CPU, CUDA, OpenCL,
-and Metal solvers and a nondispersive terminal edge; dispersive materials may
-exist elsewhere in the model. A terminal may be placed in a CPU subgrid, where
-it uses the fine spatial and temporal steps. On an accelerator the complete
-recurrence and local field correction remain device-resident during time
+This implementation supports 3-D models on the CPU, CUDA, OpenCL, and Metal
+solvers, including domain-decomposed MPI CPU models, and a nondispersive
+terminal edge; dispersive materials may exist elsewhere in the model. In an
+MPI model the sparse terminal state is advanced only by the rank that owns its
+electric edge, then gathered for final port processing. A terminal may be
+placed in a CPU subgrid, where it uses the fine spatial and temporal steps. On
+an accelerator the complete recurrence and local field correction remain
+device-resident during time
 stepping. Several independent terminals may be used, but a coupled multiport
 admittance matrix is not yet supported. See [CHE2007]_ for the general PLRC
 lumped-network formulation and :ref:`Analytical comparisons
@@ -1278,7 +1284,10 @@ There is no explicit one-dimensional line, no absorbing boundary, and no
 equivalent magnetic surface current entering Faraday's law at the four Yee
 magnetic-field components immediately surrounding the feed point. The
 corrected Hyun feed-cell formulation is supported by the CPU, CUDA, OpenCL,
-and Metal solvers. The syntax is:
+and Metal solvers, and by domain-decomposed MPI CPU models. In MPI, the four
+magnetic feed edges may cross internal rank boundaries: their Ampere-loop
+terms are combined before the common terminal state is advanced, and each
+field deposit is applied by its owning rank. The syntax is:
 
 .. code-block:: none
 
@@ -1454,6 +1463,9 @@ objects (including the waveform) to the same subgrid object.
     * Two frill sources may not share a surrounding H edge. Such adjacent or
       duplicate feeds form a coupled feed-cell system and cannot be advanced
       as independent scalar terminal relations.
+    * MPI symmetry boundaries remain unsupported. An MPI frill and its thin
+      wire may cross internal rank boundaries, but must not rely on symmetry
+      completion at an outer domain face.
     * This source is a "Path A" (through-ground-plane, continuous-conductor)
       feed model. It is not intended for a dipole/bow-tie style gap feed
       (:math:`E_z \neq 0` at the feed) - use ``#voltage_source`` for that case.
@@ -1770,6 +1782,12 @@ The voltage source supplies the reference impedance :math:`Z_0`. For example:
     # Custom 75 Ohm hard-source reference; start/stop precede it positionally
     #voltage_source: z 0.070 0.050 0.020 0 source_wave 0 10e-9 75
     #rx_port: 0.070 0.050 0.020 ideal_feed_75
+
+``#rx_port`` is supported in domain-decomposed MPI CPU models. The source and
+its internal field monitor belong to one rank; for a hard source, magnetic
+halos are synchronised before the next current sample so an Ampere loop may
+cross an internal rank face or corner. Port histories are gathered and the
+frequency-domain quantities are calculated once on the coordinator rank.
 
 
 For a finite-resistance source, the voltage-source resistance is the

--- a/docs/source/output.rst
+++ b/docs/source/output.rst
@@ -401,6 +401,9 @@ subgrid's spatial step, time step, iteration count, material edge, and field
 histories. For a finite-resistance source, its resistance is the reference
 impedance :math:`Z_0`; the source-plane reflection coefficient is calculated
 from the known generator voltage and sampled total gap voltage.
+In a domain-decomposed MPI model the same schema is written after source,
+receiver, and port histories have been gathered on the coordinator. All
+``Position`` and ``GridPosition`` metadata use the global main-grid frame.
 For a zero-resistance hard source, :math:`Z_0` is supplied by the voltage
 source (50 Ohms by default) and
 the terminal quantities are calculated from the prescribed voltage and

--- a/gprMax/fractals/fractal_surface.py
+++ b/gprMax/fractals/fractal_surface.py
@@ -214,8 +214,9 @@ class FractalSurface:
         # Take the real part (numerical errors can give rise to an imaginary part)
         #  of the IFFT, and convert type to floattype. N.B calculation of fractals
         # must always be carried out at double precision, i.e. float64, complex128
-        self.fractalsurface = np.real(fftpack.ifftn(self.fractalsurface)).astype(
-            config.sim_config.dtypes["float_or_double"], copy=False
+        self.fractalsurface = np.ascontiguousarray(
+            np.real(fftpack.ifftn(self.fractalsurface)),
+            dtype=config.sim_config.dtypes["float_or_double"],
         )
         # Scale the fractal volume according to requested range
         fractalmin = np.amin(self.fractalsurface)
@@ -429,7 +430,9 @@ class MPIFractalSurface(FractalSurface):
         # Take the real part (numerical errors can give rise to an imaginary part)
         #  of the IFFT, and convert type to floattype. N.B calculation of fractals
         # must always be carried out at double precision, i.e. float64, complex128
-        A = np.real(A).astype(config.sim_config.dtypes["float_or_double"], copy=False)
+        A = np.ascontiguousarray(
+            np.real(A), dtype=config.sim_config.dtypes["float_or_double"]
+        )
 
         # Allreduce to get min and max values in the fractal surface
         min_value = np.array(np.amin(A), dtype=config.sim_config.dtypes["float_or_double"])
@@ -508,7 +511,12 @@ class MPIFractalSurface(FractalSurface):
                 )
             ):
                 mpi_type = create_mpi_type(
-                    A_shape, -negative_offset, -positive_offset, dirs, sending=True
+                    A_shape,
+                    -negative_offset,
+                    -positive_offset,
+                    dirs,
+                    A.dtype,
+                    sending=True,
                 )
 
                 logger.debug(
@@ -524,7 +532,13 @@ class MPIFractalSurface(FractalSurface):
                     dirs == Dir.NONE,
                 )
             ):
-                mpi_type = create_mpi_type(local_shape, negative_offset, positive_offset, dirs)
+                mpi_type = create_mpi_type(
+                    local_shape,
+                    negative_offset,
+                    positive_offset,
+                    dirs,
+                    self.fractalsurface.dtype,
+                )
 
                 logger.debug(
                     f"Receiving fractal surface from rank {rank}, MPI type={mpi_type.decode()}"

--- a/gprMax/fractals/fractal_volume.py
+++ b/gprMax/fractals/fractal_volume.py
@@ -263,8 +263,9 @@ class FractalVolume:
         # Take the real part (numerical errors can give rise to an imaginary part)
         # of the IFFT, and convert type to floattype. N.B calculation of fractals
         # must always be carried out at double precision, i.e. float64, complex128
-        self.fractalvolume = np.real(fftpack.ifftn(self.fractalvolume)).astype(
-            config.sim_config.dtypes["float_or_double"], copy=False
+        self.fractalvolume = np.ascontiguousarray(
+            np.real(fftpack.ifftn(self.fractalvolume)),
+            dtype=config.sim_config.dtypes["float_or_double"],
         )
 
         # Bin fractal values
@@ -489,7 +490,9 @@ class MPIFractalVolume(FractalVolume):
         # Take the real part (numerical errors can give rise to an imaginary part)
         # of the IFFT, and convert type to floattype. N.B calculation of fractals
         # must always be carried out at double precision, i.e. float64, complex128
-        A = np.real(A).astype(config.sim_config.dtypes["float_or_double"], copy=False)
+        A = np.ascontiguousarray(
+            np.real(A), dtype=config.sim_config.dtypes["float_or_double"]
+        )
 
         # Allreduce to get min and max values in the fractal volume
         min_value = np.array(np.amin(A), dtype=config.sim_config.dtypes["float_or_double"])
@@ -569,7 +572,12 @@ class MPIFractalVolume(FractalVolume):
                 )
             ):
                 mpi_type = create_mpi_type(
-                    A_shape, -negative_offset, -positive_offset, dirs, sending=True
+                    A_shape,
+                    -negative_offset,
+                    -positive_offset,
+                    dirs,
+                    A.dtype,
+                    sending=True,
                 )
 
                 logger.debug(f"Sending fractal volume to rank {rank}, MPI type={mpi_type.decode()}")
@@ -583,7 +591,13 @@ class MPIFractalVolume(FractalVolume):
                     dirs == Dir.NONE,
                 )
             ):
-                mpi_type = create_mpi_type(local_shape, negative_offset, positive_offset, dirs)
+                mpi_type = create_mpi_type(
+                    local_shape,
+                    negative_offset,
+                    positive_offset,
+                    dirs,
+                    self.fractalvolume.dtype,
+                )
 
                 logger.debug(
                     f"Receiving fractal volume from rank {rank}, MPI type={mpi_type.decode()}"

--- a/gprMax/fractals/mpi_utilities.py
+++ b/gprMax/fractals/mpi_utilities.py
@@ -23,7 +23,7 @@ import numpy as np
 import numpy.typing as npt
 from mpi4py import MPI
 
-from gprMax.utilities.mpi import Dir
+from gprMax.utilities.mpi import Dir, mpi_datatype_for_dtype
 
 
 def calculate_starts_and_subshape(
@@ -65,11 +65,15 @@ def create_mpi_type(
     negative_offset: npt.NDArray[np.int32],
     positive_offset: npt.NDArray[np.int32],
     dirs: npt.NDArray[np.int32],
+    dtype: npt.DTypeLike,
     sending: bool = False,
 ) -> MPI.Datatype:
     starts, subshape = calculate_starts_and_subshape(
         shape, negative_offset, positive_offset, dirs, sending
     )
-    mpi_type = MPI.FLOAT.Create_subarray(shape.tolist(), subshape.tolist(), starts.tolist())
+    mpi_dtype = mpi_datatype_for_dtype(dtype)
+    mpi_type = mpi_dtype.Create_subarray(
+        shape.tolist(), subshape.tolist(), starts.tolist()
+    )
     mpi_type.Commit()
     return mpi_type

--- a/gprMax/grid/fdtd_grid.py
+++ b/gprMax/grid/fdtd_grid.py
@@ -153,11 +153,18 @@ class FDTDGrid:
         self.magneticdipoles: List[MagneticDipole] = []
         self.transmissionlines: List[TransmissionLine] = []
         self.magneticfrillsources: List[MagneticFrillSource] = []
+        self.magneticfrill_specs = []
         # Rational lumped networks are sparse terminal devices rather than
         # sources or mesh materials. Definitions are reusable; each terminal
         # owns only the states associated with its selected electric edge.
         self.rationalnetworkmodels = {}
         self.networkterminals = []
+        # MPI ranks parse the same scene but instantiate a point terminal only
+        # on its owning rank. These replicated definitions let later
+        # excitation/output commands validate and bind by terminal ID on every
+        # rank without duplicating the active edge device.
+        self.networkterminal_specs = {}
+        self.networkexcitation_specs = {}
         self.discreteplanewaves: List[DiscretePlaneWave] = []
         self.eigenmodeband = None
         self.eigenmodeportdefs = {}
@@ -169,6 +176,11 @@ class FDTDGrid:
         self.virtual_waveguides = []
         self.rxs: List[Rx] = []
         self.port_monitors = []  # Source-bound S-parameter/impedance outputs
+        # Every MPI rank parses the same output commands, so this replicated
+        # registry allocates globally consistent automatic port IDs before a
+        # point object is reduced to its single owning rank.
+        self.mpi_port_output_ids = []
+        self.mpi_port_output_owners = {}
         self.snapshots = []  # List[Snapshot]
         self.ntff_monitors = []  # Time- and frequency-domain NTFF monitors
         # Reusable NTFF surface definitions are registered by user objects,
@@ -742,6 +754,9 @@ class FDTDGrid:
 
         if not self.thinwires:
             return
+        if hasattr(self, "comm"):
+            self._build_thin_wires_mpi()
+            return
 
         electric_builders = {"x": build_edge_x, "y": build_edge_y, "z": build_edge_z}
         magnetic_builders = {
@@ -806,6 +821,117 @@ class FDTDGrid:
                         raise ValueError(
                             f"{wire} has a PMC magnetic component in its surrounding "
                             f"stencil at {(x, y, z)}."
+                        )
+                    radial_axis = self._thin_wire_h_radial_axis(wire.wire_axis, component_h)
+                    material_h = self._thin_wire_material(
+                        wire,
+                        background_h,
+                        role=component_h,
+                        radial_axis=radial_axis,
+                    )
+                    magnetic_builders[component_h](x, y, z, material_h.numID, self.rigidH, self.ID)
+
+    def _build_thin_wires_mpi(self) -> None:
+        """Build globally registered thin-wire components on their owning ranks."""
+
+        electric_builders = {"x": build_edge_x, "y": build_edge_y, "z": build_edge_z}
+        magnetic_builders = {
+            "Hx": build_magnetic_edge_x,
+            "Hy": build_magnetic_edge_y,
+            "Hz": build_magnetic_edge_z,
+        }
+        electric_components = {"x": "Ex", "y": "Ey", "z": "Ez"}
+        occupied_e = {}
+        occupied_h = {}
+        global_size = np.asarray(self.global_size, dtype=np.int32)
+
+        def owned_local(global_coord):
+            local = self.global_to_local_coordinate(np.asarray(global_coord, dtype=np.int32))
+            return local if self.within_bounds(local) else None
+
+        def global_h_targets(axis, i, j, k):
+            targets = {
+                "x": (("Hy", i, j, k - 1), ("Hy", i, j, k), ("Hz", i, j - 1, k), ("Hz", i, j, k)),
+                "y": (("Hx", i, j, k - 1), ("Hx", i, j, k), ("Hz", i - 1, j, k), ("Hz", i, j, k)),
+                "z": (("Hy", i - 1, j, k), ("Hy", i, j, k), ("Hx", i, j - 1, k), ("Hx", i, j, k)),
+            }[axis]
+            nx, ny, nz = (int(value) for value in global_size)
+            active_ranges = {
+                "Hx": ((0, nx + 1), (0, ny), (0, nz)),
+                "Hy": ((0, nx), (0, ny + 1), (0, nz)),
+                "Hz": ((0, nx), (0, ny), (0, nz + 1)),
+            }
+            for component, x, y, z in targets:
+                ranges = active_ranges[component]
+                if all(low <= value < high for value, (low, high) in zip((x, y, z), ranges)):
+                    yield component, (x, y, z)
+
+        for wire in self.thinwires:
+            start = np.asarray(wire.global_start, dtype=np.int32)
+            stop = np.asarray(wire.global_stop, dtype=np.int32)
+            axis_index = "xyz".index(wire.wire_axis)
+            for index, axis in enumerate("xyz"):
+                if index == axis_index:
+                    continue
+                if int(start[index]) in (0, int(global_size[index])):
+                    raise ValueError(
+                        f"{wire} lies on transverse global domain face {axis}; "
+                        "MPI symmetry boundaries are not supported."
+                    )
+
+            component_e = electric_components[wire.wire_axis]
+            component_e_index = self.IDlookup[component_e]
+            signature = (wire.wire_axis, wire.radius)
+            for position in range(int(start[axis_index]), int(stop[axis_index])):
+                global_e = start.copy()
+                global_e[axis_index] = position
+
+                local_e = owned_local(global_e)
+                if local_e is not None:
+                    i, j, k = (int(value) for value in local_e)
+                    if self.within_pml(local_e):
+                        raise ValueError(
+                            f"{wire} enters a PML at global grid position "
+                            f"{tuple(int(value) for value in global_e)}."
+                        )
+                    e_key = (component_e, i, j, k)
+                    previous_e = occupied_e.get(e_key)
+                    if previous_e is not None and previous_e != signature:
+                        raise ValueError(
+                            "Thin-wire electric edges overlap with different axes or radii."
+                        )
+                    occupied_e[e_key] = signature
+                    background_e = self.materials[int(self.ID[component_e_index, i, j, k])]
+                    material_e = self._thin_wire_material(wire, background_e, role=component_e)
+                    electric_builders[wire.wire_axis](
+                        i, j, k, material_e.numID, self.rigidE, self.rigidH, self.ID
+                    )
+
+                gi, gj, gk = (int(value) for value in global_e)
+                for component_h, global_h in global_h_targets(wire.wire_axis, gi, gj, gk):
+                    local_h = owned_local(global_h)
+                    if local_h is None:
+                        continue
+                    x, y, z = (int(value) for value in local_h)
+                    if self.within_pml(local_h):
+                        raise ValueError(
+                            f"{wire} has a surrounding magnetic component inside a PML "
+                            f"at global grid position {global_h}."
+                        )
+                    h_key = (component_h, x, y, z)
+                    previous_h = occupied_h.get(h_key)
+                    if previous_h is not None and previous_h != signature:
+                        raise ValueError(
+                            "Thin-wire magnetic stencils overlap with different axes or radii; "
+                            "sub-cell wire junctions are not yet supported."
+                        )
+                    occupied_h[h_key] = signature
+                    component_h_index = self.IDlookup[component_h]
+                    background_h = self.materials[int(self.ID[component_h_index, x, y, z])]
+                    if background_h.ID == "pmc" or background_h.sm == float("inf"):
+                        raise ValueError(
+                            f"{wire} has a PMC magnetic component in its surrounding stencil "
+                            f"at global grid position {global_h}."
                         )
                     radial_axis = self._thin_wire_h_radial_axis(wire.wire_axis, component_h)
                     material_h = self._thin_wire_material(

--- a/gprMax/grid/mpi_grid.py
+++ b/gprMax/grid/mpi_grid.py
@@ -34,11 +34,12 @@ from gprMax.grid.fdtd_grid import FDTDGrid
 from gprMax.pml import MPIPML, PML
 from gprMax.receivers import Rx
 from gprMax.sources import Source
-from gprMax.utilities.mpi import Dim, Dir
+from gprMax.utilities.mpi import Dim, Dir, mpi_datatype_for_dtype
 
 logger = logging.getLogger(__name__)
 
 CoordType = TypeVar("CoordType", bound=Union[Rx, Source])
+ObjectType = TypeVar("ObjectType")
 
 
 class MPIGrid(FDTDGrid):
@@ -350,6 +351,16 @@ class MPIGrid(FDTDGrid):
         else:
             return objects
 
+    def gather_objects(self, objects: List[ObjectType]) -> List[ObjectType]:
+        """Gather non-coordinate runtime objects on the coordinator rank."""
+
+        gathered_objects: Optional[List[List[ObjectType]]] = self.comm.gather(
+            objects, root=self.COORDINATOR_RANK
+        )
+        if gathered_objects is not None:
+            return list(itertools.chain(*gathered_objects))
+        return objects
+
     def gather_grid_objects(self):
         """Gather sources and receivers."""
 
@@ -358,6 +369,16 @@ class MPIGrid(FDTDGrid):
         self.magneticdipoles = self.gather_coord_objects(self.magneticdipoles)
         self.hertziandipoles = self.gather_coord_objects(self.hertziandipoles)
         self.transmissionlines = self.gather_coord_objects(self.transmissionlines)
+        primary_frills = [
+            source for source in self.magneticfrillsources if getattr(source, "mpi_primary", True)
+        ]
+        self.magneticfrillsources = self.gather_coord_objects(primary_frills)
+        if self.is_coordinator():
+            self.magneticfrillsources.sort(
+                key=lambda source: getattr(source, "mpi_global_index", 0)
+            )
+        self.networkterminals = self.gather_coord_objects(self.networkterminals)
+        self.port_monitors = self.gather_objects(self.port_monitors)
 
     def _halo_swap(self, array: ndarray, dim: Dim, dir: Dir):
         """Perform a halo swap in the specifed dimension and direction.
@@ -447,6 +468,22 @@ class MPIGrid(FDTDGrid):
             self.recv_requests[0].Waitall(self.recv_requests)
             self.recv_requests = []
 
+    def complete_halo_swaps(self) -> None:
+        """Complete requests left by the final nonblocking halo exchange.
+
+        A normal timestep waits for the previous field sends at the start of
+        the opposite-field halo exchange. The final electric exchange has no
+        following magnetic exchange, so its sends must be completed explicitly
+        before MPI finalisation.
+        """
+
+        if self.send_requests:
+            MPI.Request.Waitall(self.send_requests)
+            self.send_requests = []
+        if self.recv_requests:
+            MPI.Request.Waitall(self.recv_requests)
+            self.recv_requests = []
+
     def _prepare_pml(self, pml: MPIPML) -> MPIPML:
         """Attach the communicator associated with the slab normal."""
         if pml.direction[0] == "x":
@@ -484,7 +521,7 @@ class MPIGrid(FDTDGrid):
 
         # Cast from bool to int to avoid issue with numpy>2.3
         self.negative_halo_offset = self.negative_halo_offset.astype(int)
-        
+
         if pml.ID[0] == "x":
             o1 = self.negative_halo_offset[1]
             o2 = self.negative_halo_offset[2]
@@ -642,6 +679,9 @@ class MPIGrid(FDTDGrid):
         """Create MPI DataTypes for field array halo exchanges."""
 
         size = (self.size + 1).tolist()
+        field_mpi_dtype = mpi_datatype_for_dtype(
+            config.sim_config.dtypes["float_or_double"]
+        )
 
         for dim in Dim:
             halo_size = (self.size + 1 - np.sum(self.neighbours >= 0, axis=1)).tolist()
@@ -650,18 +690,26 @@ class MPIGrid(FDTDGrid):
 
             if self.has_neighbour(dim, Dir.NEG):
                 start[dim] = 1
-                self.send_halo_map[dim][Dir.NEG] = MPI.FLOAT.Create_subarray(size, halo_size, start)
+                self.send_halo_map[dim][Dir.NEG] = field_mpi_dtype.Create_subarray(
+                    size, halo_size, start
+                )
                 start[dim] = 0
-                self.recv_halo_map[dim][Dir.NEG] = MPI.FLOAT.Create_subarray(size, halo_size, start)
+                self.recv_halo_map[dim][Dir.NEG] = field_mpi_dtype.Create_subarray(
+                    size, halo_size, start
+                )
 
                 self.send_halo_map[dim][Dir.NEG].Commit()
                 self.recv_halo_map[dim][Dir.NEG].Commit()
 
             if self.has_neighbour(dim, Dir.POS):
                 start[dim] = size[dim] - 2
-                self.send_halo_map[dim][Dir.POS] = MPI.FLOAT.Create_subarray(size, halo_size, start)
+                self.send_halo_map[dim][Dir.POS] = field_mpi_dtype.Create_subarray(
+                    size, halo_size, start
+                )
                 start[dim] = size[dim] - 1
-                self.recv_halo_map[dim][Dir.POS] = MPI.FLOAT.Create_subarray(size, halo_size, start)
+                self.recv_halo_map[dim][Dir.POS] = field_mpi_dtype.Create_subarray(
+                    size, halo_size, start
+                )
 
                 self.send_halo_map[dim][Dir.POS].Commit()
                 self.recv_halo_map[dim][Dir.POS].Commit()

--- a/gprMax/model.py
+++ b/gprMax/model.py
@@ -378,8 +378,8 @@ class Model:
         # symmetry, validate the PEC ground plane, and precompute their
         # feed-cell recurrence here. This needs final material coefficients
         # and symmetry boundaries, which do not exist during scene parsing.
-        # MPI use is rejected by the source builder; a frill can belong to a
-        # CPU subgrid and is then prepared against that fine grid.
+        # On MPI grids a frill is replicated so its four-edge feed stencil can
+        # span ranks; on a CPU subgrid it is prepared against that fine grid.
         for grid in grids:
             for frill in grid.magneticfrillsources:
                 frill.finalise_setup(grid)

--- a/gprMax/mpi_model.py
+++ b/gprMax/mpi_model.py
@@ -246,15 +246,59 @@ class MPIModel(Model):
         self.G.gather_grid_objects()
 
         # Write output data to file if they are any receivers in any grids
-        if self.is_coordinator() and (self.G.rxs or self.G.transmissionlines):
+        if self.is_coordinator() and (
+            self.G.rxs
+            or self.G.transmissionlines
+            or self.G.magneticfrillsources
+            or self.G.networkterminals
+            or self.G.port_monitors
+        ):
             self.G.size = self.G.global_size
+            for port in self.G.port_monitors:
+                rebind = getattr(port, "rebind_after_mpi_gather", None)
+                if rebind is not None:
+                    rebind(self.G)
+                local_owner = self.G.mpi_port_output_owners.get(port.output_id)
+                if local_owner is not None:
+                    port.owner = local_owner
+                    local_owner._monitor = port
+                port.finalise(self.G)
             # Transmission-line objects and their complete histories have now
             # been gathered onto the coordinator. Derived terminal quantities
             # must be calculated here, before the HDF5 file is opened.
-            from gprMax.ports import finalise_transmission_line_ports
+            from gprMax.ports import (
+                finalise_magnetic_frill_ports,
+                finalise_transmission_line_ports,
+                prepare_magnetic_frill_ports,
+            )
 
             finalise_transmission_line_ports(self.G)
+            prepare_magnetic_frill_ports(self.G)
+            finalise_magnetic_frill_ports(self.G)
+            self._rebind_mpi_frill_port_owners()
             write_hdf5_outputfile(config.get_model_config().output_file_path_ext, self.title, self)
+
+    def _rebind_mpi_frill_port_owners(self) -> None:
+        """Reconnect coordinator-side ``RxPort.result`` to gathered frills."""
+
+        dl = np.asarray((self.G.dx, self.G.dy, self.G.dz), dtype=np.float64)
+        for owner in self.G.mpi_port_output_owners.values():
+            if getattr(owner, "_monitor", None) is not None:
+                continue
+            if not hasattr(owner, "_frill_source"):
+                continue
+            coordinate = np.rint(np.asarray(owner.point, dtype=np.float64) / dl).astype(np.int32)
+            sources = [
+                source
+                for source in self.G.magneticfrillsources
+                if np.array_equal(source.coord, coordinate)
+            ]
+            if len(sources) != 1:
+                raise RuntimeError(
+                    f"RxPort at {tuple(owner.point)} could not uniquely rebind its MPI "
+                    f"magnetic frill ({len(sources)} source(s))"
+                )
+            owner._frill_source = sources[0]
 
     def _create_grid(self) -> MPIGrid:
         cart_comm = MPI.COMM_WORLD.Create_cart(config.sim_config.mpi)

--- a/gprMax/ports.py
+++ b/gprMax/ports.py
@@ -872,6 +872,29 @@ class RationalNetworkPortOutput:
         )
         self.incident_floor_db = DEFAULT_INCIDENT_FLOOR_DB
 
+    def rebind_after_mpi_gather(self, grid: "FDTDGrid") -> None:
+        """Reconnect the gathered output to its coordinator-side terminal."""
+
+        terminals = [
+            terminal
+            for terminal in getattr(grid, "networkterminals", ())
+            if terminal.ID == self.output_id
+        ]
+        if len(terminals) != 1:
+            raise RuntimeError(
+                f"NetworkPort {self.output_id!r} could not uniquely rebind its MPI "
+                f"terminal ({len(terminals)} terminal(s))"
+            )
+        self.terminal = terminals[0]
+        self.source = self.terminal
+        self.terminal.output = self
+        # Coordinates have been converted to global indices by the terminal
+        # gather; replace the owner-rank-local position cached by prepare().
+        self.source_position = np.asarray(
+            self.terminal.coord * np.asarray((grid.dx, grid.dy, grid.dz)),
+            dtype=np.float64,
+        )
+
     def prepare(self, grid: "FDTDGrid") -> None:
         if not self.terminal.prepared:
             self.terminal.prepare(grid)
@@ -1175,6 +1198,38 @@ class VoltageSourcePortMonitor:
     @property
     def component(self):
         return f"E{self.source.polarisation}"
+
+    def rebind_after_mpi_gather(self, grid: "FDTDGrid") -> None:
+        """Reconnect gathered monitor state to the coordinator's grid objects."""
+
+        receivers = [
+            receiver
+            for receiver in grid.rxs
+            if getattr(receiver, "internal", False)
+            and getattr(receiver, "port_id", None) == self.output_id
+        ]
+        sources = [
+            source
+            for source in grid.voltagesources
+            if source.polarisation == self.source.polarisation
+            and np.array_equal(source.coord, self.source.coord)
+        ]
+        if len(receivers) != 1 or len(sources) != 1:
+            raise RuntimeError(
+                f"RxPort {self.output_id!r} could not uniquely rebind its MPI "
+                f"receiver/source ({len(receivers)} receiver(s), {len(sources)} source(s))"
+            )
+        self.receiver = receivers[0]
+        self.source = sources[0]
+        self.source_index = grid.voltagesources.index(self.source) + 1
+        # ``gather_coord_objects`` has converted the rebound source coordinate
+        # to the global MPI-grid index. ``source_position`` may previously have
+        # been cached while preparing the monitor on its owning rank, where the
+        # same coordinate was rank-local.
+        self.source_position = np.asarray(
+            self.source.coord * np.asarray((grid.dx, grid.dy, grid.dz)),
+            dtype=np.float64,
+        )
 
     def _edge_geometry(self, grid):
         if self.source.polarisation == "x":

--- a/gprMax/solvers.py
+++ b/gprMax/solvers.py
@@ -78,6 +78,7 @@ class Solver:
 
             if isinstance(self.updates, MPIUpdates):
                 self.updates.halo_swap_magnetic()
+                self.updates.update_magnetic_edge_devices(iteration)
 
             if isinstance(self.updates, SubgridUpdates):
                 self.updates.hsg_2()

--- a/gprMax/sources.py
+++ b/gprMax/sources.py
@@ -3321,6 +3321,10 @@ class MagneticFrillSource(Source):
         Args:
             G: FDTDGrid class describing a grid in a model.
         """
+        if hasattr(G, "comm") and hasattr(self, "mpi_global_coord"):
+            self._finalise_setup_mpi(G)
+            return
+
         i, j, k = self.xcoord, self.ycoord, self.zcoord
         if G.within_pml(np.array([i, j, k], dtype=np.int32)):
             raise ValueError(
@@ -3392,6 +3396,146 @@ class MagneticFrillSource(Source):
         self._mirror1 = at1 and face1_pmc
         self._mirror2 = at2 and face2_pmc
         self._prepare_drive_terms(G)
+
+    def _finalise_setup_mpi(self, G):
+        """Prepare a frill whose four H edges may span several MPI ranks."""
+
+        from mpi4py import MPI
+
+        local_error = None
+        if self.mpi_primary:
+            try:
+                if G.within_pml(self.coord):
+                    raise ValueError(f"{self.ID} feed point lies inside a PML.")
+                global_coord = np.asarray(self.mpi_global_coord, dtype=np.int32)
+                transverse = {
+                    "x": (1, 2),
+                    "y": (0, 2),
+                    "z": (0, 1),
+                }[self.polarisation]
+                if any(global_coord[axis] == 0 for axis in transverse):
+                    raise ValueError(
+                        f"{self.ID} lies on a transverse global domain-minimum "
+                        "boundary; MPI symmetry boundaries are not supported."
+                    )
+                self._validate_geometry(G)
+            except Exception as exc:
+                local_error = f"rank {G.comm.rank}: {exc}"
+
+        errors = [error for error in G.comm.allgather(local_error) if error is not None]
+        if errors:
+            raise ValueError("; ".join(errors))
+
+        self.inner_radius = float(
+            G.comm.bcast(
+                self.inner_radius if self.mpi_primary else None,
+                root=self.mpi_primary_rank,
+            )
+        )
+        self._mirror1 = False
+        self._mirror2 = False
+
+        local_error = None
+        try:
+            local_g = self._prepare_drive_terms_mpi(G)
+        except Exception as exc:
+            local_error = f"rank {G.comm.rank}: {exc}"
+            local_g = 0.0
+        errors = [error for error in G.comm.allgather(local_error) if error is not None]
+        if errors:
+            raise ValueError("; ".join(errors))
+
+        self._G_coeff = float(G.comm.allreduce(local_g, op=MPI.SUM))
+        if not np.isfinite(self._G_coeff) or self._G_coeff <= 0:
+            raise ValueError(
+                f"{self.ID} produced invalid distributed feed-cell "
+                f"self-admittance G={self._G_coeff!r}."
+            )
+        self._previous_half_current = 0.0
+        if self.mpi_primary:
+            logger.info(
+                f"{self.ID}: distributed Hyun feed cell uses attached thin-wire "
+                f"radius a={self.inner_radius:g}m and self-admittance "
+                f"G={self._G_coeff:g}S."
+            )
+
+    def _prepare_drive_terms_mpi(self, G):
+        """Build only the frill H-edge terms owned by this MPI rank."""
+
+        i, j, k = (int(value) for value in self.mpi_global_coord)
+        dx, dy, dz = G.dx, G.dy, G.dz
+        axial_step = {"x": dx, "y": dy, "z": dz}[self.polarisation]
+        pairs = {
+            "x": (
+                ("Hy", ((i, j, k), -dy, -1), ((i, j, k - 1), dy, 1), "z"),
+                ("Hz", ((i, j, k), dz, 1), ((i, j - 1, k), -dz, -1), "y"),
+            ),
+            "y": (
+                ("Hx", ((i, j, k), dx, 1), ((i, j, k - 1), -dx, -1), "z"),
+                ("Hz", ((i, j, k), -dz, -1), ((i - 1, j, k), dz, 1), "x"),
+            ),
+            "z": (
+                ("Hy", ((i, j, k), dy, 1), ((i - 1, j, k), -dy, -1), "x"),
+                ("Hx", ((i, j, k), -dx, -1), ((i, j - 1, k), dx, 1), "y"),
+            ),
+        }[self.polarisation]
+        radial_steps = {"x": dx, "y": dy, "z": dz}
+        terms = []
+        for component, plus, minus, radial_axis in pairs:
+            for coordinates, current_weight, source_sign in (plus, minus):
+                global_coord = np.asarray(coordinates, dtype=np.int32)
+                local_coord = G.global_to_local_coordinate(global_coord)
+                if not G.within_bounds(local_coord):
+                    continue
+                x, y, z = (int(value) for value in local_coord)
+                material_numID = int(G.ID[G.IDlookup[component], x, y, z])
+                material = G.materials[material_numID]
+                correct_wire_row = (
+                    material.type == "thin-wire"
+                    and getattr(material, "thin_wire_axis", None) == self.polarisation
+                    and getattr(material, "thin_wire_role", None) == component
+                    and np.isclose(
+                        material.thin_wire_radius,
+                        self.inner_radius,
+                        rtol=1e-12,
+                        atol=0.0,
+                    )
+                    and getattr(material, "thin_wire_radial_axis", None) == radial_axis
+                )
+                if not correct_wire_row:
+                    raise ValueError(
+                        f"{self.ID} feed stencil component {component} at global "
+                        f"coordinate {coordinates} is not part of the attached thin wire."
+                    )
+                factor_f = float(material.thin_wire_factors["F"])
+                source_gain = (
+                    source_sign
+                    * G.updatecoeffsH[material_numID, 4]
+                    * factor_f
+                    / (axial_step * radial_steps[radial_axis])
+                )
+                terms.append((component, x, y, z, float(current_weight), float(source_gain)))
+
+        registry = getattr(G, "_magnetic_frill_drive_edges", {})
+        drive_edges = {(term[0], term[1], term[2], term[3]) for term in terms}
+        overlap = next(
+            (
+                (edge, registry[edge])
+                for edge in drive_edges
+                if edge in registry and registry[edge] is not self
+            ),
+            None,
+        )
+        if overlap is not None:
+            edge, owner = overlap
+            raise ValueError(
+                f"{self.ID} has an overlapping magnetic feed edge {edge} with "
+                f"{owner.ID}; a coupled multiport formulation is required."
+            )
+        registry.update({edge: self for edge in drive_edges})
+        G._magnetic_frill_drive_edges = registry
+        self._drive_terms = terms
+        return float(sum(term[-2] * term[-1] for term in terms))
 
     def _prepare_drive_terms(self, G):
         """Precompute Hyun's Cartesian feed stencil and self-admittance."""
@@ -3517,8 +3661,22 @@ class MagneticFrillSource(Source):
             Hx, Hy, Hz: memory view of array of magnetic field values.
             G: FDTDGrid class describing a grid in a model.
         """
-        self.Vinc[iteration] = 0.5 * self.waveformvalues_wholedt[iteration]
         current_bulk = self._calculate_Itot_frill(Hx, Hy, Hz)
+        self._advance_magnetic_frill(iteration, current_bulk, Hx, Hy, Hz)
+
+    def update_magnetic_mpi(self, iteration, updatecoeffsH, ID, Hx, Hy, Hz, G):
+        """Advance a distributed frill from the sum of rank-local loop terms."""
+
+        from mpi4py import MPI
+
+        local_current = self._calculate_Itot_frill(Hx, Hy, Hz)
+        current_bulk = G.comm.allreduce(local_current, op=MPI.SUM)
+        self._advance_magnetic_frill(iteration, current_bulk, Hx, Hy, Hz)
+
+    def _advance_magnetic_frill(self, iteration, current_bulk, Hx, Hy, Hz):
+        """Apply the common implicit terminal relation and local H deposits."""
+
+        self.Vinc[iteration] = 0.5 * self.waveformvalues_wholedt[iteration]
         zeta = self._G_coeff * self.Z0
         current_new = (
             current_bulk

--- a/gprMax/updates/mpi_updates.py
+++ b/gprMax/updates/mpi_updates.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
 #                          and Nathan Mannall
 #
 # This file is part of gprMax.
@@ -23,6 +23,59 @@ from gprMax.updates.cpu_updates import CPUUpdates
 
 class MPIUpdates(CPUUpdates[MPIGrid]):
     """Defines update functions for MPI CPU-based solver."""
+
+    def update_magnetic_sources(self, iteration):
+        """Apply magnetic-field writers before exchanging magnetic halos.
+
+        Transmission lines do not write magnetic fields: they sample an
+        Ampere contour. Their update is deliberately deferred to
+        ``update_magnetic_edge_devices`` after the halo exchange.
+        """
+
+        for source in self.grid.magneticdipoles:
+            source.update_magnetic(
+                iteration,
+                self.grid.updatecoeffsH,
+                self.grid.ID,
+                self.grid.Hx,
+                self.grid.Hy,
+                self.grid.Hz,
+                self.grid,
+            )
+        # Each rank owns only the frill H-edge terms that fall inside its
+        # interior. The distributed update sums their Ampere-loop
+        # contributions, advances one identical terminal state, and deposits
+        # only to locally owned terms before the H halo exchange.
+        for source in self.grid.magneticfrillsources:
+            source.update_magnetic_mpi(
+                iteration,
+                self.grid.updatecoeffsH,
+                self.grid.ID,
+                self.grid.Hx,
+                self.grid.Hy,
+                self.grid.Hz,
+                self.grid,
+            )
+
+    def update_magnetic_edge_devices(self, iteration):
+        """Sample transmission-line currents from synchronised H fields."""
+
+        for source in self.grid.transmissionlines:
+            source.update_magnetic(
+                iteration,
+                self.grid.updatecoeffsH,
+                self.grid.ID,
+                self.grid.Hx,
+                self.grid.Hy,
+                self.grid.Hz,
+                self.grid,
+            )
+
+    def finalise(self):
+        """Complete the last halo exchange before MPI/Python teardown."""
+
+        self.grid.complete_halo_swaps()
+        super().finalise()
 
     def halo_swap_electric(self):
         self.grid.halo_swap_electric()

--- a/gprMax/user_objects/cmds_geometry/thin_wire.py
+++ b/gprMax/user_objects/cmds_geometry/thin_wire.py
@@ -87,8 +87,6 @@ class ThinWire(RotatableMixin, GeometryUserObject):
 
         if config.get_model_config().mode.startswith("2D"):
             raise ValueError(f"{self.__str__()} is not yet supported in 2D mode.")
-        if hasattr(grid, "comm"):
-            raise ValueError(f"{self.__str__()} is not yet supported with MPI.")
         if not math.isfinite(radius) or radius <= 0:
             raise ValueError(f"{self.__str__()} requires a finite radius greater than zero.")
 
@@ -98,6 +96,9 @@ class ThinWire(RotatableMixin, GeometryUserObject):
             p2 = self.kwargs["p2"]
 
         uip = self._create_uip(grid)
+        if hasattr(grid, "comm"):
+            self._build_mpi(grid, uip, p1, p2, radius)
+            return
         p1 = uip.resolve_inf_point(p1, role="lower")
         p2 = uip.resolve_inf_point(p2, role="upper")
         within_grid, start, stop = uip.check_box_points(p1, p2, self.__str__())
@@ -131,6 +132,55 @@ class ThinWire(RotatableMixin, GeometryUserObject):
             f"{rounded_stop[0]:g}m, {rounded_stop[1]:g}m, "
             f"{rounded_stop[2]:g}m, radius {radius:g}m, created."
         )
+
+    def _build_mpi(self, grid, uip, p1, p2, radius):
+        """Register one global wire definition on every MPI rank.
+
+        Component construction later assigns each electric and magnetic edge
+        to exactly one owning rank. Keeping the uncut global endpoints here is
+        essential because the surrounding four-H-edge stencil can straddle a
+        decomposition boundary even though the wire E edge has one owner.
+        """
+
+        domain = np.asarray(grid.global_size, dtype=np.int32)
+        p1 = uip.resolve_inf_point(p1, role="lower")
+        p2 = uip.resolve_inf_point(p2, role="upper")
+        start = np.asarray(uip.discretise_static_point(p1), dtype=np.int32)
+        stop = np.asarray(uip.discretise_static_point(p2), dtype=np.int32)
+        if np.any(start < 0) or np.any(stop > domain):
+            raise ValueError(f"{self.__str__()} endpoints must lie inside the global MPI domain.")
+        changed = np.flatnonzero(start != stop)
+        if changed.size != 1 or np.any(start > stop):
+            raise ValueError(f"{self.__str__()} must define one non-zero, axis-aligned line.")
+
+        axis_index = int(changed[0])
+        transverse = [index for index in range(3) if index != axis_index]
+        limiting_step = min(float(grid.dl[index]) for index in transverse)
+        if radius >= 0.5 * limiting_step:
+            raise ValueError(
+                f"{self.__str__()} radius {radius:g}m must be smaller than half "
+                f"the minimum transverse cell size ({0.5 * limiting_step:g}m)."
+            )
+
+        self.wire_axis = "xyz"[axis_index]
+        self.global_start = start
+        self.global_stop = stop
+        # Retain local aliases for diagnostics; MPI construction uses the
+        # global endpoints above.
+        self.start = grid.global_to_local_coordinate(start)
+        self.stop = grid.global_to_local_coordinate(stop)
+        self.radius = radius
+        grid.thinwires.append(self)
+
+        if grid.is_coordinator():
+            rounded_start = start * grid.dl
+            rounded_stop = stop * grid.dl
+            logger.info(
+                f"Thin wire from {rounded_start[0]:g}m, {rounded_start[1]:g}m, "
+                f"{rounded_start[2]:g}m, to {rounded_stop[0]:g}m, "
+                f"{rounded_stop[1]:g}m, {rounded_stop[2]:g}m, radius "
+                f"{radius:g}m, created."
+            )
 
     def cells(self):
         """Yield the electric Yee-edge coordinates occupied by the wire."""

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -430,8 +430,6 @@ class NetworkTerminal(GridUserObject):
         self.ID = id
 
     def build(self, grid: FDTDGrid):
-        if config.sim_config.mpi:
-            raise ValueError(f"{self.params_str()} does not yet support the MPI solver")
         if config.get_model_config().mode != "3D":
             raise ValueError(f"{self.params_str()} currently supports only 3-D models")
         if config.sim_config.args.geometry_fixed:
@@ -441,7 +439,7 @@ class NetworkTerminal(GridUserObject):
             raise ValueError(f"{self.params_str()} polarisation must be x, y, or z")
         if not self.ID or "/" in self.ID or "\x00" in self.ID:
             raise ValueError(f"{self.params_str()} ID must be a non-empty HDF5 path component")
-        if any(terminal.ID == self.ID for terminal in grid.networkterminals):
+        if self.ID in grid.networkterminal_specs:
             raise ValueError(f"{self.params_str()} terminal ID is already in use")
         try:
             model = grid.rationalnetworkmodels[self.network_id]
@@ -452,6 +450,11 @@ class NetworkTerminal(GridUserObject):
 
         uip = self._create_uip(grid)
         self.point = uip.resolve_inf_point(self.point)
+        grid.networkterminal_specs[self.ID] = {
+            "polarisation": self.polarisation,
+            "network_id": self.network_id,
+            "point": tuple(float(value) for value in self.point),
+        }
         point_within_grid, coord = uip.check_src_rx_point(self.point, self.params_str())
         if not point_within_grid:
             return
@@ -498,17 +501,34 @@ class NetworkExcitation(GridUserObject):
         self.stop = stop
 
     def build(self, grid: FDTDGrid):
-        terminal = next(
-            (item for item in grid.networkterminals if item.ID == self.terminal_id), None
-        )
-        if terminal is None:
+        if self.terminal_id not in grid.networkterminal_specs:
             raise ValueError(
                 f"{self.params_str()} there is no network terminal with ID {self.terminal_id!r}"
+            )
+        if self.terminal_id in grid.networkexcitation_specs:
+            raise ValueError(
+                f"{self.params_str()} network terminal {self.terminal_id!r} "
+                "already has an excitation"
             )
         if not any(waveform.ID == self.waveform_id for waveform in grid.waveforms):
             raise ValueError(
                 f"{self.params_str()} there is no waveform with ID {self.waveform_id!r}"
             )
+        grid.networkexcitation_specs[self.terminal_id] = {
+            "waveform_id": self.waveform_id,
+            "start": self.start,
+            "stop": self.stop,
+        }
+        terminal = next(
+            (item for item in grid.networkterminals if item.ID == self.terminal_id), None
+        )
+        if terminal is None:
+            # In an MPI model the active terminal exists only on its owning
+            # rank. The replicated specification above is sufficient on all
+            # other ranks.
+            if config.sim_config.mpi:
+                return
+            raise RuntimeError(f"{self.params_str()} terminal definition was not instantiated")
         terminal.set_excitation(self.waveform_id, self.start, self.stop)
         logger.info(
             self.grid_name(grid) + f"Network terminal {self.terminal_id!r} excited by waveform "
@@ -1325,21 +1345,33 @@ class MagneticFrillSource(RotatableMixin, GridUserObject):
         self.point = uip.resolve_inf_point(self.point)
         point_within_grid, discretised_point = uip.check_src_rx_point(self.point, self.params_str())
 
-        if point_within_grid:
-            self._validate_parameters(grid)
+        self._validate_parameters(grid)
+        if config.sim_config.mpi:
+            global_coord = np.asarray(uip.discretise_static_point(self.point), dtype=np.int32)
+            global_index = len(grid.magneticfrill_specs) + 1
+            grid.magneticfrill_specs.append(
+                {
+                    "coord": tuple(int(value) for value in global_coord),
+                    "polarisation": self.polarisation,
+                    "index": global_index,
+                }
+            )
+            frill_source = self._create_magnetic_frill_source(grid, discretised_point)
+            frill_source.mpi_global_coord = global_coord
+            frill_source.mpi_global_index = global_index
+            frill_source.mpi_primary_rank = int(grid.get_rank_from_coordinate(global_coord))
+            frill_source.mpi_primary = bool(point_within_grid)
+            grid.add_source(frill_source)
+            if point_within_grid:
+                position = uip.round_to_grid_static_point(self.point)
+                self._log(grid, frill_source, *position)
+        elif point_within_grid:
             frill_source = self._create_magnetic_frill_source(grid, discretised_point)
             grid.add_source(frill_source)
             position = uip.round_to_grid_static_point(self.point)
             self._log(grid, frill_source, *position)
 
     def _validate_parameters(self, grid: FDTDGrid):
-        # MPI is rejected because a feed stencil cannot be split across rank
-        # boundaries. A subgrid is safe: the frill, attached thin wire,
-        # material rows, field stencil, and time histories all belong to the
-        # same fine grid and are advanced by its CPU updater.
-        if config.sim_config.mpi:
-            raise ValueError(f"{self.params_str()} does not support MPI.")
-
         # 2D mode rejected outright - the feed point's four surrounding H
         # components have no meaningful reduction to a 2D TM/TE invariant-
         # axis model at all.

--- a/gprMax/user_objects/cmds_output.py
+++ b/gprMax/user_objects/cmds_output.py
@@ -63,6 +63,27 @@ from gprMax.utilities.utilities import round_int
 logger = logging.getLogger(__name__)
 
 
+def _reserve_mpi_port_output_id(
+    grid: FDTDGrid, requested: Optional[str], owner: OutputUserObject
+) -> str:
+    """Reserve one output ID consistently while every MPI rank parses the scene."""
+
+    used = grid.mpi_port_output_ids
+    if requested is None:
+        index = 1
+        while f"port{index}" in used:
+            index += 1
+        output_id = f"port{index}"
+    else:
+        validate_identifier("port output ID", requested)
+        output_id = requested
+    if output_id in used:
+        raise ValueError(f"port output ID {output_id!r} is already in use.")
+    used.append(output_id)
+    grid.mpi_port_output_owners[output_id] = owner
+    return output_id
+
+
 class RxPort(OutputUserObject):
     """Calculate S11 and input impedance at a one-edge voltage source.
 
@@ -125,8 +146,6 @@ class RxPort(OutputUserObject):
         raise RuntimeError("RxPort result is not available until the model has solved")
 
     def _validate_context(self, grid):
-        if config.sim_config.mpi:
-            raise ValueError(f"{self.params_str()} does not yet support MPI.")
         if config.sim_config.args.geometry_fixed:
             raise ValueError(f"{self.params_str()} does not support geometry-fixed runs.")
         if config.get_model_config().mode != "3D":
@@ -136,6 +155,9 @@ class RxPort(OutputUserObject):
 
     def build(self, model: Model, grid: FDTDGrid):
         self._validate_context(grid)
+        mpi_output_id = (
+            _reserve_mpi_port_output_id(grid, self.ID, self) if config.sim_config.mpi else None
+        )
         uip = self._create_uip(grid)
         self.point = uip.resolve_inf_point(self.point)
         point_within_grid, coord = uip.check_src_rx_point(self.point, self.params_str())
@@ -171,14 +193,20 @@ class RxPort(OutputUserObject):
             raise ValueError(f"{self.params_str()} source already has an RxPort output.")
 
         if self.ID is None:
-            used = {monitor.output_id for monitor in grid.port_monitors}
-            index = 1
-            while f"port{index}" in used:
-                index += 1
-            output_id = f"port{index}"
+            if mpi_output_id is not None:
+                output_id = mpi_output_id
+            else:
+                used = {monitor.output_id for monitor in grid.port_monitors}
+                index = 1
+                while f"port{index}" in used:
+                    index += 1
+                output_id = f"port{index}"
         else:
-            validate_identifier("RxPort ID", self.ID)
-            output_id = self.ID
+            if mpi_output_id is not None:
+                output_id = mpi_output_id
+            else:
+                validate_identifier("RxPort ID", self.ID)
+                output_id = self.ID
         if any(monitor.output_id == output_id for monitor in grid.port_monitors):
             raise ValueError(f"{self.params_str()} output ID is already in use.")
 
@@ -311,24 +339,15 @@ class NetworkPort(OutputUserObject):
         return self._monitor.result
 
     def build(self, model: Model, grid: FDTDGrid):
-        if config.sim_config.mpi:
-            raise ValueError(f"{self.params_str()} does not yet support the MPI solver.")
         if config.sim_config.args.geometry_fixed:
             raise ValueError(f"{self.params_str()} does not support geometry-fixed runs.")
         if config.get_model_config().mode != "3D":
             raise ValueError(f"{self.params_str()} currently supports only 3-D models.")
         validate_identifier("NetworkPort terminal ID", self.terminal_id)
-        terminal = next(
-            (item for item in grid.networkterminals if item.ID == self.terminal_id), None
-        )
-        if terminal is None:
+        if self.terminal_id not in grid.networkterminal_specs:
             raise ValueError(
                 f"{self.params_str()} there is no network terminal with ID {self.terminal_id!r}."
             )
-        if terminal.output is not None:
-            raise ValueError(f"{self.params_str()} terminal already has a NetworkPort output.")
-        if any(monitor.output_id == self.terminal_id for monitor in grid.port_monitors):
-            raise ValueError(f"{self.params_str()} output ID is already in use.")
         if not np.isfinite(self.reference_impedance) or self.reference_impedance <= 0:
             raise ValueError(
                 f"{self.params_str()} reference impedance must be finite and positive."
@@ -342,6 +361,22 @@ class NetworkPort(OutputUserObject):
                 "per shortest material wavelength; values below 10 may have "
                 "significant spatial-dispersion error."
             )
+        if config.sim_config.mpi:
+            _reserve_mpi_port_output_id(grid, self.terminal_id, self)
+        elif any(monitor.output_id == self.terminal_id for monitor in grid.port_monitors):
+            raise ValueError(f"{self.params_str()} output ID is already in use.")
+        terminal = next(
+            (item for item in grid.networkterminals if item.ID == self.terminal_id), None
+        )
+        if terminal is None:
+            # MPI point objects are instantiated only on their owning rank.
+            if config.sim_config.mpi:
+                return
+            raise RuntimeError(
+                f"{self.params_str()} terminal definition was not instantiated"
+            )
+        if terminal.output is not None:
+            raise ValueError(f"{self.params_str()} terminal already has a NetworkPort output.")
 
         monitor = RationalNetworkPortOutput(
             self.terminal_id,

--- a/gprMax/utilities/mpi.py
+++ b/gprMax/utilities/mpi.py
@@ -20,6 +20,27 @@ class Dir(IntEnum):
     POS = 1
 
 
+def mpi_datatype_for_dtype(dtype: npt.DTypeLike) -> MPI.Datatype:
+    """Return the MPI datatype matching a supported gprMax field dtype."""
+
+    numpy_dtype = np.dtype(dtype)
+    supported_dtypes = (np.dtype(np.float32), np.dtype(np.float64))
+    if numpy_dtype not in supported_dtypes:
+        raise TypeError(
+            "MPI field data require a float32 or float64 dtype; "
+            f"got {numpy_dtype}"
+        )
+
+    mpi_dtype = MPI.Datatype.fromcode(numpy_dtype.char)
+    if mpi_dtype.Get_size() != numpy_dtype.itemsize:
+        raise RuntimeError(
+            "The MPI datatype size does not match the configured gprMax "
+            f"dtype ({mpi_dtype.Get_size()} != {numpy_dtype.itemsize})"
+        )
+
+    return mpi_dtype
+
+
 def get_neighbours(comm: MPI.Cartcomm) -> npt.NDArray[np.int32]:
     neighbours = np.full((3, 2), -1, dtype=np.int32)
     neighbours[Dim.X] = comm.Shift(direction=Dim.X, disp=1)

--- a/tests/cmds_multiuse/test_magnetic_frill_source.py
+++ b/tests/cmds_multiuse/test_magnetic_frill_source.py
@@ -100,10 +100,9 @@ def test_accelerator_solvers_are_accepted(monkeypatch, solver):
     _frill()._validate_parameters(_fake_grid())
 
 
-def test_rejected_with_mpi(monkeypatch):
+def test_allowed_with_mpi(monkeypatch):
     _set_solver(monkeypatch, "cpu", mpi=True)
-    with pytest.raises(ValueError, match="MPI"):
-        _frill()._validate_parameters(_fake_grid())
+    _frill()._validate_parameters(_fake_grid())
 
 
 def test_main_grid_frill_is_accepted_when_model_contains_subgrid(monkeypatch):

--- a/tests/ports/test_mpi_port_gather.py
+++ b/tests/ports/test_mpi_port_gather.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from gprMax.mpi_model import MPIModel
+from gprMax.ports import RationalNetworkPortOutput, VoltageSourcePortMonitor
+from gprMax.user_objects.cmds_output import _reserve_mpi_port_output_id
+
+
+def test_mpi_port_id_reservation_keeps_coordinator_owner():
+    grid = SimpleNamespace(mpi_port_output_ids=[], mpi_port_output_owners={})
+    first = SimpleNamespace()
+    second = SimpleNamespace()
+
+    assert _reserve_mpi_port_output_id(grid, None, first) == "port1"
+    assert _reserve_mpi_port_output_id(grid, "feed", second) == "feed"
+    assert grid.mpi_port_output_owners == {"port1": first, "feed": second}
+
+
+def test_voltage_port_rebind_uses_gathered_global_source_and_receiver():
+    old_source = SimpleNamespace(polarisation="z", coord=np.asarray((8, 9, 10)))
+    old_receiver = SimpleNamespace()
+    monitor = VoltageSourcePortMonitor("feed", old_source, old_receiver, 10)
+    source = SimpleNamespace(polarisation="z", coord=np.asarray((8, 9, 10)))
+    receiver = SimpleNamespace(
+        internal=True,
+        port_id="feed",
+        coord=np.asarray((8, 9, 10)),
+    )
+    grid = SimpleNamespace(
+        rxs=[receiver],
+        voltagesources=[source],
+        dx=0.1,
+        dy=0.2,
+        dz=0.3,
+    )
+
+    monitor.rebind_after_mpi_gather(grid)
+
+    assert monitor.source is source
+    assert monitor.receiver is receiver
+    np.testing.assert_allclose(monitor.source_position, (0.8, 1.8, 3.0))
+
+
+def test_network_port_rebind_uses_gathered_global_terminal():
+    monitor = RationalNetworkPortOutput.__new__(RationalNetworkPortOutput)
+    monitor.output_id = "load"
+    terminal = SimpleNamespace(ID="load", coord=np.asarray((4, 5, 6)), output=None)
+    grid = SimpleNamespace(networkterminals=[terminal], dx=0.1, dy=0.2, dz=0.3)
+
+    monitor.rebind_after_mpi_gather(grid)
+
+    assert monitor.terminal is terminal
+    assert monitor.source is terminal
+    assert terminal.output is monitor
+    np.testing.assert_allclose(monitor.source_position, (0.4, 1.0, 1.8))
+
+
+def test_frill_rx_port_owner_rebinds_to_gathered_source():
+    owner = SimpleNamespace(
+        _monitor=None,
+        _frill_source=None,
+        point=(0.008, 0.009, 0.010),
+    )
+    source = SimpleNamespace(coord=np.asarray((8, 9, 10), dtype=np.int32))
+    model = MPIModel.__new__(MPIModel)
+    model.G = SimpleNamespace(
+        dx=0.001,
+        dy=0.001,
+        dz=0.001,
+        mpi_port_output_owners={"override": owner},
+        magneticfrillsources=[source],
+    )
+
+    model._rebind_mpi_frill_port_owners()
+
+    assert owner._frill_source is source

--- a/tests/updates/test_mpi_transmission_line_timing.py
+++ b/tests/updates/test_mpi_transmission_line_timing.py
@@ -1,0 +1,94 @@
+from types import SimpleNamespace
+
+from gprMax.solvers import Solver
+from gprMax.updates.mpi_updates import MPIUpdates
+
+
+class _RecordingSource:
+    def __init__(self, name, calls):
+        self.name = name
+        self.calls = calls
+
+    def update_magnetic(self, *args):
+        self.calls.append(self.name)
+
+    def update_magnetic_mpi(self, *args):
+        self.calls.append(self.name)
+
+
+def test_mpi_separates_magnetic_writers_from_transmission_line_sampling():
+    calls = []
+    grid = SimpleNamespace(
+        transmissionlines=[_RecordingSource("transmission_line", calls)],
+        magneticdipoles=[_RecordingSource("magnetic_dipole", calls)],
+        magneticfrillsources=[_RecordingSource("magnetic_frill", calls)],
+        updatecoeffsH=None,
+        ID=None,
+        Hx=None,
+        Hy=None,
+        Hz=None,
+    )
+    updates = MPIUpdates.__new__(MPIUpdates)
+    updates.grid = grid
+
+    updates.update_magnetic_sources(3)
+    assert calls == ["magnetic_dipole", "magnetic_frill"]
+
+    updates.update_magnetic_edge_devices(3)
+    assert calls == ["magnetic_dipole", "magnetic_frill", "transmission_line"]
+
+
+def test_solver_samples_mpi_transmission_lines_after_magnetic_halo():
+    calls = []
+    updates = MPIUpdates.__new__(MPIUpdates)
+    updates.grid = SimpleNamespace(iterations=1)
+
+    def record(name):
+        return lambda *args, **kwargs: calls.append(name)
+
+    for name in (
+        "time_start",
+        "store_outputs",
+        "store_snapshots",
+        "observe_ntff_electric",
+        "update_magnetic",
+        "update_magnetic_pml",
+        "update_magnetic_sources",
+        "update_eigenmode_sources_magnetic",
+        "update_plane_waves_magnetic",
+        "observe_eigenmode_ports",
+        "halo_swap_magnetic",
+        "update_magnetic_edge_devices",
+        "observe_ntff_magnetic",
+        "update_electric_a",
+        "update_electric_pml",
+        "update_electric_sources",
+        "update_eigenmode_sources_electric",
+        "update_plane_waves_electric",
+        "update_electric_b",
+        "update_network_terminals",
+        "halo_swap_electric",
+        "finalise",
+        "cleanup",
+    ):
+        setattr(updates, name, record(name))
+    updates.calculate_solve_time = lambda: 0.0
+
+    Solver(updates).solve(range(1))
+
+    assert calls.index("update_magnetic_sources") < calls.index("halo_swap_magnetic")
+    assert calls.index("halo_swap_magnetic") < calls.index("update_magnetic_edge_devices")
+    assert calls.index("update_magnetic_edge_devices") < calls.index("update_electric_a")
+
+
+def test_mpi_finalise_completes_last_halo_exchange():
+    calls = []
+    updates = MPIUpdates.__new__(MPIUpdates)
+    updates.grid = SimpleNamespace(
+        complete_halo_swaps=lambda: calls.append("complete_halo_swaps"),
+        ntff_monitors=[],
+    )
+
+    updates.finalise()
+
+    assert calls == ["complete_halo_swaps"]

--- a/tests/utilities/test_mpi_utilities.py
+++ b/tests/utilities/test_mpi_utilities.py
@@ -1,0 +1,21 @@
+import numpy as np
+import pytest
+from mpi4py import MPI
+
+from gprMax.utilities.mpi import mpi_datatype_for_dtype
+
+
+@pytest.mark.parametrize(
+    ("numpy_dtype", "expected_mpi_dtype"),
+    [(np.float32, MPI.FLOAT), (np.float64, MPI.DOUBLE)],
+)
+def test_mpi_datatype_matches_configured_precision(numpy_dtype, expected_mpi_dtype):
+    mpi_dtype = mpi_datatype_for_dtype(numpy_dtype)
+
+    assert mpi_dtype == expected_mpi_dtype
+    assert mpi_dtype.Get_size() == np.dtype(numpy_dtype).itemsize
+
+
+def test_mpi_datatype_rejects_unsupported_precision():
+    with pytest.raises(TypeError, match="float32 or float64"):
+        mpi_datatype_for_dtype(np.int32)


### PR DESCRIPTION
# PR Description

## Summary

This PR extends MPI domain-decomposition support for local source and port devices and makes MPI communication respect the configured gprMax floating-point precision.

It adds MPI support for:

- Transmission-line sources
- Rational-network terminals
- Magnetic-frill sources
- Complete `rx_port` gathering and output
- Correct source operation at internal MPI boundaries
- Completion of outstanding halo exchanges before MPI shutdown

It also:

- Replaces hard-coded `MPI.FLOAT` field-halo communication with the MPI datatype corresponding to gprMax's configured `float32` or `float64` precision.
- Applies the same datatype handling to MPI fractal distribution.
- Ensures FFT-generated fractal arrays are contiguous before MPI communication.
- Adds documentation for the newly supported MPI features.

## Motivation

Local sources and ports associated with electric Yee edges can require magnetic-field samples from neighbouring MPI ranks. Their updates therefore need to occur only after the relevant magnetic halo exchange has completed.

The previous hard-coded `MPI.FLOAT` halo and fractal datatypes also prevented reliable double-precision MPI simulations.

## Validation

- 271 relevant tests passed; 12 hardware-marked tests were deselected.
- Two-rank MPI field simulations completed in both single and double precision.
- Single- and double-precision receiver results were numerically consistent.
- Two-rank parallel-FFTW fractal builds completed in both single and double precision.
- Documentation rendered successfully apart from two existing unrelated unreferenced-citation warnings.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] This change requires a documentation update

## Checklist

- [ ] Pre-commit passed all checks
- [x] I have performed a self-review of my code.
- [x] I have added comments for hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.