### PR TITLE
Add MPI support for eigenmode sources and virtual waveguides

### DIFF
--- a/docs/source/accelerators.rst
+++ b/docs/source/accelerators.rst
@@ -90,6 +90,13 @@ partitioned by Yee-component ownership. Axial layered profiles are assembled
 once during model construction, so plane waves add no source-specific
 communication to the timestep loop.
 
+Eigenmode ports can also span MPI subdomains. Their component-resolved modal
+cross-sections are assembled once during construction, TF/SF source terms are
+partitioned by field ownership, and the modal spectra are reduced only at
+finalisation. A virtual waveguide replicates its compact auxiliary Yee grid on
+each rank and performs one aperture-sized magnetic-field collective per time
+step to preserve bidirectional coupling.
+
 .. figure:: ../../images_shared/mpi_domain_decomposition.png
     :width: 80%
     :align: center

--- a/docs/source/eigenmode_port.rst
+++ b/docs/source/eigenmode_port.rst
@@ -426,9 +426,15 @@ aperture coupling on the selected compute device throughout time stepping.
 They may also be attached through the Python API to a port owned by an HSG
 subgrid; that path uses the CPU fine-grid update cycle. They currently require
 a 3D internal port plane, a locally uniform and non-dispersive cross-section,
-and at least two cells along each transverse axis. MPI is not supported. Use
-convergence tests for guide length, PML thickness, source clearance, mesh
-resolution, and NTFF-surface position before using quantitative results.
+and at least two cells along each transverse axis. Domain-decomposed MPI CPU
+models are supported. Every rank advances an identical copy of the small
+auxiliary guide; after each main-grid magnetic halo exchange, one collective
+operation assembles the three aperture H sheets needed for the bidirectional
+coupling. Main-grid E and H writes remain partitioned by Yee-component
+ownership. This communication scales with the aperture area rather than the
+model volume. Use convergence tests for guide length, PML thickness, source
+clearance, mesh resolution, and NTFF-surface position before using
+quantitative results.
 
 How automatic excitation and frequency anchors work
 ====================================================
@@ -2174,7 +2180,10 @@ For reliable broadband excitation:
   and mode purity matter.
 
 Eigenmode injection and modal monitoring run on the CPU, CUDA, OpenCL, and
-Metal solvers, but cannot yet be used with MPI. Material dispersion is sampled
-at each anchor frequency, but interpolation between anchors remains piecewise
+Metal solvers. Domain-decomposed MPI CPU models are also supported: the modal
+material plane is assembled collectively during model construction, each rank
+applies only its owned TF/SF corrections, and the small distributed modal DFT
+arrays are reduced once after time stepping. Material dispersion is sampled at
+each anchor frequency, but interpolation between anchors remains piecewise
 linear; additional anchors are the normal way to resolve stronger frequency
 dependence.

--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -539,6 +539,13 @@ by port number. It inherits the port orientation and cross-section:
         pml_profile=None,
     ))
 
+Direct ports and virtual guides support domain-decomposed MPI CPU models. The
+modal material slice is reconstructed from the distributed component values,
+so rank-local IDs for averaged materials are not assumed to be globally
+interchangeable. Direct TF/SF injection is ownership-clipped. For a virtual
+guide, every rank advances the same compact auxiliary grid and exchanges only
+the three H-field sheets required at its aperture.
+
 ``modes`` is a strictly increasing tuple of one-based modes. A scalar value
 ``N`` is shorthand for modes 1 through ``N``. All ports using ``'auto'``
 receive one common anchor list covering both the shared DFT band and the

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1672,7 +1672,10 @@ and output definitions.
       fine-grid material slice, spatial step, time step, and CPU update cycle.
       The complete port stencil must remain strictly inside the subgrid working
       region. See :doc:`eigenmode_port`.
-    * Eigenmode commands currently cannot be used with MPI.
+    * Domain-decomposed MPI CPU models are supported. Modal material slices
+      are assembled collectively once, TF/SF corrections are restricted to
+      locally owned Yee components, and modal DFT projections are reduced at
+      finalisation.
 
 #virtual_waveguide:
 -------------------
@@ -1711,7 +1714,10 @@ is ``i3 + i4 + 3`` cells. Main-grid virtual waveguides support 3D,
 non-dispersive guide cross-sections with the CPU, CUDA, OpenCL, and Metal
 solvers. Through the Python API, a virtual waveguide may instead be attached
 to an HSG-subgrid port; it then inherits that subgrid's fine material slice,
-spatial and temporal steps, and CPU update cycle. MPI is not supported.
+spatial and temporal steps, and CPU update cycle. Domain-decomposed MPI CPU
+models are supported. The compact auxiliary guide is replicated, while one
+aperture-sized collective communicates the three required H sheets after each
+magnetic halo exchange.
 
 Unlike a direct eigenmode source, a virtual-waveguide source lies outside the
 main FDTD domain. A closed equivalent-current or KSIR NTFF surface may

--- a/gprMax/contexts.py
+++ b/gprMax/contexts.py
@@ -213,6 +213,12 @@ class MPIContext(Context):
     def run(self) -> Dict:
         try:
             result = super().run()
+            # A geometry-fixed series retains the same MPIGrid (and its
+            # committed halo datatypes) across every model run. Release them
+            # only after the complete series has finished. Ordinary grids are
+            # retired in _run_model() and self.model is already None here.
+            if self.model is not None:
+                self.model.G.free_halo_maps()
             logger.debug("Waiting for all ranks to finish.")
             self.comm.Barrier()
             logger.debug("Completed.")
@@ -258,6 +264,7 @@ class MPIContext(Context):
         if not config.sim_config.geometry_fixed:
             # Manual garbage collection required to stop memory leak on GPUs
             # when using pycuda
+            self.model.G.free_halo_maps()
             del self.model.G
             self.model = None
 

--- a/gprMax/cython/eigenmode_dft.pyx
+++ b/gprMax/cython/eigenmode_dft.pyx
@@ -15,6 +15,14 @@ from cython.parallel import prange
 from gprMax.config cimport float_or_double, float_or_double_complex
 
 
+cdef inline int _imax(int a, int b) noexcept nogil:
+    return a if a > b else b
+
+
+cdef inline int _imin(int a, int b) noexcept nogil:
+    return a if a < b else b
+
+
 @cython.wraparound(False)
 @cython.boundscheck(False)
 cpdef void accumulate_eigenmode_dft(
@@ -27,6 +35,8 @@ cpdef void accumulate_eigenmode_dft(
     int u1,
     int v1,
     int plane_index,
+    int[:] owned_lower,
+    int[:] owned_upper,
     float_or_double dt,
     float_or_double measure,
     int handedness,
@@ -54,6 +64,35 @@ cpdef void accumulate_eigenmode_dft(
     cdef float_or_double eu_value, ev_value, hu_value, hv_value
     cdef float_or_double factor = 0.5 * handedness * measure * dt
     cdef float_or_double_complex electric_sum, magnetic_sum
+    cdef int sample_u0, sample_v0, sample_u1, sample_v1
+    cdef bint plane_owned
+
+    if normal_axis == 0:
+        plane_owned = owned_lower[0] <= plane_index < owned_upper[0]
+        sample_u0 = _imax(u0, owned_lower[1])
+        sample_u1 = _imin(u1, owned_upper[1])
+        sample_v0 = _imax(v0, owned_lower[2])
+        sample_v1 = _imin(v1, owned_upper[2])
+    elif normal_axis == 1:
+        plane_owned = owned_lower[1] <= plane_index < owned_upper[1]
+        sample_u0 = _imax(u0, owned_lower[0])
+        sample_u1 = _imin(u1, owned_upper[0])
+        sample_v0 = _imax(v0, owned_lower[2])
+        sample_v1 = _imin(v1, owned_upper[2])
+    else:
+        plane_owned = owned_lower[2] <= plane_index < owned_upper[2]
+        sample_u0 = _imax(u0, owned_lower[0])
+        sample_u1 = _imin(u1, owned_upper[0])
+        sample_v0 = _imax(v0, owned_lower[1])
+        sample_v1 = _imin(v1, owned_upper[1])
+
+    if not plane_owned:
+        sample_u1 = sample_u0
+        sample_v1 = sample_v0
+    if sample_u1 < sample_u0:
+        sample_u1 = sample_u0
+    if sample_v1 < sample_v0:
+        sample_v1 = sample_v0
 
     for frequency in prange(
         nf, nogil=True, schedule="static", num_threads=nthreads
@@ -61,8 +100,8 @@ cpdef void accumulate_eigenmode_dft(
         for mode in range(nm):
             electric_sum = 0
             magnetic_sum = 0
-            for u in range(u0, u1):
-                for v in range(v0, v1):
+            for u in range(sample_u0, sample_u1):
+                for v in range(sample_v0, sample_v1):
                     if normal_axis == 0:
                         eu_value = 0.5 * (Ey[plane_index, u, v] + Ey[plane_index, u, v + 1])
                         ev_value = 0.5 * (Ez[plane_index, u, v] + Ez[plane_index, u + 1, v])

--- a/gprMax/cython/eigenmode_source.pyx
+++ b/gprMax/cython/eigenmode_source.pyx
@@ -7,6 +7,14 @@ from cython.parallel import prange
 from gprMax.config cimport float_or_double
 
 
+cdef inline int _imax(int a, int b) noexcept nogil:
+    return a if a > b else b
+
+
+cdef inline int _imin(int a, int b) noexcept nogil:
+    return a if a < b else b
+
+
 @cython.wraparound(False)
 @cython.boundscheck(False)
 cpdef void update_eigenmode_magnetic(
@@ -18,6 +26,8 @@ cpdef void update_eigenmode_magnetic(
     int u1,
     int v1,
     int plane_index,
+    int[:] owned_lower,
+    int[:] owned_upper,
     float_or_double envelope,
     float_or_double[:, ::1] modal_Ex,
     float_or_double[:, ::1] modal_Ey,
@@ -31,27 +41,37 @@ cpdef void update_eigenmode_magnetic(
     cdef Py_ssize_t i, j, k
     cdef int target
     cdef float_or_double coeff
+    cdef int x0 = owned_lower[0]
+    cdef int y0 = owned_lower[1]
+    cdef int z0 = owned_lower[2]
+    cdef int x1 = owned_upper[0]
+    cdef int y1 = owned_upper[1]
+    cdef int z1 = owned_upper[2]
 
     if normal_axis == 0:
         i = plane_index
         if direction_sign > 0:
             target = i - 1
-            for j in prange(u0, u1 + 1, nogil=True, schedule="static", num_threads=nthreads):
-                for k in range(v0, v1):
+            if not x0 <= target < x1:
+                return
+            for j in prange(_imax(u0, y0), _imin(u1 + 1, y1), nogil=True, schedule="static", num_threads=nthreads):
+                for k in range(_imax(v0, z0), _imin(v1, z1)):
                     coeff = updatecoeffsH[ID[4, target, j, k], 1]
                     Hy[target, j, k] -= coeff * envelope * modal_Ez[j - u0, k - v0]
-            for j in prange(u0, u1, nogil=True, schedule="static", num_threads=nthreads):
-                for k in range(v0, v1 + 1):
+            for j in prange(_imax(u0, y0), _imin(u1, y1), nogil=True, schedule="static", num_threads=nthreads):
+                for k in range(_imax(v0, z0), _imin(v1 + 1, z1)):
                     coeff = updatecoeffsH[ID[5, target, j, k], 1]
                     Hz[target, j, k] += coeff * envelope * modal_Ey[j - u0, k - v0]
         else:
             target = i
-            for j in prange(u0, u1 + 1, nogil=True, schedule="static", num_threads=nthreads):
-                for k in range(v0, v1):
+            if not x0 <= target < x1:
+                return
+            for j in prange(_imax(u0, y0), _imin(u1 + 1, y1), nogil=True, schedule="static", num_threads=nthreads):
+                for k in range(_imax(v0, z0), _imin(v1, z1)):
                     coeff = updatecoeffsH[ID[4, target, j, k], 1]
                     Hy[target, j, k] += coeff * envelope * modal_Ez[j - u0, k - v0]
-            for j in prange(u0, u1, nogil=True, schedule="static", num_threads=nthreads):
-                for k in range(v0, v1 + 1):
+            for j in prange(_imax(u0, y0), _imin(u1, y1), nogil=True, schedule="static", num_threads=nthreads):
+                for k in range(_imax(v0, z0), _imin(v1 + 1, z1)):
                     coeff = updatecoeffsH[ID[5, target, j, k], 1]
                     Hz[target, j, k] -= coeff * envelope * modal_Ey[j - u0, k - v0]
 
@@ -59,22 +79,26 @@ cpdef void update_eigenmode_magnetic(
         j = plane_index
         if direction_sign > 0:
             target = j - 1
-            for i in prange(u0, u1 + 1, nogil=True, schedule="static", num_threads=nthreads):
-                for k in range(v0, v1):
+            if not y0 <= target < y1:
+                return
+            for i in prange(_imax(u0, x0), _imin(u1 + 1, x1), nogil=True, schedule="static", num_threads=nthreads):
+                for k in range(_imax(v0, z0), _imin(v1, z1)):
                     coeff = updatecoeffsH[ID[3, i, target, k], 2]
                     Hx[i, target, k] += coeff * envelope * modal_Ez[i - u0, k - v0]
-            for i in prange(u0, u1, nogil=True, schedule="static", num_threads=nthreads):
-                for k in range(v0, v1 + 1):
+            for i in prange(_imax(u0, x0), _imin(u1, x1), nogil=True, schedule="static", num_threads=nthreads):
+                for k in range(_imax(v0, z0), _imin(v1 + 1, z1)):
                     coeff = updatecoeffsH[ID[5, i, target, k], 2]
                     Hz[i, target, k] -= coeff * envelope * modal_Ex[i - u0, k - v0]
         else:
             target = j
-            for i in prange(u0, u1 + 1, nogil=True, schedule="static", num_threads=nthreads):
-                for k in range(v0, v1):
+            if not y0 <= target < y1:
+                return
+            for i in prange(_imax(u0, x0), _imin(u1 + 1, x1), nogil=True, schedule="static", num_threads=nthreads):
+                for k in range(_imax(v0, z0), _imin(v1, z1)):
                     coeff = updatecoeffsH[ID[3, i, target, k], 2]
                     Hx[i, target, k] -= coeff * envelope * modal_Ez[i - u0, k - v0]
-            for i in prange(u0, u1, nogil=True, schedule="static", num_threads=nthreads):
-                for k in range(v0, v1 + 1):
+            for i in prange(_imax(u0, x0), _imin(u1, x1), nogil=True, schedule="static", num_threads=nthreads):
+                for k in range(_imax(v0, z0), _imin(v1 + 1, z1)):
                     coeff = updatecoeffsH[ID[5, i, target, k], 2]
                     Hz[i, target, k] += coeff * envelope * modal_Ex[i - u0, k - v0]
 
@@ -82,22 +106,26 @@ cpdef void update_eigenmode_magnetic(
         k = plane_index
         if direction_sign > 0:
             target = k - 1
-            for i in prange(u0, u1, nogil=True, schedule="static", num_threads=nthreads):
-                for j in range(v0, v1 + 1):
+            if not z0 <= target < z1:
+                return
+            for i in prange(_imax(u0, x0), _imin(u1, x1), nogil=True, schedule="static", num_threads=nthreads):
+                for j in range(_imax(v0, y0), _imin(v1 + 1, y1)):
                     coeff = updatecoeffsH[ID[4, i, j, target], 3]
                     Hy[i, j, target] += coeff * envelope * modal_Ex[i - u0, j - v0]
-            for i in prange(u0, u1 + 1, nogil=True, schedule="static", num_threads=nthreads):
-                for j in range(v0, v1):
+            for i in prange(_imax(u0, x0), _imin(u1 + 1, x1), nogil=True, schedule="static", num_threads=nthreads):
+                for j in range(_imax(v0, y0), _imin(v1, y1)):
                     coeff = updatecoeffsH[ID[3, i, j, target], 3]
                     Hx[i, j, target] -= coeff * envelope * modal_Ey[i - u0, j - v0]
         else:
             target = k
-            for i in prange(u0, u1, nogil=True, schedule="static", num_threads=nthreads):
-                for j in range(v0, v1 + 1):
+            if not z0 <= target < z1:
+                return
+            for i in prange(_imax(u0, x0), _imin(u1, x1), nogil=True, schedule="static", num_threads=nthreads):
+                for j in range(_imax(v0, y0), _imin(v1 + 1, y1)):
                     coeff = updatecoeffsH[ID[4, i, j, target], 3]
                     Hy[i, j, target] -= coeff * envelope * modal_Ex[i - u0, j - v0]
-            for i in prange(u0, u1 + 1, nogil=True, schedule="static", num_threads=nthreads):
-                for j in range(v0, v1):
+            for i in prange(_imax(u0, x0), _imin(u1 + 1, x1), nogil=True, schedule="static", num_threads=nthreads):
+                for j in range(_imax(v0, y0), _imin(v1, y1)):
                     coeff = updatecoeffsH[ID[3, i, j, target], 3]
                     Hx[i, j, target] += coeff * envelope * modal_Ey[i - u0, j - v0]
 
@@ -113,6 +141,8 @@ cpdef void update_eigenmode_electric(
     int u1,
     int v1,
     int plane_index,
+    int[:] owned_lower,
+    int[:] owned_upper,
     float_or_double envelope,
     float_or_double[:, ::1] modal_Hx,
     float_or_double[:, ::1] modal_Hy,
@@ -126,66 +156,78 @@ cpdef void update_eigenmode_electric(
     cdef Py_ssize_t i, j, k
     cdef float_or_double hsign = 1.0 if direction_sign > 0 else -1.0
     cdef float_or_double coeff
+    cdef int x0 = owned_lower[0]
+    cdef int y0 = owned_lower[1]
+    cdef int z0 = owned_lower[2]
+    cdef int x1 = owned_upper[0]
+    cdef int y1 = owned_upper[1]
+    cdef int z1 = owned_upper[2]
 
     if normal_axis == 0:
         i = plane_index
+        if not x0 <= i < x1:
+            return
         if direction_sign > 0:
-            for j in prange(u0, u1 + 1, nogil=True, schedule="static", num_threads=nthreads):
-                for k in range(v0, v1):
+            for j in prange(_imax(u0, y0), _imin(u1 + 1, y1), nogil=True, schedule="static", num_threads=nthreads):
+                for k in range(_imax(v0, z0), _imin(v1, z1)):
                     coeff = updatecoeffsE[ID[2, i, j, k], 1]
                     Ez[i, j, k] -= coeff * envelope * hsign * modal_Hy[j - u0, k - v0]
-            for j in prange(u0, u1, nogil=True, schedule="static", num_threads=nthreads):
-                for k in range(v0, v1 + 1):
+            for j in prange(_imax(u0, y0), _imin(u1, y1), nogil=True, schedule="static", num_threads=nthreads):
+                for k in range(_imax(v0, z0), _imin(v1 + 1, z1)):
                     coeff = updatecoeffsE[ID[1, i, j, k], 1]
                     Ey[i, j, k] += coeff * envelope * hsign * modal_Hz[j - u0, k - v0]
         else:
-            for j in prange(u0, u1 + 1, nogil=True, schedule="static", num_threads=nthreads):
-                for k in range(v0, v1):
+            for j in prange(_imax(u0, y0), _imin(u1 + 1, y1), nogil=True, schedule="static", num_threads=nthreads):
+                for k in range(_imax(v0, z0), _imin(v1, z1)):
                     coeff = updatecoeffsE[ID[2, i, j, k], 1]
                     Ez[i, j, k] += coeff * envelope * hsign * modal_Hy[j - u0, k - v0]
-            for j in prange(u0, u1, nogil=True, schedule="static", num_threads=nthreads):
-                for k in range(v0, v1 + 1):
+            for j in prange(_imax(u0, y0), _imin(u1, y1), nogil=True, schedule="static", num_threads=nthreads):
+                for k in range(_imax(v0, z0), _imin(v1 + 1, z1)):
                     coeff = updatecoeffsE[ID[1, i, j, k], 1]
                     Ey[i, j, k] -= coeff * envelope * hsign * modal_Hz[j - u0, k - v0]
 
     elif normal_axis == 1:
         j = plane_index
+        if not y0 <= j < y1:
+            return
         if direction_sign > 0:
-            for i in prange(u0, u1 + 1, nogil=True, schedule="static", num_threads=nthreads):
-                for k in range(v0, v1):
+            for i in prange(_imax(u0, x0), _imin(u1 + 1, x1), nogil=True, schedule="static", num_threads=nthreads):
+                for k in range(_imax(v0, z0), _imin(v1, z1)):
                     coeff = updatecoeffsE[ID[2, i, j, k], 2]
                     Ez[i, j, k] += coeff * envelope * hsign * modal_Hx[i - u0, k - v0]
-            for i in prange(u0, u1, nogil=True, schedule="static", num_threads=nthreads):
-                for k in range(v0, v1 + 1):
+            for i in prange(_imax(u0, x0), _imin(u1, x1), nogil=True, schedule="static", num_threads=nthreads):
+                for k in range(_imax(v0, z0), _imin(v1 + 1, z1)):
                     coeff = updatecoeffsE[ID[0, i, j, k], 2]
                     Ex[i, j, k] -= coeff * envelope * hsign * modal_Hz[i - u0, k - v0]
         else:
-            for i in prange(u0, u1 + 1, nogil=True, schedule="static", num_threads=nthreads):
-                for k in range(v0, v1):
+            for i in prange(_imax(u0, x0), _imin(u1 + 1, x1), nogil=True, schedule="static", num_threads=nthreads):
+                for k in range(_imax(v0, z0), _imin(v1, z1)):
                     coeff = updatecoeffsE[ID[2, i, j, k], 2]
                     Ez[i, j, k] -= coeff * envelope * hsign * modal_Hx[i - u0, k - v0]
-            for i in prange(u0, u1, nogil=True, schedule="static", num_threads=nthreads):
-                for k in range(v0, v1 + 1):
+            for i in prange(_imax(u0, x0), _imin(u1, x1), nogil=True, schedule="static", num_threads=nthreads):
+                for k in range(_imax(v0, z0), _imin(v1 + 1, z1)):
                     coeff = updatecoeffsE[ID[0, i, j, k], 2]
                     Ex[i, j, k] += coeff * envelope * hsign * modal_Hz[i - u0, k - v0]
 
     else:
         k = plane_index
+        if not z0 <= k < z1:
+            return
         if direction_sign > 0:
-            for i in prange(u0, u1 + 1, nogil=True, schedule="static", num_threads=nthreads):
-                for j in range(v0, v1):
+            for i in prange(_imax(u0, x0), _imin(u1 + 1, x1), nogil=True, schedule="static", num_threads=nthreads):
+                for j in range(_imax(v0, y0), _imin(v1, y1)):
                     coeff = updatecoeffsE[ID[1, i, j, k], 3]
                     Ey[i, j, k] -= coeff * envelope * hsign * modal_Hx[i - u0, j - v0]
-            for i in prange(u0, u1, nogil=True, schedule="static", num_threads=nthreads):
-                for j in range(v0, v1 + 1):
+            for i in prange(_imax(u0, x0), _imin(u1, x1), nogil=True, schedule="static", num_threads=nthreads):
+                for j in range(_imax(v0, y0), _imin(v1 + 1, y1)):
                     coeff = updatecoeffsE[ID[0, i, j, k], 3]
                     Ex[i, j, k] += coeff * envelope * hsign * modal_Hy[i - u0, j - v0]
         else:
-            for i in prange(u0, u1 + 1, nogil=True, schedule="static", num_threads=nthreads):
-                for j in range(v0, v1):
+            for i in prange(_imax(u0, x0), _imin(u1 + 1, x1), nogil=True, schedule="static", num_threads=nthreads):
+                for j in range(_imax(v0, y0), _imin(v1, y1)):
                     coeff = updatecoeffsE[ID[1, i, j, k], 3]
                     Ey[i, j, k] += coeff * envelope * hsign * modal_Hx[i - u0, j - v0]
-            for i in prange(u0, u1, nogil=True, schedule="static", num_threads=nthreads):
-                for j in range(v0, v1 + 1):
+            for i in prange(_imax(u0, x0), _imin(u1, x1), nogil=True, schedule="static", num_threads=nthreads):
+                for j in range(_imax(v0, y0), _imin(v1 + 1, y1)):
                     coeff = updatecoeffsE[ID[0, i, j, k], 3]
                     Ex[i, j, k] -= coeff * envelope * hsign * modal_Hy[i - u0, j - v0]

--- a/gprMax/cython/virtual_waveguide.pyx
+++ b/gprMax/cython/virtual_waveguide.pyx
@@ -380,3 +380,124 @@ cpdef void couple_virtual_waveguide_electric(
                 for u in range(nu + 1):
                     for v in range(nv):
                         main_Ey[u0 + u, v0 + v, k] = 0
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+cpdef void couple_virtual_waveguide_electric_aperture(
+    int nthreads,
+    int normal_axis,
+    int direction_sign,
+    float_or_double[:, ::1] updatecoeffsE,
+    np.uint32_t[:, :, :, ::1] aux_ID,
+    float_or_double[:, ::1] main_Hu,
+    float_or_double[:, ::1] main_Hv,
+    float_or_double[:, :, ::1] aux_Ex,
+    float_or_double[:, :, ::1] aux_Ey,
+    float_or_double[:, :, ::1] aux_Ez,
+    float_or_double[:, :, ::1] aux_Hx,
+    float_or_double[:, :, ::1] aux_Hy,
+    float_or_double[:, :, ::1] aux_Hz,
+):
+    """Close an MPI virtual-guide aperture from compact global H sheets.
+
+    ``main_Hu`` and ``main_Hv`` are the magnetic components parallel to
+    the first and second transverse axes, respectively. They are assembled
+    collectively after the main-grid H halo exchange.
+    """
+
+    cdef Py_ssize_t u, v
+    cdef int aperture, inside, material
+    cdef int nu = main_Hv.shape[0]
+    cdef int nv = main_Hu.shape[1]
+    cdef float_or_double cross_field
+
+    if normal_axis == 0:
+        aperture = 0 if direction_sign < 0 else aux_Ex.shape[0] - 1
+        inside = 0 if direction_sign < 0 else aperture - 1
+        for u in prange(nu, nogil=True, schedule="static", num_threads=nthreads):
+            for v in range(1, nv):
+                material = aux_ID[1, aperture, u, v]
+                if direction_sign < 0:
+                    cross_field = aux_Hz[0, u, v] - main_Hv[u, v]
+                else:
+                    cross_field = main_Hv[u, v] - aux_Hz[inside, u, v]
+                aux_Ey[aperture, u, v] = (
+                    updatecoeffsE[material, 0] * aux_Ey[aperture, u, v]
+                    + updatecoeffsE[material, 3]
+                    * (aux_Hx[aperture, u, v] - aux_Hx[aperture, u, v - 1])
+                    - updatecoeffsE[material, 1] * cross_field
+                )
+        for u in prange(1, nu, nogil=True, schedule="static", num_threads=nthreads):
+            for v in range(nv):
+                material = aux_ID[2, aperture, u, v]
+                if direction_sign < 0:
+                    cross_field = aux_Hy[0, u, v] - main_Hu[u, v]
+                else:
+                    cross_field = main_Hu[u, v] - aux_Hy[inside, u, v]
+                aux_Ez[aperture, u, v] = (
+                    updatecoeffsE[material, 0] * aux_Ez[aperture, u, v]
+                    + updatecoeffsE[material, 1] * cross_field
+                    - updatecoeffsE[material, 2]
+                    * (aux_Hx[aperture, u, v] - aux_Hx[aperture, u - 1, v])
+                )
+
+    elif normal_axis == 1:
+        aperture = 0 if direction_sign < 0 else aux_Ey.shape[1] - 1
+        inside = 0 if direction_sign < 0 else aperture - 1
+        for u in prange(nu, nogil=True, schedule="static", num_threads=nthreads):
+            for v in range(1, nv):
+                material = aux_ID[0, u, aperture, v]
+                if direction_sign < 0:
+                    cross_field = aux_Hz[u, 0, v] - main_Hv[u, v]
+                else:
+                    cross_field = main_Hv[u, v] - aux_Hz[u, inside, v]
+                aux_Ex[u, aperture, v] = (
+                    updatecoeffsE[material, 0] * aux_Ex[u, aperture, v]
+                    + updatecoeffsE[material, 2] * cross_field
+                    - updatecoeffsE[material, 3]
+                    * (aux_Hy[u, aperture, v] - aux_Hy[u, aperture, v - 1])
+                )
+        for u in prange(1, nu, nogil=True, schedule="static", num_threads=nthreads):
+            for v in range(nv):
+                material = aux_ID[2, u, aperture, v]
+                if direction_sign < 0:
+                    cross_field = aux_Hx[u, 0, v] - main_Hu[u, v]
+                else:
+                    cross_field = main_Hu[u, v] - aux_Hx[u, inside, v]
+                aux_Ez[u, aperture, v] = (
+                    updatecoeffsE[material, 0] * aux_Ez[u, aperture, v]
+                    + updatecoeffsE[material, 1]
+                    * (aux_Hy[u, aperture, v] - aux_Hy[u - 1, aperture, v])
+                    - updatecoeffsE[material, 2] * cross_field
+                )
+
+    else:
+        aperture = 0 if direction_sign < 0 else aux_Ez.shape[2] - 1
+        inside = 0 if direction_sign < 0 else aperture - 1
+        for u in prange(nu, nogil=True, schedule="static", num_threads=nthreads):
+            for v in range(1, nv):
+                material = aux_ID[0, u, v, aperture]
+                if direction_sign < 0:
+                    cross_field = aux_Hy[u, v, 0] - main_Hv[u, v]
+                else:
+                    cross_field = main_Hv[u, v] - aux_Hy[u, v, inside]
+                aux_Ex[u, v, aperture] = (
+                    updatecoeffsE[material, 0] * aux_Ex[u, v, aperture]
+                    + updatecoeffsE[material, 2]
+                    * (aux_Hz[u, v, aperture] - aux_Hz[u, v - 1, aperture])
+                    - updatecoeffsE[material, 3] * cross_field
+                )
+        for u in prange(1, nu, nogil=True, schedule="static", num_threads=nthreads):
+            for v in range(nv):
+                material = aux_ID[1, u, v, aperture]
+                if direction_sign < 0:
+                    cross_field = aux_Hx[u, v, 0] - main_Hu[u, v]
+                else:
+                    cross_field = main_Hu[u, v] - aux_Hx[u, v, inside]
+                aux_Ey[u, v, aperture] = (
+                    updatecoeffsE[material, 0] * aux_Ey[u, v, aperture]
+                    + updatecoeffsE[material, 3] * cross_field
+                    - updatecoeffsE[material, 1]
+                    * (aux_Hz[u, v, aperture] - aux_Hz[u - 1, v, aperture])
+                )

--- a/gprMax/eigenmode_ports.py
+++ b/gprMax/eigenmode_ports.py
@@ -32,6 +32,8 @@ except ImportError:  # Source-tree fallback before extensions are rebuilt.
         u1,
         v1,
         plane_index,
+        owned_lower,
+        owned_upper,
         dt,
         measure,
         handedness,
@@ -52,44 +54,97 @@ except ImportError:  # Source-tree fallback before extensions are rebuilt.
         Hz,
     ):
         hplane = plane_index if direction_sign * magnetic_side > 0 else plane_index - 1
+        plane_owned = owned_lower[normal_axis] <= plane_index < owned_upper[normal_axis]
+        if normal_axis == 0:
+            sample_u0 = max(u0, owned_lower[1])
+            sample_u1 = min(u1, owned_upper[1])
+            sample_v0 = max(v0, owned_lower[2])
+            sample_v1 = min(v1, owned_upper[2])
+        elif normal_axis == 1:
+            sample_u0 = max(u0, owned_lower[0])
+            sample_u1 = min(u1, owned_upper[0])
+            sample_v0 = max(v0, owned_lower[2])
+            sample_v1 = min(v1, owned_upper[2])
+        else:
+            sample_u0 = max(u0, owned_lower[0])
+            sample_u1 = min(u1, owned_upper[0])
+            sample_v0 = max(v0, owned_lower[1])
+            sample_v1 = min(v1, owned_upper[1])
+
+        if not plane_owned:
+            sample_u1 = sample_u0
+            sample_v1 = sample_v0
+        sample_u1 = max(sample_u0, sample_u1)
+        sample_v1 = max(sample_v0, sample_v1)
+
         if normal_axis == 0:
             measured_eu = 0.5 * (
-                Ey[plane_index, u0:u1, v0:v1] + Ey[plane_index, u0:u1, v0 + 1 : v1 + 1]
+                Ey[plane_index, sample_u0:sample_u1, sample_v0:sample_v1]
+                + Ey[plane_index, sample_u0:sample_u1, sample_v0 + 1 : sample_v1 + 1]
             )
             measured_ev = 0.5 * (
-                Ez[plane_index, u0:u1, v0:v1] + Ez[plane_index, u0 + 1 : u1 + 1, v0:v1]
+                Ez[plane_index, sample_u0:sample_u1, sample_v0:sample_v1]
+                + Ez[plane_index, sample_u0 + 1 : sample_u1 + 1, sample_v0:sample_v1]
             )
-            measured_hu = 0.5 * (Hy[hplane, u0:u1, v0:v1] + Hy[hplane, u0 + 1 : u1 + 1, v0:v1])
-            measured_hv = 0.5 * (Hz[hplane, u0:u1, v0:v1] + Hz[hplane, u0:u1, v0 + 1 : v1 + 1])
+            measured_hu = 0.5 * (
+                Hy[hplane, sample_u0:sample_u1, sample_v0:sample_v1]
+                + Hy[hplane, sample_u0 + 1 : sample_u1 + 1, sample_v0:sample_v1]
+            )
+            measured_hv = 0.5 * (
+                Hz[hplane, sample_u0:sample_u1, sample_v0:sample_v1]
+                + Hz[hplane, sample_u0:sample_u1, sample_v0 + 1 : sample_v1 + 1]
+            )
         elif normal_axis == 1:
             measured_eu = 0.5 * (
-                Ex[u0:u1, plane_index, v0:v1] + Ex[u0:u1, plane_index, v0 + 1 : v1 + 1]
+                Ex[sample_u0:sample_u1, plane_index, sample_v0:sample_v1]
+                + Ex[sample_u0:sample_u1, plane_index, sample_v0 + 1 : sample_v1 + 1]
             )
             measured_ev = 0.5 * (
-                Ez[u0:u1, plane_index, v0:v1] + Ez[u0 + 1 : u1 + 1, plane_index, v0:v1]
+                Ez[sample_u0:sample_u1, plane_index, sample_v0:sample_v1]
+                + Ez[sample_u0 + 1 : sample_u1 + 1, plane_index, sample_v0:sample_v1]
             )
-            measured_hu = 0.5 * (Hx[u0:u1, hplane, v0:v1] + Hx[u0 + 1 : u1 + 1, hplane, v0:v1])
-            measured_hv = 0.5 * (Hz[u0:u1, hplane, v0:v1] + Hz[u0:u1, hplane, v0 + 1 : v1 + 1])
+            measured_hu = 0.5 * (
+                Hx[sample_u0:sample_u1, hplane, sample_v0:sample_v1]
+                + Hx[sample_u0 + 1 : sample_u1 + 1, hplane, sample_v0:sample_v1]
+            )
+            measured_hv = 0.5 * (
+                Hz[sample_u0:sample_u1, hplane, sample_v0:sample_v1]
+                + Hz[sample_u0:sample_u1, hplane, sample_v0 + 1 : sample_v1 + 1]
+            )
         else:
             measured_eu = 0.5 * (
-                Ex[u0:u1, v0:v1, plane_index] + Ex[u0:u1, v0 + 1 : v1 + 1, plane_index]
+                Ex[sample_u0:sample_u1, sample_v0:sample_v1, plane_index]
+                + Ex[sample_u0:sample_u1, sample_v0 + 1 : sample_v1 + 1, plane_index]
             )
             measured_ev = 0.5 * (
-                Ey[u0:u1, v0:v1, plane_index] + Ey[u0 + 1 : u1 + 1, v0:v1, plane_index]
+                Ey[sample_u0:sample_u1, sample_v0:sample_v1, plane_index]
+                + Ey[sample_u0 + 1 : sample_u1 + 1, sample_v0:sample_v1, plane_index]
             )
-            measured_hu = 0.5 * (Hx[u0:u1, v0:v1, hplane] + Hx[u0 + 1 : u1 + 1, v0:v1, hplane])
-            measured_hv = 0.5 * (Hy[u0:u1, v0:v1, hplane] + Hy[u0:u1, v0 + 1 : v1 + 1, hplane])
+            measured_hu = 0.5 * (
+                Hx[sample_u0:sample_u1, sample_v0:sample_v1, hplane]
+                + Hx[sample_u0 + 1 : sample_u1 + 1, sample_v0:sample_v1, hplane]
+            )
+            measured_hv = 0.5 * (
+                Hy[sample_u0:sample_u1, sample_v0:sample_v1, hplane]
+                + Hy[sample_u0:sample_u1, sample_v0 + 1 : sample_v1 + 1, hplane]
+            )
+        local_u = slice(sample_u0 - u0, sample_u1 - u0)
+        local_v = slice(sample_v0 - v0, sample_v1 - v0)
+        local_conj_eu = conj_eu[:, :, local_u, local_v]
+        local_conj_ev = conj_ev[:, :, local_u, local_v]
+        local_conj_hu = conj_hu[:, :, local_u, local_v]
+        local_conj_hv = conj_hv[:, :, local_u, local_v]
         factor = 0.5 * handedness * measure * dt
         electric_overlap = factor * (
-            np.einsum("uv,fmuv->fm", measured_eu, conj_hv, optimize=True)
-            - np.einsum("uv,fmuv->fm", measured_ev, conj_hu, optimize=True)
+            np.einsum("uv,fmuv->fm", measured_eu, local_conj_hv, optimize=True)
+            - np.einsum("uv,fmuv->fm", measured_ev, local_conj_hu, optimize=True)
         )
         magnetic_overlap = (
             factor
             * direction_sign
             * (
-                np.einsum("fmuv,uv->fm", conj_eu, measured_hv, optimize=True)
-                - np.einsum("fmuv,uv->fm", conj_ev, measured_hu, optimize=True)
+                np.einsum("fmuv,uv->fm", local_conj_eu, measured_hv, optimize=True)
+                - np.einsum("fmuv,uv->fm", local_conj_ev, measured_hu, optimize=True)
             )
         )
         electric_dft += electric_phase[:, np.newaxis] * electric_overlap
@@ -196,11 +251,7 @@ def _solve_conditioned_gram(
         condition_number = float(singular_values[0] / singular_values[-1])
         return solution, np.ones(size, dtype=bool), condition_number
 
-    if (
-        not np.any(retained)
-        or not np.any(power_coordinates)
-        or not np.any(~power_coordinates)
-    ):
+    if not np.any(retained) or not np.any(power_coordinates) or not np.any(~power_coordinates):
         return failed
 
     discarded_right_vectors = right_vectors_h[~retained]
@@ -220,13 +271,9 @@ def _solve_conditioned_gram(
         (retained_left.conj().T @ right_hand_side) / singular_values[retained]
     )
     ambiguity = np.sqrt(np.sum(np.abs(discarded_right_vectors) ** 2, axis=0))
-    stable = np.isfinite(ambiguity) & (
-        ambiguity <= CONDITION_RELATIVE_ERROR_BUDGET
-    )
+    stable = np.isfinite(ambiguity) & (ambiguity <= CONDITION_RELATIVE_ERROR_BUDGET)
     retained_singular_values = singular_values[retained]
-    condition_number = float(
-        np.max(retained_singular_values) / np.min(retained_singular_values)
-    )
+    condition_number = float(np.max(retained_singular_values) / np.min(retained_singular_values))
     return solution, stable, condition_number
 
 
@@ -528,9 +575,7 @@ class EigenmodePortMonitor:
                 self.frequency.astype(np.float64),
                 self.anchor_frequencies[usable_anchors],
             )
-            reference_anchors = np.flatnonzero(
-                self.anchor_mode_reference_valid[:, mode_position]
-            )
+            reference_anchors = np.flatnonzero(self.anchor_mode_reference_valid[:, mode_position])
             evanescent_reference_mask = (
                 self.anchor_mode_reference_valid[:, mode_position]
                 & ~self.anchor_mode_propagating[:, mode_position]
@@ -575,11 +620,11 @@ class EigenmodePortMonitor:
                     if bins.size == 0:
                         continue
                     run_anchors = np.arange(start, stop + 1)
-                    reference_weights[mode_position][np.ix_(run_anchors, bins)] = (
-                        self.owner._linear_anchor_weights(
-                            nominal_frequency[bins],
-                            self.anchor_frequencies[run_anchors],
-                        )
+                    reference_weights[mode_position][
+                        np.ix_(run_anchors, bins)
+                    ] = self.owner._linear_anchor_weights(
+                        nominal_frequency[bins],
+                        self.anchor_frequencies[run_anchors],
                     )
             elif within_candidate_bins.size:
                 # Compatibility path for a bank containing only propagating
@@ -707,8 +752,7 @@ class EigenmodePortMonitor:
                 self.hu[frequency_index, mode_position] = hu
                 self.hv[frequency_index, mode_position] = hv
                 self.neff[frequency_index, mode_position] = np.sum(
-                    mode_weights[:, frequency_index]
-                    * self.anchor_neff[:, mode_position]
+                    mode_weights[:, frequency_index] * self.anchor_neff[:, mode_position]
                 )
 
         self.eu = np.ascontiguousarray(self.eu)
@@ -786,6 +830,16 @@ class EigenmodePortMonitor:
                 f"expected eigenmode DFT iteration {self._next_iteration}, " f"received {iteration}"
             )
         real_signature = config.sim_config.dtypes["C_float_or_double"]
+        owned_lower = getattr(
+            self.owner,
+            "tfsf_owned_lower",
+            np.zeros(3, dtype=np.int32),
+        )
+        owned_upper = getattr(
+            self.owner,
+            "tfsf_owned_upper",
+            np.asarray(grid.Ex.shape, dtype=np.int32),
+        )
         accumulate_eigenmode_dft[f"{real_signature}|{real_signature} complex"](
             config.get_model_config().ompthreads,
             self.owner.normal_axis,
@@ -796,6 +850,8 @@ class EigenmodePortMonitor:
             self.owner.transverse_stop[0],
             self.owner.transverse_stop[1],
             self.owner.plane_index,
+            owned_lower,
+            owned_upper,
             grid.dt,
             self.measure,
             self.handedness,
@@ -894,15 +950,10 @@ class EigenmodePortMonitor:
             a = np.zeros(active_modes.size, dtype=np.complex128)
             a[usable] = (
                 magnetic_coeff[usable]
-                + backward_phase[frequency_index, active_modes][usable]
-                * electric_coeff[usable]
+                + backward_phase[frequency_index, active_modes][usable] * electric_coeff[usable]
             ) / denominator[usable]
             b = electric_coeff - a
-            coefficient_valid = (
-                usable
-                & np.isfinite(a)
-                & np.isfinite(b)
-            )
+            coefficient_valid = usable & np.isfinite(a) & np.isfinite(b)
             valid_modes = active_modes[coefficient_valid]
             incident[valid_modes, frequency_index] = a[coefficient_valid]
             outgoing[valid_modes, frequency_index] = b[coefficient_valid]
@@ -938,7 +989,10 @@ class EigenmodePortMonitor:
         group.attrs["Direction"] = self.owner.direction
         group.attrs["Normal"] = self.owner.normal
         group.attrs["ModeIndices"] = self.mode_indices
-        group.attrs["PlaneIndex"] = self.owner.plane_index
+        global_plane_index = getattr(self.owner, "global_plane_index", None)
+        group.attrs["PlaneIndex"] = (
+            self.owner.plane_index if global_plane_index is None else global_plane_index
+        )
         group.attrs["PhaseReanchorInterval"] = DFT_PHASE_REANCHOR_INTERVAL
         group.attrs["RequestedAnchorPolicy"] = self.owner.requested_anchor_policy
         group.attrs["ResolvedAnchorPolicy"] = self.owner.resolved_anchor_policy
@@ -954,9 +1008,7 @@ class EigenmodePortMonitor:
         group["incident"] = self.result.incident
         group["outgoing"] = self.result.outgoing
         group["valid"] = self.result.valid.astype(np.uint8)
-        group["generalized_valid"] = _generalized_result_valid(self.result).astype(
-            np.uint8
-        )
+        group["generalized_valid"] = _generalized_result_valid(self.result).astype(np.uint8)
         group["condition_number"] = self.result.condition_number
         group["electric_cross_power_matrix"] = self.electric_gram
         group["power_matrix"] = self.power_matrix
@@ -997,10 +1049,9 @@ def finalise_eigenmode_ports(grid):
             raise ValueError("All eigenmode ports must use identical DFT frequency bins.")
     source_mode_position = source.mode_indices.index(source.excitation_mode_index)
     denominator = source.result.incident[source_mode_position]
-    source_generalized_result_valid = (
-        _generalized_result_valid(source.result)[source_mode_position]
-        & np.isfinite(denominator)
-    )
+    source_generalized_result_valid = _generalized_result_valid(source.result)[
+        source_mode_position
+    ] & np.isfinite(denominator)
     source_power_wave_valid_value = getattr(source, "power_wave_valid", None)
     if source_power_wave_valid_value is None:
         source_power_wave_valid_value = source.mode_power_valid
@@ -1035,8 +1086,7 @@ def finalise_eigenmode_ports(grid):
             where=source_ratio_valid[np.newaxis, :],
         )
         port.s_generalized_valid = (
-            _generalized_result_valid(port.result)
-            & source_ratio_valid[np.newaxis, :]
+            _generalized_result_valid(port.result) & source_ratio_valid[np.newaxis, :]
         )
         port_power_wave_valid_value = getattr(port, "power_wave_valid", None)
         if port_power_wave_valid_value is None:

--- a/gprMax/grid/mpi_grid.py
+++ b/gprMax/grid/mpi_grid.py
@@ -19,6 +19,8 @@
 
 import itertools
 import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import List, Optional, Tuple, TypeVar, Union
 
 import numpy as np
@@ -68,6 +70,10 @@ class MPIGrid(FDTDGrid):
 
         self.send_halo_map = np.empty((3, 2), dtype=MPI.Datatype)
         self.recv_halo_map = np.empty((3, 2), dtype=MPI.Datatype)
+        self.send_halo_map.fill(MPI.DATATYPE_NULL)
+        self.recv_halo_map.fill(MPI.DATATYPE_NULL)
+        self._halo_maps_initialised = False
+        self._halo_maps_freed = False
         self.send_requests: List[MPI.Request] = []
         self.recv_requests: List[MPI.Request] = []
 
@@ -380,6 +386,73 @@ class MPIGrid(FDTDGrid):
         self.networkterminals = self.gather_coord_objects(self.networkterminals)
         self.port_monitors = self.gather_objects(self.port_monitors)
 
+    @contextmanager
+    def gathered_output_state(self) -> Iterator[None]:
+        """Temporarily expose globally gathered objects for output writing.
+
+        ``gather_grid_objects`` converts coordinates to the global frame and,
+        on the coordinator, replaces each rank-local list with the gathered
+        list. Output writing also temporarily presents the global grid size.
+        Those mutations are harmless when a grid is immediately discarded,
+        but corrupt the next solve when ``geometry_fixed`` reuses the grid.
+
+        Preserve the rank-local runtime state and restore it after output has
+        been written. The ``finally`` block also protects reuse if output
+        finalisation or HDF5 writing raises an exception.
+        """
+
+        coordinate_list_names = (
+            "rxs",
+            "voltagesources",
+            "magneticdipoles",
+            "hertziandipoles",
+            "transmissionlines",
+            "magneticfrillsources",
+            "networkterminals",
+        )
+        object_list_names = coordinate_list_names + ("port_monitors",)
+        local_lists = {name: getattr(self, name) for name in object_list_names}
+        local_coordinates = [
+            (item, item.coord) for name in coordinate_list_names for item in local_lists[name]
+        ]
+        local_size = self.size
+
+        try:
+            self.gather_grid_objects()
+            yield
+        finally:
+            self.size = local_size
+            for item, coordinate in local_coordinates:
+                item.coord = coordinate
+            for name, objects in local_lists.items():
+                setattr(self, name, objects)
+
+    def reduce_eigenmode_ports(self):
+        """Sum distributed modal DFT projections onto the coordinator.
+
+        Eigenmode bases and Gram matrices are identical on every rank, while
+        each rank accumulates only the cells it owns on a modal plane. Reduce
+        the two complex overlap histories once after time stepping; no modal
+        collective is needed inside the FDTD iteration.
+        """
+
+        signatures = tuple(
+            (port.port_index, port.output_id, tuple(port.mode_indices))
+            for port in self.eigenmodeports
+        )
+        all_signatures = self.comm.allgather(signatures)
+        if any(value != signatures for value in all_signatures):
+            raise RuntimeError("MPI ranks constructed inconsistent eigenmode-port monitors.")
+
+        for port in self.eigenmodeports:
+            electric = np.empty_like(port.electric_dft) if self.is_coordinator() else None
+            magnetic = np.empty_like(port.magnetic_dft) if self.is_coordinator() else None
+            self.comm.Reduce(port.electric_dft, electric, op=MPI.SUM, root=self.COORDINATOR_RANK)
+            self.comm.Reduce(port.magnetic_dft, magnetic, op=MPI.SUM, root=self.COORDINATOR_RANK)
+            if self.is_coordinator():
+                port.electric_dft = electric
+                port.magnetic_dft = magnetic
+
     def _halo_swap(self, array: ndarray, dim: Dim, dir: Dir):
         """Perform a halo swap in the specifed dimension and direction.
 
@@ -483,6 +556,34 @@ class MPIGrid(FDTDGrid):
         if self.recv_requests:
             MPI.Request.Waitall(self.recv_requests)
             self.recv_requests = []
+
+    def free_halo_maps(self) -> None:
+        """Release committed MPI datatypes when this grid is retired.
+
+        The derived datatypes describe non-contiguous field-array halo faces
+        and must remain valid for the complete lifetime of the grid. In
+        particular, a geometry-fixed series reuses them on every model run,
+        so solver-level cleanup would free them too early. The owning
+        ``MPIContext`` calls this method only before discarding an ordinary
+        grid or after the final geometry-fixed run.
+
+        Cleanup is idempotent so a future error-handling path can safely call
+        it without risking a second ``MPI_Type_free`` operation.
+        """
+
+        if not self._halo_maps_initialised or self._halo_maps_freed:
+            return
+
+        self.complete_halo_swaps()
+        for dim in Dim:
+            for direction in Dir:
+                for halo_maps in (self.send_halo_map, self.recv_halo_map):
+                    datatype = halo_maps[dim][direction]
+                    if datatype != MPI.DATATYPE_NULL:
+                        datatype.Free()
+                        halo_maps[dim][direction] = MPI.DATATYPE_NULL
+
+        self._halo_maps_freed = True
 
     def _prepare_pml(self, pml: MPIPML) -> MPIPML:
         """Attach the communicator associated with the slab normal."""
@@ -676,10 +777,14 @@ class MPIGrid(FDTDGrid):
     def set_halo_map(self):
         """Create MPI DataTypes for field array halo exchanges."""
 
+        if self._halo_maps_initialised and not self._halo_maps_freed:
+            self.free_halo_maps()
+        self.send_halo_map.fill(MPI.DATATYPE_NULL)
+        self.recv_halo_map.fill(MPI.DATATYPE_NULL)
+        self._halo_maps_initialised = True
+        self._halo_maps_freed = False
         size = (self.size + 1).tolist()
-        field_mpi_dtype = mpi_datatype_for_dtype(
-            config.sim_config.dtypes["float_or_double"]
-        )
+        field_mpi_dtype = mpi_datatype_for_dtype(config.sim_config.dtypes["float_or_double"])
 
         for dim in Dim:
             halo_size = (self.size + 1 - np.sum(self.neighbours >= 0, axis=1)).tolist()

--- a/gprMax/mpi_model.py
+++ b/gprMax/mpi_model.py
@@ -242,41 +242,49 @@ class MPIModel(Model):
         if self.G.snapshots:
             save_snapshots(self.G.snapshots)
 
+        self.G.reduce_eigenmode_ports()
+
         # TODO: Output sources and receivers using parallel I/O
-        self.G.gather_grid_objects()
+        with self.G.gathered_output_state():
+            # Write output data to file if they are any receivers in any grids
+            if self.is_coordinator() and (
+                self.G.rxs
+                or self.G.transmissionlines
+                or self.G.magneticfrillsources
+                or self.G.networkterminals
+                or self.G.port_monitors
+                or self.G.eigenmodeports
+            ):
+                self.G.size = self.G.global_size
+                from gprMax.eigenmode_ports import finalise_eigenmode_ports
 
-        # Write output data to file if they are any receivers in any grids
-        if self.is_coordinator() and (
-            self.G.rxs
-            or self.G.transmissionlines
-            or self.G.magneticfrillsources
-            or self.G.networkterminals
-            or self.G.port_monitors
-        ):
-            self.G.size = self.G.global_size
-            for port in self.G.port_monitors:
-                rebind = getattr(port, "rebind_after_mpi_gather", None)
-                if rebind is not None:
-                    rebind(self.G)
-                local_owner = self.G.mpi_port_output_owners.get(port.output_id)
-                if local_owner is not None:
-                    port.owner = local_owner
-                    local_owner._monitor = port
-                port.finalise(self.G)
-            # Transmission-line objects and their complete histories have now
-            # been gathered onto the coordinator. Derived terminal quantities
-            # must be calculated here, before the HDF5 file is opened.
-            from gprMax.ports import (
-                finalise_magnetic_frill_ports,
-                finalise_transmission_line_ports,
-                prepare_magnetic_frill_ports,
-            )
+                finalise_eigenmode_ports(self.G)
+                for port in self.G.port_monitors:
+                    rebind = getattr(port, "rebind_after_mpi_gather", None)
+                    if rebind is not None:
+                        rebind(self.G)
+                    local_owner = self.G.mpi_port_output_owners.get(port.output_id)
+                    if local_owner is not None:
+                        port.owner = local_owner
+                        local_owner._monitor = port
+                    port.finalise(self.G)
+                # Transmission-line objects and their complete histories have
+                # now been gathered onto the coordinator. Derived terminal
+                # quantities must be calculated here, before the HDF5 file is
+                # opened.
+                from gprMax.ports import (
+                    finalise_magnetic_frill_ports,
+                    finalise_transmission_line_ports,
+                    prepare_magnetic_frill_ports,
+                )
 
-            finalise_transmission_line_ports(self.G)
-            prepare_magnetic_frill_ports(self.G)
-            finalise_magnetic_frill_ports(self.G)
-            self._rebind_mpi_frill_port_owners()
-            write_hdf5_outputfile(config.get_model_config().output_file_path_ext, self.title, self)
+                finalise_transmission_line_ports(self.G)
+                prepare_magnetic_frill_ports(self.G)
+                finalise_magnetic_frill_ports(self.G)
+                self._rebind_mpi_frill_port_owners()
+                write_hdf5_outputfile(
+                    config.get_model_config().output_file_path_ext, self.title, self
+                )
 
     def _rebind_mpi_frill_port_owners(self) -> None:
         """Reconnect coordinator-side ``RxPort.result`` to gathered frills."""

--- a/gprMax/solvers.py
+++ b/gprMax/solvers.py
@@ -74,11 +74,15 @@ class Solver:
             self.updates.update_magnetic_sources(iteration)
             self.updates.update_eigenmode_sources_magnetic(iteration)
             self.updates.update_plane_waves_magnetic(iteration)
-            self.updates.observe_eigenmode_ports(iteration)
 
             if isinstance(self.updates, MPIUpdates):
                 self.updates.halo_swap_magnetic()
                 self.updates.update_magnetic_edge_devices(iteration)
+                # Modal H projections interpolate across transverse Yee
+                # edges. Observe only after the current H halos are available.
+                self.updates.observe_eigenmode_ports(iteration)
+            else:
+                self.updates.observe_eigenmode_ports(iteration)
 
             if isinstance(self.updates, SubgridUpdates):
                 self.updates.hsg_2()

--- a/gprMax/sources.py
+++ b/gprMax/sources.py
@@ -265,6 +265,8 @@ class EigenmodeSource(Source):
         self.domain_polarization = None
         self.transverse_start = None
         self.transverse_stop = None
+        self.global_transverse_start = None
+        self.global_transverse_stop = None
         self.mode_index = None
         self.mode_count = None
         self.mode_indices = ()
@@ -277,6 +279,10 @@ class EigenmodeSource(Source):
         self.spectral_threshold = 1e-3
         self.spectrum_coverage_policy = "error"
         self.plane_index = None
+        self.global_plane_index = None
+        self.tfsf_owned_lower = np.zeros(3, dtype=np.int32)
+        self.tfsf_owned_upper = np.zeros(3, dtype=np.int32)
+        self.mpi_coordinator = True
         self.complex_eps_r_uu = None
         self.complex_eps_r_vv = None
         self.complex_eps_r_ww = None
@@ -366,12 +372,13 @@ class EigenmodeSource(Source):
 
     def _fallback_to_single_anchor(self, G, mismatch):
         frequency = float(self.fallback_frequency)
-        logger.warning(
-            f"{mismatch} Automatic anchors for eigenmode port {self.port_index} "
-            f"will therefore use a single modal anchor at {frequency:g} Hz. The "
-            "modal field and S-parameters may be inaccurate toward frequencies "
-            "far from this anchor."
-        )
+        if self.mpi_coordinator:
+            logger.warning(
+                f"{mismatch} Automatic anchors for eigenmode port {self.port_index} "
+                f"will therefore use a single modal anchor at {frequency:g} Hz. The "
+                "modal field and S-parameters may be inaccurate toward frequencies "
+                "far from this anchor."
+            )
         self.frequency = frequency
         self.frequencies = (frequency,)
         self.mode_solvers = None
@@ -502,10 +509,11 @@ class EigenmodeSource(Source):
         residual = self._align_tangential_mode_for_real_injection()
         self._store_real_modal_fields()
         if residual <= self.COMPLEX_PROFILE_TOLERANCE:
-            logger.info(
-                "Single-frequency eigenmode tangential complex-profile residual "
-                f"is {residual:.3e}; using real-only injection."
-            )
+            if self.mpi_coordinator:
+                logger.info(
+                    "Single-frequency eigenmode tangential complex-profile residual "
+                    f"is {residual:.3e}; using real-only injection."
+                )
             return
 
         self.uses_quadrature = True
@@ -518,11 +526,12 @@ class EigenmodeSource(Source):
         self.anchor_complex_neff = np.asarray([complex(self.complex_neff)], dtype=np.complex128)
         self.anchor_overlaps = np.empty(0, dtype=np.float64)
         self.mode_solvers = [self.mode_solver]
-        logger.info(
-            "Single-frequency eigenmode tangential complex-profile residual "
-            f"is {residual:.3e}, above the {self.COMPLEX_PROFILE_TOLERANCE:.3e} "
-            "tolerance; using in-phase/quadrature injection."
-        )
+        if self.mpi_coordinator:
+            logger.info(
+                "Single-frequency eigenmode tangential complex-profile residual "
+                f"is {residual:.3e}, above the {self.COMPLEX_PROFILE_TOLERANCE:.3e} "
+                "tolerance; using in-phase/quadrature injection."
+            )
         self._prepare_broadband_time_traces(
             G,
             (self.frequency,),
@@ -779,6 +788,7 @@ class EigenmodeSource(Source):
                             frequencies[second],
                             mode_index,
                             f"Eigenmode port {self.port_index}",
+                            coordinator=self.mpi_coordinator,
                         )
                     except EigenmodeAnchorMismatchError as exc:
                         mismatch = exc
@@ -810,14 +820,15 @@ class EigenmodeSource(Source):
                     ]
                     if trimmed != retained:
                         detail = mismatch.detail.rstrip(" .")
-                        logger.warning(
-                            f"{detail}, within the {side} spectral guard outside "
-                            f"the requested {band_low:g} to {band_high:g} Hz "
-                            f"band. Automatic eigenmode port {self.port_index} "
-                            f"mode {mode_index} will retain broadband tracking "
-                            f"from {endpoint:g} Hz and use that endpoint modal "
-                            "profile across the trimmed significant-spectrum tail."
-                        )
+                        if self.mpi_coordinator:
+                            logger.warning(
+                                f"{detail}, within the {side} spectral guard outside "
+                                f"the requested {band_low:g} to {band_high:g} Hz "
+                                f"band. Automatic eigenmode port {self.port_index} "
+                                f"mode {mode_index} will retain broadband tracking "
+                                f"from {endpoint:g} Hz and use that endpoint modal "
+                                "profile across the trimmed significant-spectrum tail."
+                            )
                         retained = trimmed
                         guard_trimmed = True
                         continue
@@ -830,13 +841,14 @@ class EigenmodeSource(Source):
                     centre=True,
                 )
                 detail = mismatch.detail.rstrip(" .")
-                logger.warning(
-                    f"{detail}. Automatic eigenmode port {self.port_index} mode "
-                    f"{mode_index} will therefore use only the centre-frequency "
-                    f"anchor at {frequencies[centre]:g} Hz. Its modal "
-                    "decomposition and S-parameters may be inaccurate toward "
-                    "frequencies far from this anchor."
-                )
+                if self.mpi_coordinator:
+                    logger.warning(
+                        f"{detail}. Automatic eigenmode port {self.port_index} mode "
+                        f"{mode_index} will therefore use only the centre-frequency "
+                        f"anchor at {frequencies[centre]:g} Hz. Its modal "
+                        "decomposition and S-parameters may be inaccurate toward "
+                        "frequencies far from this anchor."
+                    )
                 retained = [centre]
                 fallback = True
                 break
@@ -878,15 +890,16 @@ class EigenmodeSource(Source):
                         f"{frequencies[index]:g} Hz (neff={neff!s}, "
                         f"raw power={raw_power!s}, metric={metric:g})"
                     )
-                logger.warning(
-                    f"Eigenmode port {self.port_index} mode {mode_index} has "
-                    "non-propagating anchor(s) that carry no forward real power: "
-                    + "; ".join(details)
-                    + ". They will be excluded from source synthesis and one-watt "
-                    "power interpolation, but successfully tracked profiles will be "
-                    "retained as monitor-only generalized references. The corresponding "
-                    "bins will remain invalid as physical power waves."
-                )
+                if self.mpi_coordinator:
+                    logger.warning(
+                        f"Eigenmode port {self.port_index} mode {mode_index} has "
+                        "non-propagating anchor(s) that carry no forward real power: "
+                        + "; ".join(details)
+                        + ". They will be excluded from source synthesis and one-watt "
+                        "power interpolation, but successfully tracked profiles will be "
+                        "retained as monitor-only generalized references. The corresponding "
+                        "bins will remain invalid as physical power waves."
+                    )
 
             if not usable:
                 if automatic:
@@ -917,12 +930,13 @@ class EigenmodeSource(Source):
                     frequencies[centre],
                     centre=True,
                 )
-                logger.warning(
-                    f"Eigenmode port {self.port_index} mode {mode_index} has "
-                    "disconnected propagating anchor ranges. It will use only "
-                    f"the centre-frequency anchor at {frequencies[centre]:g} Hz "
-                    "instead of interpolating across a non-propagating gap."
-                )
+                if self.mpi_coordinator:
+                    logger.warning(
+                        f"Eigenmode port {self.port_index} mode {mode_index} has "
+                        "disconnected propagating anchor ranges. It will use only "
+                        f"the centre-frequency anchor at {frequencies[centre]:g} Hz "
+                        "instead of interpolating across a non-propagating gap."
+                    )
                 usable = [centre]
                 fallback = True
 
@@ -1036,6 +1050,7 @@ class EigenmodeSource(Source):
                         frequencies[frequency_index],
                         mode_index,
                         f"Eigenmode port {self.port_index}",
+                        coordinator=self.mpi_coordinator,
                     )
                 previous_e = electric
                 previous_h = magnetic
@@ -1261,6 +1276,7 @@ class EigenmodeSource(Source):
         second_frequency,
         mode_index,
         context,
+        coordinator=True,
     ):
         """Apply the fixed warning and error limits for adjacent anchors."""
         description = (
@@ -1280,7 +1296,7 @@ class EigenmodeSource(Source):
                 overlap=float(magnitude),
                 context=context,
             )
-        if magnitude < cls.ANCHOR_OVERLAP_WARNING_THRESHOLD:
+        if coordinator and magnitude < cls.ANCHOR_OVERLAP_WARNING_THRESHOLD:
             logger.warning(
                 f"{description}, below the warning threshold "
                 f"{cls.ANCHOR_OVERLAP_WARNING_THRESHOLD:.6f}. The run will "
@@ -1305,6 +1321,7 @@ class EigenmodeSource(Source):
                 frequencies[index],
                 self.mode_index,
                 "Broadband eigenmode source",
+                coordinator=self.mpi_coordinator,
             )
 
             phase_aligned = np.isfinite(magnitude) and magnitude > 1e-300
@@ -1312,15 +1329,16 @@ class EigenmodeSource(Source):
             anchor_e[index] = [field * phase_factor for field in anchor_e[index]]
             anchor_h[index] = [field * phase_factor for field in anchor_h[index]]
             overlaps.append(magnitude)
-            logger.info(
-                f"Eigenmode anchor overlap {magnitude:.6f} between "
-                f"{frequencies[index - 1]:g} Hz and {frequencies[index]:g} Hz; "
-                + (
-                    "the latter anchor was phase-aligned."
-                    if phase_aligned
-                    else "its phase was left unchanged."
+            if self.mpi_coordinator:
+                logger.info(
+                    f"Eigenmode anchor overlap {magnitude:.6f} between "
+                    f"{frequencies[index - 1]:g} Hz and {frequencies[index]:g} Hz; "
+                    + (
+                        "the latter anchor was phase-aligned."
+                        if phase_aligned
+                        else "its phase was left unchanged."
+                    )
                 )
-            )
         return overlaps
 
     @staticmethod
@@ -1440,9 +1458,7 @@ class EigenmodeSource(Source):
             dtype=np.float64,
         )
         if not np.all(np.isfinite(waveform)):
-            raise ValueError(
-                "The broadband eigenmode source waveform contains non-finite samples."
-            )
+            raise ValueError("The broadband eigenmode source waveform contains non-finite samples.")
         padded_count = 1 << int(np.ceil(np.log2(max(2, 2 * sample_count))))
         spectrum = np.fft.rfft(waveform, n=padded_count)
         bin_frequencies = np.fft.rfftfreq(padded_count, d=G.dt)
@@ -1450,27 +1466,25 @@ class EigenmodeSource(Source):
         peak = float(np.max(spectrum_magnitude))
         if not np.isfinite(peak) or peak <= 0:
             raise ValueError(
-                "The broadband eigenmode source waveform has zero or non-finite "
-                "spectral energy."
+                "The broadband eigenmode source waveform has zero or non-finite " "spectral energy."
             )
 
         endpoint_significant = spectrum_magnitude[0] >= self.spectral_threshold * peak
         if padded_count % 2 == 0:
-            endpoint_significant |= (
-                spectrum_magnitude[-1] >= self.spectral_threshold * peak
-            )
+            endpoint_significant |= spectrum_magnitude[-1] >= self.spectral_threshold * peak
         if endpoint_significant:
             source_kind = (
                 "single-frequency eigenmode source using I/Q injection"
                 if single_frequency_iq
                 else "broadband eigenmode source"
             )
-            logger.warning(
-                f"The {source_kind} waveform has significant DC or Nyquist content. "
-                "Those bins cannot carry a general complex modal coefficient and will be "
-                "discarded. Use a band-limited waveform; for a finite frequency band, "
-                "EigenmodeExcitation(..., waveform='auto') can synthesize one automatically."
-            )
+            if self.mpi_coordinator:
+                logger.warning(
+                    f"The {source_kind} waveform has significant DC or Nyquist content. "
+                    "Those bins cannot carry a general complex modal coefficient and will be "
+                    "discarded. Use a band-limited waveform; for a finite frequency band, "
+                    "EigenmodeExcitation(..., waveform='auto') can synthesize one automatically."
+                )
         spectrum = np.array(spectrum, copy=True)
         spectrum[0] = 0
         if padded_count % 2 == 0:
@@ -1514,7 +1528,7 @@ class EigenmodeSource(Source):
                     "use EigenmodeExcitation with waveform='auto' for a validated "
                     "bandpass spectrum."
                 )
-            if self.spectrum_coverage_policy == "warn":
+            if self.spectrum_coverage_policy == "warn" and self.mpi_coordinator:
                 logger.warning(
                     "Broadband eigenmode anchor frequencies do not cover the significant waveform spectrum: "
                     f"anchors span {frequencies[0]:g} to {frequencies[-1]:g} Hz, while bins above "
@@ -1631,7 +1645,7 @@ class EigenmodeSource(Source):
             self.broadband_modal_h_real,
             self.broadband_modal_h_imag,
         ) = split_fields(self.anchor_modal_h)
-        if single_frequency_iq:
+        if single_frequency_iq and self.mpi_coordinator:
             logger.info(
                 "Prepared single-frequency I/Q eigenmode source with "
                 f"{sample_count} time samples and significant waveform coverage "
@@ -1639,7 +1653,7 @@ class EigenmodeSource(Source):
                 "waveform reconstruction relative peak error is "
                 f"{reconstruction_error:.3e}."
             )
-        else:
+        elif self.mpi_coordinator:
             logger.info(
                 f"Prepared broadband eigenmode source with {anchor_count} anchors, "
                 f"{sample_count} time samples, and significant waveform coverage from "
@@ -1662,7 +1676,7 @@ class EigenmodeSource(Source):
         return bool(self.plot_waveform)
 
     def _plot_eigenmode_fields(self):
-        if not self._should_plot_eigenmode_fields():
+        if not self.mpi_coordinator or not self._should_plot_eigenmode_fields():
             return
 
         input_path = config.sim_config.input_file_path
@@ -1688,7 +1702,7 @@ class EigenmodeSource(Source):
 
     def _plot_eigenmode_excitation(self, G):
         """Write the single excitation waveform and its exact port-bin DFT."""
-        if not self._should_plot_eigenmode_excitation():
+        if not self.mpi_coordinator or not self._should_plot_eigenmode_excitation():
             return
 
         sample_count = int(G.iterations)
@@ -1724,6 +1738,9 @@ class EigenmodeSource(Source):
 
     def _extract_local_complex_property_tensors(self, G, electric):
         """Return local uu, vv, ww complex er or mu_r arrays on the Yee slice."""
+        if hasattr(G, "global_size"):
+            return self._extract_mpi_complex_property_tensors(G, electric)
+
         field_kind = "E" if electric else "H"
         component_ids = []
         local_to_global = (self.transverse_axes[0], self.transverse_axes[1], self.normal_axis)
@@ -1742,6 +1759,58 @@ class EigenmodeSource(Source):
             )
 
         return tuple(material_values[ids].copy() for ids in component_ids)
+
+    def _extract_mpi_complex_property_tensors(self, G, electric):
+        """Assemble one complete modal material slice on every MPI rank.
+
+        Compound material numeric IDs are rank-local. Communicate evaluated
+        constitutive values rather than those IDs so every rank solves the
+        same FDFD cross-section without per-timestep communication.
+        """
+
+        from mpi4py import MPI
+
+        field_kind = "E" if electric else "H"
+        local_to_global = (*self.transverse_axes, self.normal_axis)
+        materials_by_id = {material.numID: material for material in G.materials}
+        tensors = []
+
+        for local_axis, global_axis in enumerate(local_to_global):
+            component = global_axis if electric else global_axis + 3
+            shape = self._expected_local_field_shapes(field_kind)[local_axis]
+            local_values = np.zeros(shape, dtype=np.complex128)
+            local_count = np.zeros(shape, dtype=np.int32)
+
+            for u, v in np.ndindex(shape):
+                coordinate = np.zeros(3, dtype=np.int32)
+                coordinate[self.normal_axis] = self.global_plane_index
+                coordinate[self.transverse_axes[0]] = self.global_transverse_start[0] + u
+                coordinate[self.transverse_axes[1]] = self.global_transverse_start[1] + v
+                if G.get_rank_from_coordinate(coordinate) != G.rank:
+                    continue
+                local_coordinate = G.global_to_local_coordinate(coordinate)
+                material_id = int(G.ID[(component, *local_coordinate)])
+                material = materials_by_id[material_id]
+                local_values[u, v] = (
+                    self._complex_er(material) if electric else self._complex_mur(material)
+                )
+                local_count[u, v] = 1
+
+            values = np.empty_like(local_values)
+            count = np.empty_like(local_count)
+            G.comm.Allreduce(local_values, values, op=MPI.SUM)
+            G.comm.Allreduce(local_count, count, op=MPI.SUM)
+            if np.any(count != 1):
+                missing = int(np.count_nonzero(count == 0))
+                duplicate = int(np.count_nonzero(count > 1))
+                raise RuntimeError(
+                    "MPI eigenmode material slice has invalid ownership for "
+                    f"component {component}: {missing} missing and {duplicate} "
+                    "duplicate sample(s)."
+                )
+            tensors.append(values)
+
+        return tuple(tensors)
 
     def _transverse_cell_shape(self):
         u0, v0 = self.transverse_start
@@ -1833,6 +1902,9 @@ class EigenmodeSource(Source):
 
     def _slice_cell_constraint_mask(self, G, electric):
         """Return source-cross-section cells occupied by PEC or PMC."""
+        if hasattr(G, "global_size"):
+            return self._mpi_cell_constraint_mask(G, electric)
+
         u0, v0 = self.transverse_start
         u1, v1 = self.transverse_stop
         normal_indices = [
@@ -1858,6 +1930,42 @@ class EigenmodeSource(Source):
                 ids = G.solid[u0:u1, v0:v1, n]
             cell_constraint_mask |= material_is_constrained[ids]
         return cell_constraint_mask
+
+    def _mpi_cell_constraint_mask(self, G, electric):
+        """Assemble the PEC/PMC cell mask adjacent to an MPI modal plane."""
+
+        from mpi4py import MPI
+
+        nu, nv = self._transverse_cell_shape()
+        local_mask = np.zeros((nu, nv), dtype=np.uint8)
+        materials_by_id = {material.numID: material for material in G.materials}
+        normal_indices = tuple(
+            index
+            for index in (self.global_plane_index - 1, self.global_plane_index)
+            if 0 <= index < G.global_size[self.normal_axis]
+        )
+
+        for u in range(nu):
+            for v in range(nv):
+                for normal_index in normal_indices:
+                    coordinate = np.zeros(3, dtype=np.int32)
+                    coordinate[self.normal_axis] = normal_index
+                    coordinate[self.transverse_axes[0]] = self.global_transverse_start[0] + u
+                    coordinate[self.transverse_axes[1]] = self.global_transverse_start[1] + v
+                    if G.get_rank_from_coordinate(coordinate) != G.rank:
+                        continue
+                    local_coordinate = G.global_to_local_coordinate(coordinate)
+                    material_id = int(G.solid[tuple(local_coordinate)])
+                    material = materials_by_id[material_id]
+                    property_value = (
+                        self._complex_er(material) if electric else self._complex_mur(material)
+                    )
+                    if not np.isfinite(property_value):
+                        local_mask[u, v] = 1
+
+        mask = np.empty_like(local_mask)
+        G.comm.Allreduce(local_mask, mask, op=MPI.MAX)
+        return mask.astype(bool)
 
     def _complex_er(self, material):
         omega = 2 * np.pi * self.frequency
@@ -1898,6 +2006,8 @@ class EigenmodeSource(Source):
             self.transverse_stop[0],
             self.transverse_stop[1],
             self.plane_index,
+            self.tfsf_owned_lower,
+            self.tfsf_owned_upper,
             config.sim_config.dtypes["float_or_double"](self._waveform_value(time, G)),
             self.modal_e_real[0],
             self.modal_e_real[1],
@@ -1930,6 +2040,8 @@ class EigenmodeSource(Source):
             self.transverse_stop[0],
             self.transverse_stop[1],
             self.plane_index,
+            self.tfsf_owned_lower,
+            self.tfsf_owned_upper,
             config.sim_config.dtypes["float_or_double"](self._waveform_value(time, G)),
             self.modal_h_real[0],
             self.modal_h_real[1],
@@ -1965,6 +2077,8 @@ class EigenmodeSource(Source):
                     self.transverse_stop[0],
                     self.transverse_stop[1],
                     self.plane_index,
+                    self.tfsf_owned_lower,
+                    self.tfsf_owned_upper,
                     dtype(envelope),
                     modal_fields[0],
                     modal_fields[1],
@@ -2000,6 +2114,8 @@ class EigenmodeSource(Source):
                     self.transverse_stop[0],
                     self.transverse_stop[1],
                     self.plane_index,
+                    self.tfsf_owned_lower,
+                    self.tfsf_owned_upper,
                     dtype(envelope),
                     modal_fields[0],
                     modal_fields[1],
@@ -2770,9 +2886,11 @@ def dtoh_transmission_line_outputs(Vtotal, Itotal, G):
                     "Transmission-line Metal output buffer has the wrong size: "
                     f"expected {nbytes} bytes, got {buffer.length()}."
                 )
-            return np.frombuffer(
-                buffer.contents().as_buffer(nbytes), dtype=dtype
-            ).reshape(expected).copy()
+            return (
+                np.frombuffer(buffer.contents().as_buffer(nbytes), dtype=dtype)
+                .reshape(expected)
+                .copy()
+            )
 
         Vtotal, Itotal = metal_array(Vtotal), metal_array(Itotal)
     if Vtotal.shape != expected or Itotal.shape != expected:

--- a/gprMax/updates/mpi_updates.py
+++ b/gprMax/updates/mpi_updates.py
@@ -58,7 +58,7 @@ class MPIUpdates(CPUUpdates[MPIGrid]):
             )
 
     def update_magnetic_edge_devices(self, iteration):
-        """Sample transmission-line currents from synchronised H fields."""
+        """Complete devices that require synchronised magnetic fields."""
 
         for source in self.grid.transmissionlines:
             source.update_magnetic(
@@ -70,6 +70,8 @@ class MPIUpdates(CPUUpdates[MPIGrid]):
                 self.grid.Hz,
                 self.grid,
             )
+        for guide in getattr(self.grid, "virtual_waveguides", ()):
+            guide.complete_magnetic_mpi()
 
     def finalise(self):
         """Complete the last halo exchange before MPI/Python teardown."""

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -2097,8 +2097,6 @@ class EigenmodePort(GridUserObject):
     def build(self, grid: FDTDGrid):
         if grid.eigenmodeband is None:
             raise ValueError(f"{self.params_str()} requires one preceding EigenmodeBand.")
-        if config.sim_config.mpi:
-            raise ValueError(f"{self.params_str()} cannot currently be used with MPI.")
         try:
             port = int(self.kwargs["port"])
             p1 = tuple(float(value) for value in self.kwargs["p1"])
@@ -2223,9 +2221,6 @@ class VirtualWaveguide(GridUserObject):
         )
 
     def build(self, grid: FDTDGrid):
-        if config.sim_config.mpi:
-            raise ValueError(f"{self.params_str()} cannot currently be used with MPI.")
-
         def integer_parameter(name):
             try:
                 value = operator.index(self.kwargs[name])
@@ -2460,16 +2455,37 @@ def _discretise_eigenmode_plane(
     """
 
     uip = user_object._create_uip(grid)
-    full_lower = np.asarray(
-        uip.resolve_inf_point(tuple(full_lower), role="lower"),
-        dtype=np.float64,
-    )
-    full_upper = np.asarray(
-        uip.resolve_inf_point(tuple(full_upper), role="upper"),
-        dtype=np.float64,
-    )
-    lower = np.asarray(uip.discretise_point(tuple(full_lower)), dtype=np.int32)
-    upper = np.asarray(uip.discretise_point(tuple(full_upper)), dtype=np.int32)
+    if hasattr(grid, "global_size"):
+        mode = config.get_model_config().mode
+
+        def resolve_global_inf(point, role):
+            resolved = list(point)
+            for axis, value in enumerate(point):
+                if not math.isinf(value):
+                    continue
+                if not mode.startswith("2D"):
+                    raise ValueError(
+                        f"{user_object.params_str()} 'inf' coordinates require a 2D model."
+                    )
+                extent = float(grid.global_size[axis] * grid.dl[axis])
+                resolved[axis] = 0.0 if role == "lower" else extent
+            return tuple(resolved)
+
+        full_lower = np.asarray(resolve_global_inf(full_lower, "lower"), dtype=np.float64)
+        full_upper = np.asarray(resolve_global_inf(full_upper, "upper"), dtype=np.float64)
+        lower = np.asarray(uip.discretise_static_point(tuple(full_lower)), dtype=np.int32)
+        upper = np.asarray(uip.discretise_static_point(tuple(full_upper)), dtype=np.int32)
+    else:
+        full_lower = np.asarray(
+            uip.resolve_inf_point(tuple(full_lower), role="lower"),
+            dtype=np.float64,
+        )
+        full_upper = np.asarray(
+            uip.resolve_inf_point(tuple(full_upper), role="upper"),
+            dtype=np.float64,
+        )
+        lower = np.asarray(uip.discretise_point(tuple(full_lower)), dtype=np.int32)
+        upper = np.asarray(uip.discretise_point(tuple(full_upper)), dtype=np.int32)
     plane_index = int(lower[normal_axis])
 
     if int(upper[normal_axis]) != plane_index:
@@ -2507,6 +2523,39 @@ def _discretise_eigenmode_plane(
             )
 
     return full_lower, full_upper, lower, upper, plane_index
+
+
+def _configure_eigenmode_runtime_coordinates(
+    runtime,
+    grid,
+    lower,
+    upper,
+    plane_index,
+    transverse_axes,
+):
+    """Store authoritative global port geometry and rank-local coordinates."""
+
+    global_start = np.asarray(lower[transverse_axes], dtype=np.int32)
+    global_stop = np.asarray(upper[transverse_axes], dtype=np.int32)
+    runtime.global_transverse_start = global_start
+    runtime.global_transverse_stop = global_stop
+    runtime.global_plane_index = int(plane_index)
+
+    if hasattr(grid, "global_size"):
+        offset = np.asarray(grid.lower_extent, dtype=np.int32)
+        runtime.transverse_start = global_start - offset[transverse_axes]
+        runtime.transverse_stop = global_stop - offset[transverse_axes]
+        runtime.plane_index = int(plane_index - offset[runtime.normal_axis])
+        runtime.tfsf_owned_lower = np.asarray(grid.negative_halo_offset, dtype=np.int32)
+        runtime.tfsf_owned_upper = np.asarray(grid.size, dtype=np.int32)
+        runtime.mpi_coordinator = bool(grid.is_coordinator())
+    else:
+        runtime.transverse_start = global_start.copy()
+        runtime.transverse_stop = global_stop.copy()
+        runtime.plane_index = int(plane_index)
+        runtime.tfsf_owned_lower = np.zeros(3, dtype=np.int32)
+        runtime.tfsf_owned_upper = np.asarray(grid.size + 1, dtype=np.int32)
+        runtime.mpi_coordinator = True
 
 
 class _EigenmodeSourceBuilder(GridUserObject):
@@ -2566,14 +2615,6 @@ class _EigenmodeSourceBuilder(GridUserObject):
             raise ValueError(f"{self.params_str()} plot_fields must be True, False, or None.")
         if plot_fields is not None:
             plot_fields = bool(plot_fields)
-
-        # MPI decomposes the grid across ranks, but the source plane's
-        # bounds/plane-index validation below and the FDFD cross-section
-        # extraction in EigenmodeSource.grid_init() both assume a single,
-        # whole grid with globally-valid coordinates. Neither is currently
-        # rank-aware, so reject MPI outright until that support is added.
-        if config.sim_config.mpi:
-            raise ValueError(f"{self.params_str()} cannot currently be used with MPI.")
 
         if normal not in ["x", "y", "z"]:
             logger.exception(f"{self.params_str()} normal must be x, y, or z.")
@@ -2649,7 +2690,8 @@ class _EigenmodeSourceBuilder(GridUserObject):
         p2 = tuple(full_upper[transverse_axes])
         w = float(full_lower[normal_axis])
 
-        if plane_index < 0 or plane_index > grid.size[normal_axis]:
+        domain_size = np.asarray(getattr(grid, "global_size", grid.size), dtype=np.int32)
+        if plane_index < 0 or plane_index > domain_size[normal_axis]:
             logger.exception(
                 f"{self.params_str()} normal source plane coordinate is outside the grid."
             )
@@ -2662,7 +2704,7 @@ class _EigenmodeSourceBuilder(GridUserObject):
             )
 
         if np.any(lower[transverse_axes] < 0) or np.any(
-            upper[transverse_axes] > grid.size[transverse_axes]
+            upper[transverse_axes] > domain_size[transverse_axes]
         ):
             logger.exception(f"{self.params_str()} transverse source bounds are outside the grid.")
             raise ValueError
@@ -2674,7 +2716,7 @@ class _EigenmodeSourceBuilder(GridUserObject):
             raise ValueError
 
         if invariant_axis is not None and (
-            lower[invariant_axis] != 0 or upper[invariant_axis] != grid.size[invariant_axis]
+            lower[invariant_axis] != 0 or upper[invariant_axis] != domain_size[invariant_axis]
         ):
             logger.exception(
                 f"{self.params_str()} in {mode} mode must span the complete "
@@ -2697,9 +2739,14 @@ class _EigenmodeSourceBuilder(GridUserObject):
             source.domain_polarization = "TM"
         elif mode.startswith("2D TE"):
             source.domain_polarization = "TE"
-        source.transverse_start = lower[transverse_axes].copy()
-        source.transverse_stop = upper[transverse_axes].copy()
-        source.plane_index = plane_index
+        _configure_eigenmode_runtime_coordinates(
+            source,
+            grid,
+            lower,
+            upper,
+            plane_index,
+            transverse_axes,
+        )
         source.mode_index = mode_index
         source.mode_count = mode_count
         source.port_index = port_index
@@ -2782,8 +2829,6 @@ class _EigenmodeReceiverBuilder(GridUserObject):
         if plot_fields is not None and not isinstance(plot_fields, (bool, np.bool_)):
             raise ValueError(f"{self.params_str()} plot_fields must be True, False, or None.")
 
-        if config.sim_config.mpi:
-            raise ValueError(f"{self.params_str()} cannot currently be used with MPI.")
         if normal not in ("x", "y", "z") or direction not in ("+", "-"):
             raise ValueError(f"{self.params_str()} requires normal x/y/z and direction +/-.")
         if mode_count < 1:
@@ -2829,41 +2874,46 @@ class _EigenmodeReceiverBuilder(GridUserObject):
         p2 = tuple(full_upper[transverse_axes])
         w = float(full_lower[normal_axis])
 
-        if plane_index < 0 or plane_index > grid.size[normal_axis]:
+        domain_size = np.asarray(getattr(grid, "global_size", grid.size), dtype=np.int32)
+        if plane_index < 0 or plane_index > domain_size[normal_axis]:
             raise ValueError(f"{self.params_str()} receiver plane is outside the grid.")
         if direction == "+" and plane_index < 1:
             raise ValueError(
                 f"{self.params_str()} positive-direction receiver needs a lower H plane."
             )
         if np.any(lower[transverse_axes] < 0) or np.any(
-            upper[transverse_axes] > grid.size[transverse_axes]
+            upper[transverse_axes] > domain_size[transverse_axes]
         ):
             raise ValueError(f"{self.params_str()} transverse bounds are outside the grid.")
         if np.any(lower[transverse_axes] >= upper[transverse_axes]):
             raise ValueError(f"{self.params_str()} lower bounds must be less than upper bounds.")
         if invariant_axis is not None and (
-            lower[invariant_axis] != 0 or upper[invariant_axis] != grid.size[invariant_axis]
+            lower[invariant_axis] != 0 or upper[invariant_axis] != domain_size[invariant_axis]
         ):
             raise ValueError(
                 f"{self.params_str()} in {domain_mode} mode must span the invariant axis."
             )
 
-        if port_index not in grid.virtual_waveguide_specs and not isinstance(
-            grid, SubGridBaseGrid
-        ):
+        if port_index not in grid.virtual_waveguide_specs and not isinstance(grid, SubGridBaseGrid):
             axis_name = "xyz"[normal_axis]
             face = f"{axis_name}0" if direction == "+" else f"{axis_name}max"
             pml_thickness = grid.pmls["thickness"][face]
+            if hasattr(grid, "global_size"):
+                # Interior MPI ranks deliberately have zero thickness on
+                # their local faces. Recover the physical boundary value
+                # before comparing a globally indexed modal plane.
+                pml_thickness = max(grid.comm.allgather(pml_thickness))
             adjacent_plane = (
-                pml_thickness if direction == "+" else grid.size[normal_axis] - pml_thickness
+                pml_thickness if direction == "+" else domain_size[normal_axis] - pml_thickness
             )
-            if pml_thickness == 0:
+            report_warning = not hasattr(grid, "is_coordinator") or grid.is_coordinator()
+            if pml_thickness == 0 and report_warning:
                 logger.warning(
                     f"Eigenmode receiver {port_id!r} is not next to a PML because the "
                     f"{face} face has zero PML thickness. Reflections beyond the port "
                     "can contaminate its S-parameters."
                 )
-            elif plane_index != adjacent_plane:
+            elif plane_index != adjacent_plane and report_warning:
                 logger.warning(
                     f"Eigenmode receiver {port_id!r} is at plane {plane_index}, not next to the "
                     f"{face} PML interface at plane {adjacent_plane}. Reflections beyond the port "
@@ -2885,9 +2935,14 @@ class _EigenmodeReceiverBuilder(GridUserObject):
             receiver.domain_polarization = "TM"
         elif domain_mode.startswith("2D TE"):
             receiver.domain_polarization = "TE"
-        receiver.transverse_start = lower[transverse_axes].copy()
-        receiver.transverse_stop = upper[transverse_axes].copy()
-        receiver.plane_index = plane_index
+        _configure_eigenmode_runtime_coordinates(
+            receiver,
+            grid,
+            lower,
+            upper,
+            plane_index,
+            transverse_axes,
+        )
         receiver.mode_count = mode_count
         receiver.mode_indices = mode_indices
         receiver.frequency = frequencies[0]

--- a/gprMax/virtual_waveguide.py
+++ b/gprMax/virtual_waveguide.py
@@ -20,9 +20,11 @@ import numpy as np
 import gprMax.config as config
 from gprMax.cython.virtual_waveguide import (
     couple_virtual_waveguide_electric,
+    couple_virtual_waveguide_electric_aperture,
     couple_virtual_waveguide_magnetic,
 )
 from gprMax.grid.fdtd_grid import FDTDGrid
+from gprMax.materials import process_materials
 from gprMax.subgrids.grid import SubGridBaseGrid
 from gprMax.updates.cpu_updates import CPUUpdates
 
@@ -39,11 +41,24 @@ class VirtualWaveguide:
         self.normal_axis = int(port.normal_axis)
         self.direction_sign = 1 if port.direction == "+" else -1
         self.transverse_axes = tuple(int(value) for value in port.transverse_axes)
-        self.plane_index = int(port.plane_index)
-        self.u0, self.v0 = (int(value) for value in port.transverse_start)
-        self.u1, self.v1 = (int(value) for value in port.transverse_stop)
+        self.mpi = hasattr(main_grid, "global_size")
+        if self.mpi:
+            self.plane_index = int(port.global_plane_index)
+            self.u0, self.v0 = (int(value) for value in port.global_transverse_start)
+            self.u1, self.v1 = (int(value) for value in port.global_transverse_stop)
+        else:
+            self.plane_index = int(port.plane_index)
+            self.u0, self.v0 = (int(value) for value in port.transverse_start)
+            self.u1, self.v1 = (int(value) for value in port.transverse_stop)
         self.nu = self.u1 - self.u0
         self.nv = self.v1 - self.v0
+        self._mpi_materials = None
+        self._mpi_adjacent_solid = None
+        self._mpi_adjacent_ids = None
+        self._mpi_component_ids = None
+        self._mpi_solid_ids = None
+        self._mpi_h_local = None
+        self._mpi_h_global = None
 
         self._validate()
         self.aux_grid = self._build_auxiliary_grid()
@@ -64,8 +79,6 @@ class VirtualWaveguide:
         mode = config.get_model_config().mode
         if mode != "3D":
             raise ValueError("Virtual waveguides currently require a 3D model.")
-        if config.sim_config.mpi:
-            raise ValueError("Virtual waveguides do not yet support MPI.")
         if self.port.invariant_axis is not None:
             raise ValueError("Virtual waveguides do not support a 2D eigenmode port.")
         if self.spec.pml_cells < 2:
@@ -78,7 +91,10 @@ class VirtualWaveguide:
                 "Virtual-waveguide length must be at least PML cells + source "
                 f"clearance + 3 cells ({minimum_length} cells for this request)."
             )
-        normal_cells = int(self.main_grid.size[self.normal_axis])
+        domain_size = np.asarray(
+            getattr(self.main_grid, "global_size", self.main_grid.size), dtype=np.int32
+        )
+        normal_cells = int(domain_size[self.normal_axis])
         if not 1 <= self.plane_index < normal_cells:
             raise ValueError("A virtual-waveguide aperture must be an internal Yee plane.")
         if self.nu < 2 or self.nv < 2:
@@ -87,11 +103,14 @@ class VirtualWaveguide:
                 "along each transverse axis."
             )
         int32_max = np.iinfo(np.int32).max
-        main_points = int(np.prod(np.asarray(self.main_grid.size, dtype=object) + 1))
+        main_points = int(np.prod(np.asarray(domain_size, dtype=object) + 1))
         auxiliary_size = [self.nu, self.nv, self.spec.length_cells]
         auxiliary_points = int(np.prod(np.asarray(auxiliary_size, dtype=object) + 1))
         if max(main_points, auxiliary_points, (self.nu + 1) * (self.nv + 1)) > int32_max:
             raise ValueError("Virtual-waveguide device indexing exceeds the signed 32-bit range.")
+
+        if self.mpi:
+            self._prepare_mpi_cross_section()
 
         first_ids, second_ids = self._adjacent_component_ids()
         first_solid, second_solid = self._adjacent_solids()
@@ -105,9 +124,10 @@ class VirtualWaveguide:
             )
 
         material_ids = np.unique(self._component_cross_section())
+        materials = self._mpi_materials if self.mpi else self.main_grid.materials
         dispersive = [
             material.ID
-            for material in self.main_grid.materials
+            for material in materials
             if material.numID in material_ids and getattr(material, "poles", 0) > 0
         ]
         if dispersive:
@@ -117,6 +137,8 @@ class VirtualWaveguide:
             )
 
     def _adjacent_solids(self):
+        if self.mpi:
+            return self._mpi_adjacent_solid
         grid = self.main_grid
         p = self.plane_index
         if self.normal_axis == 0:
@@ -135,6 +157,8 @@ class VirtualWaveguide:
         )
 
     def _adjacent_component_ids(self):
+        if self.mpi:
+            return self._mpi_adjacent_ids
         grid = self.main_grid
         p = self.plane_index
         # Perimeter IDs may deliberately contain zero-thickness PEC connector
@@ -156,6 +180,8 @@ class VirtualWaveguide:
         )
 
     def _component_cross_section(self):
+        if self.mpi:
+            return self._mpi_component_ids
         grid = self.main_grid
         p = self.plane_index
         if self.normal_axis == 0:
@@ -165,6 +191,8 @@ class VirtualWaveguide:
         return grid.ID[:, self.u0 : self.u1 + 1, self.v0 : self.v1 + 1, p]
 
     def _solid_cross_section(self):
+        if self.mpi:
+            return self._mpi_solid_ids
         grid = self.main_grid
         # The detached side is represented by the auxiliary guide.
         cell = self.plane_index if self.direction_sign < 0 else self.plane_index - 1
@@ -173,6 +201,112 @@ class VirtualWaveguide:
         if self.normal_axis == 1:
             return grid.solid[self.u0 : self.u1, cell, self.v0 : self.v1]
         return grid.solid[self.u0 : self.u1, self.v0 : self.v1, cell]
+
+    def _prepare_mpi_cross_section(self):
+        """Collect one global material cross-section on every rank.
+
+        Numeric IDs for dielectric-smoothed materials are local to an MPI
+        rank. Build a deterministic catalogue keyed by material name, then
+        communicate the catalogue indices at the aperture. The auxiliary
+        guide is consequently identical on every rank even when the modal
+        plane crosses several partitions.
+        """
+
+        from mpi4py import MPI
+
+        grid = self.main_grid
+        local_catalogue = {material.ID: material for material in grid.materials}
+        catalogues = grid.comm.allgather(local_catalogue)
+        catalogue = {}
+        for rank_catalogue in catalogues:
+            for material_id, material in rank_catalogue.items():
+                catalogue.setdefault(material_id, material)
+
+        def material_sort_key(material_id):
+            material = catalogue[material_id]
+            return (
+                bool(material.is_compound_material()),
+                material.numID if not material.is_compound_material() else 0,
+                material_id,
+            )
+
+        material_names = sorted(catalogue, key=material_sort_key)
+        material_index = {name: index for index, name in enumerate(material_names)}
+        self._mpi_materials = []
+        for index, name in enumerate(material_names):
+            material = copy.deepcopy(catalogue[name])
+            material.numID = index
+            self._mpi_materials.append(material)
+
+        local_materials = {material.numID: material for material in grid.materials}
+
+        def collect(component, normal_index, u_start, v_start, shape):
+            local_values = np.zeros(shape, dtype=np.int64)
+            local_count = np.zeros(shape, dtype=np.int8)
+            for u in range(shape[0]):
+                for v in range(shape[1]):
+                    coordinate = np.zeros(3, dtype=np.int32)
+                    coordinate[self.normal_axis] = normal_index
+                    coordinate[self.transverse_axes[0]] = u_start + u
+                    coordinate[self.transverse_axes[1]] = v_start + v
+                    if grid.get_rank_from_coordinate(coordinate) != grid.rank:
+                        continue
+                    local_coordinate = grid.global_to_local_coordinate(coordinate)
+                    if component is None:
+                        numeric_id = int(grid.solid[tuple(local_coordinate)])
+                    else:
+                        numeric_id = int(grid.ID[(component, *local_coordinate)])
+                    name = local_materials[numeric_id].ID
+                    local_values[u, v] = material_index[name] + 1
+                    local_count[u, v] = 1
+
+            values = np.empty_like(local_values)
+            count = np.empty_like(local_count)
+            grid.comm.Allreduce(local_values, values, op=MPI.SUM)
+            grid.comm.Allreduce(local_count, count, op=MPI.SUM)
+            if np.any(count != 1):
+                raise RuntimeError(
+                    "MPI virtual-waveguide cross-section samples must have exactly one owner."
+                )
+            return (values - 1).astype(np.uint32)
+
+        component_shape = (self.nu + 1, self.nv + 1)
+        component_ids = np.empty((6, *component_shape), dtype=np.uint32)
+        for component in range(6):
+            component_ids[component] = collect(
+                component, self.plane_index, self.u0, self.v0, component_shape
+            )
+        self._mpi_component_ids = component_ids
+
+        interior_shape = (self.nu - 1, self.nv - 1)
+        adjacent_ids = []
+        for normal_index in (self.plane_index - 1, self.plane_index):
+            ids = np.empty((6, *interior_shape), dtype=np.uint32)
+            for component in range(6):
+                ids[component] = collect(
+                    component,
+                    normal_index,
+                    self.u0 + 1,
+                    self.v0 + 1,
+                    interior_shape,
+                )
+            adjacent_ids.append(ids)
+        self._mpi_adjacent_ids = tuple(adjacent_ids)
+
+        solid_shape = (self.nu, self.nv)
+        self._mpi_adjacent_solid = tuple(
+            collect(None, normal_index, self.u0, self.v0, solid_shape)
+            for normal_index in (self.plane_index - 1, self.plane_index)
+        )
+        detached_cell = self.plane_index if self.direction_sign < 0 else self.plane_index - 1
+        self._mpi_solid_ids = collect(None, detached_cell, self.u0, self.v0, solid_shape)
+
+        h_points = self.nu * self.nv
+        h_points += (self.nu + 1) * self.nv
+        h_points += self.nu * (self.nv + 1)
+        dtype = config.sim_config.dtypes["float_or_double"]
+        self._mpi_h_local = np.zeros(h_points, dtype=dtype)
+        self._mpi_h_global = np.zeros(h_points, dtype=dtype)
 
     def _resolve_pml_profile(self):
         grid = self.main_grid
@@ -197,7 +331,7 @@ class VirtualWaveguide:
         # second SubGridHSG would incorrectly require an HSG coupling region
         # and a parent coarse grid around a guide that is deliberately
         # detached from the physical domain.
-        aux = FDTDGrid() if isinstance(main, SubGridBaseGrid) else type(main)()
+        aux = FDTDGrid() if self.mpi or isinstance(main, SubGridBaseGrid) else type(main)()
         aux.name = f"virtual_waveguide_port_{self.spec.port}"
         aux.size[:] = 1
         aux.size[self.normal_axis] = self.spec.length_cells
@@ -207,7 +341,7 @@ class VirtualWaveguide:
         aux.dt = main.dt
         aux.iterations = main.iterations
         aux.timewindow = main.timewindow
-        aux.materials = main.materials
+        aux.materials = copy.deepcopy(self._mpi_materials) if self.mpi else main.materials
 
         formulation, cfs = self._resolve_pml_profile()
         aux.pmls["formulation"] = formulation
@@ -233,11 +367,18 @@ class VirtualWaveguide:
         aux._build_pmls()
         aux._terminate_pmls_with_pec()
         aux.initialise_field_arrays()
-        aux.updatecoeffsE = np.array(main.updatecoeffsE, copy=True)
-        aux.updatecoeffsH = np.array(main.updatecoeffsH, copy=True)
-        if config.get_model_config().materials["maxpoles"] > 0:
-            aux.initialise_dispersive_arrays()
-            aux.updatecoeffsdispersive = np.array(main.updatecoeffsdispersive, copy=True)
+        if self.mpi:
+            aux.initialise_std_update_coeff_arrays()
+            if config.get_model_config().materials["maxpoles"] > 0:
+                aux.initialise_dispersive_arrays()
+                aux.initialise_dispersive_update_coeff_array()
+            process_materials(aux)
+        else:
+            aux.updatecoeffsE = np.array(main.updatecoeffsE, copy=True)
+            aux.updatecoeffsH = np.array(main.updatecoeffsH, copy=True)
+            if config.get_model_config().materials["maxpoles"] > 0:
+                aux.initialise_dispersive_arrays()
+                aux.updatecoeffsdispersive = np.array(main.updatecoeffsdispersive, copy=True)
         return aux
 
     def _build_auxiliary_source(self):
@@ -250,6 +391,11 @@ class VirtualWaveguide:
         source.plane_index = (
             distance if self.direction_sign < 0 else self.spec.length_cells - distance
         )
+        source.global_plane_index = source.plane_index
+        source.global_transverse_start = np.asarray((0, 0), dtype=np.int32)
+        source.global_transverse_stop = np.asarray((self.nu, self.nv), dtype=np.int32)
+        source.tfsf_owned_lower = np.zeros(3, dtype=np.int32)
+        source.tfsf_owned_upper = np.asarray(self.aux_grid.size + 1, dtype=np.int32)
         source.port_monitor = None
         return source
 
@@ -268,12 +414,254 @@ class VirtualWaveguide:
             else:
                 self.aux_grid.htod_material_arrays(parent_updates.dev)
 
+    def _mpi_owned_global_bounds(self):
+        lower = np.asarray(
+            self.main_grid.lower_extent + self.main_grid.negative_halo_offset,
+            dtype=np.int32,
+        )
+        upper = np.asarray(
+            self.main_grid.lower_extent + self.main_grid.size,
+            dtype=np.int32,
+        )
+        return lower, upper
+
+    def _mpi_component_sheet(self, component, normal_index, u_points, v_points, output):
+        """Pack the locally owned part of one global H sheet."""
+
+        lower, upper = self._mpi_owned_global_bounds()
+        if not lower[self.normal_axis] <= normal_index < upper[self.normal_axis]:
+            return
+        global_u0 = max(self.u0, int(lower[self.transverse_axes[0]]))
+        global_u1 = min(self.u0 + u_points, int(upper[self.transverse_axes[0]]))
+        global_v0 = max(self.v0, int(lower[self.transverse_axes[1]]))
+        global_v1 = min(self.v0 + v_points, int(upper[self.transverse_axes[1]]))
+        if global_u0 >= global_u1 or global_v0 >= global_v1:
+            return
+
+        local_slices = [slice(None)] * 3
+        local_slices[self.normal_axis] = (
+            normal_index - self.main_grid.lower_extent[self.normal_axis]
+        )
+        local_slices[self.transverse_axes[0]] = slice(
+            global_u0 - self.main_grid.lower_extent[self.transverse_axes[0]],
+            global_u1 - self.main_grid.lower_extent[self.transverse_axes[0]],
+        )
+        local_slices[self.transverse_axes[1]] = slice(
+            global_v0 - self.main_grid.lower_extent[self.transverse_axes[1]],
+            global_v1 - self.main_grid.lower_extent[self.transverse_axes[1]],
+        )
+        output[
+            global_u0 - self.u0 : global_u1 - self.u0,
+            global_v0 - self.v0 : global_v1 - self.v0,
+        ] = (self.main_grid.Hx, self.main_grid.Hy, self.main_grid.Hz,)[component][
+            tuple(local_slices)
+        ]
+
+    def _collect_mpi_aperture_magnetic_fields(self):
+        """All-reduce the three H sheets needed by the aperture update."""
+
+        from mpi4py import MPI
+
+        normal_points = self.nu * self.nv
+        u_points = (self.nu + 1) * self.nv
+        normal = self._mpi_h_local[:normal_points].reshape(self.nu, self.nv)
+        h_u = self._mpi_h_local[normal_points : normal_points + u_points].reshape(
+            self.nu + 1, self.nv
+        )
+        h_v = self._mpi_h_local[normal_points + u_points :].reshape(self.nu, self.nv + 1)
+        self._mpi_h_local.fill(0)
+        self._mpi_component_sheet(self.normal_axis, self.plane_index, self.nu, self.nv, normal)
+        cross_plane = self.plane_index - 1 if self.direction_sign < 0 else self.plane_index
+        self._mpi_component_sheet(self.transverse_axes[0], cross_plane, self.nu + 1, self.nv, h_u)
+        self._mpi_component_sheet(self.transverse_axes[1], cross_plane, self.nu, self.nv + 1, h_v)
+        self.main_grid.comm.Allreduce(self._mpi_h_local, self._mpi_h_global, op=MPI.SUM)
+        normal = self._mpi_h_global[:normal_points].reshape(self.nu, self.nv)
+        h_u = self._mpi_h_global[normal_points : normal_points + u_points].reshape(
+            self.nu + 1, self.nv
+        )
+        h_v = self._mpi_h_global[normal_points + u_points :].reshape(self.nu, self.nv + 1)
+        return normal, h_u, h_v
+
+    def _set_auxiliary_normal_magnetic(self, values):
+        aperture = 0 if self.direction_sign < 0 else int(self.aux_grid.size[self.normal_axis])
+        slices = [slice(None)] * 3
+        slices[self.normal_axis] = aperture
+        slices[self.transverse_axes[0]] = slice(0, self.nu)
+        slices[self.transverse_axes[1]] = slice(0, self.nv)
+        (self.aux_grid.Hx, self.aux_grid.Hy, self.aux_grid.Hz)[self.normal_axis][
+            tuple(slices)
+        ] = values
+
+    def _write_mpi_component_sheet(self, component, normal_index, u_points, v_points, values):
+        """Write an auxiliary aperture sheet to locally owned main fields."""
+
+        lower, upper = self._mpi_owned_global_bounds()
+        if not lower[self.normal_axis] <= normal_index < upper[self.normal_axis]:
+            return
+        global_u0 = max(self.u0, int(lower[self.transverse_axes[0]]))
+        global_u1 = min(self.u0 + u_points, int(upper[self.transverse_axes[0]]))
+        global_v0 = max(self.v0, int(lower[self.transverse_axes[1]]))
+        global_v1 = min(self.v0 + v_points, int(upper[self.transverse_axes[1]]))
+        if global_u0 >= global_u1 or global_v0 >= global_v1:
+            return
+
+        local_slices = [slice(None)] * 3
+        local_slices[self.normal_axis] = (
+            normal_index - self.main_grid.lower_extent[self.normal_axis]
+        )
+        local_slices[self.transverse_axes[0]] = slice(
+            global_u0 - self.main_grid.lower_extent[self.transverse_axes[0]],
+            global_u1 - self.main_grid.lower_extent[self.transverse_axes[0]],
+        )
+        local_slices[self.transverse_axes[1]] = slice(
+            global_v0 - self.main_grid.lower_extent[self.transverse_axes[1]],
+            global_v1 - self.main_grid.lower_extent[self.transverse_axes[1]],
+        )
+        (self.main_grid.Ex, self.main_grid.Ey, self.main_grid.Ez)[component][
+            tuple(local_slices)
+        ] = values[
+            global_u0 - self.u0 : global_u1 - self.u0,
+            global_v0 - self.v0 : global_v1 - self.v0,
+        ]
+
+    def _clear_mpi_component_box(
+        self, fields, component, normal_start, normal_stop, u_points, v_points
+    ):
+        """Clear the owned intersection of a detached rear-field box."""
+
+        lower, upper = self._mpi_owned_global_bounds()
+        starts = np.zeros(3, dtype=np.int32)
+        stops = np.zeros(3, dtype=np.int32)
+        starts[self.normal_axis] = normal_start
+        stops[self.normal_axis] = normal_stop
+        starts[self.transverse_axes[0]] = self.u0
+        stops[self.transverse_axes[0]] = self.u0 + u_points
+        starts[self.transverse_axes[1]] = self.v0
+        stops[self.transverse_axes[1]] = self.v0 + v_points
+        starts = np.maximum(starts, lower)
+        stops = np.minimum(stops, upper)
+        if np.any(starts >= stops):
+            return
+        slices = tuple(
+            slice(
+                int(starts[axis] - self.main_grid.lower_extent[axis]),
+                int(stops[axis] - self.main_grid.lower_extent[axis]),
+            )
+            for axis in range(3)
+        )
+        fields[component][slices] = 0
+
+    def _clear_mpi_rear_magnetic(self):
+        fields = (self.main_grid.Hx, self.main_grid.Hy, self.main_grid.Hz)
+        domain_stop = int(self.main_grid.global_size[self.normal_axis]) + 1
+        if self.direction_sign < 0:
+            normal_start = (self.plane_index + 1, self.plane_index, self.plane_index)
+            normal_stop = (domain_stop, domain_stop - 1, domain_stop - 1)
+        else:
+            normal_start = (0, 0, 0)
+            normal_stop = (self.plane_index, self.plane_index, self.plane_index)
+
+        component_points = {
+            self.normal_axis: (self.nu, self.nv),
+            self.transverse_axes[0]: (self.nu + 1, self.nv),
+            self.transverse_axes[1]: (self.nu, self.nv + 1),
+        }
+        for component, (u_points, v_points) in component_points.items():
+            index = (
+                0
+                if component == self.normal_axis
+                else 1
+                if component == self.transverse_axes[0]
+                else 2
+            )
+            self._clear_mpi_component_box(
+                fields,
+                component,
+                normal_start[index],
+                normal_stop[index],
+                u_points,
+                v_points,
+            )
+
+    def _clear_mpi_rear_electric(self):
+        fields = (self.main_grid.Ex, self.main_grid.Ey, self.main_grid.Ez)
+        domain_stop = int(self.main_grid.global_size[self.normal_axis]) + 1
+        if self.direction_sign < 0:
+            normal_start = self.plane_index + 1
+            normal_stops = (domain_stop, domain_stop, domain_stop)
+        else:
+            normal_start = 0
+            normal_stops = (
+                self.plane_index - 1,
+                self.plane_index,
+                self.plane_index,
+            )
+        component_points = {
+            self.normal_axis: (self.nu + 1, self.nv + 1),
+            self.transverse_axes[0]: (self.nu, self.nv + 1),
+            self.transverse_axes[1]: (self.nu + 1, self.nv),
+        }
+        for component, (u_points, v_points) in component_points.items():
+            index = (
+                0
+                if component == self.normal_axis
+                else 1
+                if component == self.transverse_axes[0]
+                else 2
+            )
+            self._clear_mpi_component_box(
+                fields,
+                component,
+                normal_start,
+                normal_stops[index],
+                u_points,
+                v_points,
+            )
+
+    def _deposit_mpi_aperture_electric(self):
+        aperture = 0 if self.direction_sign < 0 else int(self.aux_grid.size[self.normal_axis])
+        inside = 0 if self.direction_sign < 0 else aperture - 1
+        aux_fields = (self.aux_grid.Ex, self.aux_grid.Ey, self.aux_grid.Ez)
+
+        def aux_sheet(component, normal_index, u_points, v_points):
+            slices = [slice(None)] * 3
+            slices[self.normal_axis] = normal_index
+            slices[self.transverse_axes[0]] = slice(0, u_points)
+            slices[self.transverse_axes[1]] = slice(0, v_points)
+            return aux_fields[component][tuple(slices)]
+
+        self._write_mpi_component_sheet(
+            self.transverse_axes[0],
+            self.plane_index,
+            self.nu,
+            self.nv + 1,
+            aux_sheet(self.transverse_axes[0], aperture, self.nu, self.nv + 1),
+        )
+        self._write_mpi_component_sheet(
+            self.transverse_axes[1],
+            self.plane_index,
+            self.nu + 1,
+            self.nv,
+            aux_sheet(self.transverse_axes[1], aperture, self.nu + 1, self.nv),
+        )
+        main_normal_index = self.plane_index if self.direction_sign < 0 else self.plane_index - 1
+        self._write_mpi_component_sheet(
+            self.normal_axis,
+            main_normal_index,
+            self.nu + 1,
+            self.nv + 1,
+            aux_sheet(self.normal_axis, inside, self.nu + 1, self.nv + 1),
+        )
+
     def update_magnetic(self, iteration):
         """Advance auxiliary H, apply modal injection, and join the aperture."""
 
         self.aux_updates.update_magnetic()
         self.aux_updates.update_magnetic_pml()
         self.aux_updates.update_eigenmode_sources_magnetic(iteration)
+        if self.mpi:
+            self._clear_mpi_rear_magnetic()
+            return
         couple_virtual_waveguide_magnetic(
             config.get_model_config().ompthreads,
             self.normal_axis,
@@ -291,6 +679,14 @@ class VirtualWaveguide:
             self.aux_grid.Hz,
         )
 
+    def complete_magnetic_mpi(self):
+        """Join the auxiliary H plane after the main MPI halo exchange."""
+
+        if not self.mpi:
+            return
+        normal, _, _ = self._collect_mpi_aperture_magnetic_fields()
+        self._set_auxiliary_normal_magnetic(normal)
+
     def update_electric(self, iteration):
         """Advance auxiliary E and close its curl with main-grid H."""
 
@@ -298,6 +694,31 @@ class VirtualWaveguide:
         self.aux_updates.update_electric_pml()
         self.aux_updates.update_eigenmode_sources_electric(iteration)
         self.aux_updates.update_electric_b()
+        if self.mpi:
+            normal_points = self.nu * self.nv
+            u_points = (self.nu + 1) * self.nv
+            h_u = self._mpi_h_global[normal_points : normal_points + u_points].reshape(
+                self.nu + 1, self.nv
+            )
+            h_v = self._mpi_h_global[normal_points + u_points :].reshape(self.nu, self.nv + 1)
+            couple_virtual_waveguide_electric_aperture(
+                config.get_model_config().ompthreads,
+                self.normal_axis,
+                self.direction_sign,
+                self.aux_grid.updatecoeffsE,
+                self.aux_grid.ID,
+                h_u,
+                h_v,
+                self.aux_grid.Ex,
+                self.aux_grid.Ey,
+                self.aux_grid.Ez,
+                self.aux_grid.Hx,
+                self.aux_grid.Hy,
+                self.aux_grid.Hz,
+            )
+            self._deposit_mpi_aperture_electric()
+            self._clear_mpi_rear_electric()
+            return
         couple_virtual_waveguide_electric(
             config.get_model_config().ompthreads,
             self.normal_axis,

--- a/tests/cmds_multiuse/test_eigenmode_source_2d.py
+++ b/tests/cmds_multiuse/test_eigenmode_source_2d.py
@@ -1,6 +1,7 @@
 import csv
 import shutil
 from pathlib import Path
+from types import SimpleNamespace
 
 import h5py
 import numpy as np
@@ -271,10 +272,11 @@ def test_2d_pmc_mode_enforces_magnetic_wall_and_injects(tmp_path):
         assert np.max(np.abs(handle["rxs/rx1/Hz"][...])) > 0
 
 
-def test_eigenmode_port_rejected_with_mpi(monkeypatch):
+def test_eigenmode_port_definition_is_available_with_mpi(monkeypatch):
     monkeypatch.setattr(config, "sim_config", type("_SC", (), {})())
     config.sim_config.general = {"solver": "cpu"}
     config.sim_config.mpi = True
+    config.sim_config.get_model_config = lambda: SimpleNamespace(mode="2D TMz")
     grid = FDTDGrid()
     grid.eigenmodeband = object()
     port = gprMax.EigenmodePort(
@@ -284,8 +286,51 @@ def test_eigenmode_port_rejected_with_mpi(monkeypatch):
         direction="+",
         modes=(1,),
     )
-    with pytest.raises(ValueError, match="MPI"):
-        port.build(grid)
+    port.build(grid)
+    assert grid.eigenmodeportdefs[1].port == 1
+
+
+def test_mpi_receiver_pml_check_uses_global_boundary_thickness(monkeypatch, caplog):
+    """An interior rank's zero local PML must not cause a false warning."""
+
+    from gprMax.user_objects.cmds_multiuse import _EigenmodeReceiverBuilder
+
+    monkeypatch.setattr(config, "sim_config", type("_SC", (), {})())
+    config.sim_config.general = {"solver": "cpu"}
+    config.sim_config.mpi = True
+    config.sim_config.get_model_config = lambda: SimpleNamespace(mode="2D TMz")
+
+    grid = FDTDGrid()
+    grid.size = np.asarray((100, 40, 1), dtype=np.int32)
+    grid.global_size = grid.size.copy()
+    grid.lower_extent = np.zeros(3, dtype=np.int32)
+    grid.negative_halo_offset = np.zeros(3, dtype=np.int32)
+    grid.dl = np.asarray((1e-3, 1e-3, 1e-3))
+    grid.dt = 1e-12
+    grid.iterations = 100
+    grid.timewindow = grid.dt * grid.iterations
+    grid.pmls["thickness"]["xmax"] = 0
+    grid.comm = SimpleNamespace(allgather=lambda value: [value, 10])
+    grid.is_coordinator = lambda: True
+
+    receiver = _EigenmodeReceiverBuilder(
+        normal="x",
+        direction="-",
+        p1=(0.005, 0),
+        p2=(0.035, INF),
+        w=0.09,
+        mode_count=1,
+        port_index=2,
+        id="port2",
+        dft_start=5e9,
+        dft_stop=5e9,
+        dft_points=1,
+        frequency=5e9,
+    )
+    with caplog.at_level("WARNING"):
+        receiver.build(grid)
+
+    assert not any("Eigenmode receiver" in record.message for record in caplog.records)
 
 
 def test_2d_eigenmode_normal_cannot_be_invariant_axis(tmp_path):
@@ -491,9 +536,7 @@ def test_2d_eigenmode_builds_for_every_invariant_axis(tmp_path, mode, invariant_
     ],
 )
 def test_2d_regression_example_builds(tmp_path, relative_path, snapshot_count):
-    source = (
-        REPOSITORY_ROOT / "testing" / "regression" / "eigenmode_sources" / relative_path
-    )
+    source = REPOSITORY_ROOT / "testing" / "regression" / "eigenmode_sources" / relative_path
     copied_input = tmp_path / source.name
     shutil.copyfile(source, copied_input)
 

--- a/tests/grid/test_mpi_halo_datatype_lifecycle.py
+++ b/tests/grid/test_mpi_halo_datatype_lifecycle.py
@@ -1,0 +1,104 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from mpi4py import MPI
+
+from gprMax.contexts import Context, MPIContext
+from gprMax.grid.mpi_grid import MPIGrid
+from gprMax.utilities.mpi import Dim, Dir
+
+
+class _RecordingDatatype:
+    def __init__(self, name, calls):
+        self.name = name
+        self.calls = calls
+
+    def Free(self):
+        self.calls.append(f"free_{self.name}")
+
+
+def _empty_halo_maps():
+    maps = np.empty((3, 2), dtype=object)
+    maps.fill(MPI.DATATYPE_NULL)
+    return maps
+
+
+def test_halo_datatype_cleanup_is_complete_and_idempotent():
+    calls = []
+    send = _empty_halo_maps()
+    recv = _empty_halo_maps()
+    send[Dim.X][Dir.NEG] = _RecordingDatatype("send", calls)
+    recv[Dim.Y][Dir.POS] = _RecordingDatatype("recv", calls)
+    grid = SimpleNamespace(
+        send_halo_map=send,
+        recv_halo_map=recv,
+        _halo_maps_initialised=True,
+        _halo_maps_freed=False,
+        complete_halo_swaps=lambda: calls.append("complete_halo_swaps"),
+    )
+
+    MPIGrid.free_halo_maps(grid)
+    MPIGrid.free_halo_maps(grid)
+
+    assert calls == ["complete_halo_swaps", "free_send", "free_recv"]
+    assert grid._halo_maps_freed
+    assert all(datatype == MPI.DATATYPE_NULL for datatype in send.flat)
+    assert all(datatype == MPI.DATATYPE_NULL for datatype in recv.flat)
+
+
+def test_mpi_context_retires_geometry_fixed_grid_after_all_runs(monkeypatch):
+    calls = []
+    grid = SimpleNamespace(free_halo_maps=lambda: calls.append("free_halo_maps"))
+    context = MPIContext.__new__(MPIContext)
+    context.model = SimpleNamespace(G=grid)
+    context.rank = 0
+    context.comm = SimpleNamespace(Barrier=lambda: calls.append("barrier"))
+
+    monkeypatch.setattr(Context, "run", lambda self: calls.append("run_all_models") or {})
+
+    assert context.run() == {}
+    assert calls == ["run_all_models", "free_halo_maps", "barrier"]
+
+
+def test_gathered_output_state_restores_rank_local_geometry_after_error():
+    receiver = SimpleNamespace(coord=np.array((2, 3, 4), dtype=np.int32))
+    source = SimpleNamespace(coord=np.array((5, 6, 7), dtype=np.int32))
+    grid = SimpleNamespace(
+        size=np.array((8, 9, 10), dtype=np.int32),
+        global_size=np.array((16, 9, 10), dtype=np.int32),
+        rxs=[receiver],
+        voltagesources=[],
+        magneticdipoles=[],
+        hertziandipoles=[source],
+        transmissionlines=[],
+        magneticfrillsources=[],
+        networkterminals=[],
+        port_monitors=[],
+    )
+    local_rxs = grid.rxs
+    local_sources = grid.hertziandipoles
+    local_receiver_coord = receiver.coord
+    local_source_coord = source.coord
+    local_size = grid.size
+
+    def gather_grid_objects():
+        receiver.coord = receiver.coord + 10
+        source.coord = source.coord + 10
+        grid.rxs = [SimpleNamespace(coord=np.array((12, 13, 14)))]
+
+    grid.gather_grid_objects = gather_grid_objects
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        with MPIGrid.gathered_output_state(grid):
+            grid.size = grid.global_size
+            raise RuntimeError("write failed")
+
+    assert grid.rxs is local_rxs
+    assert grid.hertziandipoles is local_sources
+    assert receiver.coord is local_receiver_coord
+    assert source.coord is local_source_coord
+    assert grid.size is local_size
+    np.testing.assert_array_equal(receiver.coord, (2, 3, 4))
+    np.testing.assert_array_equal(source.coord, (5, 6, 7))
+    np.testing.assert_array_equal(grid.size, (8, 9, 10))

--- a/tests/test_eigenmode_ports.py
+++ b/tests/test_eigenmode_ports.py
@@ -34,6 +34,8 @@ def test_cython_dft_updates_every_bin_once_per_time_step(real_dtype, complex_dty
     phase_step = np.asarray((1j, -1), dtype=complex_dtype)
     electric_dft = np.zeros((2, 1), dtype=complex_dtype)
     magnetic_dft = np.zeros((2, 1), dtype=complex_dtype)
+    owned_lower = np.zeros(3, dtype=np.int32)
+    owned_upper = np.asarray(field_shape, dtype=np.int32)
     real_signature = "float" if real_dtype is np.float32 else "double"
     kernel = accumulate_eigenmode_dft[f"{real_signature}|{real_signature} complex"]
 
@@ -48,6 +50,8 @@ def test_cython_dft_updates_every_bin_once_per_time_step(real_dtype, complex_dty
             1,
             1,
             1,
+            owned_lower,
+            owned_upper,
             real_dtype(0.1),
             real_dtype(1),
             1,
@@ -523,9 +527,7 @@ def test_monitor_uses_nearest_tracked_endpoint_outside_candidate_range(monkeypat
         anchor_frequencies=np.asarray([1e9, 2e9, 3e9, 4e9]),
         anchor_e=[[fields_[0] for fields_ in anchor] for anchor in anchor_fields],
         anchor_h=[[fields_[1] for fields_ in anchor] for anchor in anchor_fields],
-        anchor_neff=np.asarray(
-            [[10.0, 20.0], [0.4, -0.5j], [-0.3j, 0.6], [30.0, 40.0]]
-        ),
+        anchor_neff=np.asarray([[10.0, 20.0], [0.4, -0.5j], [-0.3j, 0.6], [30.0, 40.0]]),
         anchor_mode_valid=np.asarray(
             [[False, False], [True, False], [False, True], [False, False]]
         ),

--- a/tests/test_virtual_waveguide_coupling.py
+++ b/tests/test_virtual_waveguide_coupling.py
@@ -3,6 +3,7 @@ import pytest
 
 from gprMax.cython.virtual_waveguide import (
     couple_virtual_waveguide_electric,
+    couple_virtual_waveguide_electric_aperture,
     couple_virtual_waveguide_magnetic,
 )
 
@@ -68,3 +69,79 @@ def test_virtual_waveguide_coupling_supports_every_orientation(normal_axis, dire
     detached_index[transverse_axes[1]] = v0 + 1
     assert all(field[tuple(detached_index)] == 0 for field in main_e)
     assert all(np.all(np.isfinite(field)) for field in (*main_e, *main_h, *aux_e, *aux_h))
+
+
+@pytest.mark.parametrize("normal_axis", (0, 1, 2))
+@pytest.mark.parametrize("direction_sign", (-1, 1))
+def test_compact_mpi_aperture_update_matches_full_grid_coupling(normal_axis, direction_sign):
+    rng = np.random.default_rng(20260814)
+    shape = (10, 11, 12)
+    main_e = [rng.standard_normal(shape) for _ in range(3)]
+    main_h = [rng.standard_normal(shape) for _ in range(3)]
+    nu, nv = 4, 5
+    transverse_axes = [axis for axis in range(3) if axis != normal_axis]
+    aux_shape = [1, 1, 1]
+    aux_shape[normal_axis] = 9
+    aux_shape[transverse_axes[0]] = nu + 1
+    aux_shape[transverse_axes[1]] = nv + 1
+    aux_shape = tuple(aux_shape)
+    aux_e_full = [rng.standard_normal(aux_shape) for _ in range(3)]
+    aux_e_compact = [field.copy() for field in aux_e_full]
+    aux_h = [rng.standard_normal(aux_shape) for _ in range(3)]
+    u0, v0, u1, v1, plane = 2, 3, 2 + nu, 3 + nv, 5
+
+    aperture = 0 if direction_sign < 0 else aux_shape[normal_axis] - 1
+    main_sheet = [slice(None)] * 3
+    main_sheet[normal_axis] = plane
+    main_sheet[transverse_axes[0]] = slice(u0, u1)
+    main_sheet[transverse_axes[1]] = slice(v0, v1)
+    aux_sheet = [slice(None)] * 3
+    aux_sheet[normal_axis] = aperture
+    aux_sheet[transverse_axes[0]] = slice(0, nu)
+    aux_sheet[transverse_axes[1]] = slice(0, nv)
+    aux_h[normal_axis][tuple(aux_sheet)] = main_h[normal_axis][tuple(main_sheet)]
+
+    cross_plane = plane - 1 if direction_sign < 0 else plane
+
+    def magnetic_sheet(component, u_points, v_points):
+        sheet = [slice(None)] * 3
+        sheet[normal_axis] = cross_plane
+        sheet[transverse_axes[0]] = slice(u0, u0 + u_points)
+        sheet[transverse_axes[1]] = slice(v0, v0 + v_points)
+        return np.ascontiguousarray(main_h[component][tuple(sheet)])
+
+    main_hu = magnetic_sheet(transverse_axes[0], nu + 1, nv)
+    main_hv = magnetic_sheet(transverse_axes[1], nu, nv + 1)
+    updatecoeffs = np.asarray([[0.97, 0.11, 0.12, 0.13, 0.0]], dtype=np.float64)
+    component_ids = np.zeros((6, *aux_shape), dtype=np.uint32)
+
+    couple_virtual_waveguide_electric(
+        1,
+        normal_axis,
+        direction_sign,
+        u0,
+        v0,
+        u1,
+        v1,
+        plane,
+        updatecoeffs,
+        component_ids,
+        *(field.copy() for field in main_e),
+        *main_h,
+        *aux_e_full,
+        *aux_h,
+    )
+    couple_virtual_waveguide_electric_aperture(
+        1,
+        normal_axis,
+        direction_sign,
+        updatecoeffs,
+        component_ids,
+        main_hu,
+        main_hv,
+        *aux_e_compact,
+        *aux_h,
+    )
+
+    for full, compact in zip(aux_e_full, aux_e_compact):
+        np.testing.assert_allclose(compact, full, rtol=0, atol=0)


### PR DESCRIPTION
# PR Description

## Summary

This PR adds domain-decomposed MPI CPU support for eigenmode sources, eigenmode-port monitoring, and virtual waveguides.

The implementation:

- Collectively reconstructs modal material cross-sections from distributed material properties.
- Partitions direct eigenmode TF/SF corrections according to Yee-component ownership.
- Accumulates modal DFT projections locally and reduces them only after time stepping.
- Supports virtual waveguides in all port directions.
- Replicates the compact auxiliary waveguide on each rank and performs one aperture-sized magnetic-field collective per timestep for bidirectional coupling.
- Preserves serial CPU behaviour and existing CUDA, OpenCL, Metal, and HSG paths.
- Documents the MPI execution and communication model.

The PR also fixes two MPI lifecycle issues found during validation:

- Committed halo MPI datatypes are now explicitly released when their grid is retired.
- MPI output gathering is temporary and restores rank-local coordinates, object lists, and grid dimensions. This prevents failures when `geometry_fixed` reuses a distributed grid.

## Validation

- 97 focused eigenmode, virtual-waveguide, command, and MPI lifecycle tests pass.
- Cython extensions build successfully.
- Sphinx documentation builds successfully with no new warnings.
- Repeated `geometry_fixed` MPI runs were tested with PMLs and stepped sources/receivers.
- Ordinary multi-model MPI runs were tested with independently rebuilt grids.
- A four-rank `2 x 2 x 1` virtual-waveguide patch model was compared with the serial CPU solver:
  - all six receiver field histories were bit-for-bit identical;
  - maximum S-parameter magnitude difference was approximately `1.14e-5 dB`;
  - maximum S-parameter phase difference was approximately `4.58e-5 degrees`.
- The previous MPI datatype leak warning at shutdown is no longer produced.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update.

## Checklist

- [x] Pre-commit formatting and import checks pass.
- [x] I have performed a self-review of my code.
- [x] I have added comments for hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.