### PR TITLE
Fix mixed-pole MPI axial plane-wave profiles

### DIFF
--- a/gprMax/sources.py
+++ b/gprMax/sources.py
@@ -4551,10 +4551,20 @@ class DiscretePlaneWave(Source):
         self.axial_updatecoeffsH = np.zeros(
             (table_size, G.updatecoeffsH.shape[1]), dtype=G.updatecoeffsH.dtype
         )
-        if has_dispersion:
+        dispersive_rows = [
+            value[2]
+            for key, value in records.items()
+            if key[0] == "profile" and value[2] is not None
+        ]
+        max_dispersive_coeffs = max((row.size for row in dispersive_rows), default=0)
+        if max_dispersive_coeffs % 3:
+            raise RuntimeError(
+                "Axial DPW dispersive coefficient rows must contain three values per pole."
+            )
+        if max_dispersive_coeffs:
             self.axial_updatecoeffsdispersive = np.zeros(
-                (table_size, G.updatecoeffsdispersive.shape[1]),
-                dtype=G.updatecoeffsdispersive.dtype,
+                (table_size, max_dispersive_coeffs),
+                dtype=config.get_model_config().materials["dispersivedtype"],
             )
         else:
             self.axial_updatecoeffsdispersive = None
@@ -4567,7 +4577,7 @@ class DiscretePlaneWave(Source):
                 self.axial_updatecoeffsE[compact_id] = coeffs_e
                 self.axial_updatecoeffsH[compact_id] = coeffs_h
                 if coeffs_d is not None:
-                    self.axial_updatecoeffsdispersive[compact_id] = coeffs_d
+                    self.axial_updatecoeffsdispersive[compact_id, : coeffs_d.size] = coeffs_d
                 max_poles = max(max_poles, poles)
 
             first_id = component * n_prop + 1
@@ -4579,8 +4589,8 @@ class DiscretePlaneWave(Source):
 
         self.material = records[("material", "source")]
         self.materialPML = records[("material", "far_pml")]
-        self.max_poles = max_poles
-        self.dispersive = max_poles > 0
+        self.max_poles = max(max_poles, max_dispersive_coeffs // 3)
+        self.dispersive = self.max_poles > 0
 
     def calculate_waveform_values(self, G, cythonize=True):
         """Calculates all waveform values for source for duration of simulation.

--- a/tests/cmds_multiuse/test_discrete_plane_wave_mpi_partition.py
+++ b/tests/cmds_multiuse/test_discrete_plane_wave_mpi_partition.py
@@ -82,3 +82,61 @@ def test_axial_profile_remaps_gathered_coefficients_to_dpw_local_ids():
         np.testing.assert_array_equal(dpw.ID[component, :3], first_id)
         np.testing.assert_array_equal(dpw.ID[component, 6:], last_id)
         np.testing.assert_array_equal(dpw.axial_updatecoeffsE[first_id], coeffs_e + component + 1)
+
+
+def test_axial_profile_zero_pads_mixed_rank_dispersive_orders(monkeypatch):
+    """Use the global pole width when rank-local averaged materials differ."""
+
+    n_prop = 4
+    coeffs_e = np.arange(5, dtype=np.float64)
+    coeffs_h = coeffs_e + 10
+    records = {}
+    for component in range(6):
+        for prop_idx in range(1, n_prop):
+            poles = 2 if prop_idx == 1 else 3
+            coeffs_d = np.arange(3 * poles, dtype=np.complex128) + 1j * component
+            records[("profile", component, prop_idx)] = (
+                coeffs_e,
+                coeffs_h,
+                coeffs_d,
+                poles,
+            )
+    source_material = SimpleNamespace(ID="source", poles=0)
+    far_material = SimpleNamespace(ID="far", poles=0)
+    records[("material", "source")] = source_material
+    records[("material", "far_pml")] = far_material
+
+    class _Comm:
+        @staticmethod
+        def allgather(_local):
+            return [records]
+
+    grid = SimpleNamespace(
+        updatecoeffsE=np.zeros((1, 5), dtype=np.float64),
+        updatecoeffsH=np.zeros((1, 5), dtype=np.float64),
+        updatecoeffsdispersive=np.zeros((1, 6), dtype=np.complex128),
+        comm=_Comm(),
+    )
+    grid.global_to_local_coordinate = lambda point: point
+    grid.within_bounds = lambda point: False
+
+    dpw = SimpleNamespace(
+        transverse_pos=[1, 1, 1],
+        origin_axial=2,
+        length=10,
+        ID=np.zeros((6, 10), dtype=np.uint32),
+    )
+    model_config = SimpleNamespace(materials={"dispersivedtype": np.complex128})
+    monkeypatch.setattr("gprMax.sources.config.get_model_config", lambda: model_config)
+
+    DiscretePlaneWave._build_mpi_axial_profile(dpw, grid, prop=0, n_prop=n_prop)
+
+    assert dpw.max_poles == 3
+    assert dpw.axial_updatecoeffsdispersive.shape == (6 * n_prop, 9)
+    for component in range(6):
+        two_pole_id = component * n_prop + 1
+        np.testing.assert_array_equal(
+            dpw.axial_updatecoeffsdispersive[two_pole_id, :6],
+            records[("profile", component, 1)][2],
+        )
+        np.testing.assert_array_equal(dpw.axial_updatecoeffsdispersive[two_pole_id, 6:], 0)


### PR DESCRIPTION
# PR Description

## Summary

Fix the construction of replicated axial discrete-plane-wave material
profiles in MPI models where different ranks encounter dispersive materials
with different numbers of poles.

Previously, each rank allocated the dispersive coefficient table using its
local coefficient width. A model containing different Debye, Lorentz, or
Drude pole counts across rank-local material profiles could consequently fail
when the gathered coefficient rows had different lengths.

The updated implementation:

- determines the maximum dispersive coefficient width across all gathered
  rank-local profiles;
- allocates an identical coefficient table on every rank;
- zero-pads coefficient rows belonging to lower-order dispersive materials;
- uses gprMax's configured dispersive coefficient dtype;
- derives the replicated plane wave's maximum pole count from the global
  coefficient width;
- adds regression coverage for mixed two- and three-pole rank-local profiles.

Zero-padding is consistent with the main-grid dispersive storage convention
and does not introduce additional pole contributions.

## Related Issue

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update.

## Testing

- 14 focused MPI plane-wave and dispersive-dtype tests passed.
- Two-rank mixed dielectric/Debye/Lorentz/Drude multilayer validation passed.
- Two-rank Debye–Lorentz core-shell sphere validation completed successfully.
- Black, isort, and whitespace checks passed.

## Checklist

- [x] Pre-commit formatting checks passed.
- [x] I have performed a self-review of my code.
- [x] I have added comments where required.
- [x] No documentation change is required.
- [x] My changes generate no new warnings.
- [x] The title is a short description of the changes.