### PR TITLE
Add MPI support for NTFF outputs

### DIFF
--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -1097,6 +1097,13 @@ strictly enclose that outer surface. Sources and scatterers inside the subgrid
 then contribute through the normal HSG field exchange. A disjoint subgrid is
 permitted. NTFF surfaces cannot be defined inside a subgrid.
 
+The same interface is available with MPI domain decomposition. Surface patches
+are distributed between ranks and use the existing field halos, while the
+completed results retain the same HDF5 schema as a serial run. MPI NTFF does
+not introduce a surface collective during each FDTD iteration; accumulated
+time histories or frequency-domain phasors are combined once at finalisation.
+Geometry-fixed reuse remains unsupported.
+
 The following example reuses one surface for an exact time-domain point and a
 frequency-domain radiation pattern. Python keyword arguments replace the
 positional optional parameters used by the equivalent hash commands.

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1999,20 +1999,26 @@ The following conventions apply to every NTFF command:
   stencil. A closed surface must enclose the radiating source or the complete
   TFSF box and scatterer. An open Huygens surface instead permits an impressed
   source outside only through one of its omitted faces;
-* the implementation currently requires a three-dimensional serial model and
-  does not support MPI or geometry-fixed reuse. NTFF commands are main-grid
-  objects, but their closed surface may contain complete subgrids. A surface
-  that overlaps a subgrid must strictly enclose its HSG outer coupling surface;
-  it cannot touch or cut the coupling region. Both time- and frequency-domain
-  KSIR collection and frequency-domain equivalent-current collection are
-  available with CPU, CUDA, OpenCL, and Metal. Equivalent-current transient
-  far fields are also available with all four local solvers;
+* the implementation requires a three-dimensional model and does not support
+  geometry-fixed reuse. NTFF commands are main-grid objects, but their closed
+  surface may contain complete subgrids. A surface that overlaps a subgrid
+  must strictly enclose its HSG outer coupling surface; it cannot touch or cut
+  the coupling region. Both time- and frequency-domain KSIR collection and
+  frequency-domain equivalent-current collection are available with the
+  serial CPU, CUDA, OpenCL, Metal, and MPI domain-decomposition solvers.
+  Equivalent-current transient far fields are available with the same
+  solvers. MPI uses the CPU field-update backend;
 * CPU collection uses the Cython/OpenMP implementation. Accelerator surface
   state and time-domain output storage remain on the device during FDTD
   iterations and are transferred to the host once, after the solve. CUDA and
   OpenCL are hardware-qualified on the development server. Metal has complete
   source-generation and dispatch coverage, but still requires execution tests
-  on suitable Apple hardware.
+  on suitable Apple hardware. With MPI, every surface patch is sampled by the
+  rank which owns its inside Yee sample; the neighbouring outside sample is
+  read from the normal one-cell halo. There is therefore no additional NTFF
+  communication inside the FDTD iteration. Compact time histories are reduced
+  and frequency-domain surface phasors are assembled on the coordinator after
+  time stepping, before the normal HDF5 output is written.
 
 Directivity, gain, efficiency, and port normalisation are post-processing
 operations after the FDTD solve. Angular KSIR and equivalent-current

--- a/docs/source/output.rst
+++ b/docs/source/output.rst
@@ -566,6 +566,11 @@ NTFF field-transformation output
 Reusable KSIR and equivalent-current outputs are stored in the normal model
 file under their surface and transform IDs:
 
+MPI domain-decomposition runs use this same schema and write the completed
+datasets from the coordinator rank. A ``collection_backend`` value beginning
+with ``mpi_`` records that the integration surface was partitioned between
+ranks; it does not change field normalisation or array ordering.
+
 .. code-block:: none
 
     /ntff/<surface_id>/

--- a/gprMax/mpi_model.py
+++ b/gprMax/mpi_model.py
@@ -254,6 +254,7 @@ class MPIModel(Model):
                 or self.G.networkterminals
                 or self.G.port_monitors
                 or self.G.eigenmodeports
+                or self.G.ntff_output_writers
             ):
                 self.G.size = self.G.global_size
                 from gprMax.eigenmode_ports import finalise_eigenmode_ports

--- a/gprMax/ntff/equivalent_current_time.py
+++ b/gprMax/ntff/equivalent_current_time.py
@@ -92,12 +92,20 @@ class EquivalentCurrentTimeMonitor:
         impedance,
         nthreads=1,
         device_backend=None,
+        mpi_grid=None,
     ):
         self.name = name
         self.lower = np.asarray(lower, dtype=np.int64)
         self.upper = np.asarray(upper, dtype=np.int64)
         self.spacing = np.asarray(spacing, dtype=real_dtype)
-        self.field_shape = tuple(int(value) for value in field_shape)
+        self.global_field_shape = tuple(int(value) for value in field_shape)
+        self.mpi_grid = mpi_grid
+        self.mpi_comm = None if mpi_grid is None else mpi_grid.comm
+        self.field_shape = (
+            self.global_field_shape
+            if mpi_grid is None
+            else tuple(int(value + 1) for value in mpi_grid.size)
+        )
         self.dt = float(dt)
         self.iterations = int(iterations)
         self.real_dtype = np.dtype(real_dtype)
@@ -120,6 +128,10 @@ class EquivalentCurrentTimeMonitor:
                 else "numpy_fallback"
             )
         )
+        if self.mpi_comm is not None:
+            if self.device_backend is not None:
+                raise ValueError("MPI NTFF collection is available with the CPU solver")
+            self.collection_backend = f"mpi_{self.collection_backend}"
         if self.lower.shape != (3,) or self.upper.shape != (3,):
             raise ValueError("equivalent-current bounds must have shape (3,)")
         if np.any(self.upper <= self.lower):
@@ -166,10 +178,28 @@ class EquivalentCurrentTimeMonitor:
             normals.append(face_normals)
             areas.append(face_areas)
             normal_axes.append(np.full(face_positions.shape[0], normal_axis, dtype=np.int8))
-        self.positions = _readonly(np.concatenate(positions), self.real_dtype)
-        self.normals = _readonly(np.concatenate(normals), self.real_dtype)
-        self.area_weights = _readonly(np.concatenate(areas), self.real_dtype)
-        self.normal_axes = _readonly(np.concatenate(normal_axes), np.int8)
+        positions = np.concatenate(positions)
+        normals = np.concatenate(normals)
+        areas = np.concatenate(areas)
+        normal_axes = np.concatenate(normal_axes)
+        if self.mpi_grid is not None:
+            anchor = np.floor(positions / self.spacing).astype(np.int32)
+            positive = normals[np.arange(normals.shape[0]), normal_axes] > 0
+            anchor[np.flatnonzero(positive), normal_axes[positive]] -= 1
+            owners = np.fromiter(
+                (self.mpi_grid.get_rank_from_coordinate(item) for item in anchor),
+                dtype=np.int32,
+                count=anchor.shape[0],
+            )
+            keep = owners == self.mpi_grid.rank
+            positions = positions[keep]
+            normals = normals[keep]
+            areas = areas[keep]
+            normal_axes = normal_axes[keep]
+        self.positions = _readonly(positions, self.real_dtype)
+        self.normals = _readonly(normals, self.real_dtype)
+        self.area_weights = _readonly(areas, self.real_dtype)
+        self.normal_axes = _readonly(normal_axes, np.int8)
         self.npatches = self.positions.shape[0]
         self._stencils = self._build_stencils()
         self._gather_buffer = np.empty(self.npatches, dtype=self.real_dtype)
@@ -181,8 +211,16 @@ class EquivalentCurrentTimeMonitor:
             0.0: self._delay_map(shift, 0.0),
             0.5: self._delay_map(shift, 0.5),
         }
-        self._time_origin_step = int(np.floor(np.min(shift))) - 2
-        last_step = self.iterations - 1 + int(np.ceil(np.max(shift))) + 2
+        local_minimum = float(np.min(shift)) if self.npatches else np.inf
+        local_maximum = float(np.max(shift)) if self.npatches else -np.inf
+        if self.mpi_comm is not None:
+            bounds = self.mpi_comm.allgather((local_minimum, local_maximum))
+            local_minimum = min(item[0] for item in bounds)
+            local_maximum = max(item[1] for item in bounds)
+        if not np.isfinite(local_minimum) or not np.isfinite(local_maximum):
+            raise RuntimeError("MPI equivalent-current surface has no owned patches")
+        self._time_origin_step = int(np.floor(local_minimum)) - 2
+        last_step = self.iterations - 1 + int(np.ceil(local_maximum)) + 2
         self._raw_length = last_step - self._time_origin_step + 1
         self._theta_output = (
             np.zeros((self.directions.shape[0], self._raw_length), dtype=self.real_dtype)
@@ -190,8 +228,8 @@ class EquivalentCurrentTimeMonitor:
             else None
         )
         self._phi_output = None if self._theta_output is None else np.zeros_like(self._theta_output)
-        self._complete_start_step = int(np.ceil(np.max(shift) + 1))
-        self._complete_stop_step = int(np.floor(np.min(shift) + self.iterations - 1))
+        self._complete_start_step = int(np.ceil(local_maximum + 1))
+        self._complete_stop_step = int(np.floor(local_minimum + self.iterations - 1))
         if self._complete_stop_step < self._complete_start_step:
             raise ValueError(
                 "time window is too short to contain one complete retarded surface history"
@@ -231,9 +269,7 @@ class EquivalentCurrentTimeMonitor:
                 for axis in range(3):
                     sample_index = target[:, axis] / self.spacing[axis] - offset[axis]
                     nearest = np.rint(sample_index)
-                    if np.allclose(
-                        sample_index, nearest, rtol=0, atol=alignment_tolerance
-                    ):
+                    if np.allclose(sample_index, nearest, rtol=0, atol=alignment_tolerance):
                         shifts_by_axis.append((0.0,))
                     elif np.allclose(
                         np.abs(sample_index - nearest),
@@ -256,6 +292,8 @@ class EquivalentCurrentTimeMonitor:
                         atol=alignment_tolerance,
                     ):
                         raise RuntimeError(f"{component} stencil is not on Yee samples")
+                    if self.mpi_grid is not None:
+                        indices -= np.asarray(self.mpi_grid.lower_extent, dtype=np.int64)
                     if np.any(indices < 0) or np.any(
                         indices >= np.asarray(self.field_shape)[np.newaxis, :]
                     ):
@@ -346,7 +384,13 @@ class EquivalentCurrentTimeMonitor:
             component_ids = ids[id_lookup[component]].ravel()
             for _, stencil in self._stencils[component]:
                 sampled.append(component_ids[stencil.ravel()])
-        unique = np.unique(np.concatenate(sampled))
+        if self.mpi_comm is not None:
+            from .mpi import distributed_unique
+
+            local = np.concatenate(sampled) if sampled else np.empty(0, dtype=np.int64)
+            unique = distributed_unique(local, self.mpi_comm)
+        else:
+            unique = np.unique(np.concatenate(sampled))
         if unique.size != 1:
             raise ValueError(
                 "equivalent-current surface must lie in one material; "
@@ -418,6 +462,19 @@ class EquivalentCurrentTimeMonitor:
             raise RuntimeError("equivalent-current monitor did not receive every time step")
         if self._theta_output is None or self._phi_output is None:
             raise RuntimeError("equivalent-current device output was not loaded")
+        if self.mpi_comm is not None:
+            from mpi4py import MPI
+
+            coordinator = self.mpi_comm.Get_rank() == 0
+            theta = np.empty_like(self._theta_output) if coordinator else None
+            phi = np.empty_like(self._phi_output) if coordinator else None
+            self.mpi_comm.Reduce(self._theta_output, theta, op=MPI.SUM, root=0)
+            self.mpi_comm.Reduce(self._phi_output, phi, op=MPI.SUM, root=0)
+            if not coordinator:
+                self._finalised = True
+                return
+            self._theta_output = theta
+            self._phi_output = phi
         start = self._complete_start_step - self._time_origin_step
         stop = self._complete_stop_step - self._time_origin_step + 1
         scale = -1 / (4 * np.pi * self.wave_speed)

--- a/gprMax/ntff/frequency_domain.py
+++ b/gprMax/ntff/frequency_domain.py
@@ -35,27 +35,18 @@ try:
 except ImportError:  # pragma: no cover - permits source-tree use before compilation
     _accumulate_surface_dft = None
 
+from .closures import ResolvedKSIRClosure, closure_from_metadata
 from .conventions import (
     FORWARD_TRANSFORM_KERNEL,
     OUTGOING_GREEN_RADIAL_FACTOR,
     PHASOR_TIME_DEPENDENCE,
-)
-from .closures import (
-    ResolvedKSIRClosure,
-    closure_from_metadata,
 )
 from .evaluator import (
     evaluate_far_zone_patches,
     project_cartesian_to_spherical,
     spherical_directions,
 )
-from .surfaces import (
-    COMPONENT_OFFSETS,
-    FACES,
-    KSIRComponentSurface,
-    build_component_surface,
-)
-
+from .surfaces import COMPONENT_OFFSETS, FACES, KSIRComponentSurface, build_component_surface
 
 ELECTRIC_COMPONENTS = ("Ex", "Ey", "Ez")
 MAGNETIC_COMPONENTS = ("Hx", "Hy", "Hz")
@@ -179,9 +170,7 @@ def surface_compatibility_signature(
         np.asarray(surface.normals, dtype="<f8"),
         np.asarray(surface.area_weights, dtype="<f8"),
         np.asarray(frequencies, dtype="<f8"),
-        np.asarray(
-            (dt, sample_time_offset, background_er, background_mr), dtype="<f8"
-        ),
+        np.asarray((dt, sample_time_offset, background_er, background_mr), dtype="<f8"),
         np.asarray((iterations,), dtype="<i8"),
     )
     for array in arrays:
@@ -257,10 +246,7 @@ def _evaluate_component_with_closure(
     origin: npt.ArrayLike,
     nthreads: int = 1,
     retain_face_contributions: bool = True,
-) -> tuple[
-    npt.NDArray[np.complexfloating],
-    Optional[npt.NDArray[np.complexfloating]],
-]:
+) -> tuple[npt.NDArray[np.complexfloating], Optional[npt.NDArray[np.complexfloating]],]:
     """Evaluate one component and retain contributions by physical face."""
 
     field_values = np.asarray(field)
@@ -270,9 +256,7 @@ def _evaluate_component_with_closure(
         raise ValueError("KSIR surface phasors must use a complex dtype")
     frequency_values = np.asarray(frequencies)
     direction_values = np.asarray(directions)
-    total = np.zeros(
-        (frequency_values.size, direction_values.shape[0]), dtype=result_dtype
-    )
+    total = np.zeros((frequency_values.size, direction_values.shape[0]), dtype=result_dtype)
     face_contributions = (
         np.zeros(
             (frequency_values.size, direction_values.shape[0], len(FACES)),
@@ -308,9 +292,7 @@ def _evaluate_component_with_closure(
         total += contribution
         if face_contributions is not None:
             face_contributions[:, :, FACES.index(face_id)] += contribution
-    return _readonly(total), (
-        None if face_contributions is None else _readonly(face_contributions)
-    )
+    return _readonly(total), (None if face_contributions is None else _readonly(face_contributions))
 
 
 class _ComponentDFTAccumulator:
@@ -344,9 +326,7 @@ class _ComponentDFTAccumulator:
         shape = (frequencies.size, surface.npatches)
         self.inside_dft = np.zeros(shape, dtype=self.dtype)
         self.outside_dft = np.zeros(shape, dtype=self.dtype)
-        self._phase = _dft_phase_at_time(
-            frequencies, sample_time_offset_steps * dt, self.dtype
-        )
+        self._phase = _dft_phase_at_time(frequencies, sample_time_offset_steps * dt, self.dtype)
         self._step = _dft_phase_at_time(frequencies, dt, self.dtype)
         self._inside_indices = np.ascontiguousarray(
             np.concatenate([face.inside_flat_indices for face in surface.faces]),
@@ -376,12 +356,8 @@ class _ComponentDFTAccumulator:
 
         self._next_iteration += 1
         if self._next_iteration % DFT_PHASE_REANCHOR_INTERVAL == 0:
-            physical_time = (
-                self._next_iteration + self.sample_time_offset_steps
-            ) * self.dt
-            self._phase = _dft_phase_at_time(
-                self.frequencies, physical_time, self.dtype
-            )
+            physical_time = (self._next_iteration + self.sample_time_offset_steps) * self.dt
+            self._phase = _dft_phase_at_time(self.frequencies, physical_time, self.dtype)
         else:
             self._phase *= self._step
         return multiplier
@@ -414,9 +390,7 @@ class _ComponentDFTAccumulator:
             self.inside_dft += contribution * inside[np.newaxis, :]
             self.outside_dft += contribution * outside[np.newaxis, :]
 
-    def load_device_dfts(
-        self, inside: npt.ArrayLike, outside: npt.ArrayLike
-    ) -> None:
+    def load_device_dfts(self, inside: npt.ArrayLike, outside: npt.ArrayLike) -> None:
         """Load completed raw DFTs accumulated by a device backend."""
 
         if self._finalised:
@@ -436,9 +410,7 @@ class _ComponentDFTAccumulator:
         self.inside_dft[...] = inside_values
         self.outside_dft[...] = outside_values
 
-    def finalise(
-        self, background_er: float, background_mr: float
-    ) -> KSIRComponentPhasors:
+    def finalise(self, background_er: float, background_mr: float) -> KSIRComponentPhasors:
         if self._finalised:
             raise RuntimeError("KSIR DFT accumulator has already been finalised")
         if self._next_iteration != self.iterations:
@@ -506,6 +478,9 @@ class KSIRFrequencyDomainMonitor:
         exterior_index_bounds: Optional[Sequence[Sequence[int]]] = None,
         closure: Optional[ResolvedKSIRClosure] = None,
         allow_external_sources: bool = False,
+        mpi_comm=None,
+        mpi_grid=None,
+        global_surfaces: Optional[Mapping[str, KSIRComponentSurface]] = None,
     ):
         if not name:
             raise ValueError("KSIR monitor name must not be empty")
@@ -526,9 +501,7 @@ class KSIRFrequencyDomainMonitor:
             self.complex_dtype.kind != "c"
             or self.complex_dtype.itemsize != 2 * self.real_dtype.itemsize
         ):
-            raise ValueError(
-                "complex_dtype must be the matching complex dtype for real_dtype"
-            )
+            raise ValueError("complex_dtype must be the matching complex dtype for real_dtype")
         if not isinstance(nthreads, (int, np.integer)) or nthreads < 1:
             raise ValueError("nthreads must be an integer greater than zero")
         if not isinstance(window, str):
@@ -545,14 +518,10 @@ class KSIRFrequencyDomainMonitor:
         validate_nyquist_frequencies(frequencies, dt)
         self.theta_values = _angles("theta", theta, self.real_dtype)
         self.phi_values = _angles("phi", phi, self.real_dtype)
-        theta_grid, phi_grid = np.meshgrid(
-            self.theta_values, self.phi_values, indexing="ij"
-        )
+        theta_grid, phi_grid = np.meshgrid(self.theta_values, self.phi_values, indexing="ij")
         self.theta = _readonly(theta_grid.ravel())
         self.phi = _readonly(phi_grid.ravel())
-        self.directions = _readonly(
-            spherical_directions(self.theta, self.phi, degrees=True)
-        )
+        self.directions = _readonly(spherical_directions(self.theta, self.phi, degrees=True))
         if origin is None:
             centres = np.stack([surface.centre for surface in surfaces.values()])
             reference_origin = np.mean(centres, axis=0)
@@ -565,9 +534,7 @@ class KSIRFrequencyDomainMonitor:
         self.dt = float(dt)
         self.iterations = int(iterations)
         self.window_name = window.lower().replace("-", "_")
-        self.window_values = _window(
-            self.window_name, self.iterations, self.real_dtype
-        )
+        self.window_values = _window(self.window_name, self.iterations, self.real_dtype)
         if self.window_name in ("boxcar", "none"):
             self.window_name = "rectangular"
         elif self.window_name == "hanning":
@@ -579,9 +546,7 @@ class KSIRFrequencyDomainMonitor:
         self.nthreads = int(nthreads)
         if solver_backend == "cpu":
             self.collection_backend = (
-                "cython_openmp"
-                if _accumulate_surface_dft is not None
-                else "numpy_fallback"
+                "cython_openmp" if _accumulate_surface_dft is not None else "numpy_fallback"
             )
         else:
             self.collection_backend = f"{solver_backend}_device"
@@ -591,6 +556,15 @@ class KSIRFrequencyDomainMonitor:
         )
         self.incident_monitor_name = incident_monitor_name or name
         self.allow_external_sources = bool(allow_external_sources)
+        self.mpi_grid = mpi_grid
+        self.mpi_comm = mpi_comm if mpi_grid is None else mpi_grid.comm
+        self.global_surfaces = (
+            None if global_surfaces is None else MappingProxyType(dict(global_surfaces))
+        )
+        if self.mpi_comm is not None and self.global_surfaces is None:
+            raise ValueError("MPI NTFF collection requires the global component surfaces")
+        if self.mpi_comm is not None:
+            self.collection_backend = f"mpi_{self.collection_backend}"
         self.wave_speed = None if wave_speed is None else float(wave_speed)
         self.impedance = None if impedance is None else float(impedance)
         self._wave_speed_override = wave_speed is not None
@@ -601,9 +575,7 @@ class KSIRFrequencyDomainMonitor:
         self.background_material_name = None
         self.surface_material_id = None
         self.closure = (
-            ResolvedKSIRClosure("closed", (), (), True, True)
-            if closure is None
-            else closure
+            ResolvedKSIRClosure("closed", (), (), True, True) if closure is None else closure
         )
         for surface in surfaces.values():
             face_ids = tuple(face.face_id for face in surface.faces)
@@ -645,20 +617,14 @@ class KSIRFrequencyDomainMonitor:
         self._incident_reference_index = None
         self._incident_reference_positions = None
         self._incident_electric = None
-        self._incident_phase = np.ones(
-            self.frequencies.size, dtype=self.complex_dtype
-        )
-        self._incident_step = _dft_phase_at_time(
-            self.frequencies, self.dt, self.complex_dtype
-        )
+        self._incident_phase = np.ones(self.frequencies.size, dtype=self.complex_dtype)
+        self._incident_step = _dft_phase_at_time(self.frequencies, self.dt, self.complex_dtype)
         self._incident_next_iteration = 0
 
     @property
     def result(self) -> KSIRFrequencyResult:
         if self._result is None:
-            raise RuntimeError(
-                "KSIR result is not available until the solver has finalised"
-            )
+            raise RuntimeError("KSIR result is not available until the solver has finalised")
         return self._result
 
     @property
@@ -667,10 +633,11 @@ class KSIRFrequencyDomainMonitor:
             raise RuntimeError("KSIR surface DFT is not available until finalisation")
         return self._surface_data
 
-    def validate_materials(
-        self, material_ids: npt.ArrayLike, id_lookup: Mapping[str, int]
-    ) -> int:
+    def validate_materials(self, material_ids: npt.ArrayLike, id_lookup: Mapping[str, int]) -> int:
         """Verify that all straddling samples use one homogeneous material ID."""
+
+        if self.mpi_comm is not None:
+            return self._validate_materials_mpi(material_ids, id_lookup)
 
         ids = np.asarray(material_ids)
         sampled_ids = []
@@ -683,16 +650,11 @@ class KSIRFrequencyDomainMonitor:
                     self.real_dtype,
                 )
                 if np.any(keep):
-                    sampled_ids.append(
-                        component_ids[tuple(face.inside_indices[keep].T)]
-                    )
-                    sampled_ids.append(
-                        component_ids[tuple(face.outside_indices[keep].T)]
-                    )
+                    sampled_ids.append(component_ids[tuple(face.inside_indices[keep].T)])
+                    sampled_ids.append(component_ids[tuple(face.outside_indices[keep].T)])
         if not sampled_ids:
             raise ValueError(
-                f"KSIR monitor {self.name!r} has no off-symmetry samples "
-                "for material validation"
+                f"KSIR monitor {self.name!r} has no off-symmetry samples " "for material validation"
             )
         unique_ids = np.unique(np.concatenate(sampled_ids))
         if unique_ids.size != 1:
@@ -705,8 +667,7 @@ class KSIRFrequencyDomainMonitor:
             exterior_ids = []
             for component, surface in self.surfaces.items():
                 slices = tuple(
-                    slice(int(lower), int(upper) + 1)
-                    for lower, upper in self.exterior_index_bounds
+                    slice(int(lower), int(upper) + 1) for lower, upper in self.exterior_index_bounds
                 )
                 component_ids = ids[id_lookup[component]][slices]
                 coordinate_axes = [
@@ -715,9 +676,7 @@ class KSIRFrequencyDomainMonitor:
                         + COMPONENT_OFFSETS[component][axis]
                     )
                     * surface.grid_spacing[axis]
-                    for axis, (lower, upper) in enumerate(
-                        self.exterior_index_bounds
-                    )
+                    for axis, (lower, upper) in enumerate(self.exterior_index_bounds)
                 ]
                 coordinates = np.meshgrid(*coordinate_axes, indexing="ij")
                 outside = np.zeros(component_ids.shape, dtype=bool)
@@ -764,15 +723,187 @@ class KSIRFrequencyDomainMonitor:
                         )
                 exterior_ids.append(component_ids[outside])
             exterior_unique = np.unique(np.concatenate(exterior_ids))
-            if (
-                exterior_unique.size != 1
-                or int(exterior_unique[0]) != self.surface_material_id
-            ):
+            if exterior_unique.size != 1 or int(exterior_unique[0]) != self.surface_material_id:
                 raise ValueError(
                     f"KSIR monitor {self.name!r} exterior region is not "
                     "homogeneous with its surface"
                 )
         return self.surface_material_id
+
+    def _validate_materials_mpi(
+        self, material_ids: npt.ArrayLike, id_lookup: Mapping[str, int]
+    ) -> int:
+        """Collectively validate the rank-owned surface samples."""
+
+        from .mpi import distributed_unique
+
+        ids = np.asarray(material_ids)
+        sampled_ids = []
+        for component, surface in self.surfaces.items():
+            component_ids = ids[id_lookup[component]]
+            for face in surface.faces:
+                keep = self.closure.material_validation_mask(
+                    surface,
+                    face,
+                    self.real_dtype,
+                )
+                if np.any(keep):
+                    sampled_ids.append(component_ids[tuple(face.inside_indices[keep].T)])
+                    sampled_ids.append(component_ids[tuple(face.outside_indices[keep].T)])
+        local = np.concatenate(sampled_ids) if sampled_ids else np.empty(0, dtype=np.int64)
+        unique_ids = distributed_unique(local, self.mpi_comm)
+        if unique_ids.size != 1:
+            raise ValueError(
+                f"KSIR monitor {self.name!r} surface straddles multiple material IDs: "
+                f"{unique_ids.tolist()}"
+            )
+        self.surface_material_id = int(unique_ids[0])
+        if self.exterior_index_bounds is not None:
+            exterior_ids = []
+            local_lower = np.asarray(self.mpi_grid.negative_halo_offset, dtype=np.int64)
+            positive_boundary = np.asarray(self.mpi_grid.neighbours[:, 1] < 0, dtype=np.int64)
+            local_upper = np.asarray(self.mpi_grid.size, dtype=np.int64) + positive_boundary
+            global_lower = local_lower + np.asarray(self.mpi_grid.lower_extent, dtype=np.int64)
+            global_upper = local_upper + np.asarray(self.mpi_grid.lower_extent, dtype=np.int64)
+            requested_lower = np.asarray(self.exterior_index_bounds)[:, 0]
+            requested_upper = np.asarray(self.exterior_index_bounds)[:, 1] + 1
+            selected_lower = np.maximum(global_lower, requested_lower)
+            selected_upper = np.minimum(global_upper, requested_upper)
+            if np.all(selected_upper > selected_lower):
+                local_selected_lower = selected_lower - self.mpi_grid.lower_extent
+                local_selected_upper = selected_upper - self.mpi_grid.lower_extent
+                slices = tuple(
+                    slice(int(lower), int(upper))
+                    for lower, upper in zip(local_selected_lower, local_selected_upper)
+                )
+                for component, surface in self.surfaces.items():
+                    component_ids = ids[id_lookup[component]][slices]
+                    coordinate_axes = [
+                        (
+                            np.arange(lower, upper, dtype=self.real_dtype)
+                            + COMPONENT_OFFSETS[component][axis]
+                        )
+                        * surface.grid_spacing[axis]
+                        for axis, (lower, upper) in enumerate(zip(selected_lower, selected_upper))
+                    ]
+                    coordinates = np.meshgrid(*coordinate_axes, indexing="ij")
+                    outside = np.zeros(component_ids.shape, dtype=bool)
+                    for axis in range(3):
+                        outside |= coordinates[axis] < surface.physical_lower[axis]
+                        outside |= coordinates[axis] > surface.physical_upper[axis]
+                    on_symmetry_plane = np.zeros(component_ids.shape, dtype=bool)
+                    for plane in self.closure.symmetry_planes:
+                        tolerance = (
+                            16
+                            * np.finfo(self.real_dtype).eps
+                            * max(
+                                abs(plane.coordinate),
+                                surface.grid_spacing[plane.axis],
+                            )
+                        )
+                        on_symmetry_plane |= np.isclose(
+                            coordinates[plane.axis],
+                            plane.coordinate,
+                            rtol=0,
+                            atol=tolerance,
+                        )
+                    outside &= ~on_symmetry_plane
+                    for face in self.closure.omitted_faces:
+                        axis = "xyz".index(face[0])
+                        tolerance = (
+                            16
+                            * np.finfo(self.real_dtype).eps
+                            * max(
+                                abs(surface.physical_lower[axis]),
+                                abs(surface.physical_upper[axis]),
+                                surface.grid_spacing[axis],
+                            )
+                        )
+                        if face.endswith("0"):
+                            outside &= (
+                                coordinates[axis]
+                                > surface.physical_lower[axis]
+                                + surface.grid_spacing[axis]
+                                + tolerance
+                            )
+                        else:
+                            outside &= (
+                                coordinates[axis]
+                                < surface.physical_upper[axis]
+                                - surface.grid_spacing[axis]
+                                - tolerance
+                            )
+                    exterior_ids.append(component_ids[outside])
+            exterior_local = (
+                np.concatenate(exterior_ids) if exterior_ids else np.empty(0, dtype=np.int64)
+            )
+            exterior_unique = distributed_unique(exterior_local, self.mpi_comm)
+            if exterior_unique.size != 1 or int(exterior_unique[0]) != self.surface_material_id:
+                raise ValueError(
+                    f"KSIR monitor {self.name!r} exterior region is not "
+                    "homogeneous with its surface"
+                )
+        return self.surface_material_id
+
+    def _gather_mpi_surface_data(self, data):
+        """Assemble rank-local surface phasors on the coordinator once."""
+
+        from .mpi import global_patch_indices
+
+        payload = {}
+        for component, component_data in data.items():
+            payload[component] = (
+                global_patch_indices(component_data.surface),
+                component_data.field,
+                component_data.normal_derivative,
+            )
+        gathered = self.mpi_comm.gather(payload, root=0)
+        if self.mpi_comm.Get_rank() != 0:
+            return None
+
+        assembled = {}
+        for component in self.components:
+            surface = self.global_surfaces[component]
+            shape = (self.frequencies.size, surface.npatches)
+            field = np.empty(shape, dtype=self.complex_dtype)
+            derivative = np.empty(shape, dtype=self.complex_dtype)
+            assigned = np.zeros(surface.npatches, dtype=np.int8)
+            for rank_payload in gathered:
+                indices, rank_field, rank_derivative = rank_payload[component]
+                if np.any(assigned[indices]):
+                    raise RuntimeError(
+                        f"MPI NTFF {component} surface patches have duplicate owners"
+                    )
+                field[:, indices] = rank_field
+                derivative[:, indices] = rank_derivative
+                assigned[indices] = 1
+            if not np.all(assigned):
+                missing = np.flatnonzero(assigned == 0)
+                raise RuntimeError(
+                    f"MPI NTFF {component} surface has {missing.size} unowned patches"
+                )
+            _readonly(field)
+            _readonly(derivative)
+            signature = surface_compatibility_signature(
+                surface,
+                self.frequencies,
+                self.dt,
+                self.iterations,
+                (0.0 if component in ELECTRIC_COMPONENTS else 0.5 * self.dt),
+                self.window_name,
+                self.background_er,
+                self.background_mr,
+                self.closure.signature,
+                self.complex_dtype,
+            )
+            assembled[component] = KSIRComponentPhasors(
+                component=component,
+                surface=surface,
+                field=field,
+                normal_derivative=derivative,
+                compatibility_signature=signature,
+            )
+        return MappingProxyType(assembled)
 
     def configure_background(self, materials: Sequence) -> None:
         """Resolve lossless homogeneous Green-function properties."""
@@ -816,21 +947,15 @@ class KSIRFrequencyDomainMonitor:
         if not self._wave_speed_override:
             self.wave_speed = c / np.sqrt(self.background_er * self.background_mr)
         if not self._impedance_override:
-            self.impedance = np.sqrt(
-                mu_0 * self.background_mr / (epsilon_0 * self.background_er)
-            )
+            self.impedance = np.sqrt(mu_0 * self.background_mr / (epsilon_0 * self.background_er))
 
-    def associate_plane_wave(
-        self, plane_wave, grid_spacing: npt.ArrayLike, index: int
-    ) -> None:
+    def associate_plane_wave(self, plane_wave, grid_spacing: npt.ArrayLike, index: int) -> None:
         """Associate an enclosed DiscretePlaneWave and prepare incident DFT."""
 
         self.associated_plane_wave = plane_wave
         spacing = np.asarray(grid_spacing, dtype=self.real_dtype)
         reference_index = np.rint(self.origin / spacing).astype(np.int64)
-        one_d_index = int(
-            np.dot(plane_wave.m[:3], reference_index - plane_wave.origin)
-        )
+        one_d_index = int(np.dot(plane_wave.m[:3], reference_index - plane_wave.origin))
         if plane_wave.axial != 0:
             one_d_index += int(plane_wave.origin_axial)
         if one_d_index < 0 or one_d_index >= plane_wave.E_fields.shape[1]:
@@ -847,19 +972,13 @@ class KSIRFrequencyDomainMonitor:
                 ]
             )
         )
-        self._incident_electric = np.zeros(
-            (self.frequencies.size, 3), dtype=self.complex_dtype
-        )
+        self._incident_electric = np.zeros((self.frequencies.size, 3), dtype=self.complex_dtype)
         self.plane_wave_metadata = {
             "index": int(index),
             "corners": np.asarray(plane_wave.corners, dtype=np.int32),
             "waveform_id": plane_wave.waveformID,
-            "material_id": (
-                "" if plane_wave.materialID is None else plane_wave.materialID
-            ),
-            "actual_angles": np.asarray(
-                plane_wave.actual_angles, dtype=self.real_dtype
-            ),
+            "material_id": ("" if plane_wave.materialID is None else plane_wave.materialID),
+            "actual_angles": np.asarray(plane_wave.actual_angles, dtype=self.real_dtype),
             "polarisation_angle": float(plane_wave.psi),
             "integer_mapping": np.asarray(plane_wave.m[:3], dtype=np.int32),
             "start": float(plane_wave.start),
@@ -884,9 +1003,7 @@ class KSIRFrequencyDomainMonitor:
         if self.associated_plane_wave is None:
             return
         multiplier = self.device_incident_sampling_multiplier(iteration)
-        incident = self.associated_plane_wave.E_fields[
-            :, self._incident_reference_index
-        ]
+        incident = self.associated_plane_wave.E_fields[:, self._incident_reference_index]
         self._incident_electric += multiplier[:, np.newaxis] * incident[np.newaxis, :]
 
     def device_incident_sampling_multiplier(
@@ -900,9 +1017,7 @@ class KSIRFrequencyDomainMonitor:
         """
 
         if self.associated_plane_wave is None:
-            raise RuntimeError(
-                f"KSIR monitor {self.name!r} has no associated incident plane wave"
-            )
+            raise RuntimeError(f"KSIR monitor {self.name!r} has no associated incident plane wave")
         if iteration != self._incident_next_iteration:
             raise ValueError(
                 f"expected incident iteration {self._incident_next_iteration}, "
@@ -923,9 +1038,7 @@ class KSIRFrequencyDomainMonitor:
         """Load an incident electric-field DFT downloaded at finalisation."""
 
         if self.associated_plane_wave is None or self._incident_electric is None:
-            raise RuntimeError(
-                f"KSIR monitor {self.name!r} has no associated incident plane wave"
-            )
+            raise RuntimeError(f"KSIR monitor {self.name!r} has no associated incident plane wave")
         incident = np.asarray(values, dtype=self.complex_dtype)
         if incident.shape != self._incident_electric.shape:
             raise ValueError(
@@ -984,8 +1097,7 @@ class KSIRFrequencyDomainMonitor:
             monitor_path = f"ntff/{self.incident_monitor_name}"
             if monitor_path not in source:
                 raise ValueError(
-                    "incident surface file has no monitor "
-                    f"{self.incident_monitor_name!r}"
+                    "incident surface file has no monitor " f"{self.incident_monitor_name!r}"
                 )
             monitor_group = source[monitor_path]
             for attr, expected in (
@@ -997,30 +1109,22 @@ class KSIRFrequencyDomainMonitor:
                 if isinstance(actual, bytes):
                     actual = actual.decode()
                 if actual != expected:
-                    raise ValueError(
-                        f"incident surface convention {attr!r} is incompatible"
-                    )
+                    raise ValueError(f"incident surface convention {attr!r} is incompatible")
             if "surface" not in monitor_group:
                 raise ValueError("incident monitor does not contain saved surface DFTs")
 
             subtracted: Dict[str, KSIRComponentPhasors] = {}
             for component, current in data.items():
                 if component not in monitor_group["surface"]:
-                    raise ValueError(
-                        f"incident monitor has no {component} surface DFT"
-                    )
+                    raise ValueError(f"incident monitor has no {component} surface DFT")
                 group = monitor_group["surface"][component]
                 signature = group.attrs.get("compatibility_signature")
                 if isinstance(signature, bytes):
                     signature = signature.decode()
                 if signature != current.compatibility_signature:
-                    raise ValueError(
-                        f"incident {component} surface DFT is incompatible"
-                    )
+                    raise ValueError(f"incident {component} surface DFT is incompatible")
                 field = np.asarray(current.field) - group["psi_dft"][:]
-                derivative = (
-                    np.asarray(current.normal_derivative) - group["dn_psi_dft"][:]
-                )
+                derivative = np.asarray(current.normal_derivative) - group["dn_psi_dft"][:]
                 _readonly(field)
                 _readonly(derivative)
                 subtracted[component] = KSIRComponentPhasors(
@@ -1040,9 +1144,7 @@ class KSIRFrequencyDomainMonitor:
         if not any(component in fields for component in components):
             return None
         shape = (self.frequencies.size, self.directions.shape[0], 3)
-        cartesian = np.full(
-            shape, np.nan + 1j * np.nan, dtype=self.complex_dtype
-        )
+        cartesian = np.full(shape, np.nan + 1j * np.nan, dtype=self.complex_dtype)
         for axis, component in enumerate(components):
             if component in fields:
                 cartesian[:, :, axis] = fields[component]
@@ -1077,9 +1179,7 @@ class KSIRFrequencyDomainMonitor:
         power = np.trapezoid(phi_integral, theta_rad, axis=1)
         directivity = np.full_like(radiation_intensity, np.nan)
         valid = power > 0
-        directivity[valid] = (
-            4 * np.pi * radiation_intensity[valid] / power[valid, np.newaxis]
-        )
+        directivity[valid] = 4 * np.pi * radiation_intensity[valid] / power[valid, np.newaxis]
         maximum = np.full(power.shape, np.nan, dtype=self.real_dtype)
         maximum[valid] = np.max(directivity[valid], axis=1)
         return _readonly(power), _readonly(directivity), _readonly(maximum)
@@ -1088,9 +1188,7 @@ class KSIRFrequencyDomainMonitor:
         if self._finalised:
             return
         if self.wave_speed is None or self.impedance is None:
-            raise RuntimeError(
-                f"KSIR monitor {self.name!r} background material was not configured"
-            )
+            raise RuntimeError(f"KSIR monitor {self.name!r} background material was not configured")
         if (
             self.associated_plane_wave is not None
             and self._incident_next_iteration != self.iterations
@@ -1102,13 +1200,35 @@ class KSIRFrequencyDomainMonitor:
 
         raw_data = MappingProxyType(
             {
-                component: accumulator.finalise(
-                    self.background_er, self.background_mr
-                )
+                component: accumulator.finalise(self.background_er, self.background_mr)
                 for component, accumulator in self._accumulators.items()
             }
         )
-        data = self._subtract_incident_surface(raw_data)
+        if self.mpi_comm is not None:
+            coordinator = self.mpi_comm.Get_rank() == 0
+            mpi_error = None
+            gathered_data = None
+            try:
+                gathered_data = self._gather_mpi_surface_data(raw_data)
+                if coordinator:
+                    gathered_data = self._subtract_incident_surface(gathered_data)
+            except Exception as exc:  # propagate coordinator-only finalisation failures
+                if coordinator:
+                    mpi_error = f"{exc.__class__.__name__}: {exc}"
+                else:  # pragma: no cover - gather failures are coordinator-side
+                    raise
+            mpi_error = self.mpi_comm.bcast(mpi_error, root=0)
+            if mpi_error is not None:
+                raise RuntimeError(
+                    f"MPI NTFF monitor {self.name!r} could not assemble its surface data: "
+                    f"{mpi_error}"
+                )
+            if not coordinator:
+                self._finalised = True
+                return
+            data = gathered_data
+        else:
+            data = self._subtract_incident_surface(raw_data)
         self._surface_data = data
 
         fields: Dict[str, npt.NDArray[np.complexfloating]] = {}
@@ -1132,9 +1252,7 @@ class KSIRFrequencyDomainMonitor:
             face_contributions[component] = contributions
             numerator = np.sum(np.abs(contributions), axis=2)
             denominator = np.abs(values)
-            indicator = np.full(
-                denominator.shape, np.inf, dtype=self.real_dtype
-            )
+            indicator = np.full(denominator.shape, np.inf, dtype=self.real_dtype)
             np.divide(
                 numerator,
                 denominator,
@@ -1142,17 +1260,10 @@ class KSIRFrequencyDomainMonitor:
                 where=denominator > 0,
             )
             cancellation_indicators[component] = _readonly(indicator)
-            active_areas[component] = float(
-                np.sum(component_data.surface.area_weights)
-            )
-            extents = (
-                component_data.surface.physical_upper
-                - component_data.surface.physical_lower
-            )
+            active_areas[component] = float(np.sum(component_data.surface.area_weights))
+            extents = component_data.surface.physical_upper - component_data.surface.physical_lower
             full_area = 2 * (
-                extents[0] * extents[1]
-                + extents[0] * extents[2]
-                + extents[1] * extents[2]
+                extents[0] * extents[1] + extents[0] * extents[2] + extents[1] * extents[2]
             )
             missing_fractions[component] = (
                 max(0.0, 1.0 - active_areas[component] / full_area)
@@ -1163,12 +1274,8 @@ class KSIRFrequencyDomainMonitor:
 
         electric_cartesian = self._cartesian(fields, ELECTRIC_COMPONENTS)
         magnetic_cartesian = self._cartesian(fields, MAGNETIC_COMPONENTS)
-        complete_electric = all(
-            component in fields for component in ELECTRIC_COMPONENTS
-        )
-        complete_magnetic = all(
-            component in fields for component in MAGNETIC_COMPONENTS
-        )
+        complete_electric = all(component in fields for component in ELECTRIC_COMPONENTS)
+        complete_magnetic = all(component in fields for component in MAGNETIC_COMPONENTS)
         electric_spherical = (
             None
             if not complete_electric
@@ -1196,8 +1303,7 @@ class KSIRFrequencyDomainMonitor:
         bistatic_rcs = None
         if complete_electric:
             tangential_squared = (
-                np.abs(electric_spherical[:, :, 1]) ** 2
-                + np.abs(electric_spherical[:, :, 2]) ** 2
+                np.abs(electric_spherical[:, :, 1]) ** 2 + np.abs(electric_spherical[:, :, 2]) ** 2
             )
             radiation_intensity = _readonly(
                 np.asarray(
@@ -1206,30 +1312,22 @@ class KSIRFrequencyDomainMonitor:
                 )
             )
             tangential = np.sqrt(tangential_squared)
-            transversality_error = np.full(
-                tangential.shape, np.nan, dtype=self.real_dtype
-            )
+            transversality_error = np.full(tangential.shape, np.nan, dtype=self.real_dtype)
             nonzero = tangential > 0
             transversality_error[nonzero] = (
-                np.abs(electric_spherical[:, :, 0][nonzero])
-                / tangential[nonzero]
+                np.abs(electric_spherical[:, :, 0][nonzero]) / tangential[nonzero]
             )
             _readonly(transversality_error)
             if self.closure.mathematically_closed:
-                radiated_power, directivity, maximum_directivity = (
-                    self._integrated_metrics(radiation_intensity)
+                radiated_power, directivity, maximum_directivity = self._integrated_metrics(
+                    radiation_intensity
                 )
             if self._incident_electric is not None:
                 incident_power = np.sum(np.abs(self._incident_electric) ** 2, axis=1)
-                bistatic_rcs = np.full(
-                    tangential_squared.shape, np.nan, dtype=self.real_dtype
-                )
+                bistatic_rcs = np.full(tangential_squared.shape, np.nan, dtype=self.real_dtype)
                 valid = incident_power > 0
                 bistatic_rcs[valid] = (
-                    4
-                    * np.pi
-                    * tangential_squared[valid]
-                    / incident_power[valid, np.newaxis]
+                    4 * np.pi * tangential_squared[valid] / incident_power[valid, np.newaxis]
                 )
                 _readonly(bistatic_rcs)
 
@@ -1288,9 +1386,7 @@ class KSIRFrequencyDomainMonitor:
         group.attrs["closure"] = self.closure.name
         group.attrs["mathematically_closed"] = self.closure.mathematically_closed
         group.attrs["closure_exact"] = self.closure.exact
-        group.attrs["omitted_faces"] = np.asarray(
-            self.closure.omitted_faces, dtype="S5"
-        )
+        group.attrs["omitted_faces"] = np.asarray(self.closure.omitted_faces, dtype="S5")
         group.attrs["symmetry_plane_faces"] = np.asarray(
             [plane.face for plane in self.closure.symmetry_planes], dtype="S5"
         )
@@ -1316,14 +1412,9 @@ class KSIRFrequencyDomainMonitor:
         group.attrs["iterations"] = self.iterations
         group.attrs["components"] = np.asarray(self.components, dtype="S2")
         group.attrs["sample_time_offsets"] = np.asarray(
-            [
-                0.0 if item in ELECTRIC_COMPONENTS else 0.5 * self.dt
-                for item in self.components
-            ]
+            [0.0 if item in ELECTRIC_COMPONENTS else 0.5 * self.dt for item in self.components]
         )
-        group.attrs["incident_surface_subtracted"] = (
-            self.incident_surface_file is not None
-        )
+        group.attrs["incident_surface_subtracted"] = self.incident_surface_file is not None
         group.attrs["allow_external_sources"] = self.allow_external_sources
         if self.incident_surface_file is not None:
             group.attrs["incident_surface_file"] = str(self.incident_surface_file)
@@ -1347,9 +1438,7 @@ class KSIRFrequencyDomainMonitor:
             cancellation_group[component] = result.cancellation_indicator[component]
             component_group = diagnostics_group.create_group(component)
             component_group.attrs["active_area"] = result.active_area[component]
-            component_group.attrs["missing_area_fraction"] = (
-                result.missing_area_fraction[component]
-            )
+            component_group.attrs["missing_area_fraction"] = result.missing_area_fraction[component]
         for name, values in (
             ("E_cartesian", result.electric_cartesian),
             ("E_spherical", result.electric_spherical),
@@ -1375,9 +1464,7 @@ class KSIRFrequencyDomainMonitor:
             surface_group = group.create_group("surface")
             for component, data in self.surface_data.items():
                 component_group = surface_group.create_group(component)
-                component_group.attrs["compatibility_signature"] = (
-                    data.compatibility_signature
-                )
+                component_group.attrs["compatibility_signature"] = data.compatibility_signature
                 component_group.attrs["logical_lower"] = data.surface.lower
                 component_group.attrs["logical_upper"] = data.surface.upper
                 component_group.attrs["physical_lower"] = data.surface.physical_lower
@@ -1418,22 +1505,16 @@ def evaluate_saved_surface_dft(
                 raise ValueError(f"saved surface convention {attr!r} is incompatible")
         if "surface" not in group:
             raise ValueError("saved monitor does not contain surface DFTs")
-        stored_real_dtype = group.attrs.get(
-            "real_dtype", group["frequencies"].dtype.name
-        )
+        stored_real_dtype = group.attrs.get("real_dtype", group["frequencies"].dtype.name)
         if isinstance(stored_real_dtype, bytes):
             stored_real_dtype = stored_real_dtype.decode()
         real_dtype = np.dtype(stored_real_dtype)
         theta_values = _angles("theta", theta, real_dtype)
         phi_values = _angles("phi", phi, real_dtype)
-        theta_grid, phi_grid = np.meshgrid(
-            theta_values, phi_values, indexing="ij"
-        )
+        theta_grid, phi_grid = np.meshgrid(theta_values, phi_values, indexing="ij")
         paired_theta = _readonly(theta_grid.ravel())
         paired_phi = _readonly(phi_grid.ravel())
-        directions = _readonly(
-            spherical_directions(paired_theta, paired_phi, degrees=True)
-        )
+        directions = _readonly(spherical_directions(paired_theta, paired_phi, degrees=True))
         closure_name = group.attrs.get("closure", "closed")
         if isinstance(closure_name, bytes):
             closure_name = closure_name.decode()
@@ -1441,8 +1522,7 @@ def evaluate_saved_surface_dft(
         def decoded_strings(name):
             values = np.atleast_1d(group.attrs.get(name, ()))
             return tuple(
-                value.decode() if isinstance(value, bytes) else str(value)
-                for value in values
+                value.decode() if isinstance(value, bytes) else str(value) for value in values
             )
 
         closure = closure_from_metadata(
@@ -1450,9 +1530,7 @@ def evaluate_saved_surface_dft(
             decoded_strings("omitted_faces"),
             decoded_strings("symmetry_plane_faces"),
             decoded_strings("symmetry_plane_types"),
-            np.atleast_1d(
-                group.attrs.get("symmetry_plane_coordinates", ())
-            ),
+            np.atleast_1d(group.attrs.get("symmetry_plane_coordinates", ())),
         )
         frequencies = _readonly(group["frequencies"][:])
         reference_origin = np.asarray(
@@ -1476,12 +1554,8 @@ def evaluate_saved_surface_dft(
                     real_dtype=real_dtype,
                 )
             )
-            if not np.array_equal(
-                surface.patch_positions, component_group["patch_xyz"][:]
-            ):
-                raise ValueError(
-                    f"saved {component} surface geometry is inconsistent"
-                )
+            if not np.array_equal(surface.patch_positions, component_group["patch_xyz"][:]):
+                raise ValueError(f"saved {component} surface geometry is inconsistent")
             values, _ = _evaluate_component_with_closure(
                 surface,
                 component_group["psi_dft"][:],

--- a/gprMax/ntff/interface.py
+++ b/gprMax/ntff/interface.py
@@ -398,9 +398,13 @@ class _CompiledSurface:
 def _resolve_surface_closure(spec: NTFFSurfaceSpec, grid, real_dtype):
     lower = np.asarray(spec.lower)
     upper = np.asarray(spec.upper)
+    domain_size = np.asarray(getattr(grid, "global_size", grid.size))
     touches_symmetry = any(
         (face.endswith("0") and lower["xyz".index(face[0])] == 0)
-        or (face.endswith("max") and upper["xyz".index(face[0])] == grid.size["xyz".index(face[0])])
+        or (
+            face.endswith("max")
+            and upper["xyz".index(face[0])] == domain_size["xyz".index(face[0])]
+        )
         for face in grid.symmetry_boundaries
     )
     if spec.omit_faces:
@@ -416,7 +420,7 @@ def _resolve_surface_closure(spec: NTFFSurfaceSpec, grid, real_dtype):
         grid.symmetry_boundaries,
         spec.lower,
         spec.upper,
-        grid.size,
+        domain_size,
         grid.dl,
         real_dtype=real_dtype,
     )
@@ -449,11 +453,20 @@ def surface_reference_origin(spec: NTFFSurfaceSpec, grid, real_dtype) -> npt.NDA
 
 
 def _surface_pml_limits(grid) -> tuple[tuple[int, int], ...]:
-    pml = grid.pmls["thickness"]
+    pml = dict(grid.pmls["thickness"])
+    if hasattr(grid, "comm"):
+        gathered = grid.comm.allgather(pml)
+        pml = {
+            face: max(int(item[face]) for item in gathered)
+            for face in ("x0", "xmax", "y0", "ymax", "z0", "zmax")
+        }
+        size = np.asarray(grid.global_size, dtype=np.int64)
+    else:
+        size = np.asarray((grid.nx, grid.ny, grid.nz), dtype=np.int64)
     return (
-        (pml["x0"], grid.nx if pml["xmax"] == 0 else grid.nx - pml["xmax"] - 1),
-        (pml["y0"], grid.ny if pml["ymax"] == 0 else grid.ny - pml["ymax"] - 1),
-        (pml["z0"], grid.nz if pml["zmax"] == 0 else grid.nz - pml["zmax"] - 1),
+        (pml["x0"], size[0] if pml["xmax"] == 0 else size[0] - pml["xmax"] - 1),
+        (pml["y0"], size[1] if pml["ymax"] == 0 else size[1] - pml["ymax"] - 1),
+        (pml["z0"], size[2] if pml["zmax"] == 0 else size[2] - pml["zmax"] - 1),
     )
 
 
@@ -483,9 +496,15 @@ def _surface_material_id(surfaces: Mapping, closure, grid) -> int:
             if np.any(keep):
                 sampled_ids.append(component_ids[tuple(face.inside_indices[keep].T)])
                 sampled_ids.append(component_ids[tuple(face.outside_indices[keep].T)])
-    if not sampled_ids:
+    if hasattr(grid, "comm"):
+        from gprMax.ntff.mpi import distributed_unique
+
+        local = np.concatenate(sampled_ids) if sampled_ids else np.empty(0, dtype=np.int64)
+        unique = distributed_unique(local, grid.comm)
+    elif not sampled_ids:
         raise ValueError("NTFF surface has no off-symmetry samples for material validation")
-    unique = np.unique(np.concatenate(sampled_ids))
+    else:
+        unique = np.unique(np.concatenate(sampled_ids))
     if unique.size != 1:
         raise ValueError(f"NTFF surface straddles multiple material IDs: {unique.tolist()}")
     return int(unique[0])
@@ -670,6 +689,8 @@ def validate_ntff_source_enclosure(model, grid) -> None:
                         COMPONENT_OFFSETS[component], dtype=np.float64
                     )
                     if source_grid is model.G:
+                        if hasattr(source_grid, "global_size"):
+                            local_position = source_grid.local_to_global_coordinate(local_position)
                         position = local_position * np.asarray(source_grid.dl, dtype=np.float64)
                     else:
                         position = np.asarray(
@@ -695,6 +716,8 @@ def validate_ntff_source_enclosure(model, grid) -> None:
                     COMPONENT_OFFSETS[component], dtype=np.float64
                 )
                 if source_grid is model.G:
+                    if hasattr(source_grid, "global_size"):
+                        local_position = source_grid.local_to_global_coordinate(local_position)
                     position = local_position * np.asarray(source_grid.dl, dtype=np.float64)
                 else:
                     position = np.asarray(
@@ -730,10 +753,22 @@ def validate_ntff_source_enclosure(model, grid) -> None:
                 transverse_axes = np.asarray(source.transverse_axes, dtype=np.intp)
                 local_lower = np.zeros(3, dtype=np.float64)
                 local_upper = np.zeros(3, dtype=np.float64)
-                local_lower[source.normal_axis] = source.plane_index
-                local_upper[source.normal_axis] = source.plane_index
-                local_lower[transverse_axes] = source.transverse_start
-                local_upper[transverse_axes] = source.transverse_stop
+                if source_grid is model.G and hasattr(source_grid, "global_size"):
+                    plane_index = getattr(source, "global_plane_index", source.plane_index)
+                    transverse_start = getattr(
+                        source, "global_transverse_start", source.transverse_start
+                    )
+                    transverse_stop = getattr(
+                        source, "global_transverse_stop", source.transverse_stop
+                    )
+                else:
+                    plane_index = source.plane_index
+                    transverse_start = source.transverse_start
+                    transverse_stop = source.transverse_stop
+                local_lower[source.normal_axis] = plane_index
+                local_upper[source.normal_axis] = plane_index
+                local_lower[transverse_axes] = transverse_start
+                local_upper[transverse_axes] = transverse_stop
                 if source_grid is model.G:
                     box_lower = local_lower * spacing
                     box_upper = local_upper * spacing
@@ -755,6 +790,11 @@ def validate_ntff_source_enclosure(model, grid) -> None:
                         f"{tuple(box_lower)} m to {tuple(box_upper)} m"
                     )
 
+        if hasattr(grid, "comm"):
+            offenders = [
+                item for rank_offenders in grid.comm.allgather(offenders) for item in rank_offenders
+            ]
+            offenders = list(dict.fromkeys(offenders))
         if offenders:
             details = "; ".join(offenders)
             raise ValueError(
@@ -1707,8 +1747,6 @@ def compile_ntff_outputs(model, grid) -> Optional[NTFFCompiledOutputs]:
             "(#ntff_frequency, #ntff_far_field or #ntff_far_field_array, and "
             "#ntff_antenna_ports when gain is requested) instead"
         )
-    if config.sim_config.mpi:
-        raise ValueError("the reusable NTFF interface does not yet support MPI")
     if config.sim_config.general["solver"] not in ("cpu", "cuda", "opencl", "metal"):
         raise ValueError(
             "the reusable NTFF interface supports CPU, CUDA, OpenCL, and Metal solvers"
@@ -1871,7 +1909,9 @@ def compile_ntff_outputs(model, grid) -> Optional[NTFFCompiledOutputs]:
     needed_surface_ids.update(item.surface_id for item in time_requests)
     needed_surface_ids.update(item.surface_id for item in time_far_requests)
     real_dtype = config.sim_config.dtypes["float_or_double"]
-    field_shape = tuple(int(value + 1) for value in grid.size)
+    mpi_grid = grid if hasattr(grid, "comm") else None
+    global_size = grid.global_size if mpi_grid is not None else grid.size
+    field_shape = tuple(int(value + 1) for value in global_size)
     compiled_surfaces = {}
     for surface_id in needed_surface_ids:
         spec = surface_specs[surface_id]
@@ -1902,6 +1942,18 @@ def compile_ntff_outputs(model, grid) -> Optional[NTFFCompiledOutputs]:
             origin=origin,
             pml_limits=limits,
         )
+
+    if mpi_grid is not None:
+        from gprMax.ntff.mpi import localise_surfaces
+
+        local_surfaces = {
+            surface_id: localise_surfaces(compiled.surfaces, grid)
+            for surface_id, compiled in compiled_surfaces.items()
+        }
+    else:
+        local_surfaces = {
+            surface_id: compiled.surfaces for surface_id, compiled in compiled_surfaces.items()
+        }
 
     for transform in equivalent_transform_specs.values():
         closure = compiled_surfaces[transform.surface_id].closure
@@ -1955,7 +2007,7 @@ def compile_ntff_outputs(model, grid) -> Optional[NTFFCompiledOutputs]:
             writer.time_bindings[request.key] = (None, slice(offset, stop))
             offset = stop
         point_array = _readonly(np.concatenate(points), real_dtype)
-        selected_surfaces = {item: compiled.surfaces[item] for item in dependencies}
+        selected_surfaces = {item: local_surfaces[surface_id][item] for item in dependencies}
         _, wave_speed, _ = _background_properties(selected_surfaces, compiled.closure, grid)
         monitor = KSIRTimeDomainMonitor(
             f"_ksir_time_{surface_id}_{group_index}",
@@ -1973,6 +2025,7 @@ def compile_ntff_outputs(model, grid) -> Optional[NTFFCompiledOutputs]:
                 else None
             ),
             closure=compiled.closure,
+            mpi_comm=None if mpi_grid is None else grid.comm,
         )
         monitor.managed_output = True
         grid.ntff_monitors.append(monitor)
@@ -1994,7 +2047,9 @@ def compile_ntff_outputs(model, grid) -> Optional[NTFFCompiledOutputs]:
             stop = offset + request.theta.size
             writer.time_far_bindings[request.key] = (None, slice(offset, stop))
             offset = stop
-        _, wave_speed, impedance = _background_properties(compiled.surfaces, compiled.closure, grid)
+        _, wave_speed, impedance = _background_properties(
+            local_surfaces[surface_id], compiled.closure, grid
+        )
         monitor = EquivalentCurrentTimeMonitor(
             f"_ntff_time_far_{surface_id}_{group_index}",
             compiled.spec.lower,
@@ -2015,6 +2070,7 @@ def compile_ntff_outputs(model, grid) -> Optional[NTFFCompiledOutputs]:
                 if config.sim_config.general["solver"] in ("cuda", "opencl", "metal")
                 else None
             ),
+            mpi_grid=mpi_grid,
         )
         monitor.surfaces = compiled.surfaces
         monitor.closure = compiled.closure
@@ -2036,7 +2092,9 @@ def compile_ntff_outputs(model, grid) -> Optional[NTFFCompiledOutputs]:
                 for component in component_dependencies(request.outputs):
                     if component not in dependencies:
                         dependencies.append(component)
-        selected_surfaces = {item: compiled.surfaces[item] for item in dependencies}
+        selected_surfaces = {
+            item: local_surfaces[transform.surface_id][item] for item in dependencies
+        }
         monitor = KSIRFrequencyDomainMonitor(
             f"_ntff_frequency_{transform_id}",
             selected_surfaces,
@@ -2054,12 +2112,19 @@ def compile_ntff_outputs(model, grid) -> Optional[NTFFCompiledOutputs]:
             save_surface_dft=transform.save_surface_dft,
             exterior_index_bounds=compiled.pml_limits,
             closure=compiled.closure,
+            mpi_comm=None if mpi_grid is None else grid.comm,
+            mpi_grid=mpi_grid,
+            global_surfaces=(
+                None
+                if mpi_grid is None
+                else {item: compiled.surfaces[item] for item in dependencies}
+            ),
         )
         if transform.formulation == "equivalent_current" and compiled.closure.omitted_faces:
             monitor.external_source_faces = compiled.closure.omitted_faces
         _associate_plane_wave(
             monitor,
-            selected_surfaces,
+            {item: compiled.surfaces[item] for item in dependencies},
             np.asarray(compiled.spec.lower),
             np.asarray(compiled.spec.upper),
             grid,

--- a/gprMax/ntff/mpi.py
+++ b/gprMax/ntff/mpi.py
@@ -1,0 +1,134 @@
+# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+
+"""MPI partitioning helpers for near-to-far-field integration surfaces."""
+
+from types import MappingProxyType
+from typing import Mapping
+
+import numpy as np
+
+from .surfaces import KSIRComponentSurface, KSIRSurfaceFace
+
+
+def _readonly(values, dtype=None):
+    array = np.ascontiguousarray(values, dtype=dtype)
+    array.setflags(write=False)
+    return array
+
+
+def _patch_owner_ranks(grid, inside_indices):
+    """Return the unique rank owning each inside Yee sample.
+
+    The outside sample differs by one cell in the face-normal direction and
+    is therefore available in the selected rank's existing field halo.
+    """
+
+    return np.fromiter(
+        (grid.get_rank_from_coordinate(index) for index in inside_indices),
+        dtype=np.int32,
+        count=inside_indices.shape[0],
+    )
+
+
+def localise_component_surface(surface: KSIRComponentSurface, grid) -> KSIRComponentSurface:
+    """Partition a global component surface and map its indices to one rank."""
+
+    local_shape = tuple(int(value + 1) for value in grid.size)
+    lower_extent = np.asarray(grid.lower_extent, dtype=np.int32)
+    local_faces = []
+    global_offset = 0
+    for face in surface.faces:
+        owners = _patch_owner_ranks(grid, face.inside_indices)
+        keep = owners == grid.rank
+        global_indices = global_offset + np.flatnonzero(keep)
+        inside = np.asarray(face.inside_indices[keep] - lower_extent, dtype=np.int32)
+        outside = np.asarray(face.outside_indices[keep] - lower_extent, dtype=np.int32)
+        shape = np.asarray(local_shape, dtype=np.int32)
+        if np.any(inside < 0) or np.any(inside >= shape):
+            raise RuntimeError(
+                f"MPI NTFF {face.component} {face.face_id} inside sample is not local"
+            )
+        if np.any(outside < 0) or np.any(outside >= shape):
+            raise RuntimeError(
+                f"MPI NTFF {face.component} {face.face_id} outside sample is not in the halo"
+            )
+        inside_flat = np.ravel_multi_index(inside.T, local_shape).astype(np.int64)
+        outside_flat = np.ravel_multi_index(outside.T, local_shape).astype(np.int64)
+        local_faces.append(
+            KSIRSurfaceFace(
+                component=face.component,
+                face_id=face.face_id,
+                normal_axis=face.normal_axis,
+                normal_sign=face.normal_sign,
+                normal=face.normal,
+                inside_indices=_readonly(inside, np.int32),
+                outside_indices=_readonly(outside, np.int32),
+                inside_flat_indices=_readonly(inside_flat, np.int64),
+                outside_flat_indices=_readonly(outside_flat, np.int64),
+                patch_positions=_readonly(face.patch_positions[keep], face.patch_positions.dtype),
+                area_weights=_readonly(face.area_weights[keep], face.area_weights.dtype),
+                normal_spacing=face.normal_spacing,
+                field_shape=local_shape,
+                global_patch_indices=_readonly(global_indices, np.int64),
+            )
+        )
+        global_offset += face.npatches
+
+    return KSIRComponentSurface(
+        component=surface.component,
+        lower=surface.lower,
+        upper=surface.upper,
+        grid_spacing=surface.grid_spacing,
+        field_shape=local_shape,
+        physical_lower=surface.physical_lower,
+        physical_upper=surface.physical_upper,
+        faces=tuple(local_faces),
+    )
+
+
+def localise_surfaces(surfaces: Mapping[str, KSIRComponentSurface], grid):
+    """Return rank-local views of a set of globally defined surfaces."""
+
+    return MappingProxyType(
+        {
+            component: localise_component_surface(surface, grid)
+            for component, surface in surfaces.items()
+        }
+    )
+
+
+def global_patch_indices(surface: KSIRComponentSurface):
+    """Return concatenated global patch indices for a localised surface."""
+
+    values = [face.global_patch_indices for face in surface.faces]
+    if any(value is None for value in values):
+        raise RuntimeError("surface does not contain MPI global patch indices")
+    return np.ascontiguousarray(np.concatenate(values), dtype=np.int64)
+
+
+def distributed_unique(values, comm):
+    """Return the sorted union of small rank-local integer arrays."""
+
+    local = np.unique(np.asarray(values, dtype=np.int64))
+    gathered = comm.allgather(local)
+    nonempty = [item for item in gathered if item.size]
+    if not nonempty:
+        return np.empty(0, dtype=np.int64)
+    return np.unique(np.concatenate(nonempty))

--- a/gprMax/ntff/surfaces.py
+++ b/gprMax/ntff/surfaces.py
@@ -20,11 +20,10 @@
 """Yee-aligned closed surfaces for the KSIR NTFF formulation."""
 
 from dataclasses import dataclass
-from typing import Dict, Mapping, Sequence, Tuple
+from typing import Dict, Mapping, Optional, Sequence, Tuple
 
 import numpy as np
 import numpy.typing as npt
-
 
 COMPONENTS = ("Ex", "Ey", "Ez", "Hx", "Hy", "Hz")
 """Field components supported by the Cartesian KSIR formulation."""
@@ -74,6 +73,7 @@ class KSIRSurfaceFace:
     area_weights: npt.NDArray[np.floating]
     normal_spacing: float
     field_shape: Tuple[int, int, int]
+    global_patch_indices: Optional[npt.NDArray[np.int64]] = None
 
     @property
     def npatches(self) -> int:
@@ -190,8 +190,7 @@ def _build_face(
     normal_axis, normal_sign = _FACE_SPECS[face_id]
     tangential_axes = tuple(axis for axis in range(3) if axis != normal_axis)
     tangential_ranges = [
-        _component_index_range(lower[axis], upper[axis], offsets[axis])
-        for axis in tangential_axes
+        _component_index_range(lower[axis], upper[axis], offsets[axis]) for axis in tangential_axes
     ]
     tangential_mesh = np.meshgrid(*tangential_ranges, indexing="ij")
     npatches = tangential_mesh[0].size

--- a/gprMax/ntff/time_domain.py
+++ b/gprMax/ntff/time_domain.py
@@ -231,8 +231,12 @@ class _ComponentAccumulator:
         self._fractional_delay = np.ascontiguousarray(
             delay - self._integer_delay, dtype=self.real_dtype
         )
-        self.minimum_delay_steps = np.min(delay, axis=1)
-        self.maximum_integer_delay_steps = np.max(self._integer_delay, axis=1)
+        if surface.npatches:
+            self.minimum_delay_steps = np.min(delay, axis=1)
+            self.maximum_integer_delay_steps = np.max(self._integer_delay, axis=1)
+        else:
+            self.minimum_delay_steps = np.full(points.shape[0], np.inf)
+            self.maximum_integer_delay_steps = np.full(points.shape[0], -np.inf)
         self._inside_indices = np.ascontiguousarray(
             np.concatenate([face.inside_flat_indices for face in self.surface.faces]),
             dtype=np.int64,
@@ -274,6 +278,8 @@ class _ComponentAccumulator:
                 f"field shape {values_array.shape} does not match surface field shape "
                 f"{self.surface.field_shape}"
             )
+        if self.surface.npatches == 0:
+            return self._surface_buffer.copy(), self._derivative_buffer.copy()
         if _gather_time_domain_surface is not None:
             flat = np.ascontiguousarray(values_array, dtype=self.real_dtype).ravel()
             _gather_time_domain_surface(
@@ -305,6 +311,10 @@ class _ComponentAccumulator:
     ) -> None:
         if sample_index != self._last_deposited + 1:
             raise RuntimeError("KSIR samples must be deposited exactly once in time order")
+
+        if self.surface.npatches == 0:
+            self._last_deposited = sample_index
+            return
 
         if _deposit_time_domain_surface is not None:
             _deposit_time_domain_surface(
@@ -423,6 +433,7 @@ class KSIRTimeDomainMonitor:
         time_origin: str = "simulation",
         device_backend: str | None = None,
         closure: ResolvedKSIRClosure | None = None,
+        mpi_comm=None,
     ):
         if not name:
             raise ValueError("KSIR monitor name must not be empty")
@@ -468,6 +479,7 @@ class KSIRTimeDomainMonitor:
         self.nthreads = int(nthreads)
         self.time_origin = time_origin
         self.device_backend = device_backend
+        self.mpi_comm = mpi_comm
         if device_backend is None:
             self.collection_backend = (
                 "cython_openmp"
@@ -477,6 +489,10 @@ class KSIRTimeDomainMonitor:
             )
         else:
             self.collection_backend = f"{device_backend}_device"
+        if self.mpi_comm is not None:
+            if self.device_backend is not None:
+                raise ValueError("MPI NTFF collection is available with the CPU solver")
+            self.collection_backend = f"mpi_{self.collection_backend}"
         self.components = components
         self.surfaces = MappingProxyType(dict(surfaces))
         self.closure = closure or ResolvedKSIRClosure("closed", (), (), True, True)
@@ -541,6 +557,13 @@ class KSIRTimeDomainMonitor:
             ),
             axis=0,
         )
+        if self.mpi_comm is not None:
+            delay_values = self.mpi_comm.allgather((minimum_delay, maximum_integer_delay))
+            minimum_delay = np.min(np.stack([item[0] for item in delay_values]), axis=0)
+            maximum_integer_delay = np.max(np.stack([item[1] for item in delay_values]), axis=0)
+        if not np.all(np.isfinite(minimum_delay)) or not np.all(np.isfinite(maximum_integer_delay)):
+            raise RuntimeError("MPI KSIR surface has no owned patches")
+        maximum_integer_delay = maximum_integer_delay.astype(np.int64)
         if self.time_origin == "first_arrival":
             time_origin_steps = np.floor(minimum_delay).astype(np.int64)
         else:
@@ -600,11 +623,17 @@ class KSIRTimeDomainMonitor:
                 if np.any(keep):
                     sampled_ids.append(component_ids[tuple(face.inside_indices[keep].T)])
                     sampled_ids.append(component_ids[tuple(face.outside_indices[keep].T)])
-        if not sampled_ids:
+        if self.mpi_comm is not None:
+            from .mpi import distributed_unique
+
+            local = np.concatenate(sampled_ids) if sampled_ids else np.empty(0, dtype=np.int64)
+            unique_ids = distributed_unique(local, self.mpi_comm)
+        elif not sampled_ids:
             raise ValueError(
                 f"KSIR monitor {self.name!r} has no off-symmetry samples " "for material validation"
             )
-        unique_ids = np.unique(np.concatenate(sampled_ids))
+        else:
+            unique_ids = np.unique(np.concatenate(sampled_ids))
         if unique_ids.size != 1:
             raise ValueError(
                 f"KSIR monitor {self.name!r} surface straddles multiple material IDs: "
@@ -649,6 +678,25 @@ class KSIRTimeDomainMonitor:
                 accumulator.finalise()
         elif any(accumulator.output is None for accumulator in self._accumulators.values()):
             raise RuntimeError("not all device KSIR component outputs were loaded")
+
+        if self.mpi_comm is not None:
+            from mpi4py import MPI
+
+            coordinator = self.mpi_comm.Get_rank() == 0
+            for accumulator in self._accumulators.values():
+                reduced = np.empty_like(accumulator.output) if coordinator else None
+                self.mpi_comm.Reduce(
+                    accumulator.output,
+                    reduced,
+                    op=MPI.SUM,
+                    root=0,
+                )
+                if coordinator:
+                    reduced.setflags(write=False)
+                    accumulator.output = reduced
+            if not coordinator:
+                self._finalised = True
+                return
 
         times = self.dt * np.arange(self.output_length, dtype=self.real_dtype)
         times.setflags(write=False)

--- a/gprMax/user_objects/cmds_output.py
+++ b/gprMax/user_objects/cmds_output.py
@@ -372,9 +372,7 @@ class NetworkPort(OutputUserObject):
             # MPI point objects are instantiated only on their owning rank.
             if config.sim_config.mpi:
                 return
-            raise RuntimeError(
-                f"{self.params_str()} terminal definition was not instantiated"
-            )
+            raise RuntimeError(f"{self.params_str()} terminal definition was not instantiated")
         if terminal.output is not None:
             raise ValueError(f"{self.params_str()} terminal already has a NetworkPort output.")
 
@@ -623,8 +621,6 @@ def _check_ksir_interface_context(user_object, grid):
             f"{user_object.params_str()} must be defined on the main grid; "
             "its closed surface may enclose complete subgrids."
         )
-    if config.sim_config.mpi:
-        raise ValueError(f"{user_object.params_str()} does not yet support MPI.")
     if config.sim_config.general["solver"] not in ("cpu", "cuda", "opencl", "metal"):
         raise ValueError(
             f"{user_object.params_str()} supports CPU, CUDA, OpenCL, and Metal solvers."
@@ -779,6 +775,13 @@ class NTFFSurface(OutputUserObject):
         lower, upper = uip.check_output_object_bounds(
             self.lower_bound, self.upper_bound, self.params_str()
         )
+        # Main-grid user coordinates are translated into each rank's local
+        # frame during MPI parsing. NTFF surfaces are global objects which
+        # are partitioned only after the Yee grid has been built, so retain
+        # one identical global definition on every rank.
+        if hasattr(grid, "global_size"):
+            lower = grid.local_to_global_coordinate(lower)
+            upper = grid.local_to_global_coordinate(upper)
         origin = None
         if self.origin is not None:
             values = np.asarray(self.origin, dtype=config.sim_config.dtypes["float_or_double"])

--- a/tests/ntff/test_mpi_surface_partition.py
+++ b/tests/ntff/test_mpi_surface_partition.py
@@ -1,0 +1,87 @@
+"""Unit coverage for rank-local NTFF surface ownership."""
+
+import numpy as np
+
+from gprMax.ntff.mpi import global_patch_indices, localise_component_surface
+from gprMax.ntff.surfaces import build_component_surface
+
+
+class _TwoRankGrid:
+    """Minimal 20-cell x-slab decomposition including one negative halo."""
+
+    def __init__(self, rank):
+        self.rank = rank
+        if rank == 0:
+            self.lower_extent = np.asarray((0, 0, 0), dtype=np.int32)
+            self.negative_halo_offset = np.asarray((0, 0, 0), dtype=np.int32)
+            self.size = np.asarray((10, 20, 20), dtype=np.int32)
+        else:
+            self.lower_extent = np.asarray((9, 0, 0), dtype=np.int32)
+            self.negative_halo_offset = np.asarray((1, 0, 0), dtype=np.int32)
+            self.size = np.asarray((11, 20, 20), dtype=np.int32)
+
+    @staticmethod
+    def get_rank_from_coordinate(coordinate):
+        return 0 if int(coordinate[0]) < 10 else 1
+
+
+def test_component_surface_has_one_owner_and_local_halo_indices():
+    global_surface = build_component_surface(
+        "Ez",
+        (7, 7, 7),
+        (13, 13, 13),
+        (0.004, 0.004, 0.004),
+        (21, 21, 21),
+        real_dtype=np.float64,
+    )
+    local = [localise_component_surface(global_surface, _TwoRankGrid(rank)) for rank in (0, 1)]
+
+    indices = np.concatenate([global_patch_indices(surface) for surface in local])
+    np.testing.assert_array_equal(np.sort(indices), np.arange(global_surface.npatches))
+    assert np.unique(indices).size == global_surface.npatches
+
+    global_faces = {face.face_id: face for face in global_surface.faces}
+    face_offsets = {}
+    offset = 0
+    for face in global_surface.faces:
+        face_offsets[face.face_id] = offset
+        offset += face.npatches
+
+    for rank, surface in enumerate(local):
+        grid = _TwoRankGrid(rank)
+        shape = np.asarray(surface.field_shape)
+        for face in surface.faces:
+            assert np.all(face.inside_indices >= 0)
+            assert np.all(face.outside_indices >= 0)
+            assert np.all(face.inside_indices < shape)
+            assert np.all(face.outside_indices < shape)
+            within_face = face.global_patch_indices - face_offsets[face.face_id]
+            expected = global_faces[face.face_id]
+            np.testing.assert_array_equal(
+                face.inside_indices + grid.lower_extent,
+                expected.inside_indices[within_face],
+            )
+            np.testing.assert_array_equal(
+                face.outside_indices + grid.lower_extent,
+                expected.outside_indices[within_face],
+            )
+
+
+def test_rank_with_no_surface_patches_retains_empty_canonical_faces():
+    surface = build_component_surface(
+        "Hy",
+        (7, 7, 7),
+        (13, 13, 13),
+        (0.004, 0.004, 0.004),
+        (21, 21, 21),
+        real_dtype=np.float64,
+    )
+    grid = _TwoRankGrid(1)
+    grid.get_rank_from_coordinate = lambda coordinate: 0
+    local = localise_component_surface(surface, grid)
+
+    assert tuple(face.face_id for face in local.faces) == tuple(
+        face.face_id for face in surface.faces
+    )
+    assert local.npatches == 0
+    assert global_patch_indices(local).size == 0


### PR DESCRIPTION
# PR Description

## Summary

Add domain-decomposed MPI support for the reusable KSIR and
equivalent-current near-to-far-field output interfaces.

The implementation:

- partitions each NTFF component surface between MPI ranks;
- assigns every patch to the rank owning its inside Yee sample;
- obtains the neighbouring outside sample from the existing one-cell halo;
- introduces no additional NTFF communication during FDTD iterations;
- reduces time-domain transformed fields after time stepping;
- assembles frequency-domain surface phasors on the coordinator at
  finalisation;
- preserves the existing serial HDF5 schema and array ordering;
- records MPI collection through the `mpi_` collection-backend prefix;
- performs material, PML, source-enclosure, symmetry-completion, and TFSF
  association checks using global model coordinates;
- supports downstream RCS, directivity, gain, realised gain, efficiency, and
  port-normalised antenna outputs.

Both formulations are supported:

- KSIR time-domain field prediction;
- KSIR frequency-domain fields;
- equivalent-current transient far fields;
- equivalent-current frequency-domain far fields.

## Implementation details

Surface geometry is compiled globally and then localised independently on
each rank. Global patch indices preserve the canonical serial ordering when
frequency-domain data are assembled.

Time-domain outputs are accumulated locally and combined with an MPI
reduction after the solve. Frequency-domain monitors gather the compact
surface phasors only once, after time stepping.

No NTFF-specific collective operation is introduced into the per-iteration
field-update loop.

## Current limitations

- Geometry-fixed NTFF reuse remains unsupported.
- MPI symmetry boundaries remain unsupported.
- NTFF surfaces remain main-grid objects, although they may enclose complete
  HSG subgrids.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] This change requires a documentation update.

## Testing

- 299 NTFF tests passed after rebasing onto current `devel`.
- Serial/MPI parity tested using two- and four-rank decompositions.
- Frequency-domain serial/MPI datasets were bitwise identical.
- Time-domain maximum differences were approximately:
  - KSIR: `1.7e-13`
  - equivalent current: `2.3e-14`
- Analytical MPI checks completed for:
  - Hertzian-dipole near and far fields;
  - PEC and dielectric sphere Mie scattering;
  - dispersive and realistic-material plane-wave reflection;
  - mixed dispersive multilayers;
  - Debye–Lorentz core-shell sphere scattering;
  - rectangular-waveguide eigenmode S-parameters.
- Sphinx documentation build passed with only two unrelated existing
  unused-citation warnings.
- Black, isort, and whitespace checks passed.

## Checklist

- [x] Pre-commit formatting checks passed.
- [x] I have performed a self-review of my code.
- [x] I have added comments for non-obvious MPI ownership and assembly logic.
- [x] I have made corresponding documentation changes.
- [x] My changes generate no new warnings.
- [x] The title is a short description of the changes.
