### PR TITLE
Add MPI support for symmetry boundaries

### DIFF
--- a/docs/source/accelerators.rst
+++ b/docs/source/accelerators.rst
@@ -97,6 +97,12 @@ finalisation. A virtual waveguide replicates its compact auxiliary Yee grid on
 each rank and performs one aperture-sized magnetic-field collective per time
 step to preserve bidirectional coupling.
 
+PEC and PMC symmetry boundaries may be used on MPI domain faces. Boundary
+construction and the PMC ghost-image update are dispatched only on ranks that
+touch the selected global face. Physical domain-edge corrections are similarly
+restricted to ranks that touch both adjoining global faces, so internal halo
+seams retain the ordinary distributed Yee update.
+
 .. figure:: ../../images_shared/mpi_domain_decomposition.png
     :width: 80%
     :align: center

--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -740,10 +740,10 @@ resulting aperture remains sub-cell. For example:
 
 The corrected formulation is supported by the CPU, CUDA, OpenCL, and Metal
 solvers and by domain-decomposed MPI CPU models. Its four magnetic feed edges
-may cross internal MPI rank boundaries; symmetry-boundary completion is not
-supported with MPI. It is also supported inside a CPU ``SubGridHSG``. Add the
-waveform, PEC ground plane, thin wire, and magnetic frill to the same subgrid
-object,
+may cross internal MPI rank boundaries, and PMC image completion is supported
+at minimum-face symmetry corners. It is also supported inside a CPU
+``SubGridHSG``. Add the waveform, PEC ground plane, thin wire, and magnetic
+frill to the same subgrid object,
 using the same global-coordinate convention as other subgrid sources when
 ``autotranslate=True``:
 
@@ -1354,6 +1354,10 @@ Symmetry Boundary
 .. code-block:: python
 
     scene.add(gprMax.SymmetryBoundary(face='x0', type='pmc'))
+
+Domain-decomposed MPI CPU models support the same PEC and PMC boundaries.
+Only ranks touching a selected global face construct and update it, and
+domain-edge corrections are not applied at internal MPI seams.
 
 PML Properties
 --------------

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1463,9 +1463,9 @@ objects (including the waveform) to the same subgrid object.
     * Two frill sources may not share a surrounding H edge. Such adjacent or
       duplicate feeds form a coupled feed-cell system and cannot be advanced
       as independent scalar terminal relations.
-    * MPI symmetry boundaries remain unsupported. An MPI frill and its thin
-      wire may cross internal rank boundaries, but must not rely on symmetry
-      completion at an outer domain face.
+    * MPI symmetry boundaries are supported. A frill and its thin wire may
+      cross internal rank boundaries or use PMC image completion at supported
+      minimum-face symmetry corners.
     * This source is a "Path A" (through-ground-plane, continuous-conductor)
       feed model. It is not intended for a dipole/bow-tie style gap feed
       (:math:`E_z \neq 0` at the feed) - use ``#voltage_source`` for that case.
@@ -2794,5 +2794,13 @@ For example:
 .. note::
 
     * The PML thickness on a symmetry face is set to zero automatically.
-    * PEC and PMC boundaries, including PMC boundaries in models containing dispersive materials, are supported by the CPU, CUDA, OpenCL, and Metal solvers.
-    * Symmetry boundaries are not currently supported in 2D mode, with MPI, or on a subgrid. They may be used on the main grid of a model that contains subgrids.
+    * PEC and PMC boundaries, including PMC boundaries in models containing
+      dispersive materials, are supported by the CPU, CUDA, OpenCL, Metal, and
+      domain-decomposed MPI CPU solvers.
+    * In MPI models, each face is constructed and updated only by ranks that
+      touch that global domain face. Domain-edge corrections are likewise
+      restricted to ranks touching both physical faces; internal rank seams
+      are not treated as symmetry edges.
+    * Symmetry boundaries are not currently supported in 2D mode or on a
+      subgrid. They may be used on the main grid of a model that contains
+      subgrids.

--- a/gprMax/grid/fdtd_grid.py
+++ b/gprMax/grid/fdtd_grid.py
@@ -873,10 +873,18 @@ class FDTDGrid:
             for index, axis in enumerate("xyz"):
                 if index == axis_index:
                     continue
-                if int(start[index]) in (0, int(global_size[index])):
+                coordinate = int(start[index])
+                if coordinate == 0:
+                    face = f"{axis}0"
+                elif coordinate == int(global_size[index]):
+                    face = f"{axis}max"
+                else:
+                    continue
+                if self.symmetry_boundaries.get(face) != "pmc":
                     raise ValueError(
-                        f"{wire} lies on transverse global domain face {axis}; "
-                        "MPI symmetry boundaries are not supported."
+                        f"{wire} lies on transverse global domain face {face}; "
+                        "a thin wire can lie on a transverse wall only when "
+                        "that face is declared as a PMC symmetry boundary."
                     )
 
             component_e = electric_components[wire.wire_axis]
@@ -1154,17 +1162,33 @@ class FDTDGrid:
 
     def _build_symmetry_boundaries(self) -> None:
         """Apply PEC faces and resolve the per-iteration PMC edge dispatch."""
-        if not self.symmetry_boundaries:
+        local_boundaries = self.get_local_symmetry_boundaries()
+        if not local_boundaries:
             return
 
         pec_numid = next(m.numID for m in self.materials if m.ID == "pec")
-        for face, boundary_type in self.symmetry_boundaries.items():
+        for face, boundary_type in local_boundaries.items():
             if boundary_type == "pec":
                 self._force_pec_tangential_e(face, pec_numid)
 
         self.symmetry_boundary_edges = build_symmetry_boundary_edges(self)
         self.symmetry_boundary_edges_dispersive = build_symmetry_boundary_edges_dispersive(self)
         self.symmetry_boundary_edges_dispersive_b = build_symmetry_boundary_edges_dispersive_b(self)
+
+    def get_local_symmetry_boundaries(self) -> dict:
+        """Return symmetry faces that belong to this grid.
+
+        A serial grid owns every global domain face. ``MPIGrid`` overrides
+        this method so an internal rank boundary is never mistaken for a
+        physical PEC/PMC symmetry plane.
+        """
+
+        return self.symmetry_boundaries
+
+    def touches_global_face(self, face: str) -> bool:
+        """Return whether this grid touches a named global domain face."""
+
+        return True
 
     def _force_pec_tangential_e(self, face: str, pec_numid: int) -> None:
         """Force the two tangential E-component IDs on a domain face to PEC."""

--- a/gprMax/grid/mpi_grid.py
+++ b/gprMax/grid/mpi_grid.py
@@ -774,6 +774,39 @@ class MPIGrid(FDTDGrid):
         """
         return self.neighbours[dim][dir] >= 0
 
+    @staticmethod
+    def _symmetry_face_dimension_direction(face: str) -> Tuple[Dim, Dir]:
+        """Map a domain-face name to its Cartesian dimension and side."""
+
+        dimensions = {"x": Dim.X, "y": Dim.Y, "z": Dim.Z}
+        try:
+            dimension = dimensions[face[0]]
+        except (IndexError, KeyError) as exc:
+            raise ValueError(f"Unknown symmetry boundary face '{face}'") from exc
+        direction = Dir.NEG if face.endswith("0") else Dir.POS
+        return dimension, direction
+
+    def touches_global_face(self, face: str) -> bool:
+        """Return whether this rank touches a named global domain face."""
+
+        dimension, direction = self._symmetry_face_dimension_direction(face)
+        return not self.has_neighbour(dimension, direction)
+
+    def get_local_symmetry_boundaries(self) -> dict:
+        """Return declared symmetry faces owned by this MPI rank.
+
+        ``symmetry_boundaries`` remains the complete global declaration on
+        every rank because source and NTFF validation use that semantic
+        information. Only construction and per-iteration field dispatch use
+        this rank-local subset.
+        """
+
+        return {
+            face: boundary_type
+            for face, boundary_type in self.symmetry_boundaries.items()
+            if self.touches_global_face(face)
+        }
+
     def set_halo_map(self):
         """Create MPI DataTypes for field array halo exchanges."""
 

--- a/gprMax/model.py
+++ b/gprMax/model.py
@@ -586,8 +586,7 @@ class Model:
         """Reserved parity check after material dispersion is resolved."""
 
         # All local backends now implement both phases of the dispersive PMC
-        # ADE update. Keep this hook because MPI symmetry remains deliberately
-        # rejected by the command builder and future backends may need an
+        # ADE update. Keep this hook because future backends may need an
         # explicit capability check here.
 
     def _check_memory_requirements(self, grids: Sequence[FDTDGrid]):

--- a/gprMax/pml.py
+++ b/gprMax/pml.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
 #                          and Nathan Mannall
 #
 # This file is part of gprMax.
@@ -780,41 +780,29 @@ class MetalPML(PML):
 
     def htod_field_arrays(self, dev=None):
         """Initialises PML field and coefficient arrays on GPU."""
-        
+
         # Create Metal buffers for all PML arrays using device's method
         if dev is None:
             raise RuntimeError("Metal device not provided. PML arrays cannot be initialized.")
-        
+
         # Store shapes before creating buffers (since Metal buffers don't have shape attribute)
         self.EPhi1_shape = self.EPhi1.shape
-        self.EPhi2_shape = self.EPhi2.shape  
+        self.EPhi2_shape = self.EPhi2.shape
         self.HPhi1_shape = self.HPhi1.shape
         self.HPhi2_shape = self.HPhi2.shape
-            
-        self.ERA_dev = dev.newBufferWithBytes_length_options_(self.ERA, 
-                                                                        self.ERA.nbytes, 0)
-        self.ERB_dev = dev.newBufferWithBytes_length_options_(self.ERB, 
-                                                                        self.ERB.nbytes, 0)
-        self.ERE_dev = dev.newBufferWithBytes_length_options_(self.ERE, 
-                                                                        self.ERE.nbytes, 0)
-        self.ERF_dev = dev.newBufferWithBytes_length_options_(self.ERF, 
-                                                                        self.ERF.nbytes, 0)
-        self.HRA_dev = dev.newBufferWithBytes_length_options_(self.HRA, 
-                                                                        self.HRA.nbytes, 0)
-        self.HRB_dev = dev.newBufferWithBytes_length_options_(self.HRB, 
-                                                                        self.HRB.nbytes, 0)
-        self.HRE_dev = dev.newBufferWithBytes_length_options_(self.HRE, 
-                                                                        self.HRE.nbytes, 0)
-        self.HRF_dev = dev.newBufferWithBytes_length_options_(self.HRF, 
-                                                                        self.HRF.nbytes, 0)
-        self.EPhi1_dev = dev.newBufferWithBytes_length_options_(self.EPhi1, 
-                                                                          self.EPhi1.nbytes, 0)
-        self.EPhi2_dev = dev.newBufferWithBytes_length_options_(self.EPhi2, 
-                                                                          self.EPhi2.nbytes, 0)
-        self.HPhi1_dev = dev.newBufferWithBytes_length_options_(self.HPhi1, 
-                                                                          self.HPhi1.nbytes, 0)
-        self.HPhi2_dev = dev.newBufferWithBytes_length_options_(self.HPhi2, 
-                                                                          self.HPhi2.nbytes, 0)
+
+        self.ERA_dev = dev.newBufferWithBytes_length_options_(self.ERA, self.ERA.nbytes, 0)
+        self.ERB_dev = dev.newBufferWithBytes_length_options_(self.ERB, self.ERB.nbytes, 0)
+        self.ERE_dev = dev.newBufferWithBytes_length_options_(self.ERE, self.ERE.nbytes, 0)
+        self.ERF_dev = dev.newBufferWithBytes_length_options_(self.ERF, self.ERF.nbytes, 0)
+        self.HRA_dev = dev.newBufferWithBytes_length_options_(self.HRA, self.HRA.nbytes, 0)
+        self.HRB_dev = dev.newBufferWithBytes_length_options_(self.HRB, self.HRB.nbytes, 0)
+        self.HRE_dev = dev.newBufferWithBytes_length_options_(self.HRE, self.HRE.nbytes, 0)
+        self.HRF_dev = dev.newBufferWithBytes_length_options_(self.HRF, self.HRF.nbytes, 0)
+        self.EPhi1_dev = dev.newBufferWithBytes_length_options_(self.EPhi1, self.EPhi1.nbytes, 0)
+        self.EPhi2_dev = dev.newBufferWithBytes_length_options_(self.EPhi2, self.EPhi2.nbytes, 0)
+        self.HPhi1_dev = dev.newBufferWithBytes_length_options_(self.HPhi1, self.HPhi1.nbytes, 0)
+        self.HPhi2_dev = dev.newBufferWithBytes_length_options_(self.HPhi2, self.HPhi2.nbytes, 0)
 
     def set_queue(self, queue):
         """Sets the command queue for the PML."""
@@ -823,12 +811,12 @@ class MetalPML(PML):
     def update_electric(self):
         """Updates electric field components with the PML correction on the GPU using Metal."""
         xs, xf, ys, yf, zs, zf = self._electric_update_bounds()
-        
+
         # Create command buffer and encoder
         cmdbuffer = self.queue.commandBuffer()
         cmpencoder = cmdbuffer.computeCommandEncoder()
         cmpencoder.setComputePipelineState_(self.psoE)
-        
+
         # Set scalar parameters
         cmpencoder.setBytes_length_atIndex_(np.int32(xs).tobytes(), 4, 0)
         cmpencoder.setBytes_length_atIndex_(np.int32(xf).tobytes(), 4, 1)
@@ -843,7 +831,7 @@ class MetalPML(PML):
         cmpencoder.setBytes_length_atIndex_(np.int32(self.EPhi2_shape[2]).tobytes(), 4, 10)
         cmpencoder.setBytes_length_atIndex_(np.int32(self.EPhi2_shape[3]).tobytes(), 4, 11)
         cmpencoder.setBytes_length_atIndex_(np.int32(self.ERA.shape[1]).tobytes(), 4, 12)
-        
+
         # Set buffer arguments
         cmpencoder.setBuffer_offset_atIndex_(self.G.ID_dev, 0, 13)
         cmpencoder.setBuffer_offset_atIndex_(self.G.Ex_dev, 0, 14)
@@ -860,22 +848,22 @@ class MetalPML(PML):
         cmpencoder.setBuffer_offset_atIndex_(self.ERF_dev, 0, 25)
         d_bytes = config.sim_config.dtypes["float_or_double"](self.d).tobytes()
         cmpencoder.setBytes_length_atIndex_(d_bytes, len(d_bytes), 26)
-        
+
         # Dispatch threads using grid's thread configuration
         cmpencoder.dispatchThreads_threadsPerThreadgroup_(self.G.tptg, self.G.tgs)
-        
+
         cmpencoder.endEncoding()
         cmdbuffer.commit()
         cmdbuffer.waitUntilCompleted()
 
     def update_magnetic(self):
         """Updates magnetic field components with the PML correction on the GPU using Metal."""
-        
+
         # Create command buffer and encoder
         cmdbuffer = self.queue.commandBuffer()
         cmpencoder = cmdbuffer.computeCommandEncoder()
         cmpencoder.setComputePipelineState_(self.psoH)
-        
+
         # Set scalar parameters
         cmpencoder.setBytes_length_atIndex_(np.int32(self.xs).tobytes(), 4, 0)
         cmpencoder.setBytes_length_atIndex_(np.int32(self.xf).tobytes(), 4, 1)
@@ -890,7 +878,7 @@ class MetalPML(PML):
         cmpencoder.setBytes_length_atIndex_(np.int32(self.HPhi2_shape[2]).tobytes(), 4, 10)
         cmpencoder.setBytes_length_atIndex_(np.int32(self.HPhi2_shape[3]).tobytes(), 4, 11)
         cmpencoder.setBytes_length_atIndex_(np.int32(self.thickness).tobytes(), 4, 12)
-        
+
         # Set buffer arguments
         cmpencoder.setBuffer_offset_atIndex_(self.G.ID_dev, 0, 13)
         cmpencoder.setBuffer_offset_atIndex_(self.G.Ex_dev, 0, 14)
@@ -907,10 +895,10 @@ class MetalPML(PML):
         cmpencoder.setBuffer_offset_atIndex_(self.HRF_dev, 0, 25)
         d_bytes = config.sim_config.dtypes["float_or_double"](self.d).tobytes()
         cmpencoder.setBytes_length_atIndex_(d_bytes, len(d_bytes), 26)
-        
+
         # Dispatch threads using grid's thread configuration
         cmpencoder.dispatchThreads_threadsPerThreadgroup_(self.G.tptg, self.G.tgs)
-        
+
         cmpencoder.endEncoding()
         cmdbuffer.commit()
         cmdbuffer.waitUntilCompleted()
@@ -931,20 +919,15 @@ class MPIPML(PML):
         """
         for cfs in self.CFS:
             if not cfs.sigma.max:
-                if self.global_comm.rank == self.COORDINATOR_RANK:
-                    cfs.calculate_sigmamax(self.d, er, mr)
-                    buffer = np.array([cfs.sigma.max])
-                else:
-                    buffer = np.empty(1)
-
-                # Needs to be non-blocking because some ranks will
-                # contain multiple PMLs, but the material properties for
-                # a PML cannot be calculated until all ranks have
-                # completed that stage. Therefore a blocking broadcast
-                # would wait for ranks that are stuck calculating the
-                # material properties of the PML.
-                self.global_comm.Ibcast(buffer, self.COORDINATOR_RANK).Wait()
-                cfs.sigma.max = buffer[0]
+                # MPIGrid has already reduced the material properties over
+                # this slab's face communicator. Every participating rank
+                # therefore has the same er/mr and can calculate the same
+                # automatic sigma maximum locally. A collective over the
+                # union of all boundary-PML ranks is incorrect here: symmetry
+                # faces can leave ranks with different numbers of local PML
+                # slabs, so a broadcast per slab would deadlock when one rank
+                # finishes its slab list before another.
+                cfs.calculate_sigmamax(self.d, er, mr)
 
         super().calculate_update_coeffs(er, mr)
 
@@ -975,6 +958,5 @@ def print_pml_info(G):
 
     return (
         f"PML boundaries [{G.name}]: {{formulation: {G.pmls['formulation']}, "
-        f"order: {len(G.pmls['cfs'])}, thickness (cells): {pmlinfo}}}\n"
-        + internal_info
+        f"order: {len(G.pmls['cfs'])}, thickness (cells): {pmlinfo}}}\n" + internal_info
     )

--- a/gprMax/solvers.py
+++ b/gprMax/solvers.py
@@ -92,9 +92,8 @@ class Solver:
             # time loop at this point is still at working on fields updated to be at n+1
             self.updates.update_electric_a()
             # Apply the PMC ghost-image correction on the active local
-            # backend. MPI symmetry is deliberately unsupported.
-            if not isinstance(self.updates, MPIUpdates):
-                self.updates.update_symmetry_boundaries_electric()
+            # backend. MPI ranks dispatch only their owned global faces.
+            self.updates.update_symmetry_boundaries_electric()
 
             self.updates.update_electric_pml()
             self.updates.update_electric_sources(iteration)
@@ -107,8 +106,7 @@ class Solver:
 
             # Complete the dispersive PMC correction after PML and sources,
             # mirroring the bulk dispersive update's A/B split.
-            if not isinstance(self.updates, MPIUpdates):
-                self.updates.update_symmetry_boundaries_electric_b()
+            self.updates.update_symmetry_boundaries_electric_b()
 
             self.updates.update_electric_b()
             self.updates.update_network_terminals(iteration)

--- a/gprMax/sources.py
+++ b/gprMax/sources.py
@@ -3526,15 +3526,44 @@ class MagneticFrillSource(Source):
                 if G.within_pml(self.coord):
                     raise ValueError(f"{self.ID} feed point lies inside a PML.")
                 global_coord = np.asarray(self.mpi_global_coord, dtype=np.int32)
-                transverse = {
-                    "x": (1, 2),
-                    "y": (0, 2),
-                    "z": (0, 1),
-                }[self.polarisation]
-                if any(global_coord[axis] == 0 for axis in transverse):
+                i, j, k = (int(value) for value in global_coord)
+                gx, gy, gz = (int(value) for value in G.global_size)
+                axis_faces = {
+                    "x": ("z0", "y0", "zmax", "ymax", k == 0, j == 0, k == gz, j == gy),
+                    "y": ("z0", "x0", "zmax", "xmax", k == 0, i == 0, k == gz, i == gx),
+                    "z": ("x0", "y0", "xmax", "ymax", i == 0, j == 0, i == gx, j == gy),
+                }
+                (
+                    face1,
+                    face2,
+                    maxface1,
+                    maxface2,
+                    at1,
+                    at2,
+                    atmax1,
+                    atmax2,
+                ) = axis_faces[self.polarisation]
+                face1_pmc = G.symmetry_boundaries.get(face1) == "pmc"
+                face2_pmc = G.symmetry_boundaries.get(face2) == "pmc"
+                if at1 and not face1_pmc:
                     raise ValueError(
-                        f"{self.ID} lies on a transverse global domain-minimum "
-                        "boundary; MPI symmetry boundaries are not supported."
+                        f"{self.ID} feed point sits at global domain face {face1} "
+                        "without a PMC symmetry boundary."
+                    )
+                if at2 and not face2_pmc:
+                    raise ValueError(
+                        f"{self.ID} feed point sits at global domain face {face2} "
+                        "without a PMC symmetry boundary."
+                    )
+                if atmax1 and G.symmetry_boundaries.get(maxface1) == "pmc":
+                    raise ValueError(
+                        f"{self.ID} at a {maxface1}-type symmetry corner is not yet "
+                        "supported; only minimum-face symmetry corners are available."
+                    )
+                if atmax2 and G.symmetry_boundaries.get(maxface2) == "pmc":
+                    raise ValueError(
+                        f"{self.ID} at a {maxface2}-type symmetry corner is not yet "
+                        "supported; only minimum-face symmetry corners are available."
                     )
                 self._validate_geometry(G)
             except Exception as exc:
@@ -3550,8 +3579,21 @@ class MagneticFrillSource(Source):
                 root=self.mpi_primary_rank,
             )
         )
-        self._mirror1 = False
-        self._mirror2 = False
+        global_coord = np.asarray(self.mpi_global_coord, dtype=np.int32)
+        transverse_axes = {"x": (2, 1), "y": (2, 0), "z": (0, 1)}[self.polarisation]
+        minimum_faces = {
+            "x": ("z0", "y0"),
+            "y": ("z0", "x0"),
+            "z": ("x0", "y0"),
+        }[self.polarisation]
+        self._mirror1 = bool(
+            global_coord[transverse_axes[0]] == 0
+            and G.symmetry_boundaries.get(minimum_faces[0]) == "pmc"
+        )
+        self._mirror2 = bool(
+            global_coord[transverse_axes[1]] == 0
+            and G.symmetry_boundaries.get(minimum_faces[1]) == "pmc"
+        )
 
         local_error = None
         try:
@@ -3585,22 +3627,25 @@ class MagneticFrillSource(Source):
         axial_step = {"x": dx, "y": dy, "z": dz}[self.polarisation]
         pairs = {
             "x": (
-                ("Hy", ((i, j, k), -dy, -1), ((i, j, k - 1), dy, 1), "z"),
-                ("Hz", ((i, j, k), dz, 1), ((i, j - 1, k), -dz, -1), "y"),
+                ("Hy", ((i, j, k), -dy, -1), ((i, j, k - 1), dy, 1), "z", self._mirror1),
+                ("Hz", ((i, j, k), dz, 1), ((i, j - 1, k), -dz, -1), "y", self._mirror2),
             ),
             "y": (
-                ("Hx", ((i, j, k), dx, 1), ((i, j, k - 1), -dx, -1), "z"),
-                ("Hz", ((i, j, k), -dz, -1), ((i - 1, j, k), dz, 1), "x"),
+                ("Hx", ((i, j, k), dx, 1), ((i, j, k - 1), -dx, -1), "z", self._mirror1),
+                ("Hz", ((i, j, k), -dz, -1), ((i - 1, j, k), dz, 1), "x", self._mirror2),
             ),
             "z": (
-                ("Hy", ((i, j, k), dy, 1), ((i - 1, j, k), -dy, -1), "x"),
-                ("Hx", ((i, j, k), -dx, -1), ((i, j - 1, k), dx, 1), "y"),
+                ("Hy", ((i, j, k), dy, 1), ((i - 1, j, k), -dy, -1), "x", self._mirror1),
+                ("Hx", ((i, j, k), -dx, -1), ((i, j - 1, k), dx, 1), "y", self._mirror2),
             ),
         }[self.polarisation]
         radial_steps = {"x": dx, "y": dy, "z": dz}
         terms = []
-        for component, plus, minus, radial_axis in pairs:
-            for coordinates, current_weight, source_sign in (plus, minus):
+        for component, plus, minus, radial_axis, mirrored in pairs:
+            edges = (plus,) if mirrored else (plus, minus)
+            for edge_index, (coordinates, current_weight, source_sign) in enumerate(edges):
+                if mirrored and edge_index == 0:
+                    current_weight *= 2
                 global_coord = np.asarray(coordinates, dtype=np.int32)
                 local_coord = G.global_to_local_coordinate(global_coord)
                 if not G.within_bounds(local_coord):

--- a/gprMax/symmetry_boundaries.py
+++ b/gprMax/symmetry_boundaries.py
@@ -142,6 +142,10 @@ from gprMax.cython.symmetry_boundaries_dispersive import (
     update_symmetry_boundary_electric_dispersive_z0,
     update_symmetry_boundary_electric_dispersive_zmax,
 )
+
+# Keep the complex aliases grouped with their real-valued counterparts; the
+# generated symbol names deliberately exceed the formatter's line length.
+# isort: off
 from gprMax.cython.symmetry_boundaries_dispersive_complex import (
     update_symmetry_boundary_electric_dispersive_b_Ex_Y0_Z0 as _c_update_symmetry_boundary_electric_dispersive_b_Ex_Y0_Z0,
     update_symmetry_boundary_electric_dispersive_b_Ex_Y0_ZMax as _c_update_symmetry_boundary_electric_dispersive_b_Ex_Y0_ZMax,
@@ -180,6 +184,8 @@ from gprMax.cython.symmetry_boundaries_dispersive_complex import (
     update_symmetry_boundary_electric_dispersive_z0 as _c_update_symmetry_boundary_electric_dispersive_z0,
     update_symmetry_boundary_electric_dispersive_zmax as _c_update_symmetry_boundary_electric_dispersive_zmax,
 )
+
+# isort: on
 
 _FACE_UPDATE_FUNCS = {
     "x0": update_symmetry_boundary_electric_x0,
@@ -289,15 +295,36 @@ _EDGE_TABLE_DISPERSIVE_COMPLEX = (
     ("x0", "y0", _c_update_symmetry_boundary_electric_dispersive_Ez_X0_Y0, "Ez", "Hx", "Hy"),
     ("x0", "ymax", _c_update_symmetry_boundary_electric_dispersive_Ez_X0_YMax, "Ez", "Hx", "Hy"),
     ("xmax", "y0", _c_update_symmetry_boundary_electric_dispersive_Ez_XMax_Y0, "Ez", "Hx", "Hy"),
-    ("xmax", "ymax", _c_update_symmetry_boundary_electric_dispersive_Ez_XMax_YMax, "Ez", "Hx", "Hy"),
+    (
+        "xmax",
+        "ymax",
+        _c_update_symmetry_boundary_electric_dispersive_Ez_XMax_YMax,
+        "Ez",
+        "Hx",
+        "Hy",
+    ),
     ("x0", "z0", _c_update_symmetry_boundary_electric_dispersive_Ey_X0_Z0, "Ey", "Hx", "Hz"),
     ("x0", "zmax", _c_update_symmetry_boundary_electric_dispersive_Ey_X0_ZMax, "Ey", "Hx", "Hz"),
     ("xmax", "z0", _c_update_symmetry_boundary_electric_dispersive_Ey_XMax_Z0, "Ey", "Hx", "Hz"),
-    ("xmax", "zmax", _c_update_symmetry_boundary_electric_dispersive_Ey_XMax_ZMax, "Ey", "Hx", "Hz"),
+    (
+        "xmax",
+        "zmax",
+        _c_update_symmetry_boundary_electric_dispersive_Ey_XMax_ZMax,
+        "Ey",
+        "Hx",
+        "Hz",
+    ),
     ("y0", "z0", _c_update_symmetry_boundary_electric_dispersive_Ex_Y0_Z0, "Ex", "Hy", "Hz"),
     ("y0", "zmax", _c_update_symmetry_boundary_electric_dispersive_Ex_Y0_ZMax, "Ex", "Hy", "Hz"),
     ("ymax", "z0", _c_update_symmetry_boundary_electric_dispersive_Ex_YMax_Z0, "Ex", "Hy", "Hz"),
-    ("ymax", "zmax", _c_update_symmetry_boundary_electric_dispersive_Ex_YMax_ZMax, "Ex", "Hy", "Hz"),
+    (
+        "ymax",
+        "zmax",
+        _c_update_symmetry_boundary_electric_dispersive_Ex_YMax_ZMax,
+        "Ex",
+        "Hy",
+        "Hz",
+    ),
 )
 
 _EDGE_TABLE_DISPERSIVE_B_COMPLEX = (
@@ -345,7 +372,11 @@ def build_symmetry_boundary_edges(grid) -> list:
     for face_a, face_b, func, e_attr, h1_attr, h2_attr in _EDGE_TABLE:
         a_pmc = face_is_pmc[face_a]
         b_pmc = face_is_pmc[face_b]
-        if a_pmc or b_pmc:
+        if (
+            (a_pmc or b_pmc)
+            and grid.touches_global_face(face_a)
+            and grid.touches_global_face(face_b)
+        ):
             edges.append((func, a_pmc, b_pmc, e_attr, h1_attr, h2_attr))
 
     return edges
@@ -378,7 +409,11 @@ def build_symmetry_boundary_edges_dispersive(grid) -> list:
     for face_a, face_b, func, e_attr, h1_attr, h2_attr in table:
         a_pmc = face_is_pmc[face_a]
         b_pmc = face_is_pmc[face_b]
-        if a_pmc or b_pmc:
+        if (
+            (a_pmc or b_pmc)
+            and grid.touches_global_face(face_a)
+            and grid.touches_global_face(face_b)
+        ):
             edges.append((func, a_pmc, b_pmc, _t_attr(e_attr), e_attr, h1_attr, h2_attr))
 
     return edges
@@ -405,7 +440,11 @@ def build_symmetry_boundary_edges_dispersive_b(grid) -> list:
     for face_a, face_b, func, e_attr in table:
         a_pmc = face_is_pmc[face_a]
         b_pmc = face_is_pmc[face_b]
-        if a_pmc or b_pmc:
+        if (
+            (a_pmc or b_pmc)
+            and grid.touches_global_face(face_a)
+            and grid.touches_global_face(face_b)
+        ):
             edges.append((func, _t_attr(e_attr), e_attr))
 
     return edges
@@ -420,12 +459,13 @@ def update_symmetry_boundaries_electric_normal(grid) -> None:
     Args:
         grid: FDTDGrid class describing a grid in a model.
     """
-    if not grid.symmetry_boundaries:
+    local_boundaries = grid.get_local_symmetry_boundaries()
+    if not local_boundaries:
         return
 
     nthreads = config.get_model_config().ompthreads
 
-    for face, kind in grid.symmetry_boundaries.items():
+    for face, kind in local_boundaries.items():
         if kind != "pmc":
             continue
 
@@ -474,7 +514,8 @@ def update_symmetry_boundaries_electric_dispersive(grid) -> None:
     Args:
         grid: FDTDGrid class describing a grid in a model.
     """
-    if not grid.symmetry_boundaries:
+    local_boundaries = grid.get_local_symmetry_boundaries()
+    if not local_boundaries:
         return
 
     nthreads = config.get_model_config().ompthreads
@@ -485,7 +526,7 @@ def update_symmetry_boundaries_electric_dispersive(grid) -> None:
         else _FACE_UPDATE_FUNCS_DISPERSIVE
     )
 
-    for face, kind in grid.symmetry_boundaries.items():
+    for face, kind in local_boundaries.items():
         if kind != "pmc":
             continue
 
@@ -509,7 +550,15 @@ def update_symmetry_boundaries_electric_dispersive(grid) -> None:
             grid.Hz,
         )
 
-    for func, a_pmc, b_pmc, t_attr, e_attr, h1_attr, h2_attr in grid.symmetry_boundary_edges_dispersive:
+    for (
+        func,
+        a_pmc,
+        b_pmc,
+        t_attr,
+        e_attr,
+        h1_attr,
+        h2_attr,
+    ) in grid.symmetry_boundary_edges_dispersive:
         func(
             grid.nx,
             grid.ny,
@@ -540,7 +589,8 @@ def update_symmetry_boundaries_electric_dispersive_b(grid) -> None:
     Args:
         grid: FDTDGrid class describing a grid in a model.
     """
-    if not grid.symmetry_boundaries:
+    local_boundaries = grid.get_local_symmetry_boundaries()
+    if not local_boundaries:
         return
 
     nthreads = config.get_model_config().ompthreads
@@ -551,7 +601,7 @@ def update_symmetry_boundaries_electric_dispersive_b(grid) -> None:
         else _FACE_UPDATE_FUNCS_DISPERSIVE_B
     )
 
-    for face, kind in grid.symmetry_boundaries.items():
+    for face, kind in local_boundaries.items():
         if kind != "pmc":
             continue
 

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -4147,10 +4147,10 @@ class SymmetryBoundary(GridUserObject):
     ghost-node update for the on-wall tangential electric fields.
 
     PEC and PMC boundaries, including PMC boundaries in dispersive models, are
-    supported by the CPU, CUDA, OpenCL, and Metal solvers.
-    Symmetry boundaries are not supported in 2D mode, with MPI, or on a
-    subgrid, although they may be used on the main grid of a model that
-    contains subgrids.
+    supported by the CPU, CUDA, OpenCL, Metal, and domain-decomposed MPI CPU
+    solvers. Symmetry boundaries are not supported in 2D mode or on a subgrid,
+    although they may be used on the main grid of a model that contains
+    subgrids.
 
     Attributes:
         face: One of ``x0``, ``y0``, ``z0``, ``xmax``, ``ymax``, or ``zmax``.
@@ -4191,10 +4191,6 @@ class SymmetryBoundary(GridUserObject):
             logger.exception(
                 f"{self.params_str()} type must be one of {', '.join(self.VALID_TYPES)}."
             )
-            raise ValueError
-
-        if config.sim_config.mpi:
-            logger.exception(f"{self.params_str()} cannot currently be used with MPI.")
             raise ValueError
 
         if config.get_model_config().mode.startswith("2D"):

--- a/tests/grid/test_mpi_symmetry_boundary_partition.py
+++ b/tests/grid/test_mpi_symmetry_boundary_partition.py
@@ -1,0 +1,58 @@
+"""Rank-local ownership tests for MPI PEC/PMC symmetry boundaries."""
+
+import numpy as np
+
+from gprMax.grid.mpi_grid import MPIGrid
+from gprMax.symmetry_boundaries import build_symmetry_boundary_edges
+
+
+def _grid(neighbours, boundaries):
+    grid = object.__new__(MPIGrid)
+    grid.neighbours = np.asarray(neighbours, dtype=np.int32)
+    grid.symmetry_boundaries = boundaries
+    return grid
+
+
+def test_mpi_grid_keeps_global_declarations_but_selects_owned_faces():
+    # This rank touches x0 and zmax, but is internal in y.
+    grid = _grid(
+        [[-1, 1], [2, 3], [4, -1]],
+        {"x0": "pmc", "y0": "pec", "zmax": "pmc"},
+    )
+
+    assert grid.symmetry_boundaries == {"x0": "pmc", "y0": "pec", "zmax": "pmc"}
+    assert grid.get_local_symmetry_boundaries() == {"x0": "pmc", "zmax": "pmc"}
+
+
+def test_mpi_internal_rank_seams_do_not_create_domain_edges():
+    # Although x0 is a PMC face, this rank is internal in both transverse
+    # directions. Its local y/z limits are MPI seams, not domain edges.
+    grid = _grid([[-1, 1], [2, 3], [4, 5]], {"x0": "pmc"})
+
+    assert build_symmetry_boundary_edges(grid) == []
+
+
+def test_mpi_edge_dispatch_requires_both_global_faces():
+    # The rank touches x0 and y0 but is internal in z. Only their shared Ez
+    # edge belongs to this rank; x0-z and y0-z local limits remain MPI seams.
+    grid = _grid([[-1, 1], [-1, 2], [3, 4]], {"x0": "pmc", "y0": "pmc"})
+
+    edges = build_symmetry_boundary_edges(grid)
+    assert len(edges) == 1
+    func, x0_pmc, y0_pmc, *_ = edges[0]
+    assert func.__name__ == "update_symmetry_boundary_electric_Ez_X0_Y0"
+    assert x0_pmc and y0_pmc
+
+
+def test_mpi_global_corner_dispatches_its_three_physical_edges():
+    grid = _grid(
+        [[-1, 1], [-1, 2], [-1, 3]],
+        {"x0": "pmc", "y0": "pmc", "z0": "pmc"},
+    )
+
+    names = {edge[0].__name__ for edge in build_symmetry_boundary_edges(grid)}
+    assert names == {
+        "update_symmetry_boundary_electric_Ez_X0_Y0",
+        "update_symmetry_boundary_electric_Ey_X0_Z0",
+        "update_symmetry_boundary_electric_Ex_Y0_Z0",
+    }

--- a/tests/test_mpi_pml_update_coeffs.py
+++ b/tests/test_mpi_pml_update_coeffs.py
@@ -1,0 +1,62 @@
+"""Tests for MPI PML update-coefficient initialisation."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gprMax.pml import MPIPML, PML
+
+
+class _AutomaticCFS:
+    def __init__(self):
+        self.sigma = SimpleNamespace(max=None)
+        self.calls = []
+
+    def calculate_sigmamax(self, d, er, mr):
+        self.calls.append((d, er, mr))
+        self.sigma.max = 123.0
+
+
+class _ExplicitCFS(_AutomaticCFS):
+    def __init__(self):
+        super().__init__()
+        self.sigma.max = 456.0
+
+
+class _NoCollectiveComm:
+    """Fail if the coefficient setup attempts an MPI collective."""
+
+    def __getattr__(self, name):
+        pytest.fail(f"MPI PML coefficient setup attempted communicator operation {name!r}")
+
+
+def _make_pml(cfs):
+    pml = object.__new__(MPIPML)
+    pml.CFS = cfs
+    pml.d = 0.002
+    pml.global_comm = _NoCollectiveComm()
+    return pml
+
+
+def test_mpi_pml_calculates_automatic_sigma_locally(monkeypatch):
+    """Each slab uses its already face-reduced er/mr without a collective.
+
+    A global broadcast per local slab deadlocks when symmetry boundaries
+    leave different ranks with different numbers of exterior PML slabs.
+    """
+    automatic = _AutomaticCFS()
+    explicit = _ExplicitCFS()
+    pml = _make_pml([automatic, explicit])
+    parent_calls = []
+
+    monkeypatch.setattr(
+        PML,
+        "calculate_update_coeffs",
+        lambda self, er, mr: parent_calls.append((er, mr)),
+    )
+
+    pml.calculate_update_coeffs(er=4.0, mr=2.0)
+
+    assert automatic.calls == [(0.002, 4.0, 2.0)]
+    assert explicit.calls == []
+    assert parent_calls == [(4.0, 2.0)]

--- a/tests/updates/test_mpi_transmission_line_timing.py
+++ b/tests/updates/test_mpi_transmission_line_timing.py
@@ -61,10 +61,12 @@ def test_solver_samples_mpi_transmission_lines_after_magnetic_halo():
         "update_magnetic_edge_devices",
         "observe_ntff_magnetic",
         "update_electric_a",
+        "update_symmetry_boundaries_electric",
         "update_electric_pml",
         "update_electric_sources",
         "update_eigenmode_sources_electric",
         "update_plane_waves_electric",
+        "update_symmetry_boundaries_electric_b",
         "update_electric_b",
         "update_network_terminals",
         "halo_swap_electric",
@@ -79,6 +81,12 @@ def test_solver_samples_mpi_transmission_lines_after_magnetic_halo():
     assert calls.index("update_magnetic_sources") < calls.index("halo_swap_magnetic")
     assert calls.index("halo_swap_magnetic") < calls.index("update_magnetic_edge_devices")
     assert calls.index("update_magnetic_edge_devices") < calls.index("update_electric_a")
+    assert calls.index("update_electric_a") < calls.index("update_symmetry_boundaries_electric")
+    assert calls.index("update_symmetry_boundaries_electric") < calls.index("update_electric_pml")
+    assert calls.index("update_plane_waves_electric") < calls.index(
+        "update_symmetry_boundaries_electric_b"
+    )
+    assert calls.index("update_symmetry_boundaries_electric_b") < calls.index("update_electric_b")
 
 
 def test_mpi_finalise_completes_last_halo_exchange():


### PR DESCRIPTION
# PR Description

## Summary

Adds PEC and PMC symmetry-boundary support to the domain-decomposed MPI CPU solver.

The implementation:

- Retains the complete symmetry declaration on every rank.
- Constructs and updates each boundary only on ranks touching that global domain face.
- Applies PMC edge corrections only where both adjoining physical faces are present, preventing internal MPI halo seams from being treated as symmetry edges.
- Supports magnetic-frill image completion at minimum-face PMC symmetry corners.
- Fixes an MPI PML initialisation deadlock that occurred when symmetry boundaries left ranks with different numbers of exterior PML slabs.
- Updates the API, hash-command, and accelerator documentation.
- Adds regression tests for MPI boundary ownership, PML initialisation, and solver update ordering.

## Validation

- A 50 Ω rational-network port feeding a PEC dipole produced bit-identical serial and MPI symmetry results for voltage, current, S11, impedance, and receiver fields.
- Full-domain and quarter-domain PMC symmetry results agreed to numerical precision.
- Hertzian-dipole E- and H-plane patterns agreed with the analytical solution, with peak directivity of 1.759 dBi versus the analytical 1.761 dBi.
- Focused MPI, symmetry, PML, and solver-ordering regression suites passed.
- Black and isort checks passed.
- Documentation builds successfully with no new warnings.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [x] This change requires a documentation update.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added comments for hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of the changes.