### PR TITLE
Fix MPI ownership of terminal geometry faces

### DIFF
--- a/gprMax/user_inputs.py
+++ b/gprMax/user_inputs.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
 #                          and Nathan Mannall
 #
 # This file is part of gprMax.
@@ -30,6 +30,7 @@ from gprMax import config
 from gprMax.grid.fdtd_grid import FDTDGrid
 from gprMax.grid.mpi_grid import MPIGrid
 from gprMax.subgrids.grid import SubGridBaseGrid
+from gprMax.utilities.mpi import Dim, Dir
 
 from .utilities.utilities import round_int
 
@@ -412,15 +413,30 @@ class MPIUserInput(MainGridUserInput[MPIGrid]):
     ) -> Tuple[bool, npt.NDArray[np.int32], npt.NDArray[np.int32]]:
         _, lower_point, upper_point = super().check_box_points(p1, p2, cmd_str)
 
+        # Determine overlap before clipping. A zero-thickness dimension is a
+        # plane coordinate rather than an interval. Coordinates on an internal
+        # positive rank face belong to the neighbouring rank, while a
+        # coordinate on the global maximum face must remain on the terminal
+        # rank. The latter is required for edges and plates on xmax/ymax/zmax.
+        overlaps = []
+        for dimension in Dim:
+            lower = lower_point[dimension]
+            upper = upper_point[dimension]
+            size = self.grid.size[dimension]
+
+            if lower == upper:
+                overlaps.append(
+                    0 <= lower < size
+                    or (lower == size and not self.grid.has_neighbour(dimension, Dir.POS))
+                )
+            else:
+                overlaps.append(lower < size and upper > 0)
+
         # Restrict points to the bounds of the local grid
         lower_point = np.where(lower_point < 0, 0, lower_point)
         upper_point = np.where(upper_point > self.grid.size, self.grid.size, upper_point)
 
-        return (
-            all(lower_point <= upper_point) and all(lower_point < self.grid.size),
-            lower_point,
-            upper_point,
-        )
+        return all(overlaps), lower_point, upper_point
 
 
 class SubgridUserInput(MainGridUserInput[SubGridBaseGrid]):

--- a/reframe_tests/tests/src/geometry_tests/box_geometry/box_pec_cross_partition.in
+++ b/reframe_tests/tests/src/geometry_tests/box_geometry/box_pec_cross_partition.in
@@ -1,0 +1,11 @@
+#title: PEC box crossing MPI partitions
+#domain: 0.040 0.040 0.040
+#dx_dy_dz: 0.001 0.001 0.001
+#time_window: 3e-10
+#pml_cells: 3
+
+#waveform: ricker 1 1e10 pulse
+#hertzian_dipole: z 0.008 0.020 0.020 pulse
+#rx: 0.032 0.020 0.020
+
+#box: 0.015 0.012 0.012 0.025 0.028 0.028 pec

--- a/reframe_tests/tests/src/geometry_tests/magnetic_edge_geometry/magnetic_edge_cross_partition.in
+++ b/reframe_tests/tests/src/geometry_tests/magnetic_edge_geometry/magnetic_edge_cross_partition.in
@@ -1,0 +1,12 @@
+#title: Magnetic edge crossing MPI partitions
+#domain: 0.040 0.040 0.040
+#dx_dy_dz: 0.001 0.001 0.001
+#time_window: 3e-10
+#pml_cells: 3
+
+#material: 1 0 4 0.05 magnetic_wire
+#waveform: ricker 1 1e10 pulse
+#hertzian_dipole: y 0.008 0.020 0.019 pulse
+#rx: 0.032 0.020 0.019
+
+#magnetic_edge: 0.012 0.020 0.020 0.028 0.020 0.020 magnetic_wire

--- a/reframe_tests/tests/test_geometry.py
+++ b/reframe_tests/tests/test_geometry.py
@@ -45,6 +45,7 @@ class TestBoxGeometryDefaultPml(GprMaxRegressionTest):
             "box_full_model",
             "box_half_model",
             "box_rigid",
+            "box_pec_cross_partition",
             "box_single_rank",
             "box_outside_pml",
             "box_single_rank_outside_pml",
@@ -114,6 +115,13 @@ class TestEdgeGeometryAntennaModel(AntennaModelMixin, GprMaxRegressionTest):
     tags = {"test", "serial", "geometry", "edge", "transmission_line", "waveform", "antenna"}
     sourcesdir = "src/geometry_tests/edge_geometry"
     model = parameter(["antenna_wire_dipole_fs"])
+
+
+@rfm.simple_test
+class TestMagneticEdgeGeometry(GprMaxRegressionTest):
+    tags = {"test", "serial", "geometry", "magnetic_edge"}
+    sourcesdir = "src/geometry_tests/magnetic_edge_geometry"
+    model = parameter(["magnetic_edge_cross_partition"])
 
 
 @rfm.simple_test
@@ -277,6 +285,13 @@ class TestEdgeGeometryAntennaModelMpi(MpiMixin, TestEdgeGeometryAntennaModel):
     tags = {"test", "mpi", "geometry", "edge", "transmission_line", "waveform", "antenna"}
     mpi_layout = parameter([[2, 2, 2], [3, 3, 3], [4, 4, 4]])
     test_dependency = TestEdgeGeometryAntennaModel
+
+
+@rfm.simple_test
+class TestMagneticEdgeGeometryMpi(MpiMixin, TestMagneticEdgeGeometry):
+    tags = {"test", "mpi", "geometry", "magnetic_edge"}
+    mpi_layout = parameter([[2, 1, 1], [1, 2, 1], [1, 1, 2]])
+    test_dependency = TestMagneticEdgeGeometry
 
 
 @rfm.simple_test

--- a/tests/user_inputs/test_mpi_box_points.py
+++ b/tests/user_inputs/test_mpi_box_points.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from gprMax.user_inputs import MainGridUserInput, MPIUserInput
+from gprMax.utilities.mpi import Dim, Dir
+
+
+def _input(monkeypatch, lower, upper, positive_neighbours=()):
+    lower = np.asarray(lower, dtype=np.int32)
+    upper = np.asarray(upper, dtype=np.int32)
+
+    monkeypatch.setattr(
+        MainGridUserInput,
+        "check_box_points",
+        lambda self, p1, p2, cmd_str: (True, lower.copy(), upper.copy()),
+    )
+
+    neighbours = np.full((3, 2), -1, dtype=np.int32)
+    for dimension in positive_neighbours:
+        neighbours[dimension, Dir.POS] = 1
+
+    grid = SimpleNamespace(
+        size=np.asarray((7, 7, 7), dtype=np.int32),
+        neighbours=neighbours,
+    )
+    grid.has_neighbour = lambda dimension, direction: (grid.neighbours[dimension, direction] >= 0)
+    return MPIUserInput(grid)
+
+
+@pytest.mark.parametrize("normal", list(Dim))
+def test_global_max_zero_thickness_face_belongs_to_terminal_rank(monkeypatch, normal):
+    lower = np.asarray((2, 2, 2), dtype=np.int32)
+    upper = np.asarray((5, 5, 5), dtype=np.int32)
+    lower[normal] = 7
+    upper[normal] = 7
+    user_input = _input(monkeypatch, lower, upper)
+
+    within_grid, local_lower, local_upper = user_input.check_box_points((), (), "#plate")
+
+    assert within_grid
+    np.testing.assert_array_equal(local_lower, lower)
+    np.testing.assert_array_equal(local_upper, upper)
+
+
+@pytest.mark.parametrize("normal", list(Dim))
+def test_internal_positive_zero_thickness_face_belongs_to_next_rank(monkeypatch, normal):
+    lower = np.asarray((2, 2, 2), dtype=np.int32)
+    upper = np.asarray((5, 5, 5), dtype=np.int32)
+    lower[normal] = 7
+    upper[normal] = 7
+    user_input = _input(monkeypatch, lower, upper, positive_neighbours=(normal,))
+
+    within_grid, _, _ = user_input.check_box_points((), (), "#plate")
+
+    assert not within_grid
+
+
+@pytest.mark.parametrize("run_axis", list(Dim))
+def test_global_max_edge_belongs_to_terminal_rank(monkeypatch, run_axis):
+    lower = np.full(3, 7, dtype=np.int32)
+    upper = np.full(3, 7, dtype=np.int32)
+    lower[run_axis] = 2
+    upper[run_axis] = 5
+    user_input = _input(monkeypatch, lower, upper)
+
+    within_grid, local_lower, local_upper = user_input.check_box_points((), (), "#magnetic_edge")
+
+    assert within_grid
+    np.testing.assert_array_equal(local_lower, lower)
+    np.testing.assert_array_equal(local_upper, upper)
+
+
+@pytest.mark.parametrize("run_axis", list(Dim))
+def test_global_max_edge_is_rejected_by_non_terminal_rank(monkeypatch, run_axis):
+    lower = np.full(3, 7, dtype=np.int32)
+    upper = np.full(3, 7, dtype=np.int32)
+    lower[run_axis] = 2
+    upper[run_axis] = 5
+    transverse_axis = next(dimension for dimension in Dim if dimension != run_axis)
+    user_input = _input(
+        monkeypatch,
+        lower,
+        upper,
+        positive_neighbours=(transverse_axis,),
+    )
+
+    within_grid, _, _ = user_input.check_box_points((), (), "#magnetic_edge")
+
+    assert not within_grid
+
+
+def test_non_degenerate_object_outside_local_grid_is_rejected(monkeypatch):
+    user_input = _input(monkeypatch, (-4, 2, 2), (0, 5, 5))
+
+    within_grid, _, _ = user_input.check_box_points((), (), "#box")
+
+    assert not within_grid


### PR DESCRIPTION
# PR Description

## Summary

Fix MPI ownership of zero-thickness geometry objects located on the global
xmax, ymax, or zmax faces.

Previously, terminal-rank clipping rejected objects whose local coordinate
equalled the rank size. This could omit edges and plates—including magnetic
edges—from global maximum faces.

The change:

- distinguishes zero-thickness coordinates from finite intervals;
- assigns internal positive-rank faces to the neighbouring rank;
- retains global maximum faces on the terminal rank;
- adds explicit terminal-face and terminal-edge unit tests;
- adds serial-versus-MPI ReFrame models for magnetic edges and PEC boxes
  crossing MPI partitions.

The existing corrected PEC box builder required regression coverage but no
additional production-code changes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update

## Verification

- [x] 74 focused pytest tests passed.
- [x] Magnetic-edge receiver outputs matched serial execution exactly for
      x-, y-, and z-directed MPI decompositions.
- [x] PEC-box receiver outputs matched serial execution exactly for
      x-, y-, and z-directed MPI decompositions.
- [x] Black and isort checks passed.
- [x] `git diff --check` passed.

## Checklist

- [x] Pre-commit formatting checks pass.
- [x] I have performed a self-review.
- [x] Comments were added around the non-obvious MPI ownership logic.
- [x] My changes generate no new warnings.
- [x] The PR title is a short description of the changes.