### PR TITLE
Fix Metal plane-wave TFSF kernel rendering

### DIFF
--- a/gprMax/updates/metal_plane_waves.py
+++ b/gprMax/updates/metal_plane_waves.py
@@ -18,6 +18,14 @@ from gprMax.grid.metal_grid import MetalBufferView
 from gprMax.updates.opencl_updates import OpenCLUpdates
 
 
+def _render_planewave_kernel_source(specification, knl_common, c_real, c_complex):
+    """Render a shared plane-wave kernel for Metal."""
+
+    declaration = specification["args_metal"].substitute({"REAL": c_real, "COMPLEX": c_complex})
+    body = specification["func"].substitute({"CUDA_IDX": "", "TFSF_IDX": "", "REAL": c_real})
+    return f"{knl_common}\n{declaration}{{\n{body}}}\n"
+
+
 class _MetalElementwiseKernel:
     """Small callable matching the PyOpenCL ElementwiseKernel launch API."""
 
@@ -48,9 +56,7 @@ class _MetalElementwiseKernel:
                 encoder.setBuffer_offset_atIndex_(view[0], view[1], index)
             else:
                 scalar = np.asarray(argument)
-                encoder.setBytes_length_atIndex_(
-                    scalar.tobytes(), scalar.dtype.itemsize, index
-                )
+                encoder.setBytes_length_atIndex_(scalar.tobytes(), scalar.dtype.itemsize, index)
         encoder.dispatchThreads_threadsPerThreadgroup_(
             self.owner.metal.MTLSizeMake(count, 1, 1),
             self.owner.metal.MTLSizeMake(
@@ -85,19 +91,13 @@ class MetalPlaneWaveController(OpenCLUpdates):
         except KeyError:
             pass
         c_real = config.sim_config.dtypes["C_float_or_double"]
-        declaration = specification["args_metal"].substitute(
-            {
-                "REAL": c_real,
-                "COMPLEX": config.get_model_config().materials["dispersiveCdtype"],
-            }
+        source = _render_planewave_kernel_source(
+            specification,
+            self.knl_common,
+            c_real,
+            config.get_model_config().materials["dispersiveCdtype"],
         )
-        body = specification["func"].substitute(
-            {"CUDA_IDX": "", "TFSF_IDX": "int t = i;", "REAL": c_real}
-        )
-        source = f"{self.knl_common}\n{declaration}{{\n{body}}}\n"
-        library, error = self.dev.newLibraryWithSource_options_error_(
-            source, self.opts, None
-        )
+        library, error = self.dev.newLibraryWithSource_options_error_(source, self.opts, None)
         if library is None:
             raise RuntimeError(f"Failed to compile Metal plane-wave kernel {name}: {error}")
         function = library.newFunctionWithName_(name)

--- a/tests/updates/test_plane_wave_kernel_templates.py
+++ b/tests/updates/test_plane_wave_kernel_templates.py
@@ -1,5 +1,6 @@
 """Backend-neutral plane-wave and OpenCL NTFF kernel-source regressions."""
 
+import re
 from types import SimpleNamespace
 
 import numpy as np
@@ -7,16 +8,31 @@ import numpy as np
 from gprMax.cuda_opencl import knl_planewave_updates, knl_tfsf_injection
 from gprMax.cuda_opencl.knl_ntff import build_ntff_kernel_source
 from gprMax.grid.metal_grid import MetalBufferView
-from gprMax.updates.metal_plane_waves import _MetalElementwiseKernel
+from gprMax.updates.metal_plane_waves import (
+    _MetalElementwiseKernel,
+    _render_planewave_kernel_source,
+)
 
 
 def _plane_wave_kernel_specs(module):
     return [
         value
         for value in vars(module).values()
-        if isinstance(value, dict)
-        and {"args_metal", "func"}.issubset(value)
+        if isinstance(value, dict) and {"args_metal", "func"}.issubset(value)
     ]
+
+
+def _metal_parameter_names(declaration):
+    """Return the parameter names from a rendered Metal kernel declaration."""
+
+    parameters = declaration[declaration.find("(") + 1 : declaration.rfind(")")]
+    names = []
+    for parameter in parameters.split(","):
+        parameter = re.sub(r"\[\[.*?\]\]", "", parameter).strip()
+        match = re.search(r"([A-Za-z_]\w*)\s*$", parameter)
+        assert match is not None, f"Could not parse Metal parameter: {parameter}"
+        names.append(match.group(1))
+    return names
 
 
 def test_tfsf_kernels_use_backend_index_substitution():
@@ -70,14 +86,22 @@ def test_all_plane_wave_templates_render_for_metal():
         declaration = specification["args_metal"].substitute(
             {"REAL": "float", "COMPLEX": "metal::complex<float>"}
         )
-        body = specification["func"].substitute(
-            {"CUDA_IDX": "", "TFSF_IDX": "int t = i;", "REAL": "float"}
+        body = specification["func"].substitute({"CUDA_IDX": "", "TFSF_IDX": "", "REAL": "float"})
+        source = _render_planewave_kernel_source(
+            specification, "", "float", "metal::complex<float>"
         )
 
+        parameter_names = _metal_parameter_names(declaration)
+
+        assert source == f"\n{declaration}{{\n{body}}}\n"
         assert "$" not in declaration
         assert "$" not in body
         assert "thread_position_in_grid" in declaration
         assert "blockIdx" not in body
+        assert len(parameter_names) == len(set(parameter_names))
+        if "$TFSF_IDX" in specification["func"].template:
+            assert parameter_names.count("t") == 1
+            assert "int t =" not in body
 
 
 class _FakeEncoder:


### PR DESCRIPTION
# PR Description

## PR Description

Fix Metal kernel generation for discrete-plane-wave TFSF corrections.

Metal kernel signatures already provide the thread index `t` through
`[[thread_position_in_grid]]`. The renderer was additionally inserting
`int t = i;`, which redeclared `t` and referenced the undefined variable `i`.
Consequently, the standard and axial TFSF face kernels could not compile on
Metal.

This change:

- uses Metal's existing `thread_position_in_grid` parameter;
- centralises Metal plane-wave kernel rendering;
- checks all generated plane-wave kernel signatures for duplicate parameters;
- verifies that every TFSF kernel contains exactly one Metal thread index.

CUDA and OpenCL kernel substitutions are unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Validation

- [x] 27 Metal-focused tests passed.
- [x] 81 non-hardware update tests passed; 6 intentionally skipped.
- [x] Black and isort checks passed.
- [x] Generated kernel signatures contain no duplicate parameters.
- [x] I have performed a self-review of the code.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.

