### PR TITLE
Add reusable geometry parameter study framework

### DIFF
--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -144,6 +144,68 @@ Dispersive Averaging
 --------------------
 .. autoclass:: gprMax.user_objects.cmds_singleuse.DispersiveAveraging
 
+Reusable parameter studies
+--------------------------
+
+A :class:`gprMax.Study` runs an ordered set of source and receiver states while
+reusing one built geometry. It is intended for arbitrary GPR acquisition
+patterns and is the foundation for later multiport, antenna-array, and
+plane-wave studies. Every case restores the original object state before its
+overrides are applied, so parameters cannot accidentally accumulate between
+runs.
+
+The initial implementation supports top-level
+:class:`gprMax.HertzianDipole`, :class:`gprMax.MagneticDipole`, and
+:class:`gprMax.Rx` objects on the main grid. A state can refer directly to its
+Python object or use its deterministic ID. Sources omitted from a case are
+inactive; receivers omitted from a case keep their original position and are
+recorded.
+
+.. code-block:: python
+
+    source = gprMax.HertzianDipole(
+        polarisation='z', p1=(0.10, 0.05, 0.03), waveform_id='pulse'
+    )
+    receiver = gprMax.Rx(p1=(0.14, 0.05, 0.03), id='measurement')
+    scene.add(source)
+    scene.add(receiver)
+
+    study = gprMax.GPRStudy([
+        gprMax.StudyCase('trace_1', [
+            gprMax.ObjectState(source, position=(0.10, 0.05, 0.03), scale=1.0),
+            gprMax.ObjectState(receiver, position=(0.14, 0.05, 0.03)),
+        ]),
+        gprMax.StudyCase('trace_2', [
+            gprMax.ObjectState(source, position=(0.102, 0.052, 0.03), scale=0.8),
+            gprMax.ObjectState('measurement', position=(0.145, 0.052, 0.03)),
+        ]),
+    ])
+
+    gprMax.run(scenes=[scene], study=study, outputfile='survey')
+
+The available source overrides are ``active``, ``position``,
+``waveform_id``, ``start``, ``stop``, and the dimensionless amplitude
+``scale``. Receivers currently accept ``position`` and ``record=True``. The
+study determines the run count automatically; pass ``i=N`` to restart at the
+one-based case number ``N``. For a text input model the equivalent
+``#study`` command reads the same information from CSV.
+
+.. autoclass:: gprMax.studies.Study
+    :members: from_csv
+
+.. autoclass:: gprMax.studies.GPRStudy
+
+.. autoclass:: gprMax.studies.StudyCase
+
+.. autoclass:: gprMax.studies.ObjectState
+
+.. note::
+
+    MPI/task-farm studies, subgrid study objects, stateful ports, plane waves,
+    and eigenmode sources are not enabled in this first stage. Their cached
+    fields, transforms, and derived setup must be reset or rebuilt explicitly;
+    gprMax rejects them instead of reusing stale state.
+
 Typical general settings are added directly to the scene:
 
 .. code-block:: python

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1932,6 +1932,62 @@ Provides a simple method to allow you to move the location of all simple sources
 
     * ``#src_steps`` and ``#rx_steps`` are not suitable for moving sources which have associated geometry, e.g. antenna models.
 
+#study:
+-------
+
+Runs a sequence of source/receiver cases while building the model geometry
+only once. This is the general counterpart to ``#src_steps`` and
+``#rx_steps``: positions need not follow a regular increment, individual
+sources can be activated or scaled, and every output file records the exact
+case that produced it. The syntax is:
+
+.. code-block:: none
+
+    #study: gpr file1
+
+``file1`` is a CSV table. Its path is resolved relative to the main input
+file. The required columns are ``case_id`` and ``object_id``. The optional
+columns are ``active``, ``x_m``, ``y_m``, ``z_m``, ``waveform_id``,
+``start_s``, ``stop_s``, ``scale``, and ``record``. Blank cells mean "use the
+object's baseline value". All three position columns must be supplied
+together and contain absolute coordinates in metres.
+
+For example:
+
+.. code-block:: text
+
+    case_id,object_id,active,x_m,y_m,z_m,waveform_id,start_s,stop_s,scale,record
+    trace_1,hertzian_dipole_1,true,0.100,0.050,0.030,,,,1,
+    trace_1,rx_1,,0.140,0.050,0.030,,,,,true
+    trace_2,hertzian_dipole_1,true,0.102,0.052,0.030,,,,0.8,
+    trace_2,rx_1,,0.145,0.052,0.030,,,,,true
+
+Objects receive deterministic IDs from their order of appearance within each
+object family: ``hertzian_dipole_1``, ``hertzian_dipole_2``,
+``magnetic_dipole_1``, and ``rx_1``. An explicit ``#rx`` identifier is also
+accepted as an alias. A source listed in a case is active by default; a source
+omitted from that case, or listed with ``active=false``, is inactive. A
+receiver omitted from a case remains at its baseline position and is still
+recorded. ``record=false`` is reserved for future selective-output support and
+is currently rejected rather than silently ignored.
+
+The number of CSV cases determines the number of model runs, so ``-n`` is not
+required. ``-i N`` restarts at case ``N`` and retains absolute output numbering.
+The original geometry, materials, PMLs, and grid allocation are reused, but
+field arrays and receiver histories are reset before every case. Each output
+contains a ``/study`` group with the case ID, resolved parameters, and a copy
+of the CSV source.
+
+.. note::
+
+    The first implementation supports top-level ``#hertzian_dipole``,
+    ``#magnetic_dipole``, and ``#rx`` objects on the main grid. MPI domain
+    decomposition, task farming, subgrid objects, plane waves, voltage and
+    transmission-line sources, rational/frill ports, and eigenmode objects are
+    rejected until their family-specific state reset and rebuild hooks are
+    implemented. This explicit restriction prevents contaminated results from
+    persistent source or transform state.
+
 #snapshot:
 ----------
 

--- a/docs/source/output.rst
+++ b/docs/source/output.rst
@@ -38,9 +38,23 @@ voltage-source ports (``ports``), and KSIR outputs (``ntff``) when requested.
 Eigenmode sources and receivers add ``eigenmode_ports``. Within these are
 further groups for each named or numbered output.
 
+Reusable parameter studies add a root ``study`` group. Its attributes are
+``Type``, ``CaseID``, ``CaseIndex`` (one based), ``CaseCount``,
+``GeometryReused``, and, for CSV studies, ``SourcePath``. The ``source``
+dataset preserves the complete CSV text. ``definition`` stores the normalised
+full study as JSON, while ``resolved_case`` contains the post-validation values
+actually applied to every study-managed object, including baseline receivers
+and implicitly disabled sources.
+Study-managed source and receiver groups also carry a ``StudyID`` attribute,
+which provides an unambiguous link back to the case table.
+
 .. code-block:: none
 
     /
+        study/ [optional]
+            source [CSV studies]
+            definition
+            resolved_case
         rxs/
             rx1/
                 Name

--- a/gprMax/__init__.py
+++ b/gprMax/__init__.py
@@ -18,6 +18,7 @@ from .ntff import (
     spherical_observation_points,
 )
 from .scene import Scene
+from .studies import GPRStudy, ObjectState, Study, StudyCase
 from .subgrids.user_objects import SubGridHSG
 from .user_objects.cmds_geometry.add_grass import AddGrass
 from .user_objects.cmds_geometry.add_surface_roughness import AddSurfaceRoughness

--- a/gprMax/config.py
+++ b/gprMax/config.py
@@ -146,8 +146,11 @@ class ModelConfig:
         )
 
         # Output file path and name for specific model
+        study_case_count = (
+            len(sim_config.study.cases) if sim_config.study is not None else sim_config.args.n
+        )
         self.appendmodelnumber = (
-            "" if sim_config.args.n == 1 else str(model_num + 1)
+            "" if study_case_count == 1 else str(model_num + 1)
         )  # Indexed from 1
         self.set_output_file_path()
 
@@ -297,6 +300,7 @@ class SimulationConfig:
         self.args = args
 
         self.geometry_fixed: bool = args.geometry_fixed
+        self.study = getattr(args, "study", None)
         self.geometry_only: bool = args.geometry_only
         self.gpu: Union[List[str], bool] = args.gpu
         self.mpi: List[int] = args.mpi

--- a/gprMax/contexts.py
+++ b/gprMax/contexts.py
@@ -121,6 +121,8 @@ class Context:
         if not model_config.reuse_geometry():
             scene = self._get_scene(model_num)
             self.model = self._create_model()
+            if config.sim_config.study is not None:
+                config.sim_config.study.bind_scene(scene)
             scene.create_internal_objects(self.model)
         else:
             # model_config is freshly created every call (unlike self.model,
@@ -241,6 +243,8 @@ class MPIContext(Context):
         if not model_config.reuse_geometry():
             self.model = self._create_model()
             scene = self._get_scene(model_num)
+            if config.sim_config.study is not None:
+                config.sim_config.study.bind_scene(scene)
             scene.create_internal_objects(self.model)
         else:
             # model_config is freshly created every call (unlike self.model,

--- a/gprMax/fields_outputs.py
+++ b/gprMax/fields_outputs.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import h5py
 import numpy as np
 
+import gprMax.config as config
 from gprMax.grid.fdtd_grid import FDTDGrid
 
 from ._version import __version__
@@ -251,6 +252,9 @@ def write_hdf5_outputfile(outputfile: Path, title: str, model):
         f.attrs["rxsteps"] = model.rxsteps
         write_hd5_data(f, model.G)
 
+        if config.sim_config.study is not None:
+            config.sim_config.study.write_hdf5(f)
+
         # Write meta data and data for any subgrids
         sg_rxs = [True for sg in model.subgrids if sg.rxs]
         sg_tls = [True for sg in model.subgrids if sg.transmissionlines]
@@ -333,6 +337,8 @@ def write_hd5_data(basegrp, grid, is_subgrid=False):
         grp = basegrp.create_group(f"srcs/src{str(srcindex + 1)}")
         grp.attrs["Type"] = type(src).__name__
         grp.attrs["ID"] = str(src.ID)
+        if getattr(src, "study_id", None):
+            grp.attrs["StudyID"] = src.study_id
         grp.attrs["GridPosition"] = np.asarray(src.coord, dtype=np.int32)
         grp.attrs["Polarisation"] = str(src.polarisation or "")
         grp.attrs["Position"] = _global_position(
@@ -408,6 +414,8 @@ def write_hd5_data(basegrp, grid, is_subgrid=False):
         grp = basegrp.create_group("rxs/rx" + str(rxindex + 1))
         if rx.ID:
             grp.attrs["Name"] = rx.ID
+        if getattr(rx, "study_id", None):
+            grp.attrs["StudyID"] = rx.study_id
         grp.attrs["Position"] = _global_position(grid, rx.xcoord, rx.ycoord, rx.zcoord, is_subgrid)
         grp.attrs["GridPosition"] = np.asarray(rx.coord, dtype=np.int32)
 

--- a/gprMax/gprMax.py
+++ b/gprMax/gprMax.py
@@ -41,6 +41,7 @@ args_defaults = {
     "autotranslate": False,
     "geometry_only": False,
     "geometry_fixed": False,
+    "study": None,
     "write_processed": False,
     "show_progress_bars": False,
     "hide_progress_bars": False,
@@ -144,6 +145,7 @@ def run(
     autotranslate=args_defaults["autotranslate"],
     geometry_only=args_defaults["geometry_only"],
     geometry_fixed=args_defaults["geometry_fixed"],
+    study=args_defaults["study"],
     write_processed=args_defaults["write_processed"],
     show_progress_bars=args_defaults["show_progress_bars"],
     hide_progress_bars=args_defaults["hide_progress_bars"],
@@ -203,6 +205,8 @@ def run(
             geometry views but do not run the simulation.
         geometry_fixed: optional boolean to run a series of models where
             the geometry does not change between models.
+        study: optional Study instance defining per-run source and receiver
+            states while reusing one geometry.
         write_processed: optional boolean to write another input file
             after any #python blocks (which are deprecated) in the
             original input file has been processed.
@@ -238,6 +242,7 @@ def run(
             "autotranslate": autotranslate,
             "geometry_only": geometry_only,
             "geometry_fixed": geometry_fixed,
+            "study": study,
             "write_processed": write_processed,
             "show_progress_bars": show_progress_bars,
             "hide_progress_bars": hide_progress_bars,
@@ -247,7 +252,7 @@ def run(
         }
     )
 
-    run_main(args)
+    return run_main(args)
 
 
 def cli():
@@ -355,6 +360,9 @@ def run_main(args):
             script.
     """
 
+    from gprMax.studies import preflight_study_args
+
+    preflight_study_args(args)
     results = {}
     logging_config(
         level=args.log_level,

--- a/gprMax/hash_cmds_file.py
+++ b/gprMax/hash_cmds_file.py
@@ -229,6 +229,7 @@ def check_cmd_names(processedlines, checkessential=True):
             "#src_steps",
             "#rx_steps",
             "#output_dir",
+            "#study",
         ],
         None,
     )

--- a/gprMax/model.py
+++ b/gprMax/model.py
@@ -374,6 +374,13 @@ class Model:
         for grid in grids:
             grid.update_sources_and_recievers()
 
+        # A Study supplies absolute per-case state after the legacy linear
+        # src/rx stepping hooks. This ordering makes Study authoritative and,
+        # because it restores its captured baseline first, prevents changes
+        # leaking from one reused-geometry run into the next.
+        if config.sim_config.study is not None:
+            config.sim_config.study.apply_case(self)
+
         # Magnetic-frill sources bind the attached thin-wire radius, resolve
         # symmetry, validate the PEC ground plane, and precompute their
         # feed-cell recurrence here. This needs final material coefficients

--- a/gprMax/studies.py
+++ b/gprMax/studies.py
@@ -1,0 +1,670 @@
+# Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Reusable-geometry parameter studies.
+
+The first implementation deliberately supports only stateless local sources
+and ordinary receivers. Stateful ports, plane waves, and eigenmode objects
+need family-specific reset/rebuild hooks before they can safely participate.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+import math
+import shlex
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Optional, Sequence, Union
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+_POSITION_COLUMNS = ("x_m", "y_m", "z_m")
+_SOURCE_PARAMETERS = {"active", "position", "waveform_id", "start", "stop", "scale"}
+_RECEIVER_PARAMETERS = {"position", "record"}
+_CSV_COLUMNS = {
+    "case_id",
+    "object_id",
+    "active",
+    *_POSITION_COLUMNS,
+    "waveform_id",
+    "start_s",
+    "stop_s",
+    "scale",
+    "record",
+}
+
+
+@dataclass
+class ObjectState:
+    """Overrides for one study object in one case.
+
+    ``object`` may be a deterministic object ID such as
+    ``"hertzian_dipole_1"``/``"rx_1"`` or the corresponding Python API
+    user-object instance.
+    """
+
+    object: Any
+    parameters: dict[str, Any] = field(default_factory=dict)
+
+    def __init__(self, object: Any, **parameters: Any):
+        self.object = object
+        self.parameters = dict(parameters)
+
+
+@dataclass
+class StudyCase:
+    """A named set of object overrides."""
+
+    id: str
+    states: list[ObjectState]
+
+    def __init__(self, id: str, states: Iterable[ObjectState]):
+        self.id = str(id).strip()
+        self.states = list(states)
+        if not self.id:
+            raise ValueError("A study case ID cannot be empty.")
+        if not all(isinstance(state, ObjectState) for state in self.states):
+            raise TypeError("StudyCase states must all be ObjectState instances.")
+
+
+class Study:
+    """A sequence of cases evaluated while reusing one built geometry."""
+
+    supported_types = ("gpr",)
+
+    def __init__(
+        self,
+        type: str,
+        cases: Sequence[StudyCase],
+        *,
+        source_path: Optional[Union[str, Path]] = None,
+        source_text: Optional[str] = None,
+    ):
+        self.type = str(type).strip().lower()
+        if self.type not in self.supported_types:
+            raise ValueError(
+                f"Study type '{type}' is not supported. Currently supported types: "
+                f"{', '.join(self.supported_types)}."
+            )
+        self.cases = list(cases)
+        if not self.cases:
+            raise ValueError("A study must contain at least one case.")
+        if not all(isinstance(case, StudyCase) for case in self.cases):
+            raise TypeError("Study cases must all be StudyCase instances.")
+        case_ids = [case.id for case in self.cases]
+        if len(case_ids) != len(set(case_ids)):
+            raise ValueError("Study case IDs must be unique.")
+
+        self.source_path = Path(source_path).resolve() if source_path is not None else None
+        self.source_text = source_text
+        self._scene_bound = False
+        self._runtime_baselines: dict[str, dict[str, Any]] = {}
+        self._current_resolved_case: Optional[dict[str, Any]] = None
+
+    def reset_runtime(self) -> None:
+        """Clear bindings/state retained only for one call to :func:`gprMax.run`."""
+
+        self._scene_bound = False
+        self._runtime_baselines.clear()
+        self._current_resolved_case = None
+
+    @classmethod
+    def from_csv(cls, type: str, path: Union[str, Path]) -> "Study":
+        """Read a sparse, wide study table from CSV."""
+
+        path = Path(path).expanduser().resolve()
+        text = path.read_text(encoding="utf-8-sig")
+        reader = csv.DictReader(text.splitlines())
+        if reader.fieldnames is None:
+            raise ValueError(f"Study CSV '{path}' has no header row.")
+        fieldnames = [name.strip() for name in reader.fieldnames]
+        missing = {"case_id", "object_id"} - set(fieldnames)
+        if missing:
+            raise ValueError(
+                f"Study CSV '{path}' is missing required column(s): {', '.join(sorted(missing))}."
+            )
+        unknown = set(fieldnames) - _CSV_COLUMNS
+        if unknown:
+            raise ValueError(
+                f"Study CSV '{path}' contains unsupported column(s): "
+                f"{', '.join(sorted(unknown))}."
+            )
+
+        case_rows: dict[str, list[ObjectState]] = {}
+        seen: set[tuple[str, str]] = set()
+        for line_number, raw_row in enumerate(reader, start=2):
+            row = {(key or "").strip(): (value or "").strip() for key, value in raw_row.items()}
+            case_id = row.get("case_id", "")
+            object_id = row.get("object_id", "")
+            if not case_id or not object_id:
+                raise ValueError(
+                    f"Study CSV '{path}', line {line_number}: case_id and object_id are required."
+                )
+            key = (case_id, object_id)
+            if key in seen:
+                raise ValueError(
+                    f"Study CSV '{path}', line {line_number}: object '{object_id}' is listed "
+                    f"more than once in case '{case_id}'."
+                )
+            seen.add(key)
+
+            position_values = [row.get(name, "") for name in _POSITION_COLUMNS]
+            if any(position_values) and not all(position_values):
+                raise ValueError(
+                    f"Study CSV '{path}', line {line_number}: x_m, y_m, and z_m must be "
+                    "provided together."
+                )
+
+            parameters: dict[str, Any] = {}
+            if all(position_values):
+                parameters["position"] = tuple(
+                    _parse_finite_float(value, path, line_number, name)
+                    for name, value in zip(_POSITION_COLUMNS, position_values)
+                )
+            if row.get("active", ""):
+                parameters["active"] = _parse_bool(row["active"], path, line_number, "active")
+            if row.get("waveform_id", ""):
+                parameters["waveform_id"] = row["waveform_id"]
+            for csv_name, parameter_name in (
+                ("start_s", "start"),
+                ("stop_s", "stop"),
+                ("scale", "scale"),
+            ):
+                if row.get(csv_name, ""):
+                    parameters[parameter_name] = _parse_finite_float(
+                        row[csv_name], path, line_number, csv_name
+                    )
+            if row.get("record", ""):
+                parameters["record"] = _parse_bool(row["record"], path, line_number, "record")
+
+            case_rows.setdefault(case_id, []).append(ObjectState(object_id, **parameters))
+
+        cases = [StudyCase(case_id, states) for case_id, states in case_rows.items()]
+        return cls(type, cases, source_path=path, source_text=text)
+
+    def bind_scene(self, scene) -> None:
+        """Assign stable IDs and resolve API object references before build."""
+
+        if self._scene_bound:
+            return
+
+        from gprMax.user_objects.cmds_multiuse import (
+            DiscretePlaneWaveAngles,
+            DiscretePlaneWaveAxial,
+            DiscretePlaneWaveVector,
+            EigenmodeExcitation,
+            HertzianDipole,
+            MagneticDipole,
+            MagneticFrillSource,
+            NetworkExcitation,
+            Rx,
+            TransmissionLine,
+            VoltageSource,
+        )
+
+        supported = (
+            (HertzianDipole, "hertzian_dipole"),
+            (MagneticDipole, "magnetic_dipole"),
+            (Rx, "rx"),
+        )
+        registry: dict[str, Any] = {}
+        aliases: dict[str, str] = {}
+        reference_ids: dict[int, str] = {}
+        all_objects = list(scene.grid_objects) + list(scene.output_objects)
+        unsupported_excitation_types = (
+            VoltageSource,
+            TransmissionLine,
+            MagneticFrillSource,
+            NetworkExcitation,
+            DiscretePlaneWaveAngles,
+            DiscretePlaneWaveAxial,
+            DiscretePlaneWaveVector,
+            EigenmodeExcitation,
+        )
+        unsupported = [
+            type(user_object).__name__
+            for user_object in all_objects
+            if isinstance(user_object, unsupported_excitation_types)
+        ]
+        if unsupported:
+            raise ValueError(
+                "This study stage cannot safely manage source type(s): "
+                f"{', '.join(sorted(set(unsupported)))}. It currently supports only "
+                "HertzianDipole and MagneticDipole excitations."
+            )
+        for object_type, prefix in supported:
+            index = 0
+            for user_object in all_objects:
+                if not isinstance(user_object, object_type):
+                    continue
+                index += 1
+                study_id = f"{prefix}_{index}"
+                setattr(user_object, "_study_id", study_id)
+                registry[study_id] = user_object
+                reference_ids[id(user_object)] = study_id
+                explicit_id = getattr(user_object, "id", None)
+                if explicit_id:
+                    explicit_id = str(explicit_id)
+                    if explicit_id == study_id:
+                        aliases[explicit_id] = study_id
+                    elif explicit_id in aliases or explicit_id in registry:
+                        raise ValueError(f"Study object alias '{explicit_id}' is not unique.")
+                    else:
+                        aliases[explicit_id] = study_id
+
+        if not registry:
+            raise ValueError(
+                "The study scene contains no supported objects. The first implementation "
+                "supports HertzianDipole, MagneticDipole, and Rx objects."
+            )
+
+        for case in self.cases:
+            case_seen: set[str] = set()
+            for state in case.states:
+                if isinstance(state.object, str):
+                    requested_id = state.object.strip()
+                    study_id = aliases.get(requested_id, requested_id)
+                else:
+                    try:
+                        study_id = reference_ids[id(state.object)]
+                    except KeyError as exc:
+                        raise ValueError(
+                            f"Study case '{case.id}' references an object that is not a supported "
+                            "top-level object in its Scene."
+                        ) from exc
+                if study_id not in registry:
+                    available = ", ".join(sorted(registry))
+                    raise ValueError(
+                        f"Study case '{case.id}' references unknown object '{study_id}'. "
+                        f"Available study objects: {available}."
+                    )
+                if study_id in case_seen:
+                    raise ValueError(
+                        f"Study case '{case.id}' contains duplicate state for '{study_id}'."
+                    )
+                case_seen.add(study_id)
+                state.object = study_id
+                allowed = (
+                    _RECEIVER_PARAMETERS
+                    if isinstance(registry[study_id], Rx)
+                    else _SOURCE_PARAMETERS
+                )
+                unknown = set(state.parameters) - allowed
+                if unknown:
+                    raise ValueError(
+                        f"Study object '{study_id}' does not support parameter(s) "
+                        f"{', '.join(sorted(unknown))}. Allowed parameters: "
+                        f"{', '.join(sorted(allowed))}."
+                    )
+
+        self.registry = registry
+        self.aliases = aliases
+        self._scene_bound = True
+        logger.info(
+            "Study objects: "
+            + ", ".join(
+                f"{study_id} ({type(user_object).__name__})"
+                for study_id, user_object in registry.items()
+            )
+            + "\n"
+        )
+
+    def apply_case(self, model) -> None:
+        """Restore baselines and apply the current absolute case to a built model."""
+
+        import gprMax.config as config
+
+        case_index = config.sim_config.current_model
+        if case_index < 0 or case_index >= len(self.cases):
+            raise ValueError(
+                f"Study case index {case_index + 1} is outside the {len(self.cases)} available cases."
+            )
+
+        runtime = self._runtime_registry(model)
+        self._capture_baselines(runtime)
+        self._restore_baselines(runtime)
+
+        case = self.cases[case_index]
+        explicit_sources: set[str] = set()
+        resolved: dict[str, Any] = {"case_id": case.id, "objects": {}}
+        for state in case.states:
+            study_id = str(state.object)
+            item = runtime[study_id]
+            if _is_source(item):
+                explicit_sources.add(study_id)
+            applied = self._apply_state(model.G, study_id, item, state.parameters)
+            resolved["objects"][study_id] = applied
+
+        # Sparse tables describe the active source set for each case. A source
+        # omitted from a case is therefore disabled, while receivers retain
+        # their baseline location and remain recorded.
+        for study_id, item in runtime.items():
+            if _is_source(item) and study_id not in explicit_sources:
+                self._resample_source(model.G, item, scale=0.0)
+                resolved["objects"][study_id] = {
+                    "active": False,
+                    "position": [float(item.coord[i] * model.G.dl[i]) for i in range(3)],
+                    "waveform_id": item.waveformID,
+                    "start": float(item.start),
+                    "stop": float(item.stop),
+                    "scale": 0.0,
+                }
+            elif not _is_source(item) and study_id not in resolved["objects"]:
+                resolved["objects"][study_id] = {
+                    "position": [float(item.coord[i] * model.G.dl[i]) for i in range(3)],
+                    "record": True,
+                }
+
+        self._current_resolved_case = resolved
+
+    def write_hdf5(self, h5file) -> None:
+        """Persist the exact case and study source alongside model outputs."""
+
+        import gprMax.config as config
+
+        case_index = config.sim_config.current_model
+        case = self.cases[case_index]
+        group = h5file.create_group("study")
+        group.attrs["Type"] = self.type
+        group.attrs["CaseID"] = case.id
+        group.attrs["CaseIndex"] = case_index + 1
+        group.attrs["CaseCount"] = len(self.cases)
+        group.attrs["GeometryReused"] = bool(config.get_model_config().reuse_geometry())
+        if self.source_path is not None:
+            group.attrs["SourcePath"] = str(self.source_path)
+        if self.source_text is not None:
+            group.create_dataset("source", data=self.source_text)
+        definition = {
+            "type": self.type,
+            "cases": [
+                {
+                    "case_id": item.id,
+                    "objects": {
+                        str(state.object): _jsonable(state.parameters) for state in item.states
+                    },
+                }
+                for item in self.cases
+            ],
+        }
+        group.create_dataset("definition", data=json.dumps(definition, sort_keys=True))
+        group.create_dataset(
+            "resolved_case",
+            data=json.dumps(self._current_resolved_case or {}, sort_keys=True),
+        )
+
+    def _runtime_registry(self, model) -> dict[str, Any]:
+        registry: dict[str, Any] = {}
+        objects = model.G.hertziandipoles + model.G.magneticdipoles + model.G.rxs
+        for item in objects:
+            study_id = getattr(item, "study_id", None)
+            if study_id:
+                registry[study_id] = item
+        expected = set(self.registry)
+        if set(registry) != expected:
+            missing = ", ".join(sorted(expected - set(registry)))
+            raise RuntimeError(f"Study runtime object binding is incomplete; missing: {missing}.")
+        return registry
+
+    def _capture_baselines(self, runtime: Mapping[str, Any]) -> None:
+        if self._runtime_baselines:
+            return
+        for study_id, item in runtime.items():
+            baseline: dict[str, Any] = {"coord": np.array(item.coordorigin, copy=True)}
+            if _is_source(item):
+                baseline.update(
+                    waveform_id=item.waveformID,
+                    start=float(item.start),
+                    stop=float(item.stop),
+                )
+            self._runtime_baselines[study_id] = baseline
+
+    def _restore_baselines(self, runtime: Mapping[str, Any]) -> None:
+        for study_id, item in runtime.items():
+            baseline = self._runtime_baselines[study_id]
+            item.coord = np.array(baseline["coord"], copy=True)
+            if _is_source(item):
+                item.waveformID = baseline["waveform_id"]
+                item.start = baseline["start"]
+                item.stop = baseline["stop"]
+            else:
+                for values in item.outputs.values():
+                    values.fill(0)
+
+    def _apply_state(
+        self, grid, study_id: str, item, parameters: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        from gprMax.user_inputs import MainGridUserInput
+
+        applied: dict[str, Any] = {}
+        if "position" in parameters:
+            point = tuple(float(value) for value in parameters["position"])
+            if len(point) != 3 or not all(math.isfinite(value) for value in point):
+                raise ValueError(
+                    f"Study object '{study_id}' position must contain three finite values."
+                )
+            uip = MainGridUserInput(grid)
+            point = uip.resolve_inf_point(point)
+            _, coord = uip.check_src_rx_point(point, "#study")
+            import gprMax.config as config
+
+            mode = config.get_model_config().mode
+            if mode.startswith("2D"):
+                axis = "xyz".index(mode[-1])
+                baseline_coord = self._runtime_baselines[study_id]["coord"]
+                if coord[axis] != baseline_coord[axis]:
+                    raise ValueError(
+                        f"Study object '{study_id}' cannot move off the active {mode} invariant layer."
+                    )
+            item.coord = coord
+        applied["position"] = [float(item.coord[i] * grid.dl[i]) for i in range(3)]
+
+        if not _is_source(item):
+            if parameters.get("record") is False:
+                raise ValueError(
+                    f"Study object '{study_id}' requested record=false. Selective receiver output "
+                    "is reserved for a later study implementation; omit the row instead."
+                )
+            applied["record"] = True
+            return applied
+
+        if "waveform_id" in parameters:
+            waveform_id = str(parameters["waveform_id"])
+            if not any(waveform.ID == waveform_id for waveform in grid.waveforms):
+                raise ValueError(
+                    f"Study object '{study_id}' references unknown waveform '{waveform_id}'."
+                )
+            item.waveformID = waveform_id
+        if "start" in parameters:
+            item.start = float(parameters["start"])
+        if "stop" in parameters:
+            item.stop = float(parameters["stop"])
+        if item.start < 0 or item.stop <= item.start or item.stop > grid.timewindow:
+            raise ValueError(
+                f"Study object '{study_id}' requires 0 <= start < stop <= the model time window."
+            )
+        scale = float(parameters.get("scale", 1.0))
+        if not math.isfinite(scale):
+            raise ValueError(f"Study object '{study_id}' scale must be finite.")
+        if parameters.get("active") is False:
+            scale = 0.0
+        self._resample_source(grid, item, scale)
+        applied.update(
+            active=bool(scale != 0),
+            waveform_id=item.waveformID,
+            start=float(item.start),
+            stop=float(item.stop),
+            scale=scale,
+        )
+        return applied
+
+    def _resample_source(self, grid, source, scale: float) -> None:
+        waveform = next(w for w in grid.waveforms if w.ID == source.waveformID)
+        values = np.zeros(grid.iterations + 1, dtype=grid.Ex.dtype)
+        half_step = source.waveformvalues_halfdt is not None
+        for iteration in range(grid.iterations + 1):
+            time = grid.dt * iteration
+            if source.start <= time <= source.stop:
+                evaluation_time = time - source.start + (0.5 * grid.dt if half_step else 0.0)
+                values[iteration] = scale * waveform.calculate_value(evaluation_time, grid.dt)
+        if half_step:
+            source.waveformvalues_halfdt = values
+        else:
+            source.waveformvalues_wholedt = values
+        source.study_scale = scale
+
+
+class GPRStudy(Study):
+    """Convenience API for a ``gpr`` study."""
+
+    def __init__(self, cases: Sequence[StudyCase]):
+        super().__init__("gpr", cases)
+
+
+def preflight_study_args(args) -> Optional[Study]:
+    """Resolve API/hash study input before SimulationConfig sizes its run."""
+
+    study = getattr(args, "study", None)
+    if study is not None and not isinstance(study, Study):
+        raise TypeError("The study API argument must be a Study instance.")
+
+    hash_spec = _find_hash_study(getattr(args, "inputfile", None))
+    if study is not None and hash_spec is not None:
+        raise ValueError("Specify a study through either the Python API or #study, not both.")
+    if study is None and hash_spec is not None:
+        study_type, csv_path = hash_spec
+        study = Study.from_csv(study_type, csv_path)
+    if study is None:
+        setattr(args, "study", None)
+        return None
+
+    if getattr(args, "taskfarm", False):
+        raise ValueError("Studies do not yet support MPI task farming.")
+    if getattr(args, "mpi", None) is not None:
+        raise ValueError("Studies do not yet support MPI domain decomposition.")
+    scenes = getattr(args, "scenes", None)
+    if scenes is not None and len(scenes) != 1:
+        raise ValueError("A study requires exactly one reusable Scene.")
+
+    count = len(study.cases)
+    start = getattr(args, "i", None)
+    if start is None:
+        args.n = count
+    else:
+        if start <= 0 or start > count:
+            raise ValueError(
+                f"Study restart index i={start} is outside the {count} available cases."
+            )
+        args.n = count - start + 1
+    args.geometry_fixed = True
+    args.study = study
+    study.reset_runtime()
+    return study
+
+
+def _find_hash_study(inputfile: Optional[Union[str, Path]]) -> Optional[tuple[str, Path]]:
+    if inputfile is None:
+        return None
+    main_path = Path(inputfile).expanduser().resolve()
+    found: list[tuple[str, Path]] = []
+    visited: set[Path] = set()
+
+    def scan(path: Path) -> None:
+        path = path.resolve()
+        if path in visited:
+            return
+        visited.add(path)
+        in_python = False
+        for line in path.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("##"):
+                continue
+            if stripped.startswith("#python:"):
+                in_python = True
+                continue
+            if stripped.startswith("#end_python:"):
+                in_python = False
+                continue
+            if in_python:
+                # Preflight intentionally does not execute deprecated Python.
+                continue
+            if stripped.startswith("#include_file:"):
+                values = shlex.split(stripped.split(":", 1)[1])
+                if len(values) != 1:
+                    raise ValueError("#include_file requires exactly one parameter.")
+                include = Path(values[0]).expanduser()
+                if not include.exists():
+                    include = main_path.parent / include
+                scan(include)
+            elif stripped.startswith("#study:"):
+                values = shlex.split(stripped.split(":", 1)[1])
+                if len(values) != 2:
+                    raise ValueError("#study requires exactly two parameters: type and CSV path.")
+                csv_path = Path(values[1]).expanduser()
+                if not csv_path.is_absolute():
+                    csv_path = main_path.parent / csv_path
+                found.append((values[0].lower(), csv_path.resolve()))
+
+    scan(main_path)
+    if len(found) > 1:
+        raise ValueError("Only one #study command may be specified.")
+    return found[0] if found else None
+
+
+def _is_source(item: Any) -> bool:
+    return hasattr(item, "waveformID") and (
+        getattr(item, "waveformvalues_halfdt", None) is not None
+        or getattr(item, "waveformvalues_wholedt", None) is not None
+    )
+
+
+def _parse_bool(value: str, path: Path, line: int, name: str) -> bool:
+    normalised = value.strip().lower()
+    if normalised in {"true", "yes", "1"}:
+        return True
+    if normalised in {"false", "no", "0"}:
+        return False
+    raise ValueError(f"Study CSV '{path}', line {line}: {name} must be true/false, yes/no, or 1/0.")
+
+
+def _parse_finite_float(value: str, path: Path, line: int, name: str) -> float:
+    try:
+        result = float(value)
+    except ValueError as exc:
+        raise ValueError(f"Study CSV '{path}', line {line}: {name} must be a number.") from exc
+    if not math.isfinite(result):
+        raise ValueError(f"Study CSV '{path}', line {line}: {name} must be finite.")
+    return result
+
+
+def _jsonable(value: Any) -> Any:
+    """Convert ordinary API parameter values to JSON-compatible builtins."""
+
+    if isinstance(value, Mapping):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (tuple, list, np.ndarray)):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, np.generic):
+        return value.item()
+    return value

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -887,6 +887,7 @@ class HertzianDipole(RotatableMixin, GridUserObject):
         uip = self._create_uip(grid)
         x, y, z = uip.discretise_static_point(self.point)
         h.ID = f"{h.__class__.__name__}({x},{y},{z})"
+        h.study_id = getattr(self, "_study_id", None)
         h.waveformID = self.waveform_id
 
         if self.start is None or self.stop is None:
@@ -1084,6 +1085,7 @@ class MagneticDipole(RotatableMixin, GridUserObject):
         uip = self._create_uip(grid)
         x, y, z = uip.discretise_static_point(self.point)
         m.ID = f"{m.__class__.__name__}({x},{y},{z})"
+        m.study_id = getattr(self, "_study_id", None)
         m.waveformID = self.waveform_id
 
         if self.start is None or self.stop is None:
@@ -3021,6 +3023,7 @@ class Rx(RotatableMixin, GridUserObject):
             r.ID = f"{r.__class__.__name__}({x},{y},{z})"
         else:
             r.ID = self.id
+        r.study_id = getattr(self, "_study_id", None)
 
         if self.outputs is None:
             self.outputs = RxUser.defaultoutputs

--- a/tests/test_studies.py
+++ b/tests/test_studies.py
@@ -1,0 +1,215 @@
+"""Tests for reusable-geometry parameter studies."""
+
+import argparse
+import json
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+from gprMax.studies import Study, preflight_study_args
+
+
+def _scene(
+    source_position=(0.01, 0.01, 0.01),
+    receiver_position=(0.015, 0.01, 0.01),
+    waveform_amplitude=1.0,
+):
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(0.001, 0.001, 0.001)))
+    scene.add(gprMax.Domain(p1=(0.02, 0.02, 0.02)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=4e-10))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=waveform_amplitude, freq=5e9, id="wave"))
+    source = gprMax.HertzianDipole(polarisation="z", p1=source_position, waveform_id="wave")
+    receiver = gprMax.Rx(p1=receiver_position, id="probe")
+    scene.add(source)
+    scene.add(receiver)
+    return scene, source, receiver
+
+
+@pytest.mark.integration
+def test_api_study_reuses_geometry_and_writes_exact_case_metadata(tmp_path):
+    scene, source, receiver = _scene()
+    study = gprMax.GPRStudy(
+        [
+            gprMax.StudyCase(
+                "baseline",
+                [
+                    gprMax.ObjectState(source, scale=1.0),
+                    gprMax.ObjectState(receiver, position=(0.015, 0.01, 0.01)),
+                ],
+            ),
+            gprMax.StudyCase(
+                "moved_scaled",
+                [
+                    gprMax.ObjectState(
+                        "hertzian_dipole_1", position=(0.009, 0.01, 0.01), scale=0.5
+                    ),
+                    gprMax.ObjectState("probe", position=(0.014, 0.01, 0.01)),
+                ],
+            ),
+        ]
+    )
+    output = tmp_path / "study"
+
+    gprMax.run(
+        scenes=[scene],
+        study=study,
+        outputfile=output,
+        hide_progress_bars=True,
+        log_level=30,
+    )
+    fresh_scene, _, _ = _scene(
+        source_position=(0.009, 0.01, 0.01),
+        receiver_position=(0.014, 0.01, 0.01),
+        waveform_amplitude=0.5,
+    )
+    fresh_output = tmp_path / "fresh"
+    gprMax.run(
+        scenes=[fresh_scene],
+        outputfile=fresh_output,
+        hide_progress_bars=True,
+        log_level=30,
+    )
+
+    with h5py.File(tmp_path / "study1.h5") as first, h5py.File(
+        tmp_path / "study2.h5"
+    ) as second, h5py.File(tmp_path / "fresh.h5") as fresh:
+        assert first["study"].attrs["CaseID"] == "baseline"
+        assert second["study"].attrs["CaseID"] == "moved_scaled"
+        assert not first["study"].attrs["GeometryReused"]
+        assert second["study"].attrs["GeometryReused"]
+        assert np.allclose(first["srcs/src1"].attrs["Position"], (0.01, 0.01, 0.01))
+        assert np.allclose(second["srcs/src1"].attrs["Position"], (0.009, 0.01, 0.01))
+        assert np.allclose(second["rxs/rx1"].attrs["Position"], (0.014, 0.01, 0.01))
+
+        excitation1 = first["srcs/src1/excitation/samples"][:]
+        excitation2 = second["srcs/src1/excitation/samples"][:]
+        assert np.max(np.abs(excitation1)) > 0.9
+        assert np.allclose(excitation2, 0.5 * excitation1)
+        resolved = json.loads(second["study/resolved_case"][()].decode())
+        assert resolved["objects"]["hertzian_dipole_1"]["scale"] == 0.5
+        assert np.array_equal(second["rxs/rx1/Ez"][:], fresh["rxs/rx1/Ez"][:])
+
+
+def test_hash_study_csv_preflight_sets_case_count_and_restart(tmp_path):
+    csvfile = tmp_path / "cases.csv"
+    csvfile.write_text(
+        "case_id,object_id,active,x_m,y_m,z_m,waveform_id,start_s,stop_s,scale,record\n"
+        "one,hertzian_dipole_1,true,,,,,,,1,\n"
+        "two,hertzian_dipole_1,true,0.009,0.01,0.01,,,,0.5,\n"
+        "three,hertzian_dipole_1,false,,,,,,,,\n"
+    )
+    inputfile = tmp_path / "model.in"
+    inputfile.write_text(f"#study: gpr {csvfile.name}\n")
+
+    args = argparse.Namespace(
+        study=None,
+        inputfile=str(inputfile),
+        taskfarm=False,
+        mpi=None,
+        scenes=None,
+        geometry_fixed=False,
+        n=99,
+        i=2,
+    )
+    study = preflight_study_args(args)
+
+    assert isinstance(study, Study)
+    assert [case.id for case in study.cases] == ["one", "two", "three"]
+    assert args.geometry_fixed
+    assert args.n == 2
+
+
+@pytest.mark.integration
+def test_hash_study_runs_all_cases_and_disables_omitted_source(tmp_path):
+    csvfile = tmp_path / "cases.csv"
+    csvfile.write_text(
+        "case_id,object_id,active,x_m,y_m,z_m,scale\n"
+        "on,hertzian_dipole_1,true,0.01,0.01,0.01,1\n"
+        "on,rx_1,,0.015,0.01,0.01,\n"
+        "off,rx_1,,0.014,0.01,0.01,\n"
+    )
+    inputfile = tmp_path / "model.in"
+    inputfile.write_text(
+        "#title: hash study integration\n"
+        "#dx_dy_dz: 0.001 0.001 0.001\n"
+        "#domain: 0.02 0.02 0.02\n"
+        "#pml_cells: 0\n"
+        "#time_window: 4e-10\n"
+        "#waveform: ricker 1 5e9 wave\n"
+        "#hertzian_dipole: z 0.01 0.01 0.01 wave\n"
+        "#rx: 0.015 0.01 0.01\n"
+        f"#study: gpr {csvfile.name}\n"
+    )
+    output = tmp_path / "hash_study"
+
+    gprMax.run(
+        inputfile=inputfile,
+        outputfile=output,
+        hide_progress_bars=True,
+        log_level=30,
+    )
+
+    with h5py.File(tmp_path / "hash_study1.h5") as active, h5py.File(
+        tmp_path / "hash_study2.h5"
+    ) as inactive:
+        assert active["study"].attrs["CaseID"] == "on"
+        assert inactive["study"].attrs["CaseID"] == "off"
+        assert np.max(np.abs(active["srcs/src1/excitation/samples"][:])) > 0.9
+        assert np.all(inactive["srcs/src1/excitation/samples"][:] == 0)
+        assert inactive["study/source"][()].decode() == csvfile.read_text()
+        resolved = json.loads(inactive["study/resolved_case"][()].decode())
+        assert not resolved["objects"]["hertzian_dipole_1"]["active"]
+
+
+@pytest.mark.integration
+def test_magnetic_dipole_study_scales_whole_step_excitation(tmp_path):
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(0.001, 0.001, 0.001)))
+    scene.add(gprMax.Domain(p1=(0.02, 0.02, 0.02)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=4e-10))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="wave"))
+    source = gprMax.MagneticDipole(polarisation="z", p1=(0.01, 0.01, 0.01), waveform_id="wave")
+    scene.add(source)
+    scene.add(gprMax.Rx(p1=(0.015, 0.01, 0.01)))
+    study = gprMax.GPRStudy(
+        [
+            gprMax.StudyCase("one", [gprMax.ObjectState(source, scale=1.0)]),
+            gprMax.StudyCase("quarter", [gprMax.ObjectState(source, scale=0.25)]),
+        ]
+    )
+
+    gprMax.run(
+        scenes=[scene],
+        study=study,
+        outputfile=tmp_path / "magnetic",
+        hide_progress_bars=True,
+        log_level=30,
+    )
+
+    with h5py.File(tmp_path / "magnetic1.h5") as first, h5py.File(
+        tmp_path / "magnetic2.h5"
+    ) as second:
+        excitation1 = first["srcs/src1/excitation/samples"][:]
+        excitation2 = second["srcs/src1/excitation/samples"][:]
+        assert np.max(np.abs(excitation1)) > 0.9
+        assert np.allclose(excitation2, 0.25 * excitation1)
+        assert second["srcs/src1"].attrs["StudyID"] == "magnetic_dipole_1"
+
+
+def test_study_csv_rejects_partial_position_and_duplicate_object(tmp_path):
+    partial = tmp_path / "partial.csv"
+    partial.write_text("case_id,object_id,x_m,y_m,z_m\none,rx_1,0.1,,0.2\n")
+    with pytest.raises(ValueError, match="provided together"):
+        Study.from_csv("gpr", partial)
+
+    duplicate = tmp_path / "duplicate.csv"
+    duplicate.write_text(
+        "case_id,object_id,scale\none,hertzian_dipole_1,1\none,hertzian_dipole_1,0.5\n"
+    )
+    with pytest.raises(ValueError, match="more than once"):
+        Study.from_csv("gpr", duplicate)


### PR DESCRIPTION
# PR Description

## PR Description

This PR introduces the first stage of a reusable parameter-study framework for running multiple simulations with the same built geometry.

It provides:

- Python API classes: `Study`, `GPRStudy`, `StudyCase`, and `ObjectState`.
- A `#study` hash command using an external CSV study definition.
- Deterministic identifiers such as `hertzian_dipole_1`, `magnetic_dipole_1`, and `rx_1`.
- Per-case source activation, position, waveform, start/stop time, and amplitude scaling.
- Per-case receiver positioning.
- Restoration of the original object state before every case, preventing state leakage between runs.
- Automatic geometry reuse and study-driven output numbering.
- HDF5 study metadata and provenance, including the source definition and resolved case.
- Validation and clear rejection of source types that do not yet have safe reusable-state support.
- Documentation for both hash-command and Python API workflows.
- Automated tests covering API studies, CSV/hash-command studies, restart behaviour, source omission, scaling, receiver movement, and malformed definitions.

This PR deliberately limits the first implementation to Hertzian electric dipoles, magnetic dipoles, and receivers. Stateful sources, plane waves, eigenmode ports, and related features will be enabled in focused follow-up PRs after their reset and reconfiguration requirements are implemented.

## 🛠️ Related Issue (Number)

Closes #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update.

## Testing

- 128 relevant pytest tests passed.
- 2 CUDA tests were skipped because PyCUDA was unavailable to that pytest environment.
- Manual CPU/CUDA study parity was previously verified on the available NVIDIA hardware.
- Sphinx HTML documentation build succeeded.
- The two Sphinx warnings are existing unreferenced citations and are unrelated to this PR.
- `git diff --check` passed.

## Checklist

- [ ] Did pre-commit pass all checks?
- [x] I have performed a self-review of my code.
- [x] I have added comments for my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.