### PR TITLE
Add reusable finite-resistance multiport studies

### DIFF
--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -154,7 +154,7 @@ plane-wave studies. Every case restores the original object state before its
 overrides are applied, so parameters cannot accidentally accumulate between
 runs.
 
-The initial implementation supports top-level
+General GPR studies support top-level
 :class:`gprMax.HertzianDipole`, :class:`gprMax.MagneticDipole`, and
 :class:`gprMax.Rx` objects on the main grid. A state can refer directly to its
 Python object or use its deterministic ID. Sources omitted from a case are
@@ -195,16 +195,92 @@ one-based case number ``N``. For a text input model the equivalent
 
 .. autoclass:: gprMax.studies.GPRStudy
 
+Finite-resistance voltage-port studies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A :class:`gprMax.PortStudy` calculates a complete multiport S matrix without
+rebuilding the antenna geometry. Every finite-resistance
+:class:`gprMax.VoltageSource` remains on its original electric edge in every
+case. Exactly one source is driven, while omitted sources have zero generator
+voltage but retain their resistance and therefore act as passive matched
+terminations. Every source must have a coincident, uniquely named
+:class:`gprMax.RxPort`.
+
+.. code-block:: python
+
+    port1_source = gprMax.VoltageSource(
+        p1=(0.040, 0.050, 0.030), polarisation='z', resistance=50,
+        waveform_id='pulse'
+    )
+    port2_source = gprMax.VoltageSource(
+        p1=(0.060, 0.050, 0.030), polarisation='z', resistance=50,
+        waveform_id='pulse'
+    )
+    scene.add(port1_source)
+    scene.add(port2_source)
+    scene.add(gprMax.RxPort(p1=(0.040, 0.050, 0.030), id='port1'))
+    scene.add(gprMax.RxPort(p1=(0.060, 0.050, 0.030), id='port2'))
+
+    study = gprMax.PortStudy([
+        gprMax.StudyCase('drive_port1', [
+            gprMax.ObjectState(port1_source, scale=1.0),
+        ]),
+        gprMax.StudyCase('drive_port2', [
+            gprMax.ObjectState(port2_source, scale=1.0),
+        ]),
+    ])
+
+    results = gprMax.run(scenes=[scene], study=study, outputfile='array')
+    smatrix = results['study'].s
+
+The returned and stored matrix uses
+``S[frequency, output_port, input_port]``. Voltage waves are converted to
+power-wave normalisation, so ports may use different positive real reference
+impedances. The individual source gaps contain numerical background
+capacitance and conductance. These are removed from the complete admittance
+matrix:
+
+.. math::
+
+    \begin{aligned}
+    \overline{\mathbf{Y}}_{\mathrm{s}}
+      &= (\mathbf{I}-\mathbf{S}_{\mathrm{s}})
+         (\mathbf{I}+\mathbf{S}_{\mathrm{s}})^{-1}, \\
+    \overline{\mathbf{Y}}
+      &= \overline{\mathbf{Y}}_{\mathrm{s}}
+         - \operatorname{diag}(Z_{0,p}Y_{\mathrm{gap},p}), \\
+    \mathbf{S}
+      &= (\mathbf{I}+\overline{\mathbf{Y}})^{-1}
+         (\mathbf{I}-\overline{\mathbf{Y}}).
+    \end{aligned}
+
+This matrix operation is important: applying the scalar one-port correction
+independently to off-diagonal elements is not mathematically valid. The
+per-case files contain the raw source-plane column, and ``array_study.h5``
+contains both ``S_source`` and the corrected ``S`` matrix. Restarting with
+``i=N`` reuses compatible columns already present in this aggregate file.
+
+Source position and resistance are immutable because both affect the built
+electric-edge material. The permitted case parameters are ``active``,
+``waveform_id``, ``start``, ``stop``, and ``scale``. Hard voltage sources are
+rejected because zero drive would impose a zero electric field rather than a
+matched passive termination.
+
+.. autoclass:: gprMax.studies.PortStudy
+
+.. autoclass:: gprMax.studies.PortStudyResult
+
 .. autoclass:: gprMax.studies.StudyCase
 
 .. autoclass:: gprMax.studies.ObjectState
 
 .. note::
 
-    MPI/task-farm studies, subgrid study objects, stateful ports, plane waves,
-    and eigenmode sources are not enabled in this first stage. Their cached
-    fields, transforms, and derived setup must be reset or rebuilt explicitly;
-    gprMax rejects them instead of reusing stale state.
+    MPI/task-farm studies, subgrid study objects, transmission lines, rational
+    networks, magnetic-frill sources, plane waves, and eigenmode sources are
+    not yet enabled. Their cached fields, transforms, and derived setup must be
+    reset or rebuilt explicitly; gprMax rejects them instead of reusing stale
+    state.
 
 Typical general settings are added directly to the scene:
 

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1945,6 +1945,13 @@ case that produced it. The syntax is:
 
     #study: gpr file1
 
+The study type may be ``gpr`` for irregular source/receiver acquisition or
+``port`` for a finite-resistance voltage-source S-parameter study:
+
+.. code-block:: none
+
+    #study: port file1
+
 ``file1`` is a CSV table. Its path is resolved relative to the main input
 file. The required columns are ``case_id`` and ``object_id``. The optional
 columns are ``active``, ``x_m``, ``y_m``, ``z_m``, ``waveform_id``,
@@ -1964,12 +1971,36 @@ For example:
 
 Objects receive deterministic IDs from their order of appearance within each
 object family: ``hertzian_dipole_1``, ``hertzian_dipole_2``,
-``magnetic_dipole_1``, and ``rx_1``. An explicit ``#rx`` identifier is also
-accepted as an alias. A source listed in a case is active by default; a source
-omitted from that case, or listed with ``active=false``, is inactive. A
-receiver omitted from a case remains at its baseline position and is still
-recorded. ``record=false`` is reserved for future selective-output support and
-is currently rejected rather than silently ignored.
+``magnetic_dipole_1``, ``voltage_source_1``, and ``rx_1``. An explicit
+``#rx`` identifier is also accepted as an alias. A source listed in a case is
+active by default; a source omitted from that case, or listed with
+``active=false``, is inactive. A receiver omitted from a case remains at its
+baseline position and is still recorded. ``record=false`` is reserved for
+future selective-output support and is currently rejected rather than
+silently ignored.
+
+For a ``port`` study, every ``#voltage_source`` must have finite, non-zero
+resistance and a coincident ``#rx_port`` with a unique ID. The CSV must contain
+one case for every voltage source and drive exactly one source in each case.
+Omitted sources retain their fixed source resistance but receive a zero
+generator waveform, so they behave as passive matched terminations. For
+example, a two-port schedule is:
+
+.. code-block:: text
+
+    case_id,object_id,active,scale
+    drive_port1,voltage_source_1,true,1
+    drive_port2,voltage_source_2,true,1
+
+Source position and resistance cannot vary in a port study because they are
+part of the built electric-edge material. Hard sources are not accepted: zero
+drive on a hard source enforces zero field and is not a matched termination.
+Each case output stores its source-plane S-matrix column. After the cases
+finish, ``<output>_study.h5`` stores the complete source-plane and
+gap-corrected matrices using
+``S[frequency, output_port, input_port]``. The correction removes all numerical
+gap capacitances/conductances through the full admittance matrix, including
+the coupled off-diagonal terms.
 
 The number of CSV cases determines the number of model runs, so ``-n`` is not
 required. ``-i N`` restarts at case ``N`` and retains absolute output numbering.
@@ -1980,10 +2011,11 @@ of the CSV source.
 
 .. note::
 
-    The first implementation supports top-level ``#hertzian_dipole``,
-    ``#magnetic_dipole``, and ``#rx`` objects on the main grid. MPI domain
-    decomposition, task farming, subgrid objects, plane waves, voltage and
-    transmission-line sources, rational/frill ports, and eigenmode objects are
+    GPR studies support top-level ``#hertzian_dipole``,
+    ``#magnetic_dipole``, and ``#rx`` objects; port studies additionally
+    support finite-resistance ``#voltage_source``/``#rx_port`` pairs. MPI
+    domain decomposition, task farming, subgrid study objects, plane waves,
+    transmission lines, rational/frill ports, and eigenmode objects are
     rejected until their family-specific state reset and rebuild hooks are
     implemented. This explicit restriction prevents contaminated results from
     persistent source or transform state.

--- a/docs/source/output.rst
+++ b/docs/source/output.rst
@@ -48,6 +48,33 @@ and implicitly disabled sources.
 Study-managed source and receiver groups also carry a ``StudyID`` attribute,
 which provides an unambiguous link back to the case table.
 
+Every case in a finite-resistance voltage-port study additionally contains
+``study/port_response``. ``DrivenSourceID`` and ``DrivenPortID`` identify its
+input port; ``S_source_column`` contains the power-normalised raw source-plane
+response for every output port. ``gap_correction_c`` stores the dimensionless
+parallel-gap admittance :math:`Z_{0,p}Y_{\mathrm{gap},p}` used by the matrix
+correction.
+
+After all requested cases finish, gprMax writes ``<output>_study.h5``. Its
+principal datasets are:
+
+- ``frequency``: common frequency axis;
+- ``port_ids`` and ``source_ids``: output-port and deterministic source order;
+- ``case_ids``: case contributing each input-port column;
+- ``reference_impedance``: positive real wave-reference impedance per port;
+- ``gap_correction_c``: numerical gap shunt correction for every frequency and
+  port;
+- ``S_source``: uncorrected source-plane S matrix;
+- ``S``: matrix after removing all numerical gap admittances;
+- ``valid_S_source`` and ``valid_S``: element validity masks.
+
+Both matrices use axis order
+``S[frequency, output_port, input_port]``. The ``Complete`` attribute states
+whether every input-port column is present. A restarted study loads compatible
+columns from an existing aggregate file and replaces the newly evaluated
+columns; an incompatible existing file is rejected rather than mixed with new
+results.
+
 .. code-block:: none
 
     /
@@ -55,6 +82,14 @@ which provides an unambiguous link back to the case table.
             source [CSV studies]
             definition
             resolved_case
+            port_response/ [port studies]
+                port_ids
+                source_ids
+                frequency
+                reference_impedance
+                gap_correction_c
+                S_source_column
+                valid_S_source_column
         rxs/
             rx1/
                 Name

--- a/gprMax/__init__.py
+++ b/gprMax/__init__.py
@@ -18,7 +18,7 @@ from .ntff import (
     spherical_observation_points,
 )
 from .scene import Scene
-from .studies import GPRStudy, ObjectState, Study, StudyCase
+from .studies import GPRStudy, ObjectState, PortStudy, PortStudyResult, Study, StudyCase
 from .subgrids.user_objects import SubGridHSG
 from .user_objects.cmds_geometry.add_grass import AddGrass
 from .user_objects.cmds_geometry.add_surface_roughness import AddSurfaceRoughness

--- a/gprMax/contexts.py
+++ b/gprMax/contexts.py
@@ -103,9 +103,15 @@ class Context:
         for i in self.model_range:
             self._run_model(i)
 
+        results = {}
+        if config.sim_config.study is not None:
+            study_result = config.sim_config.study.finalise()
+            if study_result is not None:
+                results["study"] = study_result
+
         self._end_simulation()
 
-        return {}
+        return results
 
     def _run_model(self, model_num: int) -> None:
         """Process for running a single model.

--- a/gprMax/model.py
+++ b/gprMax/model.py
@@ -655,6 +655,9 @@ class Model:
             finalise_transmission_line_ports(grid)
             finalise_magnetic_frill_ports(grid)
 
+        if config.sim_config.study is not None:
+            config.sim_config.study.collect_case(self)
+
         # Write output data to file if they are any receivers in any grids
         sg_rxs = [True for sg in self.subgrids if sg.rxs]
         sg_tls = [True for sg in self.subgrids if sg.transmissionlines]

--- a/gprMax/ports.py
+++ b/gprMax/ports.py
@@ -242,11 +242,7 @@ def evaluate_port_power_spectrum(
         power_wave_valid = np.asarray(power_wave_valid_value, dtype=bool)
         result_valid = np.asarray(output.result.valid, dtype=bool)
         power_matrix_valid = np.asarray(output.power_matrix_valid, dtype=bool)
-        modal_valid = (
-            result_valid
-            & power_wave_valid.T
-            & power_matrix_valid[np.newaxis, :]
-        )
+        modal_valid = result_valid & power_wave_valid.T & power_matrix_valid[np.newaxis, :]
         physical_power_valid = np.zeros(frequency.shape, dtype=bool)
         for frequency_index in range(frequency.size):
             physical_modes = np.flatnonzero(power_wave_valid[frequency_index])
@@ -764,6 +760,56 @@ def correct_s11_for_parallel_gap(s11_source, gap_correction, complex_dtype=None)
     return _safe_complex_divide(numerator, denominator, complex_dtype)
 
 
+def correct_smatrix_for_parallel_gaps(s_source, gap_correction, complex_dtype=None):
+    """Remove the Yee-gap shunt admittances from a multiport S matrix.
+
+    ``s_source`` uses power-wave normalisation and has shape
+    ``(nfrequency, nport, nport)``. ``gap_correction`` is the dimensionless
+    diagonal admittance ``Z0 * Ygap`` for every frequency and port, with
+    shape ``(nfrequency, nport)``. The conversion is performed through the
+    normalised admittance matrix so coupling terms are corrected consistently
+    rather than treating every matrix element as an independent S11.
+
+    Returns the corrected matrix and one validity flag per frequency.
+    """
+
+    if complex_dtype is None:
+        complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
+    else:
+        complex_dtype = np.dtype(complex_dtype)
+    source = np.asarray(s_source, dtype=complex_dtype)
+    correction = np.asarray(gap_correction, dtype=complex_dtype)
+    if source.ndim != 3 or source.shape[1] != source.shape[2]:
+        raise ValueError("s_source must have shape (nfrequency, nport, nport)")
+    if correction.shape != source.shape[:2]:
+        raise ValueError("gap_correction must have shape (nfrequency, nport)")
+
+    corrected = np.full(source.shape, np.nan + 1j * np.nan, dtype=complex_dtype)
+    valid = np.zeros(source.shape[0], dtype=bool)
+    identity = np.eye(source.shape[1], dtype=complex_dtype)
+    for index, (matrix, gaps) in enumerate(zip(source, correction)):
+        if not np.all(np.isfinite(matrix)) or not np.all(np.isfinite(gaps)):
+            continue
+        try:
+            # y_source = (I - S_source) (I + S_source)^-1. The transpose
+            # form applies the right-hand inverse using numpy's left solve.
+            y_source = np.linalg.solve(
+                (identity + matrix).T,
+                (identity - matrix).T,
+            ).T
+            y_corrected = y_source - np.diag(gaps)
+            matrix_corrected = np.linalg.solve(
+                identity + y_corrected,
+                identity - y_corrected,
+            )
+        except np.linalg.LinAlgError:
+            continue
+        if np.all(np.isfinite(matrix_corrected)):
+            corrected[index] = np.asarray(matrix_corrected, dtype=complex_dtype)
+            valid[index] = True
+    return corrected, valid
+
+
 def impedance_from_s11(s11, reference_impedance, complex_dtype=None):
     """Calculate input impedance from S11 with a separate validity mask."""
 
@@ -1198,6 +1244,22 @@ class VoltageSourcePortMonitor:
     @property
     def component(self):
         return f"E{self.source.polarisation}"
+
+    def reset_run_state(self) -> None:
+        """Clear histories and derived results before a reused-geometry run."""
+
+        for values in self.receiver.outputs.values():
+            values.fill(0)
+        self.result = None
+        for name in (
+            "_hard_current_time",
+            "_hard_loop_current",
+            "_hard_loop_current_spectrum",
+            "_hard_terminal_current_spectrum",
+            "_hard_source_plane_valid",
+        ):
+            if hasattr(self, name):
+                delattr(self, name)
 
     def rebind_after_mpi_gather(self, grid: "FDTDGrid") -> None:
         """Reconnect gathered monitor state to the coordinator's grid objects."""

--- a/gprMax/studies.py
+++ b/gprMax/studies.py
@@ -17,11 +17,11 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Reusable-geometry parameter studies.
+"""Reusable-geometry parameter and finite-resistance multiport studies.
 
-The first implementation deliberately supports only stateless local sources
-and ordinary receivers. Stateful ports, plane waves, and eigenmode objects
-need family-specific reset/rebuild hooks before they can safely participate.
+General GPR studies manage stateless local sources and ordinary receivers.
+Port studies additionally manage source-bound voltage-port monitors and
+assemble their frequency-domain response after the reused solves.
 """
 
 from __future__ import annotations
@@ -35,7 +35,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional, Sequence, Union
 
+import h5py
 import numpy as np
+import numpy.typing as npt
 
 logger = logging.getLogger(__name__)
 
@@ -202,6 +204,8 @@ class Study:
             case_rows.setdefault(case_id, []).append(ObjectState(object_id, **parameters))
 
         cases = [StudyCase(case_id, states) for case_id, states in case_rows.items()]
+        if str(type).strip().lower() == "port":
+            return PortStudy(cases, source_path=path, source_text=text)
         return cls(type, cases, source_path=path, source_text=text)
 
     def bind_scene(self, scene) -> None:
@@ -225,6 +229,7 @@ class Study:
         )
 
         supported = (
+            (VoltageSource, "voltage_source"),
             (HertzianDipole, "hertzian_dipole"),
             (MagneticDipole, "magnetic_dipole"),
             (Rx, "rx"),
@@ -234,7 +239,6 @@ class Study:
         reference_ids: dict[int, str] = {}
         all_objects = list(scene.grid_objects) + list(scene.output_objects)
         unsupported_excitation_types = (
-            VoltageSource,
             TransmissionLine,
             MagneticFrillSource,
             NetworkExcitation,
@@ -252,7 +256,14 @@ class Study:
             raise ValueError(
                 "This study stage cannot safely manage source type(s): "
                 f"{', '.join(sorted(set(unsupported)))}. It currently supports only "
-                "HertzianDipole and MagneticDipole excitations."
+                "voltage sources, HertzianDipole, and MagneticDipole excitations."
+            )
+        if self.type != "port" and any(
+            isinstance(user_object, VoltageSource) for user_object in all_objects
+        ):
+            raise ValueError(
+                "VoltageSource reuse is available through PortStudy so its fixed terminal "
+                "resistance and source-bound RxPort are validated together."
             )
         for object_type, prefix in supported:
             index = 0
@@ -276,8 +287,8 @@ class Study:
 
         if not registry:
             raise ValueError(
-                "The study scene contains no supported objects. The first implementation "
-                "supports HertzianDipole, MagneticDipole, and Rx objects."
+                "The study scene contains no supported objects. Studies currently support "
+                "VoltageSource, HertzianDipole, MagneticDipole, and Rx objects."
             )
 
         for case in self.cases:
@@ -306,11 +317,16 @@ class Study:
                     )
                 case_seen.add(study_id)
                 state.object = study_id
-                allowed = (
-                    _RECEIVER_PARAMETERS
-                    if isinstance(registry[study_id], Rx)
-                    else _SOURCE_PARAMETERS
-                )
+                if isinstance(registry[study_id], Rx):
+                    allowed = _RECEIVER_PARAMETERS
+                elif isinstance(registry[study_id], VoltageSource):
+                    # A finite-resistance source changes the electric-edge
+                    # update coefficients during geometry construction. Its
+                    # position and resistance are therefore immutable in a
+                    # reused model; only the generator drive may vary.
+                    allowed = _SOURCE_PARAMETERS - {"position"}
+                else:
+                    allowed = _SOURCE_PARAMETERS
                 unknown = set(state.parameters) - allowed
                 if unknown:
                     raise ValueError(
@@ -416,7 +432,9 @@ class Study:
 
     def _runtime_registry(self, model) -> dict[str, Any]:
         registry: dict[str, Any] = {}
-        objects = model.G.hertziandipoles + model.G.magneticdipoles + model.G.rxs
+        objects = (
+            model.G.voltagesources + model.G.hertziandipoles + model.G.magneticdipoles + model.G.rxs
+        )
         for item in objects:
             study_id = getattr(item, "study_id", None)
             if study_id:
@@ -521,18 +539,35 @@ class Study:
 
     def _resample_source(self, grid, source, scale: float) -> None:
         waveform = next(w for w in grid.waveforms if w.ID == source.waveformID)
-        values = np.zeros(grid.iterations + 1, dtype=grid.Ex.dtype)
-        half_step = source.waveformvalues_halfdt is not None
-        for iteration in range(grid.iterations + 1):
-            time = grid.dt * iteration
-            if source.start <= time <= source.stop:
-                evaluation_time = time - source.start + (0.5 * grid.dt if half_step else 0.0)
-                values[iteration] = scale * waveform.calculate_value(evaluation_time, grid.dt)
-        if half_step:
-            source.waveformvalues_halfdt = values
-        else:
-            source.waveformvalues_wholedt = values
+        if source.waveformvalues_halfdt is not None:
+            half_values = np.zeros(grid.iterations + 1, dtype=grid.Ex.dtype)
+            for iteration in range(grid.iterations + 1):
+                time = grid.dt * iteration
+                if source.start <= time <= source.stop:
+                    half_values[iteration] = scale * waveform.calculate_value(
+                        time - source.start + 0.5 * grid.dt,
+                        grid.dt,
+                    )
+            source.waveformvalues_halfdt = half_values
+        if source.waveformvalues_wholedt is not None:
+            whole_values = np.zeros(grid.iterations + 1, dtype=grid.Ex.dtype)
+            for iteration in range(grid.iterations + 1):
+                time = grid.dt * iteration
+                if source.start <= time <= source.stop:
+                    whole_values[iteration] = scale * waveform.calculate_value(
+                        time - source.start,
+                        grid.dt,
+                    )
+            source.waveformvalues_wholedt = whole_values
         source.study_scale = scale
+
+    def collect_case(self, model) -> None:
+        """Collect derived results after a case has solved."""
+
+    def finalise(self):
+        """Finalise any study-level result after all requested cases."""
+
+        return None
 
 
 class GPRStudy(Study):
@@ -540,6 +575,405 @@ class GPRStudy(Study):
 
     def __init__(self, cases: Sequence[StudyCase]):
         super().__init__("gpr", cases)
+
+
+@dataclass(frozen=True)
+class PortStudyResult:
+    """Assembled source-plane and gap-corrected multiport S parameters."""
+
+    frequency: npt.NDArray[np.floating]
+    port_ids: tuple[str, ...]
+    source_ids: tuple[str, ...]
+    case_ids: tuple[str, ...]
+    reference_impedance: npt.NDArray[np.floating]
+    gap_correction: npt.NDArray[np.complexfloating]
+    s_source: npt.NDArray[np.complexfloating]
+    s: npt.NDArray[np.complexfloating]
+    valid_s_source: npt.NDArray[np.bool_]
+    valid_s: npt.NDArray[np.bool_]
+    output_file: Path
+
+
+class PortStudy(Study):
+    """One-active-port-per-case finite-resistance voltage-source study."""
+
+    supported_types = ("port",)
+
+    def __init__(
+        self,
+        cases: Sequence[StudyCase],
+        *,
+        source_path: Optional[Union[str, Path]] = None,
+        source_text: Optional[str] = None,
+    ):
+        super().__init__(
+            "port",
+            cases,
+            source_path=source_path,
+            source_text=source_text,
+        )
+        self._case_drive_ids: list[str] = []
+        self._port_source_ids: tuple[str, ...] = ()
+        self._port_ids: tuple[str, ...] = ()
+        self._port_monitors: dict[str, Any] = {}
+        self._columns: dict[str, dict[str, Any]] = {}
+        self._current_port_column: Optional[dict[str, Any]] = None
+        self._aggregate_output_path: Optional[Path] = None
+        self.result: Optional[PortStudyResult] = None
+
+    def reset_runtime(self) -> None:
+        super().reset_runtime()
+        self._case_drive_ids = []
+        self._port_source_ids = ()
+        self._port_ids = ()
+        self._port_monitors.clear()
+        self._columns.clear()
+        self._current_port_column = None
+        self._aggregate_output_path = None
+        self.result = None
+
+    def bind_scene(self, scene) -> None:
+        """Validate the fixed finite-resistance port topology and drive cases."""
+
+        super().bind_scene(scene)
+        from gprMax.user_objects.cmds_multiuse import HertzianDipole, MagneticDipole, VoltageSource
+        from gprMax.user_objects.cmds_output import RxPort
+
+        other_sources = [
+            study_id
+            for study_id, user_object in self.registry.items()
+            if isinstance(user_object, (HertzianDipole, MagneticDipole))
+        ]
+        if other_sources:
+            raise ValueError(
+                "PortStudy cases may contain only finite-resistance VoltageSource "
+                f"excitations; remove {', '.join(other_sources)}."
+            )
+        voltage_ids = [
+            study_id
+            for study_id, user_object in self.registry.items()
+            if isinstance(user_object, VoltageSource)
+        ]
+        if not voltage_ids:
+            raise ValueError("PortStudy requires at least one finite-resistance VoltageSource.")
+        for study_id in voltage_ids:
+            source = self.registry[study_id]
+            if not np.isfinite(source.resistance) or source.resistance <= 0:
+                raise ValueError(
+                    f"PortStudy source '{study_id}' must have a finite resistance greater "
+                    "than zero; hard voltage sources are not matched passive ports."
+                )
+
+        rx_ports = [
+            user_object for user_object in scene.output_objects if isinstance(user_object, RxPort)
+        ]
+        if len(rx_ports) != len(voltage_ids):
+            raise ValueError(
+                "PortStudy requires exactly one RxPort at every VoltageSource; found "
+                f"{len(rx_ports)} RxPort object(s) for {len(voltage_ids)} source(s)."
+            )
+
+        drive_ids: list[str] = []
+        for case in self.cases:
+            active = []
+            for state in case.states:
+                study_id = str(state.object)
+                if study_id not in voltage_ids:
+                    continue
+                scale = float(state.parameters.get("scale", 1.0))
+                if state.parameters.get("active") is not False and scale != 0:
+                    active.append(study_id)
+            if len(active) != 1:
+                raise ValueError(
+                    f"PortStudy case '{case.id}' must explicitly drive exactly one "
+                    f"VoltageSource; found {len(active)}. Omitted sources remain passive."
+                )
+            drive_ids.append(active[0])
+        if len(set(drive_ids)) != len(drive_ids):
+            raise ValueError("PortStudy must drive every voltage port in exactly one case.")
+        if set(drive_ids) != set(voltage_ids):
+            missing = ", ".join(study_id for study_id in voltage_ids if study_id not in drive_ids)
+            raise ValueError(f"PortStudy has no driven case for: {missing}.")
+        self._case_drive_ids = drive_ids
+
+    def apply_case(self, model) -> None:
+        for monitor in getattr(model.G, "port_monitors", ()):
+            reset = getattr(monitor, "reset_run_state", None)
+            if reset is not None:
+                reset()
+        super().apply_case(model)
+        self._bind_runtime_ports(model)
+
+        import gprMax.config as config
+
+        drive_id = self._case_drive_ids[config.sim_config.current_model]
+        resolved = self._current_resolved_case or {}
+        active = [
+            study_id
+            for study_id in self._port_source_ids
+            if resolved.get("objects", {}).get(study_id, {}).get("active", False)
+        ]
+        if active != [drive_id]:
+            raise RuntimeError(
+                f"PortStudy case '{resolved.get('case_id', '')}' resolved active ports "
+                f"{active}, expected [{drive_id!r}]."
+            )
+        self._current_drive_id = drive_id
+
+    def _bind_runtime_ports(self, model) -> None:
+        if self._port_monitors:
+            return
+        from gprMax.user_objects.cmds_multiuse import VoltageSource
+
+        voltage_ids = tuple(
+            study_id
+            for study_id, user_object in self.registry.items()
+            if isinstance(user_object, VoltageSource)
+        )
+        monitors = {}
+        for monitor in getattr(model.G, "port_monitors", ()):
+            study_id = getattr(monitor.source, "study_id", None)
+            if study_id in voltage_ids:
+                if study_id in monitors:
+                    raise ValueError(f"PortStudy source '{study_id}' has more than one RxPort.")
+                monitors[study_id] = monitor
+        if set(monitors) != set(voltage_ids):
+            missing = ", ".join(study_id for study_id in voltage_ids if study_id not in monitors)
+            raise ValueError(f"PortStudy has no source-bound RxPort for: {missing}.")
+        port_ids = tuple(monitors[study_id].output_id for study_id in voltage_ids)
+        if len(port_ids) != len(set(port_ids)):
+            raise ValueError("PortStudy RxPort output IDs must be unique.")
+        self._port_source_ids = voltage_ids
+        self._port_ids = port_ids
+        self._port_monitors = monitors
+
+    def collect_case(self, model) -> None:
+        """Collect one power-normalised source-plane S-matrix column."""
+
+        import gprMax.config as config
+
+        self._bind_runtime_ports(model)
+        drive_id = self._current_drive_id
+        drive_index = self._port_source_ids.index(drive_id)
+        ordered = [self._port_monitors[study_id] for study_id in self._port_source_ids]
+        results = [monitor.result for monitor in ordered]
+        if any(result is None for result in results):
+            raise RuntimeError("PortStudy results were collected before every RxPort finalised.")
+
+        frequency = np.asarray(results[0].frequency)
+        for port_id, result in zip(self._port_ids[1:], results[1:]):
+            if not np.array_equal(result.frequency, frequency):
+                raise ValueError(
+                    f"PortStudy port '{port_id}' has a different frequency axis; use the "
+                    "same spectrum_limit for every RxPort."
+                )
+
+        complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
+        real_dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
+        impedances = np.asarray(
+            [monitor.reference_impedance for monitor in ordered], dtype=real_dtype
+        )
+        drive_incident = np.asarray(results[drive_index].incident_spectrum, dtype=complex_dtype)
+        drive_valid = np.asarray(results[drive_index].source_valid, dtype=bool)
+        column = np.full((frequency.size, len(ordered)), np.nan + 1j * np.nan, dtype=complex_dtype)
+        valid_column = np.zeros(column.shape, dtype=bool)
+        for output_index, result in enumerate(results):
+            ratio, defined = _safe_divide(
+                np.asarray(result.reflected_source_spectrum, dtype=complex_dtype),
+                drive_incident,
+                complex_dtype,
+            )
+            ratio *= np.sqrt(impedances[drive_index] / impedances[output_index])
+            column[:, output_index] = ratio
+            valid_column[:, output_index] = (
+                defined & drive_valid & np.asarray(result.mesh_valid, dtype=bool)
+            )
+
+        gap_correction = np.stack(
+            [np.asarray(result.gap_correction, dtype=complex_dtype) for result in results], axis=1
+        )
+        # Scalar S11 validity on an unexcited port is false by definition,
+        # but the port's gap admittance remains perfectly well defined and
+        # is required for the matrix correction. Build this mask from the
+        # gap data itself and exclude only the exact discrete Nyquist pole.
+        gap_valid = np.logical_and.reduce(
+            [np.isfinite(result.gap_correction) for result in results]
+        )
+        for monitor in ordered:
+            if monitor.gap_capacitance != 0:
+                gap_valid &= ~np.isclose(
+                    frequency,
+                    monitor.nyquist_frequency,
+                    rtol=64 * np.finfo(real_dtype).eps,
+                    atol=0,
+                )
+        case_index = config.sim_config.current_model
+        case_data = {
+            "case_id": self.cases[case_index].id,
+            "case_index": case_index,
+            "drive_id": drive_id,
+            "drive_port_id": self._port_ids[drive_index],
+            "frequency": np.asarray(frequency, dtype=real_dtype),
+            "reference_impedance": impedances,
+            "gap_correction": gap_correction,
+            "gap_valid": gap_valid,
+            "column": column,
+            "valid_column": valid_column,
+        }
+        self._columns[drive_id] = case_data
+        self._current_port_column = case_data
+        if self._aggregate_output_path is None:
+            model_config = config.get_model_config()
+            base = Path(model_config.output_file_path)
+            suffix = model_config.appendmodelnumber
+            if suffix and base.name.endswith(suffix):
+                base = base.with_name(base.name[: -len(suffix)])
+            self._aggregate_output_path = base.with_name(base.name + "_study").with_suffix(".h5")
+
+    def write_hdf5(self, h5file) -> None:
+        super().write_hdf5(h5file)
+        if self._current_port_column is None:
+            raise RuntimeError("PortStudy case data was not collected before HDF5 output.")
+        data = self._current_port_column
+        group = h5file["study"].create_group("port_response")
+        group.attrs["DrivenSourceID"] = data["drive_id"]
+        group.attrs["DrivenPortID"] = data["drive_port_id"]
+        group.attrs["MatrixConvention"] = "S[frequency, output_port, input_port]"
+        group.create_dataset("port_ids", data=np.asarray(self._port_ids, dtype="S"))
+        group.create_dataset("source_ids", data=np.asarray(self._port_source_ids, dtype="S"))
+        group.create_dataset("frequency", data=data["frequency"])
+        group.create_dataset("reference_impedance", data=data["reference_impedance"])
+        group.create_dataset("gap_correction_c", data=data["gap_correction"])
+        group.create_dataset("S_source_column", data=data["column"])
+        group.create_dataset("valid_S_source_column", data=data["valid_column"].astype(np.uint8))
+        group.create_dataset("gap_correction_valid", data=data["gap_valid"].astype(np.uint8))
+        if self._aggregate_output_path is not None:
+            group.attrs["AggregateOutput"] = str(self._aggregate_output_path)
+
+    def finalise(self) -> Optional[PortStudyResult]:
+        """Assemble, gap-correct, store, and expose the multiport S matrix."""
+
+        if not self._columns or self._aggregate_output_path is None:
+            return None
+        first = next(iter(self._columns.values()))
+        frequency = first["frequency"]
+        nfrequency = frequency.size
+        nports = len(self._port_source_ids)
+        complex_dtype = first["column"].dtype
+        s_source = np.full((nfrequency, nports, nports), np.nan + 1j * np.nan, dtype=complex_dtype)
+        valid_source = np.zeros(s_source.shape, dtype=bool)
+        case_ids = [""] * nports
+        if len(self._columns) < nports and self._aggregate_output_path.exists():
+            with h5py.File(self._aggregate_output_path, "r") as previous:
+                previous_ports = tuple(item.decode() for item in previous["port_ids"][...])
+                previous_sources = tuple(item.decode() for item in previous["source_ids"][...])
+                compatible = (
+                    previous.attrs.get("StudyType", "") == "port"
+                    and previous_ports == self._port_ids
+                    and previous_sources == self._port_source_ids
+                    and np.array_equal(previous["frequency"][...], frequency)
+                    and np.allclose(
+                        previous["reference_impedance"][...],
+                        first["reference_impedance"],
+                    )
+                    and np.allclose(
+                        previous["gap_correction_c"][...],
+                        first["gap_correction"],
+                        equal_nan=True,
+                    )
+                )
+                if not compatible:
+                    raise ValueError(
+                        f"Existing PortStudy output '{self._aggregate_output_path}' is not "
+                        "compatible with this restarted study. Remove or rename it, or use "
+                        "a different output base."
+                    )
+                s_source[...] = previous["S_source"][...]
+                valid_source[...] = previous["valid_S_source"][...].astype(bool)
+                case_ids = [item.decode() for item in previous["case_ids"][...]]
+        for input_index, source_id in enumerate(self._port_source_ids):
+            data = self._columns.get(source_id)
+            if data is None:
+                continue
+            if not np.array_equal(data["frequency"], frequency):
+                raise RuntimeError("PortStudy collected inconsistent frequency axes.")
+            if not np.allclose(data["gap_correction"], first["gap_correction"], equal_nan=True):
+                raise RuntimeError("PortStudy gap correction changed between reused runs.")
+            s_source[:, :, input_index] = data["column"]
+            valid_source[:, :, input_index] = data["valid_column"]
+            case_ids[input_index] = data["case_id"]
+
+        if not all(case_ids):
+            missing_ports = ", ".join(
+                self._port_ids[index] for index, case_id in enumerate(case_ids) if not case_id
+            )
+            logger.warning(
+                "PortStudy output is incomplete; no compatible prior aggregate supplied "
+                f"columns for: {missing_ports}. Corrected matrix values remain invalid."
+            )
+
+        from gprMax.ports import correct_smatrix_for_parallel_gaps
+
+        s_corrected, matrix_valid = correct_smatrix_for_parallel_gaps(
+            s_source,
+            first["gap_correction"],
+            complex_dtype,
+        )
+        matrix_valid &= first["gap_valid"] & np.all(valid_source, axis=(1, 2))
+        valid_corrected = np.broadcast_to(
+            matrix_valid[:, np.newaxis, np.newaxis], s_source.shape
+        ).copy()
+        s_corrected[~valid_corrected] = np.nan + 1j * np.nan
+
+        self.result = PortStudyResult(
+            frequency=np.asarray(frequency),
+            port_ids=self._port_ids,
+            source_ids=self._port_source_ids,
+            case_ids=tuple(case_ids),
+            reference_impedance=np.asarray(first["reference_impedance"]),
+            gap_correction=np.asarray(first["gap_correction"]),
+            s_source=s_source,
+            s=s_corrected,
+            valid_s_source=valid_source,
+            valid_s=valid_corrected,
+            output_file=self._aggregate_output_path,
+        )
+        self._write_aggregate_hdf5()
+        logger.info(f"Written PortStudy output file: {self._aggregate_output_path.name}\n")
+        return self.result
+
+    def _write_aggregate_hdf5(self) -> None:
+        if self.result is None:
+            return
+        from gprMax._version import __version__
+        from gprMax.ntff.conventions import FORWARD_TRANSFORM_KERNEL, PHASOR_TIME_DEPENDENCE
+
+        result = self.result
+        with h5py.File(result.output_file, "w") as output:
+            output.attrs["gprMax"] = __version__
+            output.attrs["StudyType"] = self.type
+            output.attrs["MatrixConvention"] = "S[frequency, output_port, input_port]"
+            output.attrs["WaveNormalisation"] = "power_wave_real_reference_impedance"
+            output.attrs["GapCorrection"] = "multiport_diagonal_shunt_admittance"
+            output.attrs["phasor_time_sign"] = PHASOR_TIME_DEPENDENCE
+            output.attrs["forward_transform_sign"] = FORWARD_TRANSFORM_KERNEL
+            output.attrs["CasesCompleted"] = sum(bool(case_id) for case_id in result.case_ids)
+            output.attrs["CaseCount"] = len(self.cases)
+            output.attrs["Complete"] = all(bool(case_id) for case_id in result.case_ids)
+            if self.source_path is not None:
+                output.attrs["SourcePath"] = str(self.source_path)
+            if self.source_text is not None:
+                output.create_dataset("source", data=self.source_text)
+            output.create_dataset("frequency", data=result.frequency)
+            output.create_dataset("port_ids", data=np.asarray(result.port_ids, dtype="S"))
+            output.create_dataset("source_ids", data=np.asarray(result.source_ids, dtype="S"))
+            output.create_dataset("case_ids", data=np.asarray(result.case_ids, dtype="S"))
+            output.create_dataset("reference_impedance", data=result.reference_impedance)
+            output.create_dataset("gap_correction_c", data=result.gap_correction)
+            output.create_dataset("S_source", data=result.s_source)
+            output.create_dataset("S", data=result.s)
+            output.create_dataset("valid_S_source", data=result.valid_s_source.astype(np.uint8))
+            output.create_dataset("valid_S", data=result.valid_s.astype(np.uint8))
 
 
 def preflight_study_args(args) -> Optional[Study]:
@@ -563,6 +997,8 @@ def preflight_study_args(args) -> Optional[Study]:
         raise ValueError("Studies do not yet support MPI task farming.")
     if getattr(args, "mpi", None) is not None:
         raise ValueError("Studies do not yet support MPI domain decomposition.")
+    if isinstance(study, PortStudy) and getattr(args, "geometry_only", False):
+        raise ValueError("PortStudy requires a field solve and cannot use geometry_only.")
     scenes = getattr(args, "scenes", None)
     if scenes is not None and len(scenes) != 1:
         raise ValueError("A study requires exactly one reusable Scene.")
@@ -656,6 +1092,22 @@ def _parse_finite_float(value: str, path: Path, line: int, name: str) -> float:
     if not math.isfinite(result):
         raise ValueError(f"Study CSV '{path}', line {line}: {name} must be finite.")
     return result
+
+
+def _safe_divide(numerator, denominator, complex_dtype):
+    """Complex division retaining a separate algebraic validity mask."""
+
+    numerator = np.asarray(numerator, dtype=complex_dtype)
+    denominator = np.asarray(denominator, dtype=complex_dtype)
+    magnitude = np.abs(denominator)
+    finite = np.isfinite(denominator)
+    scale = float(np.max(magnitude[finite], initial=0.0))
+    threshold = np.finfo(np.empty((), dtype=complex_dtype).real.dtype).eps * scale
+    valid = finite & (magnitude > threshold)
+    result = np.full(numerator.shape, np.nan + 1j * np.nan, dtype=complex_dtype)
+    np.divide(numerator, denominator, out=result, where=valid)
+    valid &= np.isfinite(result)
+    return result, valid
 
 
 def _jsonable(value: Any) -> Any:

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -698,9 +698,11 @@ class VoltageSource(RotatableMixin, GridUserObject):
         voltage_source = VoltageSourceUser()
         voltage_source.polarisation = self.polarisation
         voltage_source.coord = coord
+        voltage_source.coordorigin = coord.copy()
         uip = self._create_uip(grid)
         x, y, z = uip.discretise_static_point(self.point)
         voltage_source.ID = f"{voltage_source.__class__.__name__}({x},{y},{z})"
+        voltage_source.study_id = getattr(self, "_study_id", None)
         voltage_source.resistance = self.resistance
         voltage_source.reference_impedance = (
             float(self.reference_impedance)

--- a/gprMax/user_objects/cmds_output.py
+++ b/gprMax/user_objects/cmds_output.py
@@ -146,8 +146,13 @@ class RxPort(OutputUserObject):
         raise RuntimeError("RxPort result is not available until the model has solved")
 
     def _validate_context(self, grid):
-        if config.sim_config.args.geometry_fixed:
-            raise ValueError(f"{self.params_str()} does not support geometry-fixed runs.")
+        if (
+            config.sim_config.args.geometry_fixed
+            and getattr(config.sim_config.study, "type", None) != "port"
+        ):
+            raise ValueError(
+                f"{self.params_str()} does not support geometry-fixed runs outside a PortStudy."
+            )
         if config.get_model_config().mode != "3D":
             raise ValueError(f"{self.params_str()} currently supports only 3-D models.")
         if config.sim_config.general["solver"] not in ("cpu", "cuda", "opencl", "metal"):

--- a/tests/ports/test_port_study.py
+++ b/tests/ports/test_port_study.py
@@ -1,0 +1,359 @@
+"""Reusable finite-resistance voltage-port studies."""
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+from gprMax.ports import correct_s11_for_parallel_gap, correct_smatrix_for_parallel_gaps
+
+
+def _two_port_scene(active_port=None, resistances=(50, 50)):
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(0.002, 0.002, 0.002)))
+    scene.add(gprMax.Domain(p1=(0.024, 0.024, 0.024)))
+    scene.add(gprMax.TimeWindow(time=4e-10))
+    scene.add(gprMax.PMLThickness(thickness=2))
+    scene.add(gprMax.OMPThreads(1))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="on"))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=0, freq=5e9, id="off"))
+
+    sources = []
+    for index, (x, resistance) in enumerate(zip((0.010, 0.014), resistances), start=1):
+        waveform_id = "on" if active_port in (None, index) else "off"
+        source = gprMax.VoltageSource(
+            p1=(x, 0.012, 0.012),
+            polarisation="z",
+            resistance=resistance,
+            waveform_id=waveform_id,
+        )
+        sources.append(source)
+        scene.add(source)
+        scene.add(gprMax.RxPort(p1=(x, 0.012, 0.012), id=f"p{index}"))
+    return scene, sources
+
+
+def _two_port_study(sources):
+    return gprMax.PortStudy(
+        [
+            gprMax.StudyCase("drive_p1", [gprMax.ObjectState(sources[0], scale=1)]),
+            gprMax.StudyCase("drive_p2", [gprMax.ObjectState(sources[1], scale=1)]),
+        ]
+    )
+
+
+@pytest.mark.integration
+def test_two_port_study_matches_fresh_models_and_writes_smatrix(tmp_path):
+    scene, sources = _two_port_scene()
+    study = _two_port_study(sources)
+    returned = gprMax.run(
+        scenes=[scene],
+        study=study,
+        outputfile=tmp_path / "ports",
+        hide_progress_bars=True,
+        log_level=30,
+    )
+
+    for active_port in (1, 2):
+        fresh_scene, _ = _two_port_scene(active_port=active_port)
+        gprMax.run(
+            scenes=[fresh_scene],
+            outputfile=tmp_path / f"fresh{active_port}",
+            hide_progress_bars=True,
+            log_level=30,
+        )
+    combined_scene, _ = _two_port_scene()
+    gprMax.run(
+        scenes=[combined_scene],
+        outputfile=tmp_path / "fresh_combined",
+        hide_progress_bars=True,
+        log_level=30,
+    )
+
+    assert returned["study"] is study.result
+    assert study.result.output_file == tmp_path / "ports_study.h5"
+    assert study.result.s.shape[1:] == (2, 2)
+    assert study.result.valid_s.any()
+
+    for case_index in (1, 2):
+        with h5py.File(tmp_path / f"ports{case_index}.h5") as reused, h5py.File(
+            tmp_path / f"fresh{case_index}.h5"
+        ) as fresh:
+            assert reused["study/port_response"].attrs["DrivenPortID"] == f"p{case_index}"
+            for port_id in ("p1", "p2"):
+                np.testing.assert_array_equal(
+                    reused[f"ports/{port_id}/Vtotal"],
+                    fresh[f"ports/{port_id}/Vtotal"],
+                )
+            passive = 2 if case_index == 1 else 1
+            assert np.all(reused[f"ports/p{passive}/Vgenerator"][...] == 0)
+            assert np.all(reused[f"srcs/src{passive}/excitation/samples"][...] == 0)
+
+    with h5py.File(tmp_path / "ports1.h5") as first, h5py.File(
+        tmp_path / "ports2.h5"
+    ) as second, h5py.File(tmp_path / "fresh_combined.h5") as combined:
+        for port_id in ("p1", "p2"):
+            np.testing.assert_allclose(
+                first[f"ports/{port_id}/Vtotal"][...] + second[f"ports/{port_id}/Vtotal"][...],
+                combined[f"ports/{port_id}/Vtotal"][...],
+                rtol=2e-6,
+                atol=2e-6,
+            )
+
+    with h5py.File(tmp_path / "ports_study.h5") as output:
+        assert output.attrs["StudyType"] == "port"
+        assert output.attrs["MatrixConvention"] == "S[frequency, output_port, input_port]"
+        assert [item.decode() for item in output["port_ids"][...]] == ["p1", "p2"]
+        source = output["S_source"][...]
+        corrected = output["S"][...]
+        valid = output["valid_S"][...].astype(bool)
+        assert source.shape == corrected.shape == valid.shape
+        assert valid.any()
+
+        reciprocal = valid[:, 0, 1] & valid[:, 1, 0]
+        assert reciprocal.any()
+        np.testing.assert_allclose(
+            source[reciprocal, 0, 1],
+            source[reciprocal, 1, 0],
+            rtol=2e-6,
+            atol=2e-6,
+        )
+        np.testing.assert_allclose(
+            corrected[reciprocal, 0, 1],
+            corrected[reciprocal, 1, 0],
+            rtol=2e-6,
+            atol=2e-6,
+        )
+
+        for input_index in range(2):
+            with h5py.File(tmp_path / f"ports{input_index + 1}.h5") as case:
+                drive = case[f"ports/p{input_index + 1}"]
+                incident = drive["Vincident_spectrum"][...]
+                for output_index in range(2):
+                    reflected = case[f"ports/p{output_index + 1}/Vreflected_source_spectrum"][...]
+                    expected = np.full(incident.shape, np.nan + 1j * np.nan, dtype=source.dtype)
+                    np.divide(reflected, incident, out=expected, where=np.abs(incident) > 0)
+                    finite = np.isfinite(source[:, output_index, input_index])
+                    np.testing.assert_allclose(
+                        source[finite, output_index, input_index],
+                        expected[finite],
+                        rtol=2e-6,
+                        atol=2e-6,
+                    )
+
+
+def test_multiport_gap_correction_reduces_to_existing_one_port_formula():
+    s11_source = np.asarray([0.1 + 0.2j, -0.25 + 0.05j], dtype=np.complex128)
+    correction = np.asarray([0.02 + 0.1j, 0.03 + 0.2j], dtype=np.complex128)
+    scalar, scalar_valid = correct_s11_for_parallel_gap(s11_source, correction, np.complex128)
+    matrix, matrix_valid = correct_smatrix_for_parallel_gaps(
+        s11_source[:, np.newaxis, np.newaxis],
+        correction[:, np.newaxis],
+        np.complex128,
+    )
+
+    np.testing.assert_allclose(matrix[:, 0, 0], scalar, rtol=1e-13, atol=1e-13)
+    np.testing.assert_array_equal(matrix_valid, scalar_valid)
+
+
+def test_multiport_gap_correction_recovers_coupled_two_port_matrix():
+    identity = np.eye(2, dtype=np.complex128)
+    device_admittance = np.asarray([[0.31 + 0.08j, -0.07 + 0.02j], [-0.07 + 0.02j, 0.44 + 0.11j]])
+    gap = np.asarray([0.03 + 0.09j, 0.05 + 0.13j])
+
+    def admittance_to_s(admittance):
+        return np.linalg.solve(identity + admittance, identity - admittance)
+
+    expected = admittance_to_s(device_admittance)
+    source = admittance_to_s(device_admittance + np.diag(gap))
+    corrected, valid = correct_smatrix_for_parallel_gaps(
+        source[np.newaxis, ...], gap[np.newaxis, ...], np.complex128
+    )
+
+    assert valid[0]
+    np.testing.assert_allclose(corrected[0], expected, rtol=1e-13, atol=1e-13)
+
+
+@pytest.mark.integration
+def test_port_study_uses_power_waves_for_unequal_reference_impedances(tmp_path):
+    scene, sources = _two_port_scene(resistances=(50, 75))
+    study = _two_port_study(sources)
+    gprMax.run(
+        scenes=[scene],
+        study=study,
+        outputfile=tmp_path / "unequal",
+        hide_progress_bars=True,
+        log_level=30,
+    )
+
+    for input_index, input_impedance in enumerate((50, 75)):
+        with h5py.File(tmp_path / f"unequal{input_index + 1}.h5") as output:
+            incident = output[f"ports/p{input_index + 1}/Vincident_spectrum"][...]
+            for output_index, output_impedance in enumerate((50, 75)):
+                reflected = output[f"ports/p{output_index + 1}/Vreflected_source_spectrum"][...]
+                expected = np.full(incident.shape, np.nan + 1j * np.nan)
+                np.divide(reflected, incident, out=expected, where=np.abs(incident) > 0)
+                expected *= np.sqrt(input_impedance / output_impedance)
+                finite = np.isfinite(study.result.s_source[:, output_index, input_index])
+                np.testing.assert_allclose(
+                    study.result.s_source[finite, output_index, input_index],
+                    expected[finite],
+                    rtol=2e-6,
+                    atol=2e-6,
+                )
+
+
+def test_port_study_rejects_hard_sources_and_incomplete_drive_schedule():
+    scene, sources = _two_port_scene()
+    sources[0].resistance = 0
+    study = gprMax.PortStudy(
+        [
+            gprMax.StudyCase("drive_p1", [gprMax.ObjectState(sources[0])]),
+            gprMax.StudyCase("drive_p2", [gprMax.ObjectState(sources[1])]),
+        ]
+    )
+    with pytest.raises(ValueError, match="hard voltage sources"):
+        study.bind_scene(scene)
+
+    scene, sources = _two_port_scene()
+    duplicate = gprMax.PortStudy(
+        [
+            gprMax.StudyCase("first", [gprMax.ObjectState(sources[0])]),
+            gprMax.StudyCase("again", [gprMax.ObjectState(sources[0])]),
+        ]
+    )
+    with pytest.raises(ValueError, match="exactly one case"):
+        duplicate.bind_scene(scene)
+
+
+@pytest.mark.integration
+def test_port_study_restart_preserves_compatible_completed_columns(tmp_path):
+    output = tmp_path / "restart"
+    scene, sources = _two_port_scene()
+    study = _two_port_study(sources)
+    gprMax.run(
+        scenes=[scene],
+        study=study,
+        outputfile=output,
+        hide_progress_bars=True,
+        log_level=30,
+    )
+    with h5py.File(tmp_path / "restart_study.h5") as complete:
+        original = complete["S_source"][...]
+        assert complete.attrs["Complete"]
+
+    restart_scene, restart_sources = _two_port_scene()
+    restarted = _two_port_study(restart_sources)
+    gprMax.run(
+        scenes=[restart_scene],
+        study=restarted,
+        i=2,
+        outputfile=output,
+        hide_progress_bars=True,
+        log_level=30,
+    )
+
+    with h5py.File(tmp_path / "restart_study.h5") as complete:
+        assert complete.attrs["Complete"]
+        assert complete.attrs["CasesCompleted"] == 2
+        np.testing.assert_array_equal(complete["S_source"][...], original)
+
+
+def test_port_study_csv_factory(tmp_path):
+    cases = tmp_path / "ports.csv"
+    cases.write_text(
+        "case_id,object_id,active,scale\n"
+        "drive_p1,voltage_source_1,true,1\n"
+        "drive_p2,voltage_source_2,true,1\n"
+    )
+
+    study = gprMax.Study.from_csv("port", cases)
+
+    assert isinstance(study, gprMax.PortStudy)
+    assert [case.id for case in study.cases] == ["drive_p1", "drive_p2"]
+
+
+@pytest.mark.integration
+def test_hash_port_study_runs_and_writes_complete_smatrix(tmp_path):
+    cases = tmp_path / "ports.csv"
+    cases.write_text(
+        "case_id,object_id,active,scale\n"
+        "drive_p1,voltage_source_1,true,1\n"
+        "drive_p2,voltage_source_2,true,1\n"
+    )
+    inputfile = tmp_path / "ports.in"
+    inputfile.write_text(
+        "#title: hash port study integration\n"
+        "#dx_dy_dz: 0.002 0.002 0.002\n"
+        "#domain: 0.024 0.024 0.024\n"
+        "#pml_cells: 2\n"
+        "#time_window: 4e-10\n"
+        "#waveform: ricker 1 5e9 pulse\n"
+        "#voltage_source: z 0.010 0.012 0.012 50 pulse\n"
+        "#voltage_source: z 0.014 0.012 0.012 50 pulse\n"
+        "#rx_port: 0.010 0.012 0.012 p1\n"
+        "#rx_port: 0.014 0.012 0.012 p2\n"
+        f"#study: port {cases.name}\n"
+    )
+
+    returned = gprMax.run(
+        inputfile=inputfile,
+        outputfile=tmp_path / "hash_ports",
+        hide_progress_bars=True,
+        log_level=30,
+    )
+
+    assert isinstance(returned["study"], gprMax.PortStudyResult)
+    with h5py.File(tmp_path / "hash_ports_study.h5") as output:
+        assert output.attrs["Complete"]
+        assert output.attrs["CasesCompleted"] == 2
+        assert [item.decode() for item in output["port_ids"][...]] == ["p1", "p2"]
+        assert output["S"].shape[1:] == (2, 2)
+
+
+def _assert_device_port_study_matches_cpu(tmp_path, device_name, **device_options):
+    cpu_scene, cpu_sources = _two_port_scene()
+    device_scene, device_sources = _two_port_scene()
+    cpu = _two_port_study(cpu_sources)
+    device = _two_port_study(device_sources)
+
+    gprMax.run(
+        scenes=[cpu_scene],
+        study=cpu,
+        outputfile=tmp_path / "cpu",
+        hide_progress_bars=True,
+        log_level=30,
+    )
+    gprMax.run(
+        scenes=[device_scene],
+        study=device,
+        outputfile=tmp_path / device_name,
+        hide_progress_bars=True,
+        log_level=30,
+        **device_options,
+    )
+
+    np.testing.assert_array_equal(device.result.frequency, cpu.result.frequency)
+    valid = cpu.result.valid_s_source & device.result.valid_s_source
+    assert valid.any()
+    np.testing.assert_allclose(
+        device.result.s_source[valid],
+        cpu.result.s_source[valid],
+        rtol=3e-4,
+        atol=3e-4,
+    )
+    valid = cpu.result.valid_s & device.result.valid_s
+    assert valid.any()
+    np.testing.assert_allclose(device.result.s[valid], cpu.result.s[valid], rtol=3e-4, atol=3e-4)
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+def test_cuda_port_study_matches_cpu(tmp_path, gpu_device):
+    _assert_device_port_study_matches_cpu(tmp_path, "cuda", gpu=[gpu_device])
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+def test_opencl_port_study_matches_cpu(tmp_path, opencl_device):
+    _assert_device_port_study_matches_cpu(tmp_path, "opencl", opencl=[opencl_device])


### PR DESCRIPTION
# PR Description

## Summary

This PR adds Phase 2 of the reusable-geometry study framework: finite-resistance voltage-port studies.

It introduces:

- `PortStudy` for Python API models;
- `#study: port <CSV>` for hash-command models;
- one driven finite-resistance voltage source per run;
- passive matched termination of omitted voltage sources;
- reset of source waveforms, port histories, and derived results between reused runs;
- complete power-normalised multiport S-matrix assembly;
- support for unequal positive real reference impedances;
- full-matrix de-embedding of numerical Yee-gap capacitance and conductance;
- per-case raw S-matrix columns;
- restartable aggregate `<output>_study.h5` output;
- API, hash-command, and HDF5 documentation.

Hard voltage sources are deliberately rejected because zero excitation would impose zero electric field rather than create a passive matched termination.

## Related Issue

N/A

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] This change requires a documentation update.

## Validation

- 105 relevant CPU tests passed.
- Reused runs match independently rebuilt models.
- Passive matched-port behaviour verified.
- Coupled two-port reciprocity verified.
- Simultaneous-source linear superposition verified.
- Unequal-impedance power-wave normalisation verified.
- Multiport gap correction verified independently in admittance form.
- CPU/CUDA parity passed on NVIDIA hardware.
- CPU/OpenCL parity passed.
- Full Sphinx HTML build succeeded.
- Black 23.12.0, isort 5.13.2, syntax, and whitespace checks passed.

Metal uses the same host-side study machinery but was not hardware-tested on this server.

## Checklist

- [ ] Did pre-commit pass all checks? *(Awaiting GitHub CI; equivalent local checks passed.)*
- [x] I have performed a self-review of my code.
- [x] I have added comments for hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new documentation warnings.
- [x] The title of my pull request is a short description of my changes.