### PR TITLE
Add reusable eigenmode port studies

### DIFF
--- a/docs/source/eigenmode_port.rst
+++ b/docs/source/eigenmode_port.rst
@@ -189,6 +189,45 @@ Try changing one thing at a time:
   conversion terms are no longer available; the unmeasured field has not
   physically disappeared.
 
+Build the complete modal S matrix without rebuilding
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A normal run excites the single port and mode selected by
+``#eigenmode_excitation`` and therefore produces one column of a modal S
+matrix. To characterize every declared port/mode channel, add an eigenmode
+study whose CSV selects each channel exactly once:
+
+.. code-block:: text
+
+   case_id,object_id,port,mode
+   p1m1,eigenmode_excitation_1,1,1
+   p1m2,eigenmode_excitation_1,1,2
+   p2m1,eigenmode_excitation_1,2,1
+   p2m2,eigenmode_excitation_1,2,2
+
+Reference it from the input file with:
+
+.. code-block:: none
+
+   #study: eigenmode modal_cases.csv
+
+gprMax solves the FDFD modal anchors for every port during the first geometry
+build. Each later case resets the FDTD fields, modal DFT phases and
+accumulators, and any virtual-waveguide fields and PML histories, then
+synthesizes the selected source from the cached phase-aligned modal basis. It
+does not repeat the FDFD solves. This works when the complete eigenmode setup
+belongs either to the main grid or to one HSG subgrid; ports from different
+grids cannot be combined in one modal study.
+
+The per-case files identify their input port and mode. The aggregate
+``<output>_study.h5`` stores the complete matrix using
+``S[frequency, output_channel, input_channel]``; ``channel_ports`` and
+``channel_modes`` map both channel axes. The physical and generalized
+validity masks remain separate. Use ``-i N`` to restart at case ``N`` while
+retaining compatible columns already stored in the aggregate file. The
+Python API additionally provides modal power/phase/delay weights for array
+synthesis; see :ref:`input-api`.
+
 Example 2: a curved waveguide
 -----------------------------
 

--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -270,17 +270,94 @@ matched passive termination.
 
 .. autoclass:: gprMax.studies.PortStudyResult
 
+Eigenmode-port studies and array synthesis
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An :class:`gprMax.EigenmodeStudy` constructs the complete modal S matrix by
+exciting one declared ``(port, mode)`` channel per case. The geometry, Yee
+arrays, FDFD modal solutions, phase-aligned anchor fields, and modal power
+normalisation are prepared once. Between cases gprMax clears the main and
+virtual-waveguide fields, PML histories, modal DFT accumulators, recursive DFT
+phases, and derived S data before selecting the next cached modal basis.
+
+Every declared mode on every :class:`gprMax.EigenmodePort` must appear in
+exactly one case. This deliberate one-active-channel policy gives ordinary
+S-parameters; exciting several ports in one solve would yield only the active
+relation :math:`b(f)=S(f)a(f)`, not all columns of :math:`S`.
+
+.. code-block:: python
+
+    excitation = gprMax.EigenmodeExcitation(
+        port=1, mode=1, waveform='auto', plot_waveform=False
+    )
+    scene.add(excitation)
+
+    study = gprMax.EigenmodeStudy([
+        gprMax.StudyCase('p1m1', [
+            gprMax.ObjectState(excitation, port=1, mode=1),
+        ]),
+        gprMax.StudyCase('p2m1', [
+            gprMax.ObjectState(excitation, port=2, mode=1),
+        ]),
+    ])
+
+    results = gprMax.run(scenes=[scene], study=study, outputfile='array')
+    modal_s = results['study'].s
+
+The matrix convention is
+``S[frequency, output_channel, input_channel]``. ``channel_ports`` and
+``channel_modes`` define both channel axes. Physical power-wave and
+generalized-coefficient validity masks are stored separately, so an
+evanescent generalized coefficient is never mistaken for a propagating power
+wave. Compatible columns in an existing ``<output>_study.h5`` are retained
+when restarting with ``i=N``.
+
+Embedded far fields from the individual cases can be combined without a new
+FDTD solve. A :class:`gprMax.ModalWeight` supports either a constant phase
+shifter, a true time delay, or both:
+
+.. code-block:: python
+
+    weights = results['study'].excitation_weights([
+        gprMax.ModalWeight(port=1, mode=1, power=1, phase_deg=0),
+        gprMax.ModalWeight(port=2, mode=1, power=1, phase_deg=90),
+    ])
+    outgoing = results['study'].outgoing([
+        gprMax.ModalWeight(port=1, mode=1, power=1),
+    ])
+    field = gprMax.combine_embedded_modal_responses(embedded_fields, weights)
+
+Here ``power`` is incident modal power in watts, so the power-wave magnitude
+is its square root. With the engineering Fourier convention a constant phase
+uses :math:`\exp(+j\phi)`, whereas a delay uses
+:math:`\exp(-j2\pi f\tau)`. Constant phase produces ordinary narrowband
+beam steering and beam squint; true time delay preserves steering over
+bandwidth. ``embedded_fields`` is a complex array whose first axis is
+frequency and whose selected channel axis follows ``channel_ports`` and
+``channel_modes``.
+
+.. autoclass:: gprMax.studies.EigenmodeStudy
+
+.. autoclass:: gprMax.studies.EigenmodeStudyResult
+    :members: excitation_weights, outgoing
+
+.. autoclass:: gprMax.studies.ModalWeight
+
+.. autofunction:: gprMax.studies.modal_array_weights
+
+.. autofunction:: gprMax.studies.combine_embedded_modal_responses
+
 .. autoclass:: gprMax.studies.StudyCase
 
 .. autoclass:: gprMax.studies.ObjectState
 
 .. note::
 
-    MPI/task-farm studies, subgrid study objects, transmission lines, rational
-    networks, magnetic-frill sources, plane waves, and eigenmode sources are
-    not yet enabled. Their cached fields, transforms, and derived setup must be
-    reset or rebuilt explicitly; gprMax rejects them instead of reusing stale
-    state.
+    MPI/task-farm studies, transmission lines, rational networks,
+    magnetic-frill sources, and plane waves are not yet enabled. General GPR
+    study objects remain main-grid only. Eigenmode studies support the owning
+    main grid or subgrid and reset direct and virtual-waveguide modal state
+    explicitly.
 
 Typical general settings are added directly to the scene:
 

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1945,19 +1945,22 @@ case that produced it. The syntax is:
 
     #study: gpr file1
 
-The study type may be ``gpr`` for irregular source/receiver acquisition or
-``port`` for a finite-resistance voltage-source S-parameter study:
+The study type may be ``gpr`` for irregular source/receiver acquisition,
+``port`` for a finite-resistance voltage-source S-parameter study, or
+``eigenmode`` for a modal-port S-parameter study:
 
 .. code-block:: none
 
     #study: port file1
+    #study: eigenmode file1
 
 ``file1`` is a CSV table. Its path is resolved relative to the main input
 file. The required columns are ``case_id`` and ``object_id``. The optional
 columns are ``active``, ``x_m``, ``y_m``, ``z_m``, ``waveform_id``,
-``start_s``, ``stop_s``, ``scale``, and ``record``. Blank cells mean "use the
-object's baseline value". All three position columns must be supplied
-together and contain absolute coordinates in metres.
+``start_s``, ``stop_s``, ``scale``, ``record``, ``port``, and ``mode``. Blank
+cells mean "use the object's baseline value". All three position columns must
+be supplied together and contain absolute coordinates in metres. ``port`` and
+``mode`` are positive integers used only by an eigenmode study.
 
 For example:
 
@@ -2002,6 +2005,23 @@ gap-corrected matrices using
 gap capacitances/conductances through the full admittance matrix, including
 the coupled off-diagonal terms.
 
+For an ``eigenmode`` study, every case contains the single deterministic
+object ``eigenmode_excitation_1`` and selects one declared port/mode channel.
+Every mode on every ``#eigenmode_port`` must be selected exactly once:
+
+.. code-block:: text
+
+    case_id,object_id,port,mode
+    p1m1,eigenmode_excitation_1,1,1
+    p2m1,eigenmode_excitation_1,2,1
+
+All port modal anchors are solved during the first geometry build, including
+source-grade spectral-guard anchors. Later cases reuse those bases, reset the
+modal DFT and any ``#virtual_waveguide`` fields/PML history, and switch the
+active channel without another FDFD solve. The aggregate file stores
+``S[frequency, output_channel, input_channel]`` together with ``channel_ports``
+and ``channel_modes``.
+
 The number of CSV cases determines the number of model runs, so ``-n`` is not
 required. ``-i N`` restarts at case ``N`` and retains absolute output numbering.
 The original geometry, materials, PMLs, and grid allocation are reused, but
@@ -2013,12 +2033,11 @@ of the CSV source.
 
     GPR studies support top-level ``#hertzian_dipole``,
     ``#magnetic_dipole``, and ``#rx`` objects; port studies additionally
-    support finite-resistance ``#voltage_source``/``#rx_port`` pairs. MPI
-    domain decomposition, task farming, subgrid study objects, plane waves,
-    transmission lines, rational/frill ports, and eigenmode objects are
-    rejected until their family-specific state reset and rebuild hooks are
-    implemented. This explicit restriction prevents contaminated results from
-    persistent source or transform state.
+    support finite-resistance ``#voltage_source``/``#rx_port`` pairs;
+    eigenmode studies support ``#eigenmode_port``, ``#eigenmode_excitation``,
+    and ``#virtual_waveguide``. MPI domain decomposition, task farming, plane
+    waves, transmission lines, and rational/frill ports remain excluded from
+    studies until their family-specific state reset hooks are implemented.
 
 #snapshot:
 ----------

--- a/docs/source/output.rst
+++ b/docs/source/output.rst
@@ -75,6 +75,21 @@ columns from an existing aggregate file and replaces the newly evaluated
 columns; an incompatible existing file is rejected rather than mixed with new
 results.
 
+Every eigenmode-study case instead contains
+``study/eigenmode_response``. ``InputPort`` and ``InputMode`` identify the
+incident modal channel; ``S_column`` is ordered by ``channel_ports`` and
+``channel_modes``. ``valid_S_column`` selects physical propagating power-wave
+coefficients, while ``generalized_valid_S_column`` also permits conditioned
+generalized coefficients that are not valid for power accounting.
+
+The eigenmode aggregate ``<output>_study.h5`` contains ``frequency``,
+``channel_ports``, ``channel_modes``, ``case_ids``, ``S``, ``valid_S``, and
+``generalized_valid_S``. Its convention is
+``S[frequency, output_channel, input_channel]``. Modal channels can represent
+different mode counts on different ports; the two channel-index datasets are
+therefore authoritative and should be used instead of assuming one mode per
+port.
+
 .. code-block:: none
 
     /
@@ -90,6 +105,13 @@ results.
                 gap_correction_c
                 S_source_column
                 valid_S_source_column
+            eigenmode_response/ [eigenmode studies]
+                channel_ports
+                channel_modes
+                frequency
+                S_column
+                valid_S_column
+                generalized_valid_S_column
         rxs/
             rx1/
                 Name

--- a/gprMax/__init__.py
+++ b/gprMax/__init__.py
@@ -18,7 +18,19 @@ from .ntff import (
     spherical_observation_points,
 )
 from .scene import Scene
-from .studies import GPRStudy, ObjectState, PortStudy, PortStudyResult, Study, StudyCase
+from .studies import (
+    EigenmodeStudy,
+    EigenmodeStudyResult,
+    GPRStudy,
+    ModalWeight,
+    ObjectState,
+    PortStudy,
+    PortStudyResult,
+    Study,
+    StudyCase,
+    combine_embedded_modal_responses,
+    modal_array_weights,
+)
 from .subgrids.user_objects import SubGridHSG
 from .user_objects.cmds_geometry.add_grass import AddGrass
 from .user_objects.cmds_geometry.add_surface_roughness import AddSurfaceRoughness

--- a/gprMax/eigenmode_ports.py
+++ b/gprMax/eigenmode_ports.py
@@ -884,6 +884,22 @@ class EigenmodePortMonitor:
                 self.magnetic_phase.dtype,
             )
 
+    def reset_run_state(self, grid):
+        """Clear DFT, recursive phase, and derived state for a reused run."""
+
+        self.electric_dft.fill(0)
+        self.magnetic_dft.fill(0)
+        self.electric_phase[:] = _dft_phase_at_time(self.frequency, 0.0, self.electric_phase.dtype)
+        self.magnetic_phase[:] = _dft_phase_at_time(
+            self.frequency, 0.5 * grid.dt, self.magnetic_phase.dtype
+        )
+        self._next_iteration = 0
+        self.result = None
+        self.s_parameters = None
+        self.s_valid = None
+        self.s_generalized_valid = None
+        self.s_power_wave_valid = None
+
     def finalise(self, grid):
         nf, nm = self.electric_dft.shape
         complex_dtype = np.dtype(config.sim_config.dtypes["complex"])

--- a/gprMax/model.py
+++ b/gprMax/model.py
@@ -542,7 +542,9 @@ class Model:
                     "Vtotal/S11/Zin output with no error. Run a single model "
                     "instead."
                 )
-            if any(
+            from gprMax.studies import EigenmodeStudy
+
+            if not isinstance(config.sim_config.study, EigenmodeStudy) and any(
                 grid.eigenmodesources or grid.eigenmodereceivers or grid.virtual_waveguide_specs
                 for grid in grids
             ):

--- a/gprMax/sources.py
+++ b/gprMax/sources.py
@@ -370,6 +370,116 @@ class EigenmodeSource(Source):
             self._prepare_single_frequency_injection(G)
         self._register_port_monitor(G)
 
+    def configure_cached_excitation(self, G, mode_index, waveform):
+        """Prepare one excitation from this port's cached modal anchor bank.
+
+        The transverse FDFD problems are deliberately not solved here.  This
+        method is used by reusable eigenmode studies after the first geometry
+        build, when every declared port already owns a phase-aligned anchor
+        bank prepared by :meth:`grid_init`.
+        """
+
+        mode_index = int(mode_index)
+        mode_indices = tuple(int(value) for value in self.mode_indices)
+        if mode_index not in mode_indices:
+            raise ValueError(
+                f"Eigenmode port {self.port_index} does not monitor mode "
+                f"{mode_index}; available modes are {mode_indices}."
+            )
+        if self.port_anchor_frequencies is None or self.port_anchor_mode_valid is None:
+            raise RuntimeError(
+                f"Eigenmode port {self.port_index} has no reusable modal anchor bank."
+            )
+
+        mode_position = mode_indices.index(mode_index)
+        used = np.flatnonzero(self.port_anchor_mode_valid[:, mode_position])
+        if used.size == 0:
+            raise ValueError(
+                f"Eigenmode port {self.port_index} mode {mode_index} has no "
+                "propagating anchor suitable for excitation."
+            )
+
+        self.mode_index = mode_index
+        self.waveform = waveform
+        self.waveformID = waveform.ID
+        self.start = 0
+        self.stop = G.timewindow
+        self.uses_quadrature = False
+        self.broadband_e_envelopes = None
+        self.broadband_h_envelopes = None
+        self.broadband_modal_e_real = None
+        self.broadband_modal_e_imag = None
+        self.broadband_modal_h_real = None
+        self.broadband_modal_h_imag = None
+        self.broadband_input_waveform = None
+        self.broadband_reconstructed_waveform = None
+        self.broadband_waveform_error = None
+        self.complex_profile_phase = None
+        self.complex_profile_residual = None
+        self.representative_frequency = None
+
+        frequencies = tuple(float(self.port_anchor_frequencies[index]) for index in used)
+        self.frequencies = frequencies
+        self.anchor_modal_e = [
+            [
+                np.array(field, dtype=np.complex128, copy=True)
+                for field in self.port_anchor_e[index][mode_position]
+            ]
+            for index in used
+        ]
+        self.anchor_modal_h = [
+            [
+                np.array(field, dtype=np.complex128, copy=True)
+                for field in self.port_anchor_h[index][mode_position]
+            ]
+            for index in used
+        ]
+        self.anchor_complex_neff = np.asarray(
+            [self.port_anchor_neff[index, mode_position] for index in used],
+            dtype=np.complex128,
+        )
+        self.mode_solvers = [self.port_mode_solvers[index] for index in used]
+
+        policy = self.port_mode_anchor_policies[mode_position]
+        # This value may have been relaxed for a different mode in the
+        # preceding reusable case.  Start from the normal source policy and
+        # relax it only when this selected mode's resolved anchor policy
+        # explicitly permits trimmed waveform coverage.
+        self.spectrum_coverage_policy = "error"
+        if "nonpropagating_trimmed" in policy or (
+            self._automatic_anchor_policy()
+            and ("guard_trimmed" in policy or policy == "auto_single_fallback")
+        ):
+            self.spectrum_coverage_policy = "allow"
+
+        if len(frequencies) == 1 or policy == "auto_single_fallback":
+            representative = 0
+            self.frequency = frequencies[representative]
+            self.modal_e = [field.copy() for field in self.anchor_modal_e[representative]]
+            self.modal_h = [field.copy() for field in self.anchor_modal_h[representative]]
+            self.mode_solver = self.mode_solvers[representative]
+            self.complex_neff = self.anchor_complex_neff[representative]
+            self.neff = float(np.real(self.complex_neff))
+            self._prepare_single_frequency_injection(G)
+            return
+
+        self._prepare_broadband_time_traces(G, frequencies)
+        representative = (
+            len(frequencies) // 2
+            if self.representative_frequency is None
+            else min(
+                range(len(frequencies)),
+                key=lambda index: abs(frequencies[index] - self.representative_frequency),
+            )
+        )
+        self.frequency = frequencies[representative]
+        self.modal_e = [field.copy() for field in self.anchor_modal_e[representative]]
+        self.modal_h = [field.copy() for field in self.anchor_modal_h[representative]]
+        self.mode_solver = self.mode_solvers[representative]
+        self.complex_neff = self.anchor_complex_neff[representative]
+        self.neff = float(np.real(self.complex_neff))
+        self._store_real_modal_fields()
+
     def _fallback_to_single_anchor(self, G, mismatch):
         frequency = float(self.fallback_frequency)
         if self.mpi_coordinator:

--- a/gprMax/studies.py
+++ b/gprMax/studies.py
@@ -17,11 +17,13 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Reusable-geometry parameter and finite-resistance multiport studies.
+"""Reusable-geometry source, receiver, and port studies.
 
 General GPR studies manage stateless local sources and ordinary receivers.
 Port studies additionally manage source-bound voltage-port monitors and
 assemble their frequency-domain response after the reused solves.
+Eigenmode studies reuse phase-aligned FDFD modal bases and assemble a full
+modal S matrix from one active port/mode channel per run.
 """
 
 from __future__ import annotations
@@ -30,6 +32,7 @@ import csv
 import json
 import logging
 import math
+import operator
 import shlex
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -55,6 +58,8 @@ _CSV_COLUMNS = {
     "stop_s",
     "scale",
     "record",
+    "port",
+    "mode",
 }
 
 
@@ -198,6 +203,9 @@ class Study:
                     parameters[parameter_name] = _parse_finite_float(
                         row[csv_name], path, line_number, csv_name
                     )
+            for name in ("port", "mode"):
+                if row.get(name, ""):
+                    parameters[name] = _parse_positive_int(row[name], path, line_number, name)
             if row.get("record", ""):
                 parameters["record"] = _parse_bool(row["record"], path, line_number, "record")
 
@@ -206,6 +214,8 @@ class Study:
         cases = [StudyCase(case_id, states) for case_id, states in case_rows.items()]
         if str(type).strip().lower() == "port":
             return PortStudy(cases, source_path=path, source_text=text)
+        if str(type).strip().lower() == "eigenmode":
+            return EigenmodeStudy(cases, source_path=path, source_text=text)
         return cls(type, cases, source_path=path, source_text=text)
 
     def bind_scene(self, scene) -> None:
@@ -976,6 +986,554 @@ class PortStudy(Study):
             output.create_dataset("valid_S", data=result.valid_s.astype(np.uint8))
 
 
+@dataclass(frozen=True)
+class EigenmodeStudyResult:
+    """Assembled modal S matrix from one active port/mode per run."""
+
+    frequency: npt.NDArray[np.floating]
+    channel_ports: npt.NDArray[np.integer]
+    channel_modes: npt.NDArray[np.integer]
+    case_ids: tuple[str, ...]
+    s: npt.NDArray[np.complexfloating]
+    valid_s: npt.NDArray[np.bool_]
+    generalized_valid_s: npt.NDArray[np.bool_]
+    output_file: Path
+
+    def excitation_weights(self, excitations: Iterable["ModalWeight"]):
+        """Return frequency-dependent incident power-wave weights."""
+
+        return modal_array_weights(
+            self.frequency,
+            self.channel_ports,
+            self.channel_modes,
+            excitations,
+        )
+
+    def outgoing(self, excitations: Iterable["ModalWeight"]):
+        """Apply the assembled S matrix to a weighted incident-wave vector.
+
+        Zero-weight channels are omitted rather than multiplied by their
+        stored NaNs.  An output is NaN when any active input lacks a valid
+        generalized coefficient to that output.  Use ``valid_s`` separately
+        when the result must also represent propagating real-power waves.
+        """
+
+        incident = self.excitation_weights(excitations)
+        active = np.abs(incident) > 0
+        selected_s = np.where(active[:, np.newaxis, :], self.s, 0)
+        result = np.einsum("foi,fi->fo", selected_s, incident)
+        valid = np.all(
+            ~active[:, np.newaxis, :] | self.generalized_valid_s,
+            axis=-1,
+        )
+        result[~valid] = np.nan + 1j * np.nan
+        return result
+
+
+@dataclass(frozen=True)
+class ModalWeight:
+    """One modal array weight using power, phase, and/or true time delay."""
+
+    port: int
+    mode: int
+    power: float = 1.0
+    phase_deg: float = 0.0
+    delay_s: float = 0.0
+
+
+def modal_array_weights(
+    frequency,
+    channel_ports,
+    channel_modes,
+    excitations: Iterable[ModalWeight],
+):
+    """Build incident modal power waves using the engineering FFT convention.
+
+    A constant phase shifter contributes ``exp(+j phase)``.  A true time
+    delay contributes ``exp(-j 2 pi f delay)``.  The coefficient magnitude is
+    the square root of the requested incident power in watts.
+    """
+
+    frequency = np.asarray(frequency)
+    channel_ports = np.asarray(channel_ports, dtype=np.int64)
+    channel_modes = np.asarray(channel_modes, dtype=np.int64)
+    if frequency.ndim != 1:
+        raise ValueError("Modal array frequencies must be one-dimensional.")
+    if channel_ports.shape != channel_modes.shape or channel_ports.ndim != 1:
+        raise ValueError("Modal channel port/mode arrays must be matching vectors.")
+    channels = {
+        (int(port), int(mode)): index
+        for index, (port, mode) in enumerate(zip(channel_ports, channel_modes))
+    }
+    if len(channels) != channel_ports.size:
+        raise ValueError("Modal channel port/mode pairs must be unique.")
+    result = np.zeros((frequency.size, channel_ports.size), dtype=np.complex128)
+    seen = set()
+    for excitation in excitations:
+        if not isinstance(excitation, ModalWeight):
+            raise TypeError("Modal excitations must be ModalWeight instances.")
+        channel = (int(excitation.port), int(excitation.mode))
+        if channel not in channels:
+            raise ValueError(
+                f"Modal weight references unavailable port {channel[0]}, mode {channel[1]}."
+            )
+        if channel in seen:
+            raise ValueError(
+                f"Modal weight for port {channel[0]}, mode {channel[1]} is duplicated."
+            )
+        seen.add(channel)
+        values = (excitation.power, excitation.phase_deg, excitation.delay_s)
+        if not all(np.isfinite(value) for value in values) or excitation.power < 0:
+            raise ValueError(
+                "Modal weight power must be finite and non-negative; phase and "
+                "delay must be finite."
+            )
+        phase = np.deg2rad(excitation.phase_deg) - 2 * np.pi * frequency * excitation.delay_s
+        result[:, channels[channel]] = np.sqrt(excitation.power) * np.exp(1j * phase)
+    return result
+
+
+def combine_embedded_modal_responses(responses, weights, *, channel_axis=-1):
+    """Linearly combine complex embedded responses with modal weights.
+
+    ``responses`` must have frequency as its first axis and one axis ordered
+    like the study's modal channels.  All intervening axes (observation point,
+    angle, field component, and so on) are retained.
+    """
+
+    responses = np.asarray(responses)
+    weights = np.asarray(weights)
+    if weights.ndim != 2:
+        raise ValueError("Modal weights must have shape (frequency, channel).")
+    if responses.ndim < 2:
+        raise ValueError("Embedded responses require frequency and channel axes.")
+    try:
+        channel_axis = operator.index(channel_axis)
+    except TypeError as exc:
+        raise TypeError("The embedded-response channel axis must be an integer.") from exc
+    if not -responses.ndim <= channel_axis < responses.ndim:
+        raise ValueError("The embedded-response channel axis is outside the response array.")
+    channel_axis %= responses.ndim
+    if channel_axis == 0:
+        raise ValueError("The embedded-response channel axis cannot be its frequency axis.")
+    moved = np.moveaxis(responses, channel_axis, -1)
+    if moved.shape[0] != weights.shape[0]:
+        raise ValueError("Embedded responses and weights require the same frequency axis.")
+    if moved.shape[-1] != weights.shape[1]:
+        raise ValueError("Embedded response channels do not match modal weights.")
+    shape = (weights.shape[0],) + (1,) * (moved.ndim - 2) + (weights.shape[1],)
+    reshaped_weights = weights.reshape(shape)
+    selected = np.where(np.abs(reshaped_weights) > 0, moved, 0)
+    return np.sum(selected * reshaped_weights, axis=-1)
+
+
+class EigenmodeStudy(Study):
+    """One-active-modal-channel-per-case reusable eigenmode-port study.
+
+    All transverse modal anchor problems are solved during the first geometry
+    build.  Later cases only synthesize an injection from those cached bases,
+    clear modal/virtual-guide state, and select a new active ``(port, mode)``.
+    """
+
+    supported_types = ("eigenmode",)
+
+    def __init__(
+        self,
+        cases: Sequence[StudyCase],
+        *,
+        source_path: Optional[Union[str, Path]] = None,
+        source_text: Optional[str] = None,
+    ):
+        super().__init__(
+            "eigenmode",
+            cases,
+            source_path=source_path,
+            source_text=source_text,
+        )
+        self._excitation = None
+        self._case_channels: list[tuple[int, int]] = []
+        self._channels: tuple[tuple[int, int], ...] = ()
+        self._runtime_grid = None
+        self._runtime_ports: dict[int, Any] = {}
+        self._runtime_monitors: dict[int, Any] = {}
+        self._runtime_guides: dict[int, Any] = {}
+        self._waveform = None
+        self._columns: dict[tuple[int, int], dict[str, Any]] = {}
+        self._current_column: Optional[dict[str, Any]] = None
+        self._aggregate_output_path: Optional[Path] = None
+        self.result: Optional[EigenmodeStudyResult] = None
+
+    def reset_runtime(self) -> None:
+        super().reset_runtime()
+        self._runtime_grid = None
+        self._runtime_ports.clear()
+        self._runtime_monitors.clear()
+        self._runtime_guides.clear()
+        self._waveform = None
+        self._columns.clear()
+        self._current_column = None
+        self._aggregate_output_path = None
+        self.result = None
+
+    def bind_scene(self, scene) -> None:
+        """Validate a complete, unambiguous modal-channel schedule."""
+
+        if self._scene_bound:
+            return
+        from gprMax.user_objects.cmds_multiuse import EigenmodeExcitation, EigenmodePort
+
+        containers = [("main grid", list(scene.grid_objects) + list(scene.output_objects))]
+        containers.extend(
+            (
+                f"subgrid {subgrid.kwargs.get('id', '')!r}",
+                list(subgrid.children_grid) + list(subgrid.children_output),
+            )
+            for subgrid in scene.subgrid_objects
+        )
+        excitations = [
+            (label, objects, item)
+            for label, objects in containers
+            for item in objects
+            if isinstance(item, EigenmodeExcitation)
+        ]
+        if len(excitations) != 1:
+            raise ValueError(
+                "EigenmodeStudy requires exactly one EigenmodeExcitation in its Scene; "
+                f"found {len(excitations)}."
+            )
+        owner_label, owner_objects, excitation = excitations[0]
+        ports = [item for item in owner_objects if isinstance(item, EigenmodePort)]
+        if not ports:
+            raise ValueError("EigenmodeStudy requires at least one EigenmodePort.")
+        foreign_ports = [
+            label
+            for label, objects in containers
+            if objects is not owner_objects
+            for item in objects
+            if isinstance(item, EigenmodePort)
+        ]
+        if foreign_ports:
+            raise ValueError(
+                "EigenmodeStudy requires its excitation and every eigenmode port to "
+                f"belong to one grid ({owner_label}); ports were also found on "
+                + ", ".join(sorted(set(foreign_ports)))
+                + "."
+            )
+
+        study_id = "eigenmode_excitation_1"
+        setattr(excitation, "_study_id", study_id)
+        # The builder uses this marker to resolve source-grade anchor coverage
+        # at every port, not only at the initially selected source.
+        setattr(excitation, "_reusable_study", True)
+        self._excitation = excitation
+        self.registry = {study_id: excitation}
+        self.aliases = {}
+
+        available: set[tuple[int, int]] = set()
+        for port in ports:
+            port_number = int(port.kwargs["port"])
+            modes = port.kwargs.get("modes", (1,))
+            if np.isscalar(modes):
+                modes = tuple(range(1, int(modes) + 1))
+            available.update((port_number, int(mode)) for mode in modes)
+
+        scheduled: list[tuple[int, int]] = []
+        for case in self.cases:
+            if len(case.states) != 1:
+                raise ValueError(
+                    f"EigenmodeStudy case '{case.id}' must contain exactly one "
+                    "EigenmodeExcitation state."
+                )
+            state = case.states[0]
+            if isinstance(state.object, str):
+                requested = state.object.strip()
+                if requested != study_id:
+                    raise ValueError(
+                        f"EigenmodeStudy case '{case.id}' references '{requested}', "
+                        f"expected '{study_id}'."
+                    )
+            elif state.object is not excitation:
+                raise ValueError(
+                    f"EigenmodeStudy case '{case.id}' must reference the Scene's "
+                    "EigenmodeExcitation object."
+                )
+            unknown = set(state.parameters) - {"port", "mode"}
+            if unknown:
+                raise ValueError(
+                    f"EigenmodeStudy case '{case.id}' has unsupported parameter(s) "
+                    f"{', '.join(sorted(unknown))}; allowed parameters are port and mode."
+                )
+            if "port" not in state.parameters or "mode" not in state.parameters:
+                raise ValueError(f"EigenmodeStudy case '{case.id}' requires both port and mode.")
+            channel = (int(state.parameters["port"]), int(state.parameters["mode"]))
+            if channel not in available:
+                raise ValueError(
+                    f"EigenmodeStudy case '{case.id}' requests unavailable channel "
+                    f"port {channel[0]}, mode {channel[1]}."
+                )
+            state.object = study_id
+            scheduled.append(channel)
+
+        if len(scheduled) != len(set(scheduled)):
+            raise ValueError("EigenmodeStudy may excite each port/mode channel only once.")
+        if set(scheduled) != available:
+            missing = ", ".join(
+                f"port {port}, mode {mode}" for port, mode in sorted(available - set(scheduled))
+            )
+            raise ValueError(
+                "EigenmodeStudy requires one case for every declared modal channel; "
+                f"missing {missing}."
+            )
+        self._case_channels = scheduled
+        self._channels = tuple(sorted(available))
+        self._scene_bound = True
+        logger.info(
+            "EigenmodeStudy channels: "
+            + ", ".join(f"port {port}/mode {mode}" for port, mode in self._channels)
+            + "\n"
+        )
+
+    def _bind_runtime(self, model) -> None:
+        if self._runtime_grid is not None:
+            return
+        grids = [model.G] + list(model.subgrids)
+        matches = [grid for grid in grids if grid.eigenmodeexcitation is self._excitation]
+        if len(matches) != 1:
+            raise RuntimeError(
+                "EigenmodeStudy could not identify exactly one built grid for its excitation."
+            )
+        grid = matches[0]
+        monitors = {int(monitor.port_index): monitor for monitor in grid.eigenmodeports}
+        ports = {port_number: monitor.owner for port_number, monitor in monitors.items()}
+        expected_ports = {port for port, _ in self._channels}
+        if set(ports) != expected_ports:
+            raise RuntimeError(
+                "EigenmodeStudy runtime ports do not match its declared modal channels."
+            )
+        guides = {int(guide.spec.port): guide for guide in grid.virtual_waveguides}
+        waveforms = [
+            port.waveform for port in ports.values() if getattr(port, "waveform", None) is not None
+        ]
+        if len(waveforms) != 1:
+            raise RuntimeError("EigenmodeStudy requires exactly one baseline excitation waveform.")
+        self._runtime_grid = grid
+        self._runtime_ports = ports
+        self._runtime_monitors = monitors
+        self._runtime_guides = guides
+        self._waveform = waveforms[0]
+
+    def apply_case(self, model) -> None:
+        """Reset persistent state and activate the scheduled modal channel."""
+
+        import gprMax.config as config
+
+        self._bind_runtime(model)
+        grid = self._runtime_grid
+        case_index = config.sim_config.current_model
+        port_number, mode_index = self._case_channels[case_index]
+
+        for monitor in self._runtime_monitors.values():
+            monitor.reset_run_state(grid)
+            monitor.is_source = False
+            monitor.excitation_mode_index = None
+            monitor.magnetic_side = 1 if int(monitor.port_index) in self._runtime_guides else -1
+        for guide in self._runtime_guides.values():
+            guide.clear_active_source()
+            guide.reset_run_state()
+
+        all_ports = list(self._runtime_ports.values())
+        grid.eigenmodesources.clear()
+        grid.eigenmodereceivers[:] = all_ports
+
+        source = self._runtime_ports[port_number]
+        source.spectral_threshold = grid.eigenmodeband.spectral_threshold
+        source.configure_cached_excitation(grid, mode_index, self._waveform)
+        monitor = self._runtime_monitors[port_number]
+        monitor.is_source = True
+        monitor.excitation_mode_index = mode_index
+        monitor.magnetic_side = 1
+        guide = self._runtime_guides.get(port_number)
+        if guide is None:
+            grid.eigenmodereceivers.remove(source)
+            grid.eigenmodesources.append(source)
+        else:
+            guide.set_active_source(source)
+
+        case = self.cases[case_index]
+        self._current_resolved_case = {
+            "case_id": case.id,
+            "objects": {
+                "eigenmode_excitation_1": {
+                    "port": port_number,
+                    "mode": mode_index,
+                }
+            },
+        }
+        if self._aggregate_output_path is None:
+            model_config = config.get_model_config()
+            base = Path(model_config.output_file_path)
+            suffix = model_config.appendmodelnumber
+            if suffix and base.name.endswith(suffix):
+                base = base.with_name(base.name[: -len(suffix)])
+            self._aggregate_output_path = base.with_name(base.name + "_study").with_suffix(".h5")
+
+    def collect_case(self, model) -> None:
+        """Collect one modal S-matrix column from finalised port monitors."""
+
+        import gprMax.config as config
+
+        grid = self._runtime_grid
+        input_channel = self._case_channels[config.sim_config.current_model]
+        first = self._runtime_monitors[self._channels[0][0]]
+        frequency = np.asarray(first.result.frequency)
+        complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
+        column = np.full(
+            (frequency.size, len(self._channels)),
+            np.nan + 1j * np.nan,
+            dtype=complex_dtype,
+        )
+        valid = np.zeros(column.shape, dtype=bool)
+        generalized_valid = np.zeros(column.shape, dtype=bool)
+        for output_index, (port_number, mode_index) in enumerate(self._channels):
+            monitor = self._runtime_monitors[port_number]
+            if not np.array_equal(monitor.result.frequency, frequency):
+                raise ValueError("All EigenmodeStudy ports must use identical DFT bins.")
+            mode_position = monitor.mode_indices.index(mode_index)
+            column[:, output_index] = monitor.s_parameters[mode_position]
+            valid[:, output_index] = monitor.s_valid[mode_position]
+            generalized_valid[:, output_index] = monitor.s_generalized_valid[mode_position]
+
+        data = {
+            "case_id": self.cases[config.sim_config.current_model].id,
+            "input_channel": input_channel,
+            "frequency": frequency.copy(),
+            "column": column,
+            "valid": valid,
+            "generalized_valid": generalized_valid,
+        }
+        self._columns[input_channel] = data
+        self._current_column = data
+
+    def write_hdf5(self, h5file) -> None:
+        super().write_hdf5(h5file)
+        if self._current_column is None:
+            raise RuntimeError("EigenmodeStudy case data was not collected before HDF5 output.")
+        data = self._current_column
+        group = h5file["study"].create_group("eigenmode_response")
+        group.attrs["InputPort"] = data["input_channel"][0]
+        group.attrs["InputMode"] = data["input_channel"][1]
+        group.attrs["MatrixConvention"] = "S[frequency, output_channel, input_channel]"
+        group.create_dataset("channel_ports", data=[item[0] for item in self._channels])
+        group.create_dataset("channel_modes", data=[item[1] for item in self._channels])
+        group.create_dataset("frequency", data=data["frequency"])
+        group.create_dataset("S_column", data=data["column"])
+        group.create_dataset("valid_S_column", data=data["valid"].astype(np.uint8))
+        group.create_dataset(
+            "generalized_valid_S_column",
+            data=data["generalized_valid"].astype(np.uint8),
+        )
+        if self._aggregate_output_path is not None:
+            group.attrs["AggregateOutput"] = str(self._aggregate_output_path)
+
+    def finalise(self) -> Optional[EigenmodeStudyResult]:
+        """Assemble and store the complete modal S matrix."""
+
+        if not self._columns or self._aggregate_output_path is None:
+            return None
+        first = next(iter(self._columns.values()))
+        frequency = first["frequency"]
+        channel_count = len(self._channels)
+        shape = (frequency.size, channel_count, channel_count)
+        s = np.full(shape, np.nan + 1j * np.nan, dtype=first["column"].dtype)
+        valid = np.zeros(shape, dtype=bool)
+        generalized_valid = np.zeros(shape, dtype=bool)
+        case_ids = [""] * channel_count
+
+        if len(self._columns) < channel_count and self._aggregate_output_path.exists():
+            with h5py.File(self._aggregate_output_path, "r") as previous:
+                previous_channels = tuple(
+                    zip(
+                        previous["channel_ports"][...].astype(int),
+                        previous["channel_modes"][...].astype(int),
+                    )
+                )
+                compatible = (
+                    previous.attrs.get("StudyType", "") == "eigenmode"
+                    and previous_channels == self._channels
+                    and np.array_equal(previous["frequency"][...], frequency)
+                )
+                if not compatible:
+                    raise ValueError(
+                        f"Existing EigenmodeStudy output '{self._aggregate_output_path}' "
+                        "is not compatible with this restarted study."
+                    )
+                s[...] = previous["S"][...]
+                valid[...] = previous["valid_S"][...].astype(bool)
+                generalized_valid[...] = previous["generalized_valid_S"][...].astype(bool)
+                case_ids = [item.decode() for item in previous["case_ids"][...]]
+        elif len(self._columns) < channel_count:
+            logger.warning(
+                "EigenmodeStudy is incomplete and no compatible aggregate output "
+                "exists from an earlier run; uncomputed S-matrix columns will be NaN."
+            )
+
+        for input_index, channel in enumerate(self._channels):
+            data = self._columns.get(channel)
+            if data is None:
+                continue
+            if not np.array_equal(data["frequency"], frequency):
+                raise RuntimeError("EigenmodeStudy collected inconsistent frequency axes.")
+            s[:, :, input_index] = data["column"]
+            valid[:, :, input_index] = data["valid"]
+            generalized_valid[:, :, input_index] = data["generalized_valid"]
+            case_ids[input_index] = data["case_id"]
+
+        self.result = EigenmodeStudyResult(
+            frequency=np.asarray(frequency),
+            channel_ports=np.asarray([item[0] for item in self._channels], dtype=np.int32),
+            channel_modes=np.asarray([item[1] for item in self._channels], dtype=np.int32),
+            case_ids=tuple(case_ids),
+            s=s,
+            valid_s=valid,
+            generalized_valid_s=generalized_valid,
+            output_file=self._aggregate_output_path,
+        )
+        self._write_aggregate_hdf5()
+        logger.info(f"Written EigenmodeStudy output file: {self._aggregate_output_path.name}\n")
+        return self.result
+
+    def _write_aggregate_hdf5(self) -> None:
+        if self.result is None:
+            return
+        from gprMax._version import __version__
+        from gprMax.ntff.conventions import FORWARD_TRANSFORM_KERNEL, PHASOR_TIME_DEPENDENCE
+
+        result = self.result
+        with h5py.File(result.output_file, "w") as output:
+            output.attrs["gprMax"] = __version__
+            output.attrs["StudyType"] = self.type
+            output.attrs["MatrixConvention"] = "S[frequency, output_channel, input_channel]"
+            output.attrs["WaveNormalisation"] = "modal_power_wave"
+            output.attrs["phasor_time_sign"] = PHASOR_TIME_DEPENDENCE
+            output.attrs["forward_transform_sign"] = FORWARD_TRANSFORM_KERNEL
+            output.attrs["CasesCompleted"] = sum(bool(case_id) for case_id in result.case_ids)
+            output.attrs["CaseCount"] = len(self.cases)
+            output.attrs["Complete"] = all(bool(case_id) for case_id in result.case_ids)
+            if self.source_path is not None:
+                output.attrs["SourcePath"] = str(self.source_path)
+            if self.source_text is not None:
+                output.create_dataset("source", data=self.source_text)
+            output.create_dataset("frequency", data=result.frequency)
+            output.create_dataset("channel_ports", data=result.channel_ports)
+            output.create_dataset("channel_modes", data=result.channel_modes)
+            output.create_dataset("case_ids", data=np.asarray(result.case_ids, dtype="S"))
+            output.create_dataset("S", data=result.s)
+            output.create_dataset("valid_S", data=result.valid_s.astype(np.uint8))
+            output.create_dataset(
+                "generalized_valid_S", data=result.generalized_valid_s.astype(np.uint8)
+            )
+
+
 def preflight_study_args(args) -> Optional[Study]:
     """Resolve API/hash study input before SimulationConfig sizes its run."""
 
@@ -997,8 +1555,10 @@ def preflight_study_args(args) -> Optional[Study]:
         raise ValueError("Studies do not yet support MPI task farming.")
     if getattr(args, "mpi", None) is not None:
         raise ValueError("Studies do not yet support MPI domain decomposition.")
-    if isinstance(study, PortStudy) and getattr(args, "geometry_only", False):
-        raise ValueError("PortStudy requires a field solve and cannot use geometry_only.")
+    if isinstance(study, (PortStudy, EigenmodeStudy)) and getattr(args, "geometry_only", False):
+        raise ValueError(
+            f"{type(study).__name__} requires a field solve and cannot use geometry_only."
+        )
     scenes = getattr(args, "scenes", None)
     if scenes is not None and len(scenes) != 1:
         raise ValueError("A study requires exactly one reusable Scene.")
@@ -1091,6 +1651,18 @@ def _parse_finite_float(value: str, path: Path, line: int, name: str) -> float:
         raise ValueError(f"Study CSV '{path}', line {line}: {name} must be a number.") from exc
     if not math.isfinite(result):
         raise ValueError(f"Study CSV '{path}', line {line}: {name} must be finite.")
+    return result
+
+
+def _parse_positive_int(value: str, path: Path, line: int, name: str) -> int:
+    try:
+        result = int(value)
+    except ValueError as exc:
+        raise ValueError(
+            f"Study CSV '{path}', line {line}: {name} must be a positive integer."
+        ) from exc
+    if result < 1:
+        raise ValueError(f"Study CSV '{path}', line {line}: {name} must be a positive integer.")
     return result
 
 

--- a/gprMax/updates/cuda_updates.py
+++ b/gprMax/updates/cuda_updates.py
@@ -308,9 +308,7 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 self.subs_name_args,
                 substitutions,
             )
-            module_a = self.source_module(
-                source, options=config.sim_config.devices["nvcc_opts"]
-            )
+            module_a = self.source_module(source, options=config.sim_config.devices["nvcc_opts"])
             self.update_electric_pmc_dispersive_dev = module_a.get_function(
                 "update_electric_pmc_dispersive"
             )
@@ -320,9 +318,7 @@ class CUDAUpdates(Updates[CUDAGrid]):
                 self.subs_name_args,
                 self.subs_func,
             )
-            module_b = self.source_module(
-                source, options=config.sim_config.devices["nvcc_opts"]
-            )
+            module_b = self.source_module(source, options=config.sim_config.devices["nvcc_opts"])
             self.update_electric_pmc_dispersive_b_dev = module_b.get_function(
                 "update_electric_pmc_dispersive_b"
             )
@@ -491,8 +487,10 @@ class CUDAUpdates(Updates[CUDAGrid]):
     def _set_eigenmode_source_knls(self):
         """Upload modal bases and compile device TF/SF source kernels."""
 
-        if not hasattr(self.grid, "updatecoeffsE_dev"):
-            self.grid.htod_mat_coeff_arrays()
+        # Geometry reuse creates a fresh CUDA context for every run.  Python
+        # attributes from the former context can still exist on the retained
+        # grid, so presence is not evidence that a device pointer is valid.
+        self.grid.htod_mat_coeff_arrays()
         for source in self.grid.eigenmodesources:
             prepare_device_eigenmode_source(source, "cuda")
         self.eigenmode_tpb = (128, 1, 1)
@@ -1719,9 +1717,7 @@ class CUDAUpdates(Updates[CUDAGrid]):
             return
         dispersive = config.get_model_config().materials["maxpoles"] > 0
         kernel = (
-            self.update_electric_pmc_dispersive_dev
-            if dispersive
-            else self.update_electric_pmc_dev
+            self.update_electric_pmc_dispersive_dev if dispersive else self.update_electric_pmc_dev
         )
         leading = [
             np.int32(self.grid.nx),
@@ -1743,15 +1739,17 @@ class CUDAUpdates(Updates[CUDAGrid]):
                     self.grid.Tz_dev.gpudata,
                 ]
             )
-        arguments.extend([
-            self.grid.ID_dev.gpudata,
-            self.grid.Ex_dev.gpudata,
-            self.grid.Ey_dev.gpudata,
-            self.grid.Ez_dev.gpudata,
-            self.grid.Hx_dev.gpudata,
-            self.grid.Hy_dev.gpudata,
-            self.grid.Hz_dev.gpudata,
-        ])
+        arguments.extend(
+            [
+                self.grid.ID_dev.gpudata,
+                self.grid.Ex_dev.gpudata,
+                self.grid.Ey_dev.gpudata,
+                self.grid.Ez_dev.gpudata,
+                self.grid.Hx_dev.gpudata,
+                self.grid.Hy_dev.gpudata,
+                self.grid.Hz_dev.gpudata,
+            ]
+        )
         kernel(
             *arguments,
             block=self.grid.tpb,
@@ -1766,13 +1764,21 @@ class CUDAUpdates(Updates[CUDAGrid]):
         ):
             return
         self.update_electric_pmc_dispersive_b_dev(
-            np.int32(self.grid.nx), np.int32(self.grid.ny), np.int32(self.grid.nz),
+            np.int32(self.grid.nx),
+            np.int32(self.grid.ny),
+            np.int32(self.grid.nz),
             np.int32(config.get_model_config().materials["maxpoles"]),
-            *self._pmc_flags(), self.grid.updatecoeffsdispersive_dev.gpudata,
-            self.grid.Tx_dev.gpudata, self.grid.Ty_dev.gpudata,
-            self.grid.Tz_dev.gpudata, self.grid.ID_dev.gpudata,
-            self.grid.Ex_dev.gpudata, self.grid.Ey_dev.gpudata,
-            self.grid.Ez_dev.gpudata, block=self.grid.tpb, grid=self.grid.bpg,
+            *self._pmc_flags(),
+            self.grid.updatecoeffsdispersive_dev.gpudata,
+            self.grid.Tx_dev.gpudata,
+            self.grid.Ty_dev.gpudata,
+            self.grid.Tz_dev.gpudata,
+            self.grid.ID_dev.gpudata,
+            self.grid.Ex_dev.gpudata,
+            self.grid.Ey_dev.gpudata,
+            self.grid.Ez_dev.gpudata,
+            block=self.grid.tpb,
+            grid=self.grid.bpg,
         )
 
     def update_electric_pml(self):

--- a/gprMax/updates/opencl_updates.py
+++ b/gprMax/updates/opencl_updates.py
@@ -312,9 +312,9 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
             }
             self.update_electric_pmc_dispersive_dev = self.elwiseknl(
                 self.ctx,
-                knl_symmetry_boundaries.update_electric_pmc_dispersive[
-                    "args_opencl"
-                ].substitute(arguments),
+                knl_symmetry_boundaries.update_electric_pmc_dispersive["args_opencl"].substitute(
+                    arguments
+                ),
                 knl_symmetry_boundaries.update_electric_pmc_dispersive["func"].substitute(
                     dispersive
                 ),
@@ -324,9 +324,9 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
             )
             self.update_electric_pmc_dispersive_b_dev = self.elwiseknl(
                 self.ctx,
-                knl_symmetry_boundaries.update_electric_pmc_dispersive_b[
-                    "args_opencl"
-                ].substitute(arguments),
+                knl_symmetry_boundaries.update_electric_pmc_dispersive_b["args_opencl"].substitute(
+                    arguments
+                ),
                 knl_symmetry_boundaries.update_electric_pmc_dispersive_b["func"].substitute(
                     substitutions
                 ),
@@ -567,8 +567,9 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
     def _set_eigenmode_source_knls(self):
         """Upload modal bases and compile device TF/SF source kernels."""
 
-        if not hasattr(self.grid, "updatecoeffsE_dev"):
-            self.grid.htod_mat_coeff_arrays(self.queue)
+        # A reused grid retains Python attributes but receives a fresh OpenCL
+        # queue.  Always re-upload pointer arguments to that current queue.
+        self.grid.htod_mat_coeff_arrays(self.queue)
         for source in self.grid.eigenmodesources:
             prepare_device_eigenmode_source(source, "opencl", queue=self.queue)
         arguments = {"REAL": config.sim_config.dtypes["C_float_or_double"]}
@@ -2045,9 +2046,7 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
             return
         dispersive = config.get_model_config().materials["maxpoles"] > 0
         kernel = (
-            self.update_electric_pmc_dispersive_dev
-            if dispersive
-            else self.update_electric_pmc_dev
+            self.update_electric_pmc_dispersive_dev if dispersive else self.update_electric_pmc_dev
         )
         leading = [
             np.int32(self.grid.nx),
@@ -2077,15 +2076,17 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
                 ]
             )
         else:
-            arguments.extend([
-            self.grid.ID_dev,
-            self.grid.Ex_dev,
-            self.grid.Ey_dev,
-            self.grid.Ez_dev,
-            self.grid.Hx_dev,
-            self.grid.Hy_dev,
-            self.grid.Hz_dev,
-            ])
+            arguments.extend(
+                [
+                    self.grid.ID_dev,
+                    self.grid.Ex_dev,
+                    self.grid.Ey_dev,
+                    self.grid.Ez_dev,
+                    self.grid.Hx_dev,
+                    self.grid.Hy_dev,
+                    self.grid.Hz_dev,
+                ]
+            )
         kernel(*arguments)
 
     def update_symmetry_boundaries_electric_b(self):
@@ -2096,12 +2097,19 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
         ):
             return
         self.update_electric_pmc_dispersive_b_dev(
-            np.int32(self.grid.nx), np.int32(self.grid.ny), np.int32(self.grid.nz),
+            np.int32(self.grid.nx),
+            np.int32(self.grid.ny),
+            np.int32(self.grid.nz),
             np.int32(config.get_model_config().materials["maxpoles"]),
-            *self._pmc_flags(), self.grid.ID_dev, self.grid.Ex_dev,
-            self.grid.Ey_dev, self.grid.Ez_dev,
-            self.grid.updatecoeffsdispersive_dev, self.grid.Tx_dev,
-            self.grid.Ty_dev, self.grid.Tz_dev,
+            *self._pmc_flags(),
+            self.grid.ID_dev,
+            self.grid.Ex_dev,
+            self.grid.Ey_dev,
+            self.grid.Ez_dev,
+            self.grid.updatecoeffsdispersive_dev,
+            self.grid.Tx_dev,
+            self.grid.Ty_dev,
+            self.grid.Tz_dev,
         )
 
     def update_electric_pml(self):

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -2376,10 +2376,11 @@ class EigenmodeExcitation(GridUserObject):
             waveform = matches[0]
         band.resolve_spectrum(grid, waveform, generated_waveform=generated_waveform)
 
+        reusable_study = bool(getattr(self, "_reusable_study", False))
         for port_number in sorted(grid.eigenmodeportdefs):
             port = grid.eigenmodeportdefs[port_number]
             is_source = port_number == source_port_number
-            port.resolve_anchors(band, is_source=is_source)
+            port.resolve_anchors(band, is_source=(is_source or reusable_study))
             common = self._runtime_plane_kwargs(port, band)
             if is_source:
                 common.update(
@@ -2399,6 +2400,7 @@ class EigenmodeExcitation(GridUserObject):
                 _EigenmodeReceiverBuilder(**common).build(grid)
                 runtime = grid.eigenmodereceivers[-1]
                 runtime.mode_indices = port.modes
+                runtime.spectral_threshold = band.spectral_threshold
             runtime.anchor_policy = port.anchor_policy
             runtime.requested_anchor_policy = port.anchor_policy
             runtime.resolved_anchor_policy = port.anchor_policy

--- a/gprMax/virtual_waveguide.py
+++ b/gprMax/virtual_waveguide.py
@@ -399,6 +399,43 @@ class VirtualWaveguide:
         source.port_monitor = None
         return source
 
+    def set_active_source(self, source):
+        """Install a configured cached modal source in the auxiliary guide."""
+
+        self.port = source
+        self.aux_source = copy.copy(source)
+        self.aux_source.transverse_start = np.asarray((0, 0), dtype=np.int32)
+        self.aux_source.transverse_stop = np.asarray((self.nu, self.nv), dtype=np.int32)
+        distance = self.spec.length_cells - self.spec.pml_cells - self.spec.source_clearance_cells
+        self.aux_source.plane_index = (
+            distance if self.direction_sign < 0 else self.spec.length_cells - distance
+        )
+        self.aux_source.global_plane_index = self.aux_source.plane_index
+        self.aux_source.global_transverse_start = np.asarray((0, 0), dtype=np.int32)
+        self.aux_source.global_transverse_stop = np.asarray((self.nu, self.nv), dtype=np.int32)
+        self.aux_source.tfsf_owned_lower = np.zeros(3, dtype=np.int32)
+        self.aux_source.tfsf_owned_upper = np.asarray(self.aux_grid.size + 1, dtype=np.int32)
+        self.aux_source.port_monitor = None
+        self.aux_grid.eigenmodesources[:] = [self.aux_source]
+
+    def clear_active_source(self):
+        """Leave this guide as a passive matched modal load."""
+
+        self.aux_source = None
+        self.aux_grid.eigenmodesources.clear()
+
+    def reset_run_state(self):
+        """Clear auxiliary fields/PML history and stale accelerator bindings."""
+
+        self.aux_grid.reset_fields()
+        if config.sim_config.general["solver"] == "cpu":
+            self.aux_updates = CPUUpdates(self.aux_grid)
+        else:
+            # Device update objects share their parent's context/queue.  A new
+            # parent is created for every reused run, so the auxiliary object
+            # must be rebound as well.
+            self.aux_updates = None
+
     def initialise_device(self, parent_updates):
         """Create the auxiliary solver in the parent's accelerator context."""
 
@@ -406,13 +443,15 @@ class VirtualWaveguide:
             return
         self.aux_updates = type(parent_updates)(self.aux_grid, shared=parent_updates)
         solver = config.sim_config.general["solver"]
-        if not hasattr(self.aux_grid, "updatecoeffsE_dev"):
-            if solver == "cuda":
-                self.aux_grid.htod_mat_coeff_arrays()
-            elif solver == "opencl":
-                self.aux_grid.htod_mat_coeff_arrays(parent_updates.queue)
-            else:
-                self.aux_grid.htod_material_arrays(parent_updates.dev)
+        # Always refresh these arrays: a geometry-reuse run creates a new
+        # accelerator context/queue, while Python attributes from the former
+        # context may still exist on the persistent auxiliary grid.
+        if solver == "cuda":
+            self.aux_grid.htod_mat_coeff_arrays()
+        elif solver == "opencl":
+            self.aux_grid.htod_mat_coeff_arrays(parent_updates.queue)
+        else:
+            self.aux_grid.htod_material_arrays(parent_updates.dev)
 
     def _mpi_owned_global_bounds(self):
         lower = np.asarray(

--- a/tests/cmds_multiuse/test_eigenmode_subgrid.py
+++ b/tests/cmds_multiuse/test_eigenmode_subgrid.py
@@ -8,7 +8,6 @@ import gprMax
 import gprMax.model as model_mod
 from gprMax.subgrids.subgrid_hsg import SubGridHSG
 
-
 FREQUENCY = 12e9
 
 
@@ -159,9 +158,7 @@ def _subgrid_scene(
             virtual_waveguide=virtual_waveguide,
         )
     else:
-        subgrid.add(
-            gprMax.Waveform(wave_type="contsine", amp=1, freq=FREQUENCY, id="wave")
-        )
+        subgrid.add(gprMax.Waveform(wave_type="contsine", amp=1, freq=FREQUENCY, id="wave"))
         subgrid.add(
             gprMax.EigenmodeBand(
                 id="band",
@@ -295,9 +292,7 @@ def test_subgrid_eigenmode_plane_cannot_touch_coupling_surface(tmp_path, p1, p2)
 
 @pytest.mark.integration
 @pytest.mark.parametrize("normal_axis", range(3), ids=("x", "y", "z"))
-def test_subgrid_virtual_waveguide_inherits_fine_grid(
-    monkeypatch, tmp_path, normal_axis
-):
+def test_subgrid_virtual_waveguide_inherits_fine_grid(monkeypatch, tmp_path, normal_axis):
     captured = _capture_built_grids(monkeypatch)
 
     gprMax.run(
@@ -356,9 +351,7 @@ def test_subgrid_virtual_waveguide_inherits_fine_grid(
 
 
 @pytest.mark.integration
-def test_subgrid_virtual_waveguide_transient_matches_uniform_fine_grid(
-    monkeypatch, tmp_path
-):
+def test_subgrid_virtual_waveguide_transient_matches_uniform_fine_grid(monkeypatch, tmp_path):
     captured = _capture_built_grids(monkeypatch, uniform_source_stop_iteration=3)
     fine_iterations = 6
     gprMax.run(
@@ -399,9 +392,7 @@ def test_subgrid_virtual_waveguide_transient_matches_uniform_fine_grid(
 
 
 @pytest.mark.integration
-def test_subgrid_transient_modal_response_matches_uniform_fine_grid(
-    monkeypatch, tmp_path
-):
+def test_subgrid_transient_modal_response_matches_uniform_fine_grid(monkeypatch, tmp_path):
     """Compare identical fine updates before a boundary return can arrive."""
 
     # An HSG run performs ``ratio`` fine updates per main iteration but all
@@ -444,9 +435,7 @@ def test_subgrid_transient_modal_response_matches_uniform_fine_grid(
     )
     outer = np.asarray(fine_grid.size) - inner
     cell_slices = tuple(slice(int(start), int(stop)) for start, stop in zip(inner, outer))
-    component_slices = tuple(
-        slice(int(start), int(stop + 1)) for start, stop in zip(inner, outer)
-    )
+    component_slices = tuple(slice(int(start), int(stop + 1)) for start, stop in zip(inner, outer))
     np.testing.assert_array_equal(fine_grid.solid[cell_slices], uniform_grid.solid)
     np.testing.assert_array_equal(
         fine_grid.ID[(slice(None), *component_slices)],
@@ -490,9 +479,7 @@ def test_subgrid_transient_modal_response_matches_uniform_fine_grid(
 
 @pytest.mark.integration
 @pytest.mark.parametrize("virtual_waveguide", (False, True), ids=("direct", "virtual"))
-def test_subgrid_eigenmode_source_runs_and_writes_fine_grid_port(
-    tmp_path, virtual_waveguide
-):
+def test_subgrid_eigenmode_source_runs_and_writes_fine_grid_port(tmp_path, virtual_waveguide):
     scene, subgrid_object = _subgrid_scene(
         timewindow=5e-10,
         virtual_waveguide=virtual_waveguide,
@@ -519,32 +506,112 @@ def test_subgrid_eigenmode_source_runs_and_writes_fine_grid_port(
         assert np.max(np.abs(group["port1/incident"][...])) > 0
 
     fine_grid = subgrid_object.subgrid
-    assert all(
-        port._next_iteration == fine_grid.iterations for port in fine_grid.eigenmodeports
-    )
-    assert max(
-        float(np.max(np.abs(field)))
-        for field in (
-            fine_grid.Ex,
-            fine_grid.Ey,
-            fine_grid.Ez,
-            fine_grid.Hx,
-            fine_grid.Hy,
-            fine_grid.Hz,
+    assert all(port._next_iteration == fine_grid.iterations for port in fine_grid.eigenmodeports)
+    assert (
+        max(
+            float(np.max(np.abs(field)))
+            for field in (
+                fine_grid.Ex,
+                fine_grid.Ey,
+                fine_grid.Ez,
+                fine_grid.Hx,
+                fine_grid.Hy,
+                fine_grid.Hz,
+            )
         )
-    ) > 0
+        > 0
+    )
     if virtual_waveguide:
         assert len(fine_grid.virtual_waveguides) == 1
         guide = fine_grid.virtual_waveguides[0]
         assert guide.aux_grid.iterations == fine_grid.iterations
-        assert max(
-            float(np.max(np.abs(field)))
-            for field in (
-                guide.aux_grid.Ex,
-                guide.aux_grid.Ey,
-                guide.aux_grid.Ez,
-                guide.aux_grid.Hx,
-                guide.aux_grid.Hy,
-                guide.aux_grid.Hz,
+        assert (
+            max(
+                float(np.max(np.abs(field)))
+                for field in (
+                    guide.aux_grid.Ex,
+                    guide.aux_grid.Ey,
+                    guide.aux_grid.Ez,
+                    guide.aux_grid.Hx,
+                    guide.aux_grid.Hy,
+                    guide.aux_grid.Hz,
+                )
             )
-        ) > 0
+            > 0
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("virtual_waveguide", (False, True), ids=("direct", "virtual"))
+def test_subgrid_eigenmode_study_switches_modal_source(tmp_path, virtual_waveguide):
+    """A reusable modal study may be owned wholly by one fine grid."""
+
+    scene, subgrid_object = _subgrid_scene(
+        timewindow=5e-10,
+        virtual_waveguide=virtual_waveguide,
+    )
+    # The reusable study requires a complete channel schedule, so add a
+    # second port to the helper's fine-grid model when it was not requested
+    # by the original source-only fixture.
+    if not any(
+        isinstance(item, gprMax.EigenmodePort) and item.kwargs["port"] == 2
+        for item in subgrid_object.children_grid
+    ):
+        offset = np.full(3, 0.03)
+        subgrid_object.add(
+            gprMax.EigenmodePort(
+                port=2,
+                p1=tuple(np.asarray((0.024, 0.009, 0.009)) + offset),
+                p2=tuple(np.asarray((0.024, 0.021, 0.019)) + offset),
+                direction="-",
+                modes=(1,),
+                anchors=(FREQUENCY,),
+                plot_fields=False,
+            )
+        )
+    if virtual_waveguide and not any(
+        isinstance(item, gprMax.VirtualWaveguide) and item.kwargs["port"] == 2
+        for item in subgrid_object.children_grid
+    ):
+        subgrid_object.add(
+            gprMax.VirtualWaveguide(
+                port=2,
+                length_cells=12,
+                pml_cells=4,
+                source_clearance_cells=3,
+            )
+        )
+    excitation = next(
+        item
+        for item in subgrid_object.children_grid
+        if isinstance(item, gprMax.EigenmodeExcitation)
+    )
+    study = gprMax.EigenmodeStudy(
+        [
+            gprMax.StudyCase(
+                f"drive_port{port}",
+                [gprMax.ObjectState(excitation, port=port, mode=1)],
+            )
+            for port in (1, 2)
+        ]
+    )
+    outputfile = tmp_path / f"subgrid_study_{'virtual' if virtual_waveguide else 'direct'}"
+    gprMax.run(
+        scenes=[scene],
+        study=study,
+        outputfile=outputfile,
+        subgrid=True,
+        autotranslate=True,
+        cpu_precision="double",
+        hide_progress_bars=True,
+        log_level=30,
+    )
+
+    assert study.result.s.shape[1:] == (2, 2)
+    assert study.result.generalized_valid_s.any()
+    for case_index in (1, 2):
+        with h5py.File(tmp_path / f"{outputfile.name}{case_index}.h5") as output:
+            assert "subgrids/fine_grid/eigenmode_ports/port1" in output
+            assert "study/eigenmode_response" in output
+    fine_grid = subgrid_object.subgrid
+    assert len(fine_grid.virtual_waveguides) == (2 if virtual_waveguide else 0)

--- a/tests/test_eigenmode_study.py
+++ b/tests/test_eigenmode_study.py
@@ -1,0 +1,565 @@
+"""Reusable eigenmode-port studies."""
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+import gprMax.sources as sources_module
+
+INF = float("inf")
+
+
+def _two_port_waveguide_scene(active_port=1, active_mode=1, modes=(1,)):
+    multimode = max(modes) > 1
+    domain_y = 0.08 if multimode else 0.05
+    aperture_y = 0.075 if multimode else 0.045
+    scene = gprMax.Scene()
+    scene.add(gprMax.DomainMode(mode="TM"))
+    scene.add(gprMax.Discretisation(p1=(1e-3, 1e-3, 1e-3)))
+    scene.add(gprMax.Domain(p1=(0.06, domain_y, INF)))
+    scene.add(gprMax.PMLThickness(thickness=(5, 0, 0, 5, 0, 0)))
+    scene.add(gprMax.TimeWindow(time=0.4e-9))
+    scene.add(gprMax.Waveform(wave_type="contsine", amp=1, freq=5e9, id="wave"))
+    scene.add(gprMax.Box(p1=(0, 0, 0), p2=(0.06, 0.005, INF), material_id="pec"))
+    scene.add(
+        gprMax.Box(
+            p1=(0, aperture_y, 0),
+            p2=(0.06, domain_y, INF),
+            material_id="pec",
+        )
+    )
+    scene.add(gprMax.EigenmodeBand(id="band", fmin=5e9, fmax=5e9, points=1))
+    scene.add(
+        gprMax.EigenmodePort(
+            port=1,
+            p1=(0.010, 0.005, 0),
+            p2=(0.010, aperture_y, INF),
+            direction="+",
+            modes=modes,
+            anchors=(5e9,),
+            plot_fields=False,
+        )
+    )
+    scene.add(
+        gprMax.EigenmodePort(
+            port=2,
+            p1=(0.050, 0.005, 0),
+            p2=(0.050, aperture_y, INF),
+            direction="-",
+            modes=modes,
+            anchors=(5e9,),
+            plot_fields=False,
+        )
+    )
+    excitation = gprMax.EigenmodeExcitation(
+        port=active_port,
+        mode=active_mode,
+        waveform="wave",
+        plot_waveform=False,
+    )
+    scene.add(excitation)
+    return scene, excitation
+
+
+def _study(excitation):
+    return gprMax.EigenmodeStudy(
+        [
+            gprMax.StudyCase(
+                "drive_port1_mode1",
+                [gprMax.ObjectState(excitation, port=1, mode=1)],
+            ),
+            gprMax.StudyCase(
+                "drive_port2_mode1",
+                [gprMax.ObjectState(excitation, port=2, mode=1)],
+            ),
+        ]
+    )
+
+
+def _study_for_channels(excitation, channels):
+    return gprMax.EigenmodeStudy(
+        [
+            gprMax.StudyCase(
+                f"drive_port{port}_mode{mode}",
+                [gprMax.ObjectState(excitation, port=port, mode=mode)],
+            )
+            for port, mode in channels
+        ]
+    )
+
+
+@pytest.mark.integration
+def test_eigenmode_study_matches_fresh_builds_without_resolving_modes(tmp_path, monkeypatch):
+    solves = 0
+    original_solve = sources_module.FDFD_1D_mode_solver.solve
+
+    def counted_solve(solver):
+        nonlocal solves
+        solves += 1
+        return original_solve(solver)
+
+    monkeypatch.setattr(sources_module.FDFD_1D_mode_solver, "solve", counted_solve)
+    scene, excitation = _two_port_waveguide_scene()
+    study = _study(excitation)
+    returned = gprMax.run(
+        scenes=[scene],
+        study=study,
+        outputfile=tmp_path / "reused",
+        hide_progress_bars=True,
+        log_level=30,
+    )
+    reused_solves = solves
+    assert reused_solves == 2
+
+    for port in (1, 2):
+        fresh_scene, _ = _two_port_waveguide_scene(active_port=port)
+        gprMax.run(
+            scenes=[fresh_scene],
+            outputfile=tmp_path / f"fresh{port}",
+            hide_progress_bars=True,
+            log_level=30,
+        )
+
+    assert returned["study"] is study.result
+    assert study.result.s.shape[1:] == (2, 2)
+    assert study.result.valid_s.any()
+    for case_index in (1, 2):
+        with h5py.File(tmp_path / f"reused{case_index}.h5") as reused, h5py.File(
+            tmp_path / f"fresh{case_index}.h5"
+        ) as fresh:
+            response = reused["study/eigenmode_response"]
+            assert response.attrs["InputPort"] == case_index
+            assert response.attrs["InputMode"] == 1
+            for port_index in (1, 2):
+                for dataset in ("incident", "outgoing", "S"):
+                    np.testing.assert_allclose(
+                        reused[f"eigenmode_ports/port{port_index}/{dataset}"][...],
+                        fresh[f"eigenmode_ports/port{port_index}/{dataset}"][...],
+                        rtol=2e-12,
+                        atol=2e-12,
+                    )
+
+    with h5py.File(tmp_path / "reused_study.h5") as output:
+        assert output.attrs["StudyType"] == "eigenmode"
+        assert output.attrs["Complete"]
+        np.testing.assert_array_equal(output["channel_ports"], (1, 2))
+        np.testing.assert_array_equal(output["channel_modes"], (1, 1))
+
+
+def test_eigenmode_study_csv_factory_and_complete_channel_validation(tmp_path):
+    cases = tmp_path / "eigenmode.csv"
+    cases.write_text(
+        "case_id,object_id,port,mode\n"
+        "p1m1,eigenmode_excitation_1,1,1\n"
+        "p2m1,eigenmode_excitation_1,2,1\n"
+    )
+    study = gprMax.Study.from_csv("eigenmode", cases)
+    assert isinstance(study, gprMax.EigenmodeStudy)
+    assert study.cases[1].states[0].parameters == {"port": 2, "mode": 1}
+
+    scene, excitation = _two_port_waveguide_scene()
+    incomplete = gprMax.EigenmodeStudy(
+        [gprMax.StudyCase("only", [gprMax.ObjectState(excitation, port=1, mode=1)])]
+    )
+    with pytest.raises(ValueError, match="one case for every declared modal channel"):
+        incomplete.bind_scene(scene)
+
+
+@pytest.mark.integration
+def test_hash_eigenmode_study_runs_and_writes_complete_smatrix(tmp_path):
+    cases = tmp_path / "eigenmode.csv"
+    cases.write_text(
+        "case_id,object_id,port,mode\n"
+        "p1m1,eigenmode_excitation_1,1,1\n"
+        "p2m1,eigenmode_excitation_1,2,1\n"
+    )
+    inputfile = tmp_path / "eigenmode.in"
+    inputfile.write_text(
+        "#title: hash eigenmode study integration\n"
+        "#domain_mode: TM\n"
+        "#dx_dy_dz: 0.001 0.001 0.001\n"
+        "#domain: 0.06 0.05 inf\n"
+        "#pml_cells: 5 0 0 5 0 0\n"
+        "#time_window: 4e-10\n"
+        "#waveform: contsine 1 5e9 wave\n"
+        "#box: 0 0 0 0.06 0.005 inf pec\n"
+        "#box: 0 0.045 0 0.06 0.05 inf pec\n"
+        "#eigenmode_band: band 5e9 5e9 1\n"
+        "#eigenmode_port: 1 0.010 0.005 0 0.010 0.045 inf + 1 5e9 n\n"
+        "#eigenmode_port: 2 0.050 0.005 0 0.050 0.045 inf - 1 5e9 n\n"
+        "#eigenmode_excitation: 1 1 wave n\n"
+        f"#study: eigenmode {cases.name}\n"
+    )
+
+    returned = gprMax.run(
+        inputfile=inputfile,
+        outputfile=tmp_path / "hash_eigenmode",
+        hide_progress_bars=True,
+        log_level=30,
+    )
+
+    assert isinstance(returned["study"], gprMax.EigenmodeStudyResult)
+    with h5py.File(tmp_path / "hash_eigenmode_study.h5") as output:
+        assert output.attrs["Complete"]
+        assert output.attrs["CasesCompleted"] == 2
+        np.testing.assert_array_equal(output["channel_ports"], (1, 2))
+        np.testing.assert_array_equal(output["channel_modes"], (1, 1))
+        assert output["S"].shape[1:] == (2, 2)
+
+
+@pytest.mark.integration
+def test_eigenmode_study_switches_cached_modes_without_new_fdfd_solves(tmp_path, monkeypatch):
+    solves = 0
+    original_solve = sources_module.FDFD_1D_mode_solver.solve
+
+    def counted_solve(solver):
+        nonlocal solves
+        solves += 1
+        return original_solve(solver)
+
+    monkeypatch.setattr(sources_module.FDFD_1D_mode_solver, "solve", counted_solve)
+    channels = ((1, 1), (1, 2), (2, 1), (2, 2))
+    scene, excitation = _two_port_waveguide_scene(modes=(1, 2))
+    study = _study_for_channels(excitation, channels)
+    gprMax.run(
+        scenes=[scene],
+        study=study,
+        outputfile=tmp_path / "multimode",
+        hide_progress_bars=True,
+        log_level=30,
+    )
+
+    # One two-mode FDFD solution per port is cached during the only geometry
+    # build; selecting all four source channels must not solve again.
+    assert solves == 2
+    assert study.result.s.shape[1:] == (4, 4)
+    assert study.result.generalized_valid_s.any()
+    np.testing.assert_array_equal(study.result.channel_ports, (1, 1, 2, 2))
+    np.testing.assert_array_equal(study.result.channel_modes, (1, 2, 1, 2))
+
+
+@pytest.mark.integration
+def test_eigenmode_study_restart_preserves_completed_columns(tmp_path):
+    output = tmp_path / "restart"
+    scene, excitation = _two_port_waveguide_scene()
+    study = _study(excitation)
+    gprMax.run(
+        scenes=[scene],
+        study=study,
+        outputfile=output,
+        hide_progress_bars=True,
+        log_level=30,
+    )
+    with h5py.File(tmp_path / "restart_study.h5") as complete:
+        original = complete["S"][:, :, 0].copy()
+
+    restart_scene, restart_excitation = _two_port_waveguide_scene()
+    restarted = _study(restart_excitation)
+    gprMax.run(
+        scenes=[restart_scene],
+        study=restarted,
+        i=2,
+        outputfile=output,
+        hide_progress_bars=True,
+        log_level=30,
+    )
+
+    with h5py.File(tmp_path / "restart_study.h5") as complete:
+        assert complete.attrs["Complete"]
+        assert complete.attrs["CasesCompleted"] == 2
+        np.testing.assert_array_equal(complete["S"][:, :, 0], original)
+
+
+def test_modal_array_weights_and_embedded_response_synthesis():
+    frequency = np.asarray((1e9, 2e9))
+    excitations = (
+        gprMax.ModalWeight(port=1, mode=1, power=4, phase_deg=90),
+        gprMax.ModalWeight(port=2, mode=1, power=1, delay_s=0.25e-9),
+    )
+    weights = gprMax.modal_array_weights(frequency, (1, 2), (1, 1), excitations)
+    np.testing.assert_allclose(weights[:, 0], 2j, atol=1e-14)
+    np.testing.assert_allclose(
+        weights[:, 1],
+        np.exp(-2j * np.pi * frequency * 0.25e-9),
+        atol=1e-14,
+    )
+
+    embedded = np.asarray(
+        [
+            [[1 + 0j, 2 + 0j], [3 + 0j, 4 + 0j]],
+            [[5 + 0j, 6 + 0j], [7 + 0j, 8 + 0j]],
+        ]
+    )
+    combined = gprMax.combine_embedded_modal_responses(embedded, weights)
+    expected = embedded[..., 0] * weights[:, 0, np.newaxis]
+    expected += embedded[..., 1] * weights[:, 1, np.newaxis]
+    np.testing.assert_allclose(combined, expected)
+
+    unused_nan = embedded.copy()
+    unused_nan[..., 1] = np.nan
+    first_only = weights.copy()
+    first_only[:, 1] = 0
+    np.testing.assert_allclose(
+        gprMax.combine_embedded_modal_responses(unused_nan, first_only),
+        embedded[..., 0] * weights[:, 0, np.newaxis],
+    )
+    with pytest.raises(ValueError, match="cannot be its frequency axis"):
+        gprMax.combine_embedded_modal_responses(embedded, weights, channel_axis=0)
+
+    s = np.full((2, 2, 2), np.nan + 1j * np.nan)
+    s[:, :, 0] = np.asarray((0.5, 0.25))[np.newaxis, :]
+    generalized_valid = np.zeros(s.shape, dtype=bool)
+    generalized_valid[:, :, 0] = True
+    study_result = gprMax.EigenmodeStudyResult(
+        frequency=frequency,
+        channel_ports=np.asarray((1, 2)),
+        channel_modes=np.asarray((1, 1)),
+        case_ids=("p1", "p2"),
+        s=s,
+        valid_s=generalized_valid.copy(),
+        generalized_valid_s=generalized_valid,
+        output_file=Path("unused.h5"),
+    )
+    np.testing.assert_allclose(
+        study_result.outgoing((gprMax.ModalWeight(port=1, mode=1),)),
+        np.asarray(((0.5, 0.25), (0.5, 0.25))),
+    )
+
+
+def _two_virtual_port_scene(active_port=1):
+    dl = 1e-3
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl, dl, dl)))
+    scene.add(gprMax.Domain(p1=(0.06, 0.010, 0.012)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=0.4e-9))
+    scene.add(gprMax.Waveform(wave_type="contsine", amp=1, freq=22e9, id="wave"))
+    scene.add(gprMax.Box(p1=(0, 0, 0), p2=(0.06, dl, 0.012), material_id="pec"))
+    scene.add(gprMax.Box(p1=(0, 0.009, 0), p2=(0.06, 0.010, 0.012), material_id="pec"))
+    scene.add(gprMax.Box(p1=(0, 0, 0), p2=(0.06, 0.010, dl), material_id="pec"))
+    scene.add(gprMax.Box(p1=(0, 0, 0.011), p2=(0.06, 0.010, 0.012), material_id="pec"))
+    scene.add(gprMax.EigenmodeBand(id="band", fmin=22e9, fmax=22e9, points=1))
+    for port, x, direction in ((1, 0.020, "+"), (2, 0.040, "-")):
+        scene.add(
+            gprMax.EigenmodePort(
+                port=port,
+                p1=(x, dl, dl),
+                p2=(x, 0.009, 0.011),
+                direction=direction,
+                modes=(1,),
+                anchors=(22e9,),
+                plot_fields=False,
+            )
+        )
+        scene.add(
+            gprMax.VirtualWaveguide(
+                port=port,
+                length_cells=14,
+                pml_cells=6,
+                source_clearance_cells=3,
+            )
+        )
+    excitation = gprMax.EigenmodeExcitation(
+        port=active_port,
+        mode=1,
+        waveform="wave",
+        plot_waveform=False,
+    )
+    scene.add(excitation)
+    return scene, excitation
+
+
+def _two_port_broadband_scene(active_port=1):
+    scene = gprMax.Scene()
+    scene.add(gprMax.DomainMode(mode="TM"))
+    scene.add(gprMax.Discretisation(p1=(1e-3, 1e-3, 1e-3)))
+    scene.add(gprMax.Domain(p1=(0.06, 0.05, INF)))
+    scene.add(gprMax.PMLThickness(thickness=(5, 0, 0, 5, 0, 0)))
+    scene.add(gprMax.TimeWindow(time=0.4e-9))
+    scene.add(gprMax.Box(p1=(0, 0, 0), p2=(0.06, 0.005, INF), material_id="pec"))
+    scene.add(gprMax.Box(p1=(0, 0.045, 0), p2=(0.06, 0.05, INF), material_id="pec"))
+    scene.add(gprMax.EigenmodeBand(id="band", fmin=15e9, fmax=25e9, points=3))
+    for port, x, direction in ((1, 0.010, "+"), (2, 0.050, "-")):
+        scene.add(
+            gprMax.EigenmodePort(
+                port=port,
+                p1=(x, 0.005, 0),
+                p2=(x, 0.045, INF),
+                direction=direction,
+                modes=(1,),
+                anchors="auto",
+                plot_fields=False,
+            )
+        )
+    excitation = gprMax.EigenmodeExcitation(
+        port=active_port,
+        mode=1,
+        waveform="auto",
+        plot_waveform=False,
+    )
+    scene.add(excitation)
+    return scene, excitation
+
+
+@pytest.mark.integration
+def test_eigenmode_study_resets_and_switches_virtual_waveguides(tmp_path):
+    scene, excitation = _two_virtual_port_scene()
+    study = _study(excitation)
+    gprMax.run(
+        scenes=[scene],
+        study=study,
+        outputfile=tmp_path / "virtual_reused",
+        hide_progress_bars=True,
+        log_level=30,
+    )
+
+    for active_port in (1, 2):
+        fresh_scene, _ = _two_virtual_port_scene(active_port)
+        gprMax.run(
+            scenes=[fresh_scene],
+            outputfile=tmp_path / f"virtual_fresh{active_port}",
+            hide_progress_bars=True,
+            log_level=30,
+        )
+        with h5py.File(tmp_path / f"virtual_reused{active_port}.h5") as reused, h5py.File(
+            tmp_path / f"virtual_fresh{active_port}.h5"
+        ) as fresh:
+            for port_index in (1, 2):
+                np.testing.assert_allclose(
+                    reused[f"eigenmode_ports/port{port_index}/S"][...],
+                    fresh[f"eigenmode_ports/port{port_index}/S"][...],
+                    rtol=2e-10,
+                    atol=2e-10,
+                )
+
+
+@pytest.mark.integration
+def test_eigenmode_study_reuses_broadband_anchor_banks(tmp_path, monkeypatch):
+    solve_models = []
+    original_solve = sources_module.FDFD_1D_mode_solver.solve
+
+    def counted_solve(solver):
+        import gprMax.config as config
+
+        solve_models.append(config.sim_config.current_model)
+        return original_solve(solver)
+
+    monkeypatch.setattr(sources_module.FDFD_1D_mode_solver, "solve", counted_solve)
+    scene, excitation = _two_port_broadband_scene()
+    study = _study(excitation)
+    gprMax.run(
+        scenes=[scene],
+        study=study,
+        outputfile=tmp_path / "broadband_reused",
+        hide_progress_bars=True,
+        log_level=30,
+    )
+    reused_solve_count = len(solve_models)
+    assert reused_solve_count > 2
+    assert set(solve_models) == {0}
+
+    fresh_scene, _ = _two_port_broadband_scene(active_port=2)
+    gprMax.run(
+        scenes=[fresh_scene],
+        outputfile=tmp_path / "broadband_fresh2",
+        hide_progress_bars=True,
+        log_level=30,
+    )
+    assert len(solve_models) > reused_solve_count
+    with h5py.File(tmp_path / "broadband_reused2.h5") as reused, h5py.File(
+        tmp_path / "broadband_fresh2.h5"
+    ) as fresh:
+        for port_index in (1, 2):
+            for dataset in ("incident", "outgoing", "S"):
+                np.testing.assert_allclose(
+                    reused[f"eigenmode_ports/port{port_index}/{dataset}"][...],
+                    fresh[f"eigenmode_ports/port{port_index}/{dataset}"][...],
+                    rtol=2e-10,
+                    atol=2e-10,
+                )
+
+
+def _assert_device_eigenmode_study_matches_cpu(
+    tmp_path, name, *, virtual=False, broadband=False, **device_options
+):
+    if virtual:
+        scene_factory = _two_virtual_port_scene
+    elif broadband:
+        scene_factory = _two_port_broadband_scene
+    else:
+        scene_factory = _two_port_waveguide_scene
+    cpu_scene, cpu_excitation = scene_factory()
+    device_scene, device_excitation = scene_factory()
+    cpu = _study(cpu_excitation)
+    device = _study(device_excitation)
+    gprMax.run(
+        scenes=[cpu_scene],
+        study=cpu,
+        outputfile=tmp_path / "cpu",
+        hide_progress_bars=True,
+        log_level=30,
+    )
+    gprMax.run(
+        scenes=[device_scene],
+        study=device,
+        outputfile=tmp_path / name,
+        hide_progress_bars=True,
+        log_level=30,
+        **device_options,
+    )
+    np.testing.assert_array_equal(device.result.frequency, cpu.result.frequency)
+    valid = device.result.generalized_valid_s & cpu.result.generalized_valid_s
+    assert valid.any()
+    np.testing.assert_allclose(
+        device.result.s[valid],
+        cpu.result.s[valid],
+        rtol=5e-4,
+        atol=5e-4,
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+def test_cuda_eigenmode_study_matches_cpu(tmp_path, gpu_device):
+    _assert_device_eigenmode_study_matches_cpu(
+        tmp_path,
+        "cuda",
+        broadband=True,
+        gpu=[gpu_device],
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+def test_opencl_eigenmode_study_matches_cpu(tmp_path, opencl_device):
+    _assert_device_eigenmode_study_matches_cpu(
+        tmp_path,
+        "opencl",
+        broadband=True,
+        opencl=[opencl_device],
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+def test_cuda_virtual_waveguide_eigenmode_study_matches_cpu(tmp_path, gpu_device):
+    _assert_device_eigenmode_study_matches_cpu(
+        tmp_path,
+        "cuda_virtual",
+        virtual=True,
+        gpu=[gpu_device],
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+def test_opencl_virtual_waveguide_eigenmode_study_matches_cpu(tmp_path, opencl_device):
+    _assert_device_eigenmode_study_matches_cpu(
+        tmp_path,
+        "opencl_virtual",
+        virtual=True,
+        opencl=[opencl_device],
+    )


### PR DESCRIPTION
## Summary

This PR adds reusable eigenmode-port studies for multiport and multimode antenna analysis while preserving one active modal channel per FDTD run.

- adds `EigenmodeStudy` and assembles the complete modal S-matrix using one reusable-geometry case per port/mode channel
- caches all required FDFD modal anchor solutions during the initial build and reuses them in later cases
- supports restartable aggregate HDF5 study output with channel metadata and separate physical/generalized validity masks
- adds frequency-domain modal array synthesis using incident power, constant phase, true time delay, or both
- supports superposition of embedded modal far-field responses without additional FDTD runs
- resets modal-monitor and virtual-waveguide state safely between reusable cases
- supports eigenmode studies in a compatible HSG subgrid
- corrects reusable eigenmode and virtual-waveguide device state handling for CUDA and OpenCL
- documents the Python API, hash-command limitations, HDF5 schema, phase convention, and array synthesis workflow
- adds focused unit and CPU/device parity tests

## Motivation

A complete multiport S-matrix and phased-array response should not require rebuilding an unchanged geometry for every excitation. This study workflow retains the established one-active-port policy used to obtain unambiguous S-parameters, while reusing the geometry and modal basis and allowing arbitrary linear array weights during post-processing.

The modal coefficient follows the engineering Fourier convention:

`a(f) = sqrt(P) exp[j(phi - 2 pi f tau)]`

A constant phase therefore models an ordinary phase shifter, while `delay_s` models true time delay for broadband steering.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update.

## Testing

- Focused eigenmode-study and subgrid suite: 25 passed
- CUDA parity cases: 2 skipped because CUDA could not be initialised in the current execution context
- OpenCL CPU-parity cases: passed using an isolated PyOpenCL compiler cache
- `git diff --check`: passed

## Checklist

- [ ] Did pre-commit pass all checks? (not installed in the active environment; GitHub CI will run the configured checks)
- [x] I have performed a self-review of my code.
- [x] I have added comments for my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no known new warnings.
- [x] The title of my pull request is a short description of my changes.