### PR TITLE
Add reusable plane-wave and RCS studies

### DIFF
--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -149,8 +149,8 @@ Reusable parameter studies
 
 A :class:`gprMax.Study` runs an ordered set of source and receiver states while
 reusing one built geometry. It is intended for arbitrary GPR acquisition
-patterns and is the foundation for later multiport, antenna-array, and
-plane-wave studies. Every case restores the original object state before its
+patterns and underlies the specialised multiport, antenna-array, and
+plane-wave workflows. Every case restores the original object state before its
 overrides are applied, so parameters cannot accidentally accumulate between
 runs.
 
@@ -347,6 +347,69 @@ frequency and whose selected channel axis follows ``channel_ports`` and
 
 .. autofunction:: gprMax.studies.combine_embedded_modal_responses
 
+Plane-wave and RCS studies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A :class:`gprMax.PlaneWaveStudy` evaluates several incident plane waves while
+building the main Yee geometry only once. The Scene contains exactly one
+discrete-plane-wave object, which acts as the reusable template, and each case
+changes its direction, polarisation, timing, waveform, or amplitude. Other
+active source types are rejected so that scattered-field and RCS results have
+an unambiguous incident wave.
+
+.. code-block:: python
+
+    plane_wave = gprMax.DiscretePlaneWaveAngles(
+        p1=(0.03, 0.03, 0.03),
+        p2=(0.07, 0.07, 0.07),
+        theta=90,
+        phi=0,
+        psi=90,
+        waveform_id='pulse',
+    )
+    scene.add(plane_wave)
+
+    study = gprMax.PlaneWaveStudy([
+        gprMax.StudyCase('x_incidence', [
+            gprMax.ObjectState(plane_wave, theta=90, phi=0, psi=90),
+        ]),
+        gprMax.StudyCase('y_incidence', [
+            gprMax.ObjectState(plane_wave, theta=90, phi=90, psi=90),
+        ]),
+    ])
+
+    gprMax.run(scenes=[scene], study=study, outputfile='angular_rcs')
+
+The TFSF box, background material, and angular-approximation tolerance remain
+fixed because they define the reusable source topology. The parameters which
+may change depend on the template:
+
+* :class:`gprMax.DiscretePlaneWaveAngles`: ``theta``, ``phi``, and ``psi``;
+* :class:`gprMax.DiscretePlaneWaveVector`: ``m_vec`` and ``psi``;
+* :class:`gprMax.DiscretePlaneWaveAxial`: ``axis`` and ``psi``.
+
+All three forms also accept per-case ``waveform_id``, ``start``, ``stop``, and
+non-zero dimensionless ``scale``. The principal Yee arrays and material IDs
+are retained, but the small auxiliary one-dimensional DPW grid is rebuilt for
+each case. This is necessary because its length, rational integer mapping,
+field projections, material profile, and PML state depend on the propagation
+direction.
+
+Declarative NTFF transforms are also reconstructed for every case. Their
+surface geometry is reused, while all time/frequency accumulators and the
+incident-wave DFT are new. Consequently an RCS result cannot contain state
+from an earlier direction. Each numbered HDF5 file records the requested
+study case under ``/study`` and the actual rationalised plane-wave parameters
+under the frequency transform's ``plane_wave`` group. A complete subgrid may
+be enclosed by the fixed TFSF and NTFF surfaces, subject to the normal
+enclosure rules, but it cannot contain another excitation. Far-field
+observation directions are part of the fixed output definition rather than a
+case parameter. Request every direction needed by the study (for example a
+complete angular sweep), then select the appropriate monostatic or bistatic
+direction from each case file.
+
+.. autoclass:: gprMax.studies.PlaneWaveStudy
+
 .. autoclass:: gprMax.studies.StudyCase
 
 .. autoclass:: gprMax.studies.ObjectState
@@ -354,10 +417,11 @@ frequency and whose selected channel axis follows ``channel_ports`` and
 .. note::
 
     MPI/task-farm studies, transmission lines, rational networks,
-    magnetic-frill sources, and plane waves are not yet enabled. General GPR
-    study objects remain main-grid only. Eigenmode studies support the owning
-    main grid or subgrid and reset direct and virtual-waveguide modal state
-    explicitly.
+    magnetic-frill sources are not yet enabled. General GPR study objects
+    remain main-grid only. Eigenmode studies support the owning main grid or
+    subgrid and reset direct and virtual-waveguide modal state explicitly.
+    Plane-wave studies use a main-grid TFSF source but may enclose complete
+    subgrids.
 
 Typical general settings are added directly to the scene:
 

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1947,12 +1947,14 @@ case that produced it. The syntax is:
 
 The study type may be ``gpr`` for irregular source/receiver acquisition,
 ``port`` for a finite-resistance voltage-source S-parameter study, or
-``eigenmode`` for a modal-port S-parameter study:
+``eigenmode`` for a modal-port S-parameter study, or ``plane_wave`` for an
+angular TFSF/RCS study:
 
 .. code-block:: none
 
     #study: port file1
     #study: eigenmode file1
+    #study: plane_wave file1
 
 ``file1`` is a CSV table. Its path is resolved relative to the main input
 file. The required columns are ``case_id`` and ``object_id``. The optional
@@ -1961,6 +1963,27 @@ columns are ``active``, ``x_m``, ``y_m``, ``z_m``, ``waveform_id``,
 cells mean "use the object's baseline value". All three position columns must
 be supplied together and contain absolute coordinates in metres. ``port`` and
 ``mode`` are positive integers used only by an eigenmode study.
+
+A plane-wave table uses the deterministic object ID ``plane_wave_1``. Its
+additional optional columns are ``theta_deg``, ``phi_deg``, ``psi_deg``,
+``axis``, ``m_x``, ``m_y``, and ``m_z``. The permitted columns follow the
+plane-wave command used in the model: angles use theta/phi/psi, vector sources
+use all three integer mapping columns and psi, and axial sources use axis and
+psi. ``waveform_id``, ``start_s``, ``stop_s``, and a non-zero ``scale`` are
+available for every form. For example:
+
+.. code-block:: text
+
+    case_id,object_id,theta_deg,phi_deg,psi_deg,scale
+    x_incidence,plane_wave_1,90,0,90,1
+    y_incidence,plane_wave_1,90,90,90,1
+
+The TFSF box and its background material remain fixed. gprMax rebuilds the
+auxiliary one-dimensional discrete plane wave and resets/recompiles
+declarative NTFF accumulators for each row, while retaining the main model
+geometry. NTFF observation directions also remain fixed: request all angles
+needed across the cases in the input file and select the appropriate direction
+from each numbered output file.
 
 For example:
 

--- a/docs/source/output.rst
+++ b/docs/source/output.rst
@@ -48,6 +48,11 @@ and implicitly disabled sources.
 Study-managed source and receiver groups also carry a ``StudyID`` attribute,
 which provides an unambiguous link back to the case table.
 
+For a plane-wave study, ``resolved_case`` records the requested case together
+with the actual rationalised propagation angles and integer DPW mapping. Each
+case remains an ordinary numbered model output; no aggregate matrix is needed
+because RCS patterns from different illuminations are independent results.
+
 Every case in a finite-resistance voltage-port study additionally contains
 ``study/port_response``. ``DrivenSourceID`` and ``DrivenPortID`` identify its
 input port; ``S_source_column`` contains the power-normalised raw source-plane
@@ -912,6 +917,12 @@ spectrum produces ``NaN`` RCS. Very small incident values are mathematically
 non-zero but can give unreliable results, so the requested frequencies should
 remain within the useful excitation bandwidth.
 
+When a frequency transform is associated with a plane wave, its
+``plane_wave`` subgroup stores the source index, TFSF corners, waveform and
+material IDs, actual angles, polarisation, rational integer mapping, start and
+stop times, and the incident-field reference positions. This metadata is the
+authoritative description of the illumination used for that transform.
+
 For plotting in dBsm, convert the stored values explicitly:
 
 .. code-block:: python
@@ -928,7 +939,9 @@ Here ``theta`` and ``phi`` in the same group define the observation direction.
 Monostatic RCS is the value in the direction opposite to plane-wave
 propagation; all other directions are bistatic RCS. Use separate simulations
 for different incident plane waves because selecting an association does not
-separate simultaneously accumulated scattered fields.
+separate simultaneously accumulated scattered fields. A
+:class:`gprMax.PlaneWaveStudy` automates those separate illuminations while
+reusing the unchanged Yee geometry.
 
 Exact finite-distance KSIR time-domain fields retain the complete raw retarded
 buffer and have shape ``(npoints, max(valid_lengths))``. Its final bins may contain only part of the

--- a/gprMax/__init__.py
+++ b/gprMax/__init__.py
@@ -24,6 +24,7 @@ from .studies import (
     GPRStudy,
     ModalWeight,
     ObjectState,
+    PlaneWaveStudy,
     PortStudy,
     PortStudyResult,
     Study,

--- a/gprMax/model.py
+++ b/gprMax/model.py
@@ -521,7 +521,11 @@ class Model:
                     "repeat the identical, contaminated source. Run a single model "
                     "instead, or use #voltage_source if you need geometry_fixed."
                 )
-            if any(grid.discreteplanewaves for grid in grids):
+            from gprMax.studies import PlaneWaveStudy
+
+            if not isinstance(config.sim_config.study, PlaneWaveStudy) and any(
+                grid.discreteplanewaves for grid in grids
+            ):
                 raise ValueError(
                     "A discrete plane wave command cannot be used with "
                     "geometry_fixed when more than one model is requested (n > 1) "

--- a/gprMax/ntff/interface.py
+++ b/gprMax/ntff/interface.py
@@ -1521,6 +1521,10 @@ class NTFFCompiledOutputs:
             group.attrs["solver"] = monitor.solver_backend
             group.attrs["collection_backend"] = monitor.collection_backend
             group["frequencies"] = monitor.frequencies
+            if monitor.plane_wave_metadata is not None:
+                plane_wave_group = group.create_group("plane_wave")
+                for name, value in monitor.plane_wave_metadata.items():
+                    plane_wave_group.attrs[name] = value
             if transform.save_surface_dft:
                 dft_group = group.create_group("surface_dft")
                 for component, data in monitor.surface_data.items():

--- a/gprMax/studies.py
+++ b/gprMax/studies.py
@@ -24,10 +24,13 @@ Port studies additionally manage source-bound voltage-port monitors and
 assemble their frequency-domain response after the reused solves.
 Eigenmode studies reuse phase-aligned FDFD modal bases and assemble a full
 modal S matrix from one active port/mode channel per run.
+Plane-wave studies rebuild only the auxiliary DPW source and declarative NTFF
+accumulators while retaining the main Yee geometry.
 """
 
 from __future__ import annotations
 
+import copy
 import csv
 import json
 import logging
@@ -48,6 +51,7 @@ logger = logging.getLogger(__name__)
 _POSITION_COLUMNS = ("x_m", "y_m", "z_m")
 _SOURCE_PARAMETERS = {"active", "position", "waveform_id", "start", "stop", "scale"}
 _RECEIVER_PARAMETERS = {"position", "record"}
+_PLANE_WAVE_COMMON_PARAMETERS = {"psi", "waveform_id", "start", "stop", "scale"}
 _CSV_COLUMNS = {
     "case_id",
     "object_id",
@@ -60,6 +64,13 @@ _CSV_COLUMNS = {
     "record",
     "port",
     "mode",
+    "theta_deg",
+    "phi_deg",
+    "psi_deg",
+    "axis",
+    "m_x",
+    "m_y",
+    "m_z",
 }
 
 
@@ -206,6 +217,28 @@ class Study:
             for name in ("port", "mode"):
                 if row.get(name, ""):
                     parameters[name] = _parse_positive_int(row[name], path, line_number, name)
+            for csv_name, parameter_name in (
+                ("theta_deg", "theta"),
+                ("phi_deg", "phi"),
+                ("psi_deg", "psi"),
+            ):
+                if row.get(csv_name, ""):
+                    parameters[parameter_name] = _parse_finite_float(
+                        row[csv_name], path, line_number, csv_name
+                    )
+            mapping_values = [row.get(name, "") for name in ("m_x", "m_y", "m_z")]
+            if any(mapping_values) and not all(mapping_values):
+                raise ValueError(
+                    f"Study CSV '{path}', line {line_number}: m_x, m_y, and m_z must be "
+                    "provided together."
+                )
+            if all(mapping_values):
+                parameters["m_vec"] = tuple(
+                    _parse_int(value, path, line_number, name)
+                    for name, value in zip(("m_x", "m_y", "m_z"), mapping_values)
+                )
+            if row.get("axis", ""):
+                parameters["axis"] = row["axis"]
             if row.get("record", ""):
                 parameters["record"] = _parse_bool(row["record"], path, line_number, "record")
 
@@ -216,6 +249,8 @@ class Study:
             return PortStudy(cases, source_path=path, source_text=text)
         if str(type).strip().lower() == "eigenmode":
             return EigenmodeStudy(cases, source_path=path, source_text=text)
+        if str(type).strip().lower() == "plane_wave":
+            return PlaneWaveStudy(cases, source_path=path, source_text=text)
         return cls(type, cases, source_path=path, source_text=text)
 
     def bind_scene(self, scene) -> None:
@@ -585,6 +620,274 @@ class GPRStudy(Study):
 
     def __init__(self, cases: Sequence[StudyCase]):
         super().__init__("gpr", cases)
+
+
+class PlaneWaveStudy(Study):
+    """Reusable-geometry study with one rebuilt discrete plane wave per case.
+
+    The main Yee geometry is retained, but the auxiliary one-dimensional DPW
+    grid is deliberately reconstructed because its integer direction mapping,
+    length, projections, material profile, and PML state depend on the case.
+    Declarative NTFF monitors are reconstructed with it so their accumulated
+    DFT and incident-wave normalisation state cannot leak between cases.
+    """
+
+    supported_types = ("plane_wave",)
+
+    def __init__(
+        self,
+        cases: Sequence[StudyCase],
+        *,
+        source_path: Optional[Union[str, Path]] = None,
+        source_text: Optional[str] = None,
+    ):
+        super().__init__(
+            "plane_wave",
+            cases,
+            source_path=source_path,
+            source_text=source_text,
+        )
+        self._definition = None
+        self._definition_type = None
+        self._baseline_kwargs: dict[str, Any] = {}
+
+    def reset_runtime(self) -> None:
+        super().reset_runtime()
+        self._definition = None
+        self._definition_type = None
+        self._baseline_kwargs = {}
+
+    def bind_scene(self, scene) -> None:
+        """Bind one main-grid DPW template and validate every case override."""
+
+        if self._scene_bound:
+            return
+
+        from gprMax.user_objects.cmds_multiuse import (
+            DiscretePlaneWaveAngles,
+            DiscretePlaneWaveAxial,
+            DiscretePlaneWaveVector,
+            EigenmodeExcitation,
+            HertzianDipole,
+            MagneticDipole,
+            MagneticFrillSource,
+            NetworkExcitation,
+            TransmissionLine,
+            VoltageSource,
+        )
+
+        plane_wave_types = (
+            DiscretePlaneWaveAngles,
+            DiscretePlaneWaveAxial,
+            DiscretePlaneWaveVector,
+        )
+        containers = [("main grid", list(scene.grid_objects))]
+        containers.extend(
+            (
+                f"subgrid {subgrid.kwargs.get('id', '')!r}",
+                list(subgrid.children_grid),
+            )
+            for subgrid in scene.subgrid_objects
+        )
+        definitions = [item for item in scene.grid_objects if isinstance(item, plane_wave_types)]
+        subgrid_plane_waves = [
+            label
+            for label, objects in containers[1:]
+            for item in objects
+            if isinstance(item, plane_wave_types)
+        ]
+        if subgrid_plane_waves:
+            raise ValueError(
+                "PlaneWaveStudy requires its plane-wave template on the main grid; "
+                "plane waves were also found on "
+                + ", ".join(sorted(set(subgrid_plane_waves)))
+                + "."
+            )
+        if len(definitions) != 1:
+            raise ValueError(
+                "PlaneWaveStudy requires exactly one plane-wave template on the main grid; "
+                f"found {len(definitions)}."
+            )
+        other_source_types = (
+            VoltageSource,
+            HertzianDipole,
+            MagneticDipole,
+            TransmissionLine,
+            MagneticFrillSource,
+            NetworkExcitation,
+            EigenmodeExcitation,
+        )
+        other_sources = [
+            f"{type(item).__name__} on {label}"
+            for label, objects in containers
+            for item in objects
+            if isinstance(item, other_source_types)
+        ]
+        if other_sources:
+            raise ValueError(
+                "PlaneWaveStudy requires the plane wave to be the only excitation; remove "
+                + ", ".join(sorted(set(other_sources)))
+                + "."
+            )
+
+        definition = definitions[0]
+        setattr(definition, "_study_id", "plane_wave_1")
+        if isinstance(definition, DiscretePlaneWaveAngles):
+            allowed = _PLANE_WAVE_COMMON_PARAMETERS | {"theta", "phi"}
+        elif isinstance(definition, DiscretePlaneWaveVector):
+            allowed = _PLANE_WAVE_COMMON_PARAMETERS | {"m_vec"}
+        else:
+            allowed = _PLANE_WAVE_COMMON_PARAMETERS | {"axis"}
+
+        for case in self.cases:
+            if len(case.states) != 1:
+                raise ValueError(
+                    f"PlaneWaveStudy case '{case.id}' must contain exactly one plane-wave state."
+                )
+            state = case.states[0]
+            if isinstance(state.object, str):
+                if state.object.strip() != "plane_wave_1":
+                    raise ValueError(
+                        f"PlaneWaveStudy case '{case.id}' references '{state.object}', "
+                        "expected 'plane_wave_1'."
+                    )
+            elif state.object is not definition:
+                raise ValueError(
+                    f"PlaneWaveStudy case '{case.id}' must reference its Scene's plane wave."
+                )
+            unknown = set(state.parameters) - allowed
+            if unknown:
+                raise ValueError(
+                    f"PlaneWaveStudy case '{case.id}' has unsupported parameter(s) "
+                    f"{', '.join(sorted(unknown))}. Allowed parameters: "
+                    f"{', '.join(sorted(allowed))}."
+                )
+            if "m_vec" in state.parameters:
+                mapping = tuple(state.parameters["m_vec"])
+                if len(mapping) != 3 or not all(
+                    isinstance(value, (int, np.integer)) for value in mapping
+                ):
+                    raise ValueError(
+                        f"PlaneWaveStudy case '{case.id}' m_vec must contain three integers."
+                    )
+                if not any(mapping):
+                    raise ValueError(
+                        f"PlaneWaveStudy case '{case.id}' m_vec cannot be the zero vector."
+                    )
+                state.parameters["m_vec"] = mapping
+            scale = float(state.parameters.get("scale", 1.0))
+            if not math.isfinite(scale) or scale == 0:
+                raise ValueError(
+                    f"PlaneWaveStudy case '{case.id}' scale must be finite and non-zero."
+                )
+            state.object = "plane_wave_1"
+
+        self._definition = definition
+        self._definition_type = type(definition)
+        self._baseline_kwargs = copy.deepcopy(definition.kwargs)
+        self.registry = {"plane_wave_1": definition}
+        self.aliases = {}
+        self._scene_bound = True
+        logger.info(
+            f"PlaneWaveStudy object: plane_wave_1 ({self._definition_type.__name__})\n"
+        )
+
+    def apply_case(self, model) -> None:
+        """Rebuild the case DPW and all declarative NTFF accumulator state."""
+
+        import gprMax.config as config
+
+        if self._definition_type is None:
+            raise RuntimeError("PlaneWaveStudy was not bound to a Scene before model build.")
+        case_index = config.sim_config.current_model
+        if case_index < 0 or case_index >= len(self.cases):
+            raise ValueError(
+                f"PlaneWaveStudy case index {case_index + 1} is outside the "
+                f"{len(self.cases)} available cases."
+            )
+
+        case = self.cases[case_index]
+        parameters = dict(case.states[0].parameters)
+        scale = float(parameters.pop("scale", 1.0))
+        kwargs = copy.deepcopy(self._baseline_kwargs)
+        kwargs.update(parameters)
+        definition = self._definition_type(**kwargs)
+
+        grid = model.G
+        previous = list(grid.discreteplanewaves)
+        try:
+            definition.build(grid)
+            plane_wave = grid.discreteplanewaves[-1]
+            grid.discreteplanewaves[:] = [plane_wave]
+            if plane_wave.axial != 0:
+                plane_wave.grid_init(grid)
+        except Exception:
+            grid.discreteplanewaves[:] = previous
+            raise
+
+        for name in ("waveformvalues_wholedt", "waveformvalues_halfdt"):
+            values = getattr(plane_wave, name, None)
+            if values is not None:
+                values *= scale
+        plane_wave.study_id = "plane_wave_1"
+        plane_wave.study_scale = scale
+
+        # Receiver histories are ordinary per-run outputs, but reset_fields()
+        # intentionally clears only field/PML state. Clear them explicitly.
+        for receiver in grid.rxs:
+            for values in receiver.outputs.values():
+                values.fill(0)
+
+        self._recompile_ntff(model, grid)
+        self._current_resolved_case = {
+            "case_id": case.id,
+            "objects": {
+                "plane_wave_1": {
+                    "type": self._definition_type.__name__,
+                    "theta": float(plane_wave.theta),
+                    "phi": float(plane_wave.phi),
+                    "psi": float(plane_wave.psi),
+                    "actual_angles": [float(value) for value in plane_wave.actual_angles],
+                    "integer_mapping": [int(value) for value in plane_wave.m[:3]],
+                    "waveform_id": plane_wave.waveformID,
+                    "start": float(plane_wave.start),
+                    "stop": float(plane_wave.stop),
+                    "scale": scale,
+                    "tfsf_corners": [int(value) for value in plane_wave.corners],
+                }
+            },
+        }
+
+    @staticmethod
+    def _recompile_ntff(model, grid) -> None:
+        """Replace declarative NTFF monitors with pristine case instances."""
+
+        if not grid.ntff_monitors and not grid.ntff_output_writers:
+            return
+        if not grid.ntff_output_writers:
+            raise ValueError(
+                "PlaneWaveStudy cannot reset directly constructed NTFF monitors; use the "
+                "declarative NTFF surface/transform/output API or hash commands."
+            )
+
+        referenced = set()
+        for writer in grid.ntff_output_writers:
+            referenced.update(writer.frequency_monitors.values())
+            for mapping_name in ("time_bindings", "time_far_bindings"):
+                for binding in getattr(writer, mapping_name, {}).values():
+                    referenced.add(binding[0])
+        unmanaged = [monitor for monitor in grid.ntff_monitors if monitor not in referenced]
+        if unmanaged:
+            raise ValueError(
+                "PlaneWaveStudy found NTFF monitors outside the declarative reusable interface; "
+                "these cannot be reset safely between cases."
+            )
+
+        grid.ntff_monitors.clear()
+        grid.ntff_output_writers.clear()
+        from gprMax.ntff.interface import compile_ntff_outputs
+
+        compile_ntff_outputs(model, grid)
 
 
 @dataclass(frozen=True)
@@ -1555,7 +1858,9 @@ def preflight_study_args(args) -> Optional[Study]:
         raise ValueError("Studies do not yet support MPI task farming.")
     if getattr(args, "mpi", None) is not None:
         raise ValueError("Studies do not yet support MPI domain decomposition.")
-    if isinstance(study, (PortStudy, EigenmodeStudy)) and getattr(args, "geometry_only", False):
+    if isinstance(study, (PortStudy, EigenmodeStudy, PlaneWaveStudy)) and getattr(
+        args, "geometry_only", False
+    ):
         raise ValueError(
             f"{type(study).__name__} requires a field solve and cannot use geometry_only."
         )
@@ -1664,6 +1969,15 @@ def _parse_positive_int(value: str, path: Path, line: int, name: str) -> int:
     if result < 1:
         raise ValueError(f"Study CSV '{path}', line {line}: {name} must be a positive integer.")
     return result
+
+
+def _parse_int(value: str, path: Path, line: int, name: str) -> int:
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ValueError(
+            f"Study CSV '{path}', line {line}: {name} must be an integer."
+        ) from exc
 
 
 def _safe_divide(numerator, denominator, complex_dtype):

--- a/gprMax/user_objects/cmds_output.py
+++ b/gprMax/user_objects/cmds_output.py
@@ -631,7 +631,10 @@ def _check_ksir_interface_context(user_object, grid):
             f"{user_object.params_str()} supports CPU, CUDA, OpenCL, and Metal solvers."
         )
     if config.sim_config.args.geometry_fixed:
-        raise ValueError(f"{user_object.params_str()} does not support geometry-fixed runs.")
+        from gprMax.studies import PlaneWaveStudy
+
+        if not isinstance(config.sim_config.study, PlaneWaveStudy):
+            raise ValueError(f"{user_object.params_str()} does not support geometry-fixed runs.")
     if config.get_model_config().mode != "3D":
         raise ValueError(f"{user_object.params_str()} currently supports only 3-D models.")
 

--- a/tests/test_plane_wave_study.py
+++ b/tests/test_plane_wave_study.py
@@ -1,0 +1,399 @@
+"""Reusable discrete-plane-wave and RCS studies."""
+
+import json
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+
+
+def _two_dimensional_scene(phi=0, amplitude=1.0):
+    inf = float("inf")
+    scene = gprMax.Scene()
+    scene.add(gprMax.DomainMode(mode="TM"))
+    scene.add(gprMax.Discretisation(p1=(1e-3,) * 3))
+    scene.add(gprMax.Domain(p1=(0.04, 0.04, inf)))
+    scene.add(gprMax.TimeWindow(time=2e-10))
+    scene.add(gprMax.PMLThickness(thickness=(3, 3, 0, 3, 3, 0)))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=amplitude, freq=8e9, id="pulse"))
+    plane_wave = gprMax.DiscretePlaneWaveAngles(
+        p1=(0.010, 0.010, inf),
+        p2=(0.030, 0.030, inf),
+        theta=90,
+        phi=phi,
+        psi=90,
+        waveform_id="pulse",
+    )
+    scene.add(plane_wave)
+    scene.add(gprMax.Rx(p1=(0.020, 0.020, inf), id="probe"))
+    return scene, plane_wave
+
+
+def _rcs_scene(phi=0):
+    dl = 0.002
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl,) * 3))
+    scene.add(gprMax.Domain(p1=(0.048,) * 3))
+    scene.add(gprMax.TimeWindow(iterations=240))
+    scene.add(gprMax.PMLThickness(thickness=3))
+    scene.add(gprMax.OMPThreads(n=1))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=8e9, id="pulse"))
+    plane_wave = gprMax.DiscretePlaneWaveAngles(
+        p1=(0.018,) * 3,
+        p2=(0.030,) * 3,
+        theta=90,
+        phi=phi,
+        psi=90,
+        waveform_id="pulse",
+    )
+    scene.add(plane_wave)
+    scene.add(gprMax.Sphere(p1=(0.024,) * 3, r=0.004, material_id="pec"))
+    scene.add(
+        gprMax.NTFFSurface(
+            p1=(0.012,) * 3,
+            p2=(0.036,) * 3,
+            id="surface",
+            origin=(0.024,) * 3,
+        )
+    )
+    scene.add(
+        gprMax.KSIRFrequencyTransform(
+            "surface",
+            "spectrum",
+            (8e9,),
+            save_surface_dft=False,
+            plane_wave_index=0,
+        )
+    )
+    scene.add(
+        gprMax.KSIRFarField(
+            theta=(90, 90),
+            phi=(0, 180),
+            transform_id="spectrum",
+            id="pattern",
+            outputs=("Etheta", "rcs"),
+        )
+    )
+    return scene, plane_wave
+
+
+def _axial_scene(axis="x"):
+    inf = float("inf")
+    scene = gprMax.Scene()
+    scene.add(gprMax.DomainMode(mode="TM"))
+    scene.add(gprMax.Discretisation(p1=(1e-3,) * 3))
+    scene.add(gprMax.Domain(p1=(0.04, 0.04, inf)))
+    scene.add(gprMax.TimeWindow(time=2e-10))
+    scene.add(gprMax.PMLThickness(thickness=(3, 3, 0, 3, 3, 0)))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=8e9, id="pulse"))
+    plane_wave = gprMax.DiscretePlaneWaveAxial(
+        p1=(0.010, 0.010, inf),
+        p2=(0.030, 0.030, inf),
+        axis=axis,
+        psi=90,
+        waveform_id="pulse",
+    )
+    scene.add(plane_wave)
+    scene.add(gprMax.Rx(p1=(0.020, 0.020, inf), id="probe"))
+    return scene, plane_wave
+
+
+@pytest.mark.integration
+def test_plane_wave_study_rebuilds_dpw_and_matches_fresh_runs(tmp_path):
+    scene, plane_wave = _two_dimensional_scene()
+    study = gprMax.PlaneWaveStudy(
+        [
+            gprMax.StudyCase(
+                "x_incidence", [gprMax.ObjectState(plane_wave, phi=0, scale=1)]
+            ),
+            gprMax.StudyCase(
+                "y_incidence", [gprMax.ObjectState(plane_wave, phi=90, scale=0.5)]
+            ),
+        ]
+    )
+    gprMax.run(
+        scenes=[scene],
+        study=study,
+        outputfile=tmp_path / "reused",
+        hide_progress_bars=True,
+        log_level=30,
+        cpu_precision="double",
+    )
+
+    for index, (phi, amplitude) in enumerate(((0, 1), (90, 0.5)), start=1):
+        fresh_scene, _ = _two_dimensional_scene(phi=phi, amplitude=1)
+        gprMax.run(
+            scenes=[fresh_scene],
+            outputfile=tmp_path / f"fresh{index}",
+            hide_progress_bars=True,
+            log_level=30,
+            cpu_precision="double",
+        )
+        with h5py.File(tmp_path / f"reused{index}.h5") as reused, h5py.File(
+            tmp_path / f"fresh{index}.h5"
+        ) as fresh:
+            np.testing.assert_allclose(
+                reused["rxs/rx1/Ez"],
+                amplitude * fresh["rxs/rx1/Ez"][...],
+                rtol=2e-12,
+                atol=2e-12,
+            )
+            resolved = json.loads(reused["study/resolved_case"][()].decode())
+            assert resolved["objects"]["plane_wave_1"]["scale"] == amplitude
+            assert resolved["objects"]["plane_wave_1"]["actual_angles"][1] == phi
+
+
+@pytest.mark.integration
+def test_plane_wave_study_recreates_ntff_rcs_state_per_case(tmp_path):
+    scene, plane_wave = _rcs_scene()
+    study = gprMax.PlaneWaveStudy(
+        [
+            gprMax.StudyCase("x_incidence", [gprMax.ObjectState(plane_wave, phi=0)]),
+            gprMax.StudyCase("y_incidence", [gprMax.ObjectState(plane_wave, phi=90)]),
+        ]
+    )
+    gprMax.run(
+        scenes=[scene],
+        study=study,
+        outputfile=tmp_path / "reused_rcs",
+        hide_progress_bars=True,
+        log_level=30,
+        cpu_precision="double",
+    )
+
+    path = "ntff/surface/frequency/spectrum/far_field/pattern/fields/rcs"
+    for index, phi in enumerate((0, 90), start=1):
+        fresh_scene, _ = _rcs_scene(phi=phi)
+        gprMax.run(
+            scenes=[fresh_scene],
+            outputfile=tmp_path / f"fresh_rcs{index}",
+            hide_progress_bars=True,
+            log_level=30,
+            cpu_precision="double",
+        )
+        with h5py.File(tmp_path / f"reused_rcs{index}.h5") as reused, h5py.File(
+            tmp_path / f"fresh_rcs{index}.h5"
+        ) as fresh:
+            np.testing.assert_allclose(reused[path], fresh[path], rtol=2e-11, atol=1e-18)
+            plane_wave_group = reused["ntff/surface/frequency/spectrum/plane_wave"]
+            assert plane_wave_group.attrs["actual_angles"][1] == phi
+
+
+@pytest.mark.integration
+def test_plane_wave_study_rebuilds_axial_material_profile(tmp_path):
+    scene, plane_wave = _axial_scene()
+    study = gprMax.PlaneWaveStudy(
+        [
+            gprMax.StudyCase("x_incidence", [gprMax.ObjectState(plane_wave, axis="x")]),
+            gprMax.StudyCase("y_incidence", [gprMax.ObjectState(plane_wave, axis="y")]),
+        ]
+    )
+    gprMax.run(
+        scenes=[scene],
+        study=study,
+        outputfile=tmp_path / "reused_axial",
+        hide_progress_bars=True,
+        log_level=30,
+        cpu_precision="double",
+    )
+
+    for index, axis in enumerate(("x", "y"), start=1):
+        fresh_scene, _ = _axial_scene(axis=axis)
+        gprMax.run(
+            scenes=[fresh_scene],
+            outputfile=tmp_path / f"fresh_axial{index}",
+            hide_progress_bars=True,
+            log_level=30,
+            cpu_precision="double",
+        )
+        with h5py.File(tmp_path / f"reused_axial{index}.h5") as reused, h5py.File(
+            tmp_path / f"fresh_axial{index}.h5"
+        ) as fresh:
+            np.testing.assert_allclose(
+                reused["rxs/rx1/Ez"], fresh["rxs/rx1/Ez"], rtol=2e-12, atol=2e-12
+            )
+
+
+def test_plane_wave_study_csv_and_type_specific_validation(tmp_path):
+    cases = tmp_path / "angles.csv"
+    cases.write_text(
+        "case_id,object_id,theta_deg,phi_deg,psi_deg,scale\n"
+        "front,plane_wave_1,90,0,90,1\n"
+        "side,plane_wave_1,90,90,90,0.5\n"
+    )
+    study = gprMax.Study.from_csv("plane_wave", cases)
+    assert isinstance(study, gprMax.PlaneWaveStudy)
+    assert study.cases[1].states[0].parameters == {
+        "theta": 90,
+        "phi": 90,
+        "psi": 90,
+        "scale": 0.5,
+    }
+
+    vectors = tmp_path / "vectors.csv"
+    vectors.write_text(
+        "case_id,object_id,m_x,m_y,m_z,psi_deg\n"
+        "x,plane_wave_1,1,0,0,90\n"
+        "reverse_y,plane_wave_1,0,-1,0,90\n"
+    )
+    vector_study = gprMax.Study.from_csv("plane_wave", vectors)
+    assert vector_study.cases[1].states[0].parameters == {
+        "psi": 90,
+        "m_vec": (0, -1, 0),
+    }
+
+    vector_scene = gprMax.Scene()
+    vector = gprMax.DiscretePlaneWaveVector(
+        p1=(0.01,) * 3,
+        p2=(0.02,) * 3,
+        m_vec=(1, 0, 0),
+        psi=0,
+        waveform_id="pulse",
+    )
+    vector_scene.add(vector)
+    wrong = gprMax.PlaneWaveStudy(
+        [gprMax.StudyCase("wrong", [gprMax.ObjectState(vector, theta=90)])]
+    )
+    with pytest.raises(ValueError, match="unsupported parameter.*theta"):
+        wrong.bind_scene(vector_scene)
+
+
+@pytest.mark.integration
+def test_hash_plane_wave_study_runs_all_csv_cases(tmp_path):
+    cases = tmp_path / "angles.csv"
+    cases.write_text(
+        "case_id,object_id,theta_deg,phi_deg,psi_deg\n"
+        "x,plane_wave_1,90,0,90\n"
+        "y,plane_wave_1,90,90,90\n"
+    )
+    inputfile = tmp_path / "plane_wave.in"
+    inputfile.write_text(
+        "#title: reusable plane-wave study\n"
+        "#dx_dy_dz: 0.002 0.002 0.002\n"
+        "#domain: 0.04 0.04 0.04\n"
+        "#pml_cells: 3\n"
+        "#time_window: 2e-10\n"
+        "#waveform: ricker 1 8e9 pulse\n"
+        "#plane_wave_angles: 0.012 0.012 0.012 0.028 0.028 0.028 "
+        "90 0 90 pulse\n"
+        "#rx: 0.02 0.02 0.02\n"
+        f"#study: plane_wave {cases.name}\n"
+    )
+    gprMax.run(
+        inputfile=inputfile,
+        outputfile=tmp_path / "hash",
+        hide_progress_bars=True,
+        log_level=30,
+        cpu_precision="double",
+    )
+
+    for index, phi in enumerate((0, 90), start=1):
+        with h5py.File(tmp_path / f"hash{index}.h5") as output:
+            assert output["study"].attrs["Type"] == "plane_wave"
+            resolved = json.loads(output["study/resolved_case"][()].decode())
+            assert resolved["objects"]["plane_wave_1"]["actual_angles"][1] == phi
+            assert output["study/source"][()].decode() == cases.read_text()
+
+
+def test_plane_wave_study_rejects_multiple_or_zero_incident_sources():
+    scene, plane_wave = _two_dimensional_scene()
+    duplicate = gprMax.DiscretePlaneWaveAngles(
+        p1=(0.010, 0.010, float("inf")),
+        p2=(0.030, 0.030, float("inf")),
+        theta=90,
+        phi=90,
+        psi=90,
+        waveform_id="pulse",
+    )
+    scene.add(duplicate)
+    study = gprMax.PlaneWaveStudy(
+        [gprMax.StudyCase("one", [gprMax.ObjectState(plane_wave, phi=0)])]
+    )
+    with pytest.raises(ValueError, match="exactly one plane-wave template"):
+        study.bind_scene(scene)
+
+    single_scene, single = _two_dimensional_scene()
+    zero = gprMax.PlaneWaveStudy(
+        [gprMax.StudyCase("zero", [gprMax.ObjectState(single, scale=0)])]
+    )
+    with pytest.raises(ValueError, match="non-zero"):
+        zero.bind_scene(single_scene)
+
+
+def test_plane_wave_study_rejects_subgrid_excitation():
+    scene, plane_wave = _two_dimensional_scene()
+    subgrid = gprMax.SubGridHSG(
+        p1=(0.01, 0.01, 0),
+        p2=(0.03, 0.03, 0),
+        ratio=3,
+        id="fine",
+    )
+    subgrid.add(
+        gprMax.HertzianDipole(
+            polarisation="z",
+            p1=(0.02, 0.02, 0),
+            waveform_id="pulse",
+        )
+    )
+    scene.add(subgrid)
+    study = gprMax.PlaneWaveStudy(
+        [gprMax.StudyCase("one", [gprMax.ObjectState(plane_wave, phi=0)])]
+    )
+
+    with pytest.raises(ValueError, match="HertzianDipole on subgrid 'fine'"):
+        study.bind_scene(scene)
+
+
+def _run_device_study(tmp_path, name, **backend):
+    scene, plane_wave = _two_dimensional_scene()
+    study = gprMax.PlaneWaveStudy(
+        [
+            gprMax.StudyCase("x", [gprMax.ObjectState(plane_wave, phi=0)]),
+            gprMax.StudyCase("y", [gprMax.ObjectState(plane_wave, phi=90)]),
+        ]
+    )
+    gprMax.run(
+        scenes=[scene],
+        study=study,
+        outputfile=tmp_path / name,
+        hide_progress_bars=True,
+        log_level=30,
+        **backend,
+    )
+    traces = []
+    for index in (1, 2):
+        with h5py.File(tmp_path / f"{name}{index}.h5") as output:
+            traces.append(output["rxs/rx1/Ez"][...])
+    return traces
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+def test_cuda_plane_wave_study_matches_cpu(tmp_path, gpu_device):
+    cpu = _run_device_study(tmp_path, "cpu_cuda", cpu_precision="single")
+    cuda = _run_device_study(
+        tmp_path,
+        "cuda",
+        gpu=[gpu_device],
+        gpu_precision="single",
+    )
+    scale = max(np.max(np.abs(trace)) for trace in cpu)
+    for expected, actual in zip(cpu, cuda):
+        np.testing.assert_allclose(actual, expected, rtol=3e-4, atol=3e-4 * scale)
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+def test_opencl_plane_wave_study_matches_cpu(tmp_path, opencl_device):
+    cpu = _run_device_study(tmp_path, "cpu_opencl", cpu_precision="single")
+    opencl = _run_device_study(
+        tmp_path,
+        "opencl",
+        opencl=[opencl_device],
+        gpu_precision="single",
+    )
+    scale = max(np.max(np.abs(trace)) for trace in cpu)
+    for expected, actual in zip(cpu, opencl):
+        np.testing.assert_allclose(actual, expected, rtol=3e-4, atol=3e-4 * scale)


### PR DESCRIPTION
# PR Description

## Summary

Adds reusable-geometry studies for discrete plane-wave and RCS simulations.

The new `PlaneWaveStudy`:

- supports angle-, vector-, and axial-defined discrete plane waves;
- permits per-case direction, polarisation, waveform, timing, and amplitude scaling;
- reuses the main Yee geometry;
- rebuilds direction-dependent DPW grids and their PML state for every case;
- resets and recompiles declarative KSIR/NTFF accumulators and incident-field normalization;
- supports both Python API and CSV/hash-command workflows;
- stores requested and actual rationalised plane-wave parameters in HDF5;
- rejects additional excitations that would make RCS normalization ambiguous;
- allows passive subgrids enclosed by the TFSF and NTFF surfaces.

NTFF plane-wave metadata is now also written into the frequency-transform output group.

## Motivation

Angular and polarization sweeps previously required rebuilding the entire model. Simply retaining the existing plane-wave object is unsafe because its auxiliary grid, integer propagation mapping, material profile, projections, PML state, and incident-field DFT depend on the selected direction.

This implementation retains only the direction-independent Yee geometry and reconstructs all dependent source and NTFF state.

## Related Issue

N/A

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] This change requires a documentation update.

## Testing

- 34 focused CPU tests passed.
- Reused angle and axial cases match independent fresh simulations.
- Reused PEC-sphere RCS cases match independent fresh simulations.
- OpenCL/CPU parity passed.
- CUDA parity coverage is included but was skipped because CUDA was unavailable in the execution context.
- Sphinx documentation build passed.
- `git diff --check` and Python compilation checks passed.

## Checklist

- [ ] Did pre-commit pass all checks?
- [x] I have performed a self-review of my code.
- [x] I have added comments for my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.
