### PR TITLE
Add reusable stateful source studies

### DIFF
--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -195,6 +195,66 @@ one-based case number ``N``. For a text input model the equivalent
 
 .. autoclass:: gprMax.studies.GPRStudy
 
+Fixed-topology terminal-source studies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A :class:`gprMax.SourceStudy` reuses a model containing stateful terminal
+sources. It supports main-grid :class:`gprMax.TransmissionLine`,
+:class:`gprMax.MagneticFrillSource`, and
+:class:`gprMax.NetworkExcitation` objects. Their positions and physical
+definitions remain fixed, but each case may change ``waveform_id``, ``start``,
+``stop``, and the dimensionless generator ``scale``. ``active=false`` is
+equivalent to zero generator drive.
+
+This is deliberately different from an S-parameter study: any number of
+terminals may be active in one case, which is useful for phased-array and
+multiple-feed antenna patterns. A source omitted from a case is not removed.
+Its transmission-line resistance, coaxial-frill termination, or rational
+network remains coupled to the Yee grid as a passive load.
+
+.. code-block:: python
+
+    scene.add(gprMax.RationalNetwork(id='load50', conductance=1 / 50))
+    scene.add(gprMax.NetworkTerminal(
+        p1=(0.040, 0.050, 0.030), polarisation='z',
+        network_id='load50', id='port1'
+    ))
+    scene.add(gprMax.NetworkTerminal(
+        p1=(0.060, 0.050, 0.030), polarisation='z',
+        network_id='load50', id='port2'
+    ))
+    feed1 = gprMax.NetworkExcitation('port1', 'pulse')
+    feed2 = gprMax.NetworkExcitation('port2', 'pulse')
+    scene.add(feed1)
+    scene.add(feed2)
+
+    study = gprMax.SourceStudy([
+        gprMax.StudyCase('feed_1_only', [
+            gprMax.ObjectState(feed1, scale=1),
+        ]),
+        gprMax.StudyCase('equal_feeds', [
+            gprMax.ObjectState(feed1, scale=1),
+            gprMax.ObjectState(feed2, scale=1),
+        ]),
+        gprMax.StudyCase('weighted_feeds', [
+            gprMax.ObjectState(feed1, scale=1),
+            gprMax.ObjectState(feed2, scale=-1),
+        ]),
+    ])
+
+    gprMax.run(scenes=[scene], study=study, outputfile='fed_array')
+
+Before every case gprMax reconstructs the selected source waveform and clears
+all transmission-line voltage/current and ABC state, magnetic-frill recurrence
+and histories, rational-network pole state, receiver histories, and derived
+port results. Declarative NTFF monitors are recompiled with new accumulators,
+so every case may safely produce an independent antenna pattern. SourceStudy
+uses the normal CPU, CUDA, OpenCL, or Metal implementation of each terminal.
+It does not currently support source objects inside a subgrid, MPI execution,
+or task farming.
+
+.. autoclass:: gprMax.studies.SourceStudy
+
 Finite-resistance voltage-port studies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -416,12 +476,11 @@ direction from each case file.
 
 .. note::
 
-    MPI/task-farm studies, transmission lines, rational networks,
-    magnetic-frill sources are not yet enabled. General GPR study objects
-    remain main-grid only. Eigenmode studies support the owning main grid or
-    subgrid and reset direct and virtual-waveguide modal state explicitly.
-    Plane-wave studies use a main-grid TFSF source but may enclose complete
-    subgrids.
+    MPI/task-farm studies are not yet enabled. General GPR and SourceStudy
+    objects remain main-grid only. Eigenmode studies support the owning main
+    grid or subgrid and reset direct and virtual-waveguide modal state
+    explicitly. Plane-wave studies use a main-grid TFSF source but may enclose
+    complete subgrids.
 
 Typical general settings are added directly to the scene:
 

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1946,12 +1946,14 @@ case that produced it. The syntax is:
     #study: gpr file1
 
 The study type may be ``gpr`` for irregular source/receiver acquisition,
-``port`` for a finite-resistance voltage-source S-parameter study, or
-``eigenmode`` for a modal-port S-parameter study, or ``plane_wave`` for an
-angular TFSF/RCS study:
+``source`` for fixed-topology stateful terminal sources, ``port`` for a
+finite-resistance voltage-source S-parameter study, ``eigenmode`` for a
+modal-port S-parameter study, or ``plane_wave`` for an angular TFSF/RCS
+study:
 
 .. code-block:: none
 
+    #study: source file1
     #study: port file1
     #study: eigenmode file1
     #study: plane_wave file1
@@ -1984,6 +1986,32 @@ declarative NTFF accumulators for each row, while retaining the main model
 geometry. NTFF observation directions also remain fixed: request all angles
 needed across the cases in the input file and select the appropriate direction
 from each numbered output file.
+
+A ``source`` study manages main-grid ``#transmission_line``,
+``#magnetic_frill_source``, and ``#network_excitation`` commands. Their
+deterministic IDs are ``transmission_line_1``, ``magnetic_frill_source_1``,
+and ``network_excitation_1`` (and so on within each family). Positions,
+impedances, thin-wire/coax geometry, and rational-network definitions are
+fixed. The CSV may vary ``active``, ``waveform_id``, ``start_s``, ``stop_s``,
+and ``scale``. For example:
+
+.. code-block:: text
+
+    case_id,object_id,active,waveform_id,start_s,stop_s,scale
+    full_drive,transmission_line_1,true,pulse,0,4e-9,1
+    half_drive,transmission_line_1,true,pulse,0,4e-9,0.5
+    passive,transmission_line_1,false,,,,
+
+Any number of listed sources may be active in a case. An omitted or inactive
+source keeps its physical terminal and acts as a passive termination with
+zero generator drive. gprMax resets the terminal's internal field, recurrence,
+history, and derived port state before every case. Declarative NTFF outputs
+are also rebuilt with pristine accumulators. ``source`` studies are therefore
+suitable for comparing multiple-feed antenna excitations, but do not
+calculate a complete S matrix; use ``port`` or ``eigenmode`` for that purpose.
+The normal CPU, CUDA, OpenCL, and Metal implementations are available.
+Stateful sources inside subgrids, MPI, and task farming are not currently
+supported by this study type.
 
 For example:
 

--- a/docs/source/output.rst
+++ b/docs/source/output.rst
@@ -46,12 +46,20 @@ full study as JSON, while ``resolved_case`` contains the post-validation values
 actually applied to every study-managed object, including baseline receivers
 and implicitly disabled sources.
 Study-managed source and receiver groups also carry a ``StudyID`` attribute,
-which provides an unambiguous link back to the case table.
+including the ``tls`` and ``frills`` groups used by a source study. This
+provides an unambiguous link back to the case table.
 
 For a plane-wave study, ``resolved_case`` records the requested case together
 with the actual rationalised propagation angles and integer DPW mapping. Each
 case remains an ordinary numbered model output; no aggregate matrix is needed
 because RCS patterns from different illuminations are independent results.
+
+For a source study, ``resolved_case`` records every stateful terminal,
+including sources omitted from the sparse case table. ``active=false`` and
+``scale=0`` identify a passive physical termination rather than an object
+removed from the model. Transmission-line, magnetic-frill, rational-network,
+receiver, port, and declarative NTFF datasets in each numbered file contain
+only that case's reset state.
 
 Every case in a finite-resistance voltage-port study additionally contains
 ``study/port_response``. ``DrivenSourceID`` and ``DrivenPortID`` identify its

--- a/gprMax/__init__.py
+++ b/gprMax/__init__.py
@@ -27,6 +27,7 @@ from .studies import (
     PlaneWaveStudy,
     PortStudy,
     PortStudyResult,
+    SourceStudy,
     Study,
     StudyCase,
     combine_embedded_modal_responses,

--- a/gprMax/fields_outputs.py
+++ b/gprMax/fields_outputs.py
@@ -354,6 +354,8 @@ def write_hd5_data(basegrp, grid, is_subgrid=False):
         grp.attrs["Resistance"] = tl.resistance
         grp.attrs["dl"] = tl.dl
         grp.attrs["ID"] = str(tl.ID)
+        if getattr(tl, "study_id", None):
+            grp.attrs["StudyID"] = tl.study_id
         grp.attrs["GridPosition"] = np.asarray(tl.coord, dtype=np.int32)
         # Save incident voltage and current
         grp["Vinc"] = tl.Vinc
@@ -383,6 +385,8 @@ def write_hd5_data(basegrp, grid, is_subgrid=False):
         grp.attrs["CurrentTimeApproximation"] = "average"
         grp.attrs["FeedSelfAdmittance"] = frill._G_coeff
         grp.attrs["ID"] = str(frill.ID)
+        if getattr(frill, "study_id", None):
+            grp.attrs["StudyID"] = frill.study_id
         grp.attrs["GridPosition"] = np.asarray(frill.coord, dtype=np.int32)
         # The two faces transverse to Polarisation, in the fixed order used
         # throughout MagneticFrillSource.finalise_setup()/update_magnetic()

--- a/gprMax/gprMax.py
+++ b/gprMax/gprMax.py
@@ -205,7 +205,7 @@ def run(
             geometry views but do not run the simulation.
         geometry_fixed: optional boolean to run a series of models where
             the geometry does not change between models.
-        study: optional Study instance defining per-run source and receiver
+        study: optional Study instance defining validated per-run object
             states while reusing one geometry.
         write_processed: optional boolean to write another input file
             after any #python blocks (which are deprecated) in the

--- a/gprMax/model.py
+++ b/gprMax/model.py
@@ -489,37 +489,27 @@ class Model:
             grid.dispersion_analysis(self.iterations)
 
     def _check_stateful_sources_with_geometry_fixed(self, grids: Sequence[FDTDGrid]):
-        # TransmissionLine and DiscretePlaneWave each carry their own
-        # persistent internal state (TL: voltage/current/ABC history;
-        # DPW: its own internal 1D E/H-field and PML-integral arrays) that
-        # is never reset between geometry_fixed reuse runs (only grid
-        # fields/PMLs are). Neither source can even vary between those
-        # runs in the first place - TransmissionLine is explicitly
-        # excluded from #src_steps repositioning
-        # (FDTDGrid.update_simple_source_positions()), and a
-        # DiscretePlaneWave's angle/direction is fixed once at scene-parse
-        # time with no per-run mechanism to change it. So with
-        # geometry_fixed and more than one model requested, every run
-        # after the first would silently reuse the exact same source at
-        # the exact same configuration, contaminated by the previous
-        # run's leftover internal state - not a "reuse the geometry, vary
-        # something else" scenario at all, just a broken repeat of an
-        # identical model. (A stepped receiver/dipole elsewhere in the
-        # same scene doesn't need multiple runs either - use multiple
-        # #rx commands, or #src_steps/#rx_steps, in a single run instead.)
-        # Eigenmode sources and receivers also attach persistent modal DFT
-        # accumulators, recursive phase state, and derived S-parameters to
-        # their grids. grid.reset_fields() does not reset any of that state.
+        # These sources and monitors own state outside the principal Yee
+        # arrays cleared by grid.reset_fields(). Unmanaged geometry-fixed
+        # repetition would therefore contaminate later runs. Each specialised
+        # Study listed below provides the corresponding explicit reset and
+        # per-case reconfiguration contract; retain the protective rejection
+        # for all other geometry-fixed workflows.
         if config.sim_config.geometry_fixed and config.sim_config.number_of_models > 1:
-            if any(grid.transmissionlines for grid in grids):
+            from gprMax.studies import SourceStudy
+
+            if not isinstance(config.sim_config.study, SourceStudy) and any(
+                grid.transmissionlines for grid in grids
+            ):
                 raise ValueError(
                     "#transmission_line cannot be used with geometry_fixed when more "
                     "than one model is requested (n > 1) - a transmission line's "
                     "internal state (voltage/current/ABC history) is not reset "
                     "between reused-geometry runs, and it cannot be repositioned "
                     "via #src_steps, so every run after the first would silently "
-                    "repeat the identical, contaminated source. Run a single model "
-                    "instead, or use #voltage_source if you need geometry_fixed."
+                    "repeat the identical, contaminated source. Use a SourceStudy "
+                    "to vary and reset a fixed transmission-line terminal, or run "
+                    "a single model instead."
                 )
             from gprMax.studies import PlaneWaveStudy
 
@@ -533,18 +523,21 @@ class Model:
                     "PML-integral arrays) is not reset between reused-geometry "
                     "runs, and its angle/direction cannot vary between runs, so "
                     "every run after the first would silently repeat the "
-                    "identical, contaminated source. Run a single model instead."
+                    "identical, contaminated source. Use a PlaneWaveStudy to vary "
+                    "and rebuild the TFSF source, or run a single model instead."
                 )
-            if any(grid.magneticfrillsources for grid in grids):
+            if not isinstance(config.sim_config.study, SourceStudy) and any(
+                grid.magneticfrillsources for grid in grids
+            ):
                 raise ValueError(
                     "#magnetic_frill_source cannot be used with geometry_fixed "
                     "when more than one model is requested (n > 1) - its "
                     "internal voltage/current history arrays are not reset "
                     "between reused-geometry runs, so every run after the "
                     "first would retain state from the previous run and "
-                    "contaminate "
-                    "Vtotal/S11/Zin output with no error. Run a single model "
-                    "instead."
+                    "contaminate Vtotal/S11/Zin output with no error. Use a "
+                    "SourceStudy to vary and reset the fixed frill terminal, or "
+                    "run a single model instead."
                 )
             from gprMax.studies import EigenmodeStudy
 
@@ -558,8 +551,8 @@ class Model:
                     "be used with geometry_fixed when more "
                     "than one model is requested (n > 1) - their modal DFT "
                     "accumulators, recursive phase state, and derived "
-                    "S-parameters are not reset between reused-geometry runs. "
-                    "Run a single model instead."
+                    "S-parameters are not reset between reused-geometry runs. Use "
+                    "an EigenmodeStudy, or run a single model instead."
                 )
 
     def _check_for_dispersive_materials(self, grids: Sequence[FDTDGrid]):

--- a/gprMax/network_ports.py
+++ b/gprMax/network_ports.py
@@ -193,6 +193,7 @@ class RationalNetworkTerminal:
         self.stop = 0.0
         self.output = None
         self.prepared = False
+        self.study_scale = 1.0
 
     @property
     def xcoord(self) -> int:
@@ -218,6 +219,35 @@ class RationalNetworkTerminal:
         self.waveformID = waveform_id
         self.start = 0.0 if start is None else float(start)
         self.stop = np.inf if stop is None else float(stop)
+
+    def configure_study_excitation(self, grid, waveform_id, start, stop, scale) -> None:
+        """Replace only the generator drive while retaining terminal topology."""
+
+        if not any(waveform.ID == waveform_id for waveform in grid.waveforms):
+            raise ValueError(
+                f"network terminal {self.ID!r} study drive references unknown "
+                f"waveform {waveform_id!r}"
+            )
+        start = float(start)
+        stop = min(float(stop), float(grid.timewindow))
+        scale = float(scale)
+        if not np.isfinite(scale):
+            raise ValueError(f"network terminal {self.ID!r} study scale must be finite")
+        if start < 0 or stop <= start:
+            raise ValueError(
+                f"network terminal {self.ID!r} study drive requires "
+                "0 <= start < stop <= the model time window"
+            )
+
+        self.waveformID = waveform_id
+        self.start = start
+        self.stop = stop
+        self.study_scale = scale
+        if self.prepared:
+            self._prepare_waveform(grid)
+            self.reset()
+        if self.output is not None:
+            self.output.result = None
 
     def _edge_geometry(self, grid) -> tuple[float, float]:
         if self.polarisation == "x":
@@ -350,6 +380,8 @@ class RationalNetworkTerminal:
                 self.waveform_half[iteration] = waveform.calculate_value(
                     half_time - self.start, grid.dt
                 )
+        self.waveform_whole *= self.study_scale
+        self.waveform_half *= self.study_scale
 
     def reset(self) -> None:
         """Return all dynamic network state and histories to rest."""

--- a/gprMax/ports.py
+++ b/gprMax/ports.py
@@ -997,6 +997,11 @@ class RationalNetworkPortOutput:
             )
         self.prepared = True
 
+    def reset_run_state(self) -> None:
+        """Clear derived output before a reused-geometry source-study case."""
+
+        self.result = None
+
     def finalise(self, grid: "FDTDGrid") -> RationalNetworkPortResult:
         if not self.prepared:
             self.prepare(grid)

--- a/gprMax/sources.py
+++ b/gprMax/sources.py
@@ -3041,6 +3041,7 @@ class TransmissionLine(Source):
         # Number of cells in the transmission line (initially a long line to
         # calculate incident voltage and current); consider putting ABCs/PML at end
         self.nl = round_value(0.667 * self.iterations)
+        self._incident_nl = self.nl
 
         # Cell position of the one-way injector excitation in the transmission line
         self.srcpos = 5
@@ -3063,7 +3064,7 @@ class TransmissionLine(Source):
         # processing is post-solve.
         self.port_output = None
 
-    def calculate_waveform_values(self, G):
+    def calculate_waveform_values(self, G, reuse_existing=True):
         """Calculates all waveform values for source for duration of simulation.
 
         Args:
@@ -3075,12 +3076,13 @@ class TransmissionLine(Source):
         # pre-calculated waveform values, otherwise calculate them.
         src_match = False
 
-        if self.start == 0 and self.stop == G.timewindow:
+        if reuse_existing and self.start == 0 and self.stop == G.timewindow:
             for src in G.transmissionlines:
-                if src.waveformID == self.waveformID:
+                if src is not self and src.waveformID == self.waveformID:
                     src_match = True
                     self.waveformvalues_wholedt = src.waveformvalues_wholedt
                     self.waveformvalues_halfdt = src.waveformvalues_halfdt
+                    break
 
         if not src_match:
             waveform = next(x for x in G.waveforms if x.ID == self.waveformID)
@@ -3115,6 +3117,7 @@ class TransmissionLine(Source):
         # use separate output histories, but they advance the same internal
         # line voltage/current vectors and ABC memories. Always start the
         # preliminary line from rest and clear any old incident histories.
+        self.nl = self._incident_nl
         self._reset_update_state()
         self.Vinc.fill(0)
         self.Iinc.fill(0)
@@ -3131,6 +3134,34 @@ class TransmissionLine(Source):
         # Vinc/Iinc retain the completed incident histories, but the actual
         # coupled source must begin with zero line fields and zero ABC memory.
         self._reset_update_state()
+
+    def configure_study_excitation(self, G, waveform_id, start, stop, scale):
+        """Apply one fixed-geometry study drive and return the line to rest."""
+
+        if not any(waveform.ID == waveform_id for waveform in G.waveforms):
+            raise ValueError(f"{self.ID} study drive references unknown waveform {waveform_id!r}.")
+        start = float(start)
+        stop = min(float(stop), float(G.timewindow))
+        scale = float(scale)
+        if not np.isfinite(scale):
+            raise ValueError(f"{self.ID} study scale must be finite.")
+        if start < 0 or stop <= start:
+            raise ValueError(
+                f"{self.ID} study drive requires 0 <= start < stop <= the model time window."
+            )
+
+        self.waveformID = waveform_id
+        self.start = start
+        self.stop = stop
+        self.calculate_waveform_values(G, reuse_existing=False)
+        self.waveformvalues_wholedt *= scale
+        self.waveformvalues_halfdt *= scale
+        self.calculate_incident_V_I(G)
+        self.Vtotal.fill(0)
+        self.Itotal.fill(0)
+        self.study_scale = scale
+        if self.port_output is not None:
+            self.port_output.result = None
 
     def _reset_update_state(self):
         """Reset mutable line and absorbing-boundary state to rest."""
@@ -3498,6 +3529,34 @@ class MagneticFrillSource(Source):
             if time >= self.start and time <= self.stop:
                 time -= self.start
                 self.waveformvalues_wholedt[iteration] = waveform.calculate_value(time, G.dt)
+
+    def configure_study_excitation(self, G, waveform_id, start, stop, scale):
+        """Apply one fixed-geometry study drive and clear terminal histories."""
+
+        if not any(waveform.ID == waveform_id for waveform in G.waveforms):
+            raise ValueError(f"{self.ID} study drive references unknown waveform {waveform_id!r}.")
+        start = float(start)
+        stop = min(float(stop), float(G.timewindow))
+        scale = float(scale)
+        if not np.isfinite(scale):
+            raise ValueError(f"{self.ID} study scale must be finite.")
+        if start < 0 or stop <= start:
+            raise ValueError(
+                f"{self.ID} study drive requires 0 <= start < stop <= the model time window."
+            )
+
+        self.waveformID = waveform_id
+        self.start = start
+        self.stop = stop
+        self.calculate_waveform_values(G)
+        self.waveformvalues_wholedt *= scale
+        self.Vinc.fill(0)
+        self.Vtotal.fill(0)
+        self.Itot.fill(0)
+        self._previous_half_current = 0.0
+        self.study_scale = scale
+        if self.port_output is not None:
+            self.port_output.result = None
 
     def _validate_geometry(self, G):
         """Bind the attached thin wire and check the local PEC ground plane."""

--- a/gprMax/studies.py
+++ b/gprMax/studies.py
@@ -26,6 +26,8 @@ Eigenmode studies reuse phase-aligned FDFD modal bases and assemble a full
 modal S matrix from one active port/mode channel per run.
 Plane-wave studies rebuild only the auxiliary DPW source and declarative NTFF
 accumulators while retaining the main Yee geometry.
+Source studies reset fixed-topology transmission-line, magnetic-frill, and
+rational-network terminals while varying only their generator drives.
 """
 
 from __future__ import annotations
@@ -52,6 +54,7 @@ _POSITION_COLUMNS = ("x_m", "y_m", "z_m")
 _SOURCE_PARAMETERS = {"active", "position", "waveform_id", "start", "stop", "scale"}
 _RECEIVER_PARAMETERS = {"position", "record"}
 _PLANE_WAVE_COMMON_PARAMETERS = {"psi", "waveform_id", "start", "stop", "scale"}
+_STATEFUL_SOURCE_PARAMETERS = {"active", "waveform_id", "start", "stop", "scale"}
 _CSV_COLUMNS = {
     "case_id",
     "object_id",
@@ -251,6 +254,8 @@ class Study:
             return EigenmodeStudy(cases, source_path=path, source_text=text)
         if str(type).strip().lower() == "plane_wave":
             return PlaneWaveStudy(cases, source_path=path, source_text=text)
+        if str(type).strip().lower() == "source":
+            return SourceStudy(cases, source_path=path, source_text=text)
         return cls(type, cases, source_path=path, source_text=text)
 
     def bind_scene(self, scene) -> None:
@@ -622,6 +627,250 @@ class GPRStudy(Study):
         super().__init__("gpr", cases)
 
 
+class SourceStudy(Study):
+    """Reusable study for fixed-topology stateful terminal sources.
+
+    Transmission-line resistance, magnetic-frill geometry/Z0, and rational
+    network topology remain fixed. Cases may select the active generators and
+    change only their waveform, time window, and scale. An omitted or inactive
+    source retains its physical terminal with a zero generator drive.
+    """
+
+    supported_types = ("source",)
+
+    def __init__(
+        self,
+        cases: Sequence[StudyCase],
+        *,
+        source_path: Optional[Union[str, Path]] = None,
+        source_text: Optional[str] = None,
+    ):
+        super().__init__(
+            "source",
+            cases,
+            source_path=source_path,
+            source_text=source_text,
+        )
+
+    def bind_scene(self, scene) -> None:
+        """Bind fixed main-grid terminal definitions and validate cases."""
+
+        if self._scene_bound:
+            return
+
+        from gprMax.user_objects.cmds_multiuse import (
+            DiscretePlaneWaveAngles,
+            DiscretePlaneWaveAxial,
+            DiscretePlaneWaveVector,
+            EigenmodeExcitation,
+            HertzianDipole,
+            MagneticDipole,
+            MagneticFrillSource,
+            NetworkExcitation,
+            TransmissionLine,
+            VoltageSource,
+        )
+
+        supported = (
+            (TransmissionLine, "transmission_line"),
+            (MagneticFrillSource, "magnetic_frill_source"),
+            (NetworkExcitation, "network_excitation"),
+        )
+        unsupported_types = (
+            VoltageSource,
+            HertzianDipole,
+            MagneticDipole,
+            DiscretePlaneWaveAngles,
+            DiscretePlaneWaveAxial,
+            DiscretePlaneWaveVector,
+            EigenmodeExcitation,
+        )
+        supported_types = tuple(item_type for item_type, _ in supported)
+        all_source_types = supported_types + unsupported_types
+        unsupported = [
+            type(item).__name__
+            for item in scene.grid_objects
+            if isinstance(item, unsupported_types)
+        ]
+        subgrid_sources = [
+            f"{type(item).__name__} on subgrid {subgrid.kwargs.get('id', '')!r}"
+            for subgrid in scene.subgrid_objects
+            for item in subgrid.children_grid
+            if isinstance(item, all_source_types)
+        ]
+        if unsupported or subgrid_sources:
+            details = sorted(set(unsupported + subgrid_sources))
+            raise ValueError(
+                "SourceStudy supports only main-grid TransmissionLine, "
+                "MagneticFrillSource, and NetworkExcitation objects; remove "
+                + ", ".join(details)
+                + "."
+            )
+
+        registry: dict[str, Any] = {}
+        reference_ids: dict[int, str] = {}
+        for object_type, prefix in supported:
+            index = 0
+            for item in scene.grid_objects:
+                if not isinstance(item, object_type):
+                    continue
+                index += 1
+                study_id = f"{prefix}_{index}"
+                setattr(item, "_study_id", study_id)
+                registry[study_id] = item
+                reference_ids[id(item)] = study_id
+
+        if not registry:
+            raise ValueError(
+                "SourceStudy requires at least one TransmissionLine, "
+                "MagneticFrillSource, or NetworkExcitation."
+            )
+
+        for case in self.cases:
+            seen: set[str] = set()
+            for state in case.states:
+                if isinstance(state.object, str):
+                    study_id = state.object.strip()
+                else:
+                    try:
+                        study_id = reference_ids[id(state.object)]
+                    except KeyError as exc:
+                        raise ValueError(
+                            f"SourceStudy case '{case.id}' references an object that is not "
+                            "a supported main-grid source in its Scene."
+                        ) from exc
+                if study_id not in registry:
+                    available = ", ".join(sorted(registry))
+                    raise ValueError(
+                        f"SourceStudy case '{case.id}' references unknown object "
+                        f"'{study_id}'. Available objects: {available}."
+                    )
+                if study_id in seen:
+                    raise ValueError(
+                        f"SourceStudy case '{case.id}' contains duplicate state for "
+                        f"'{study_id}'."
+                    )
+                unknown = set(state.parameters) - _STATEFUL_SOURCE_PARAMETERS
+                if unknown:
+                    raise ValueError(
+                        f"SourceStudy object '{study_id}' does not support parameter(s) "
+                        f"{', '.join(sorted(unknown))}. Allowed parameters: "
+                        f"{', '.join(sorted(_STATEFUL_SOURCE_PARAMETERS))}."
+                    )
+                if "scale" in state.parameters:
+                    scale = float(state.parameters["scale"])
+                    if not math.isfinite(scale):
+                        raise ValueError(f"SourceStudy case '{case.id}' scale must be finite.")
+                if "active" in state.parameters and not isinstance(
+                    state.parameters["active"], (bool, np.bool_)
+                ):
+                    raise ValueError(f"SourceStudy case '{case.id}' active must be a boolean.")
+                state.object = study_id
+                seen.add(study_id)
+
+        self.registry = registry
+        self.aliases = {}
+        self._scene_bound = True
+        logger.info(
+            "SourceStudy objects: "
+            + ", ".join(
+                f"{study_id} ({type(item).__name__})" for study_id, item in registry.items()
+            )
+            + "\n"
+        )
+
+    def _runtime_registry(self, model) -> dict[str, Any]:
+        runtime: dict[str, Any] = {}
+        for item in (
+            list(model.G.transmissionlines)
+            + list(model.G.magneticfrillsources)
+            + list(model.G.networkterminals)
+        ):
+            study_id = getattr(item, "study_id", None)
+            if study_id:
+                runtime[study_id] = item
+        expected = set(self.registry)
+        if set(runtime) != expected:
+            missing = ", ".join(sorted(expected - set(runtime)))
+            raise RuntimeError(
+                f"SourceStudy runtime object binding is incomplete; missing: {missing}."
+            )
+        return runtime
+
+    def _capture_baselines(self, runtime: Mapping[str, Any]) -> None:
+        if self._runtime_baselines:
+            return
+        for study_id, item in runtime.items():
+            self._runtime_baselines[study_id] = {
+                "waveform_id": item.waveformID,
+                "start": float(item.start),
+                "stop": float(item.stop),
+            }
+
+    def apply_case(self, model) -> None:
+        """Reset every terminal and apply the current absolute drive state."""
+
+        import gprMax.config as config
+
+        case_index = config.sim_config.current_model
+        if case_index < 0 or case_index >= len(self.cases):
+            raise ValueError(
+                f"SourceStudy case index {case_index + 1} is outside the "
+                f"{len(self.cases)} available cases."
+            )
+
+        runtime = self._runtime_registry(model)
+        self._capture_baselines(runtime)
+        states = {str(state.object): state for state in self.cases[case_index].states}
+        resolved: dict[str, Any] = {
+            "case_id": self.cases[case_index].id,
+            "objects": {},
+        }
+        for study_id, item in runtime.items():
+            baseline = self._runtime_baselines[study_id]
+            parameters = dict(states[study_id].parameters) if study_id in states else {}
+            active = bool(parameters.pop("active", study_id in states))
+            waveform_id = str(parameters.pop("waveform_id", baseline["waveform_id"]))
+            start = float(parameters.pop("start", baseline["start"]))
+            stop = min(
+                float(parameters.pop("stop", baseline["stop"])),
+                float(model.G.timewindow),
+            )
+            scale = float(parameters.pop("scale", 1.0)) if active else 0.0
+            item.configure_study_excitation(
+                model.G,
+                waveform_id=waveform_id,
+                start=start,
+                stop=stop,
+                scale=scale,
+            )
+            resolved["objects"][study_id] = {
+                "type": type(self.registry[study_id]).__name__,
+                "active": bool(scale != 0),
+                "waveform_id": waveform_id,
+                "start": start,
+                "stop": stop,
+                "scale": scale,
+            }
+            if hasattr(item, "coord"):
+                resolved["objects"][study_id]["position"] = [
+                    float(item.coord[index] * model.G.dl[index]) for index in range(3)
+                ]
+            if hasattr(item, "ID"):
+                resolved["objects"][study_id]["terminal_id"] = str(item.ID)
+
+        for receiver in model.G.rxs:
+            for values in receiver.outputs.values():
+                values.fill(0)
+        for monitor in getattr(model.G, "port_monitors", ()):
+            reset = getattr(monitor, "reset_run_state", None)
+            if reset is not None:
+                reset()
+
+        _recompile_declarative_ntff(model, model.G, "SourceStudy")
+        self._current_resolved_case = resolved
+
+
 class PlaneWaveStudy(Study):
     """Reusable-geometry study with one rebuilt discrete plane wave per case.
 
@@ -788,9 +1037,7 @@ class PlaneWaveStudy(Study):
         self.registry = {"plane_wave_1": definition}
         self.aliases = {}
         self._scene_bound = True
-        logger.info(
-            f"PlaneWaveStudy object: plane_wave_1 ({self._definition_type.__name__})\n"
-        )
+        logger.info(f"PlaneWaveStudy object: plane_wave_1 ({self._definition_type.__name__})\n")
 
     def apply_case(self, model) -> None:
         """Rebuild the case DPW and all declarative NTFF accumulator state."""
@@ -838,7 +1085,7 @@ class PlaneWaveStudy(Study):
             for values in receiver.outputs.values():
                 values.fill(0)
 
-        self._recompile_ntff(model, grid)
+        _recompile_declarative_ntff(model, grid, "PlaneWaveStudy")
         self._current_resolved_case = {
             "case_id": case.id,
             "objects": {
@@ -858,36 +1105,36 @@ class PlaneWaveStudy(Study):
             },
         }
 
-    @staticmethod
-    def _recompile_ntff(model, grid) -> None:
-        """Replace declarative NTFF monitors with pristine case instances."""
 
-        if not grid.ntff_monitors and not grid.ntff_output_writers:
-            return
-        if not grid.ntff_output_writers:
-            raise ValueError(
-                "PlaneWaveStudy cannot reset directly constructed NTFF monitors; use the "
-                "declarative NTFF surface/transform/output API or hash commands."
-            )
+def _recompile_declarative_ntff(model, grid, study_name: str) -> None:
+    """Replace declarative NTFF monitors with pristine per-case instances."""
 
-        referenced = set()
-        for writer in grid.ntff_output_writers:
-            referenced.update(writer.frequency_monitors.values())
-            for mapping_name in ("time_bindings", "time_far_bindings"):
-                for binding in getattr(writer, mapping_name, {}).values():
-                    referenced.add(binding[0])
-        unmanaged = [monitor for monitor in grid.ntff_monitors if monitor not in referenced]
-        if unmanaged:
-            raise ValueError(
-                "PlaneWaveStudy found NTFF monitors outside the declarative reusable interface; "
-                "these cannot be reset safely between cases."
-            )
+    if not grid.ntff_monitors and not grid.ntff_output_writers:
+        return
+    if not grid.ntff_output_writers:
+        raise ValueError(
+            f"{study_name} cannot reset directly constructed NTFF monitors; use the "
+            "declarative NTFF surface/transform/output API or hash commands."
+        )
 
-        grid.ntff_monitors.clear()
-        grid.ntff_output_writers.clear()
-        from gprMax.ntff.interface import compile_ntff_outputs
+    referenced = set()
+    for writer in grid.ntff_output_writers:
+        referenced.update(writer.frequency_monitors.values())
+        for mapping_name in ("time_bindings", "time_far_bindings"):
+            for binding in getattr(writer, mapping_name, {}).values():
+                referenced.add(binding[0])
+    unmanaged = [monitor for monitor in grid.ntff_monitors if monitor not in referenced]
+    if unmanaged:
+        raise ValueError(
+            f"{study_name} found NTFF monitors outside the declarative reusable "
+            "interface; these cannot be reset safely between cases."
+        )
 
-        compile_ntff_outputs(model, grid)
+    grid.ntff_monitors.clear()
+    grid.ntff_output_writers.clear()
+    from gprMax.ntff.interface import compile_ntff_outputs
+
+    compile_ntff_outputs(model, grid)
 
 
 @dataclass(frozen=True)
@@ -1858,7 +2105,7 @@ def preflight_study_args(args) -> Optional[Study]:
         raise ValueError("Studies do not yet support MPI task farming.")
     if getattr(args, "mpi", None) is not None:
         raise ValueError("Studies do not yet support MPI domain decomposition.")
-    if isinstance(study, (PortStudy, EigenmodeStudy, PlaneWaveStudy)) and getattr(
+    if isinstance(study, (PortStudy, EigenmodeStudy, PlaneWaveStudy, SourceStudy)) and getattr(
         args, "geometry_only", False
     ):
         raise ValueError(
@@ -1975,9 +2222,7 @@ def _parse_int(value: str, path: Path, line: int, name: str) -> int:
     try:
         return int(value)
     except ValueError as exc:
-        raise ValueError(
-            f"Study CSV '{path}', line {line}: {name} must be an integer."
-        ) from exc
+        raise ValueError(f"Study CSV '{path}', line {line}: {name} must be an integer.") from exc
 
 
 def _safe_divide(numerator, denominator, complex_dtype):

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -433,7 +433,11 @@ class NetworkTerminal(GridUserObject):
     def build(self, grid: FDTDGrid):
         if config.get_model_config().mode != "3D":
             raise ValueError(f"{self.params_str()} currently supports only 3-D models")
-        if config.sim_config.args.geometry_fixed:
+        from gprMax.studies import SourceStudy
+
+        if config.sim_config.args.geometry_fixed and not isinstance(
+            config.sim_config.study, SourceStudy
+        ):
             raise ValueError(f"{self.params_str()} does not yet support geometry-fixed runs")
         self.polarisation = self.polarisation.lower()
         if self.polarisation not in ("x", "y", "z"):
@@ -531,6 +535,7 @@ class NetworkExcitation(GridUserObject):
                 return
             raise RuntimeError(f"{self.params_str()} terminal definition was not instantiated")
         terminal.set_excitation(self.waveform_id, self.start, self.stop)
+        terminal.study_id = getattr(self, "_study_id", None)
         logger.info(
             self.grid_name(grid) + f"Network terminal {self.terminal_id!r} excited by waveform "
             f"{self.waveform_id!r}."
@@ -1246,6 +1251,7 @@ class TransmissionLine(RotatableMixin, GridUserObject):
         uip = self._create_uip(grid)
         x, y, z = uip.discretise_static_point(self.point)
         t.ID = f"{t.__class__.__name__}({x},{y},{z})"
+        t.study_id = getattr(self, "_study_id", None)
         t.resistance = self.resistance
         t.waveformID = self.waveform_id
 
@@ -1427,6 +1433,7 @@ class MagneticFrillSource(RotatableMixin, GridUserObject):
         uip = self._create_uip(grid)
         x, y, z = uip.discretise_static_point(self.point)
         f.ID = f"{f.__class__.__name__}({x},{y},{z})"
+        f.study_id = getattr(self, "_study_id", None)
         f.Z0 = self.zcoax
         f.waveformID = self.waveform_id
 

--- a/gprMax/user_objects/cmds_output.py
+++ b/gprMax/user_objects/cmds_output.py
@@ -146,12 +146,12 @@ class RxPort(OutputUserObject):
         raise RuntimeError("RxPort result is not available until the model has solved")
 
     def _validate_context(self, grid):
-        if (
-            config.sim_config.args.geometry_fixed
-            and getattr(config.sim_config.study, "type", None) != "port"
-        ):
+        if config.sim_config.args.geometry_fixed and getattr(
+            config.sim_config.study, "type", None
+        ) not in ("port", "source"):
             raise ValueError(
-                f"{self.params_str()} does not support geometry-fixed runs outside a PortStudy."
+                f"{self.params_str()} does not support geometry-fixed runs outside a "
+                "PortStudy or SourceStudy."
             )
         if config.get_model_config().mode != "3D":
             raise ValueError(f"{self.params_str()} currently supports only 3-D models.")
@@ -344,7 +344,11 @@ class NetworkPort(OutputUserObject):
         return self._monitor.result
 
     def build(self, model: Model, grid: FDTDGrid):
-        if config.sim_config.args.geometry_fixed:
+        from gprMax.studies import SourceStudy
+
+        if config.sim_config.args.geometry_fixed and not isinstance(
+            config.sim_config.study, SourceStudy
+        ):
             raise ValueError(f"{self.params_str()} does not support geometry-fixed runs.")
         if config.get_model_config().mode != "3D":
             raise ValueError(f"{self.params_str()} currently supports only 3-D models.")
@@ -631,9 +635,9 @@ def _check_ksir_interface_context(user_object, grid):
             f"{user_object.params_str()} supports CPU, CUDA, OpenCL, and Metal solvers."
         )
     if config.sim_config.args.geometry_fixed:
-        from gprMax.studies import PlaneWaveStudy
+        from gprMax.studies import PlaneWaveStudy, SourceStudy
 
-        if not isinstance(config.sim_config.study, PlaneWaveStudy):
+        if not isinstance(config.sim_config.study, (PlaneWaveStudy, SourceStudy)):
             raise ValueError(f"{user_object.params_str()} does not support geometry-fixed runs.")
     if config.get_model_config().mode != "3D":
         raise ValueError(f"{user_object.params_str()} currently supports only 3-D models.")

--- a/tests/test_source_study.py
+++ b/tests/test_source_study.py
@@ -1,0 +1,447 @@
+"""Reusable fixed-topology stateful-source studies."""
+
+import json
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+
+
+def _transmission_line_scene(amplitude=1.0):
+    scene = gprMax.Scene()
+    scene.add(gprMax.Domain(p1=(0.012,) * 3))
+    scene.add(gprMax.Discretisation(p1=(1e-3,) * 3))
+    scene.add(gprMax.TimeWindow(time=2e-10))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.OMPThreads(1))
+    scene.add(gprMax.Waveform(wave_type="gaussian", amp=amplitude, freq=2e10, id="w"))
+    source = gprMax.TransmissionLine(
+        polarisation="z",
+        p1=(0.006,) * 3,
+        resistance=50,
+        waveform_id="w",
+    )
+    scene.add(source)
+    scene.add(gprMax.Rx(p1=(0.007, 0.006, 0.006), id="field"))
+    return scene, source
+
+
+def _magnetic_frill_scene(amplitude=1.0):
+    dl = 1e-3
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(dl,) * 3))
+    scene.add(gprMax.Domain(p1=(0.02,) * 3))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=2e-10))
+    scene.add(gprMax.OMPThreads(1))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=amplitude, freq=10e9, id="w"))
+    scene.add(gprMax.Box(p1=(0, 0, 0), p2=(0.02, 0.02, dl), material_id="pec"))
+    scene.add(
+        gprMax.ThinWire(
+            p1=(0.01, 0.01, 0),
+            p2=(0.01, 0.01, 0.01),
+            radius=0.1e-3,
+        )
+    )
+    source = gprMax.MagneticFrillSource(
+        p1=(0.01, 0.01, 0),
+        polarisation="z",
+        zcoax=50,
+        waveform_id="w",
+        start=0,
+        stop=8e-11,
+    )
+    scene.add(source)
+    scene.add(gprMax.Rx(p1=(0.014, 0.01, 0.005), id="field"))
+    return scene, source
+
+
+def _network_scene(amplitude=1.0, waveform_id="w", start=None, stop=None):
+    scene = gprMax.Scene()
+    scene.add(gprMax.Domain(p1=(0.02,) * 3))
+    scene.add(gprMax.Discretisation(p1=(0.002,) * 3))
+    scene.add(gprMax.TimeWindow(time=4e-10))
+    scene.add(gprMax.PMLThickness(thickness=2))
+    scene.add(gprMax.OMPThreads(1))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=amplitude, freq=5e9, id="w"))
+    scene.add(gprMax.Waveform(wave_type="gaussian", amp=amplitude, freq=3e9, id="w_alt"))
+    scene.add(gprMax.RationalNetwork(id="source_50", conductance=1 / 50))
+    scene.add(
+        gprMax.NetworkTerminal(
+            p1=(0.01,) * 3,
+            polarisation="z",
+            network_id="source_50",
+            id="feed",
+        )
+    )
+    excitation = gprMax.NetworkExcitation("feed", waveform_id, start=start, stop=stop)
+    scene.add(excitation)
+    scene.add(gprMax.NetworkPort("feed", reference_impedance=50))
+    scene.add(gprMax.Rx(p1=(0.012, 0.01, 0.01), id="field"))
+    return scene, excitation
+
+
+def _two_network_scene(amplitudes=(1.0, 1.0)):
+    scene = gprMax.Scene()
+    scene.add(gprMax.Domain(p1=(0.024, 0.02, 0.02)))
+    scene.add(gprMax.Discretisation(p1=(0.002,) * 3))
+    scene.add(gprMax.TimeWindow(time=4e-10))
+    scene.add(gprMax.PMLThickness(thickness=2))
+    scene.add(gprMax.OMPThreads(1))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=amplitudes[0], freq=5e9, id="w1"))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=amplitudes[1], freq=5e9, id="w2"))
+    excitations = []
+    for index, (position, waveform_id) in enumerate(
+        (((0.008, 0.01, 0.01), "w1"), ((0.014, 0.01, 0.01), "w2")), start=1
+    ):
+        terminal_id = f"feed{index}"
+        network_id = f"source{index}"
+        scene.add(gprMax.RationalNetwork(id=network_id, conductance=1 / 50))
+        scene.add(
+            gprMax.NetworkTerminal(
+                p1=position,
+                polarisation="z",
+                network_id=network_id,
+                id=terminal_id,
+            )
+        )
+        excitation = gprMax.NetworkExcitation(terminal_id, waveform_id)
+        scene.add(excitation)
+        scene.add(gprMax.NetworkPort(terminal_id, reference_impedance=50))
+        excitations.append(excitation)
+    scene.add(gprMax.Rx(p1=(0.012, 0.01, 0.01), id="field"))
+    return scene, excitations
+
+
+def _run_reused(tmp_path, name, factory, *, precision="double", **backend):
+    scene, source = factory()
+    study = gprMax.SourceStudy(
+        [
+            gprMax.StudyCase("full", [gprMax.ObjectState(source, scale=1)]),
+            gprMax.StudyCase("half", [gprMax.ObjectState(source, scale=0.5)]),
+        ]
+    )
+    gprMax.run(
+        scenes=[scene],
+        study=study,
+        outputfile=tmp_path / name,
+        hide_progress_bars=True,
+        log_level=30,
+        **({"cpu_precision": precision} if not backend else {"gpu_precision": precision}),
+        **backend,
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("name", "factory", "paths"),
+    [
+        (
+            "tl",
+            _transmission_line_scene,
+            ("tls/tl1/Vinc", "tls/tl1/Vtotal", "tls/tl1/Itotal", "rxs/rx1/Ez"),
+        ),
+        (
+            "frill",
+            _magnetic_frill_scene,
+            ("frills/frill1/Vinc", "frills/frill1/Vtotal", "frills/frill1/Itot", "rxs/rx1/Ez"),
+        ),
+        (
+            "network",
+            _network_scene,
+            ("ports/feed/Vgenerator", "ports/feed/Vtotal", "ports/feed/Inetwork", "rxs/rx1/Ez"),
+        ),
+    ],
+)
+def test_source_study_matches_fresh_runs(tmp_path, name, factory, paths):
+    _run_reused(tmp_path, f"reused_{name}", factory)
+    for index, amplitude in enumerate((1.0, 0.5), start=1):
+        fresh, _ = factory(amplitude=amplitude)
+        gprMax.run(
+            scenes=[fresh],
+            outputfile=tmp_path / f"fresh_{name}_{index}",
+            hide_progress_bars=True,
+            log_level=30,
+            cpu_precision="double",
+        )
+        with h5py.File(tmp_path / f"reused_{name}{index}.h5") as reused, h5py.File(
+            tmp_path / f"fresh_{name}_{index}.h5"
+        ) as expected:
+            for path in paths:
+                np.testing.assert_allclose(reused[path], expected[path], rtol=3e-12, atol=3e-12)
+            resolved = json.loads(reused["study/resolved_case"][()].decode())
+            assert next(iter(resolved["objects"].values()))["scale"] == amplitude
+
+
+@pytest.mark.integration
+def test_source_study_multiple_drives_and_passive_omitted_terminal(tmp_path):
+    scene, (feed1, feed2) = _two_network_scene()
+    study = gprMax.SourceStudy(
+        [
+            gprMax.StudyCase("feed1", [gprMax.ObjectState(feed1, scale=1)]),
+            gprMax.StudyCase(
+                "both",
+                [gprMax.ObjectState(feed1, scale=1), gprMax.ObjectState(feed2, scale=0.5)],
+            ),
+        ]
+    )
+    gprMax.run(
+        scenes=[scene],
+        study=study,
+        outputfile=tmp_path / "reused_two",
+        hide_progress_bars=True,
+        log_level=30,
+        cpu_precision="double",
+    )
+
+    for index, amplitudes in enumerate(((1.0, 0.0), (1.0, 0.5)), start=1):
+        fresh, _ = _two_network_scene(amplitudes=amplitudes)
+        gprMax.run(
+            scenes=[fresh],
+            outputfile=tmp_path / f"fresh_two_{index}",
+            hide_progress_bars=True,
+            log_level=30,
+            cpu_precision="double",
+        )
+        with h5py.File(tmp_path / f"reused_two{index}.h5") as reused, h5py.File(
+            tmp_path / f"fresh_two_{index}.h5"
+        ) as expected:
+            for path in (
+                "ports/feed1/Vgenerator",
+                "ports/feed1/Vtotal",
+                "ports/feed2/Vgenerator",
+                "ports/feed2/Vtotal",
+                "rxs/rx1/Ez",
+            ):
+                np.testing.assert_allclose(reused[path], expected[path], rtol=3e-12, atol=3e-12)
+            if index == 1:
+                assert np.all(reused["ports/feed2/Vgenerator"][...] == 0)
+                assert np.max(np.abs(reused["ports/feed2/Vtotal"][...])) > 0
+
+
+@pytest.mark.integration
+def test_source_study_changes_waveform_and_drive_window_absolutely(tmp_path):
+    scene, excitation = _network_scene()
+    study = gprMax.SourceStudy(
+        [
+            gprMax.StudyCase("baseline", [gprMax.ObjectState(excitation)]),
+            gprMax.StudyCase(
+                "alternate",
+                [
+                    gprMax.ObjectState(
+                        excitation,
+                        waveform_id="w_alt",
+                        start=2e-11,
+                        stop=2e-10,
+                        scale=0.75,
+                    )
+                ],
+            ),
+        ]
+    )
+    gprMax.run(
+        scenes=[scene],
+        study=study,
+        outputfile=tmp_path / "reused_waveform",
+        hide_progress_bars=True,
+        log_level=30,
+        cpu_precision="double",
+    )
+
+    fresh, _ = _network_scene(
+        amplitude=0.75,
+        waveform_id="w_alt",
+        start=2e-11,
+        stop=2e-10,
+    )
+    gprMax.run(
+        scenes=[fresh],
+        outputfile=tmp_path / "fresh_waveform",
+        hide_progress_bars=True,
+        log_level=30,
+        cpu_precision="double",
+    )
+    with h5py.File(tmp_path / "reused_waveform2.h5") as reused, h5py.File(
+        tmp_path / "fresh_waveform.h5"
+    ) as expected:
+        for path in ("ports/feed/Vgenerator", "ports/feed/Vtotal", "rxs/rx1/Ez"):
+            np.testing.assert_allclose(reused[path], expected[path], rtol=3e-12, atol=3e-12)
+        resolved = json.loads(reused["study/resolved_case"][()].decode())
+        applied = resolved["objects"]["network_excitation_1"]
+        assert applied["waveform_id"] == "w_alt"
+        assert applied["start"] == 2e-11
+        assert applied["stop"] == 2e-10
+        assert applied["scale"] == 0.75
+
+
+@pytest.mark.integration
+def test_hash_source_study_runs_all_csv_cases(tmp_path):
+    cases = tmp_path / "source_cases.csv"
+    cases.write_text(
+        "case_id,object_id,active,scale\n"
+        "full,network_excitation_1,true,1\n"
+        "passive,network_excitation_1,false,1\n"
+    )
+    inputfile = tmp_path / "source_study.in"
+    inputfile.write_text(
+        "#title: reusable stateful-source study\n"
+        "#dx_dy_dz: 0.002 0.002 0.002\n"
+        "#domain: 0.02 0.02 0.02\n"
+        "#pml_cells: 2\n"
+        "#time_window: 4e-10\n"
+        "#waveform: ricker 1 5e9 w\n"
+        "#rational_network: source50 0.02 0 0\n"
+        "#network_terminal: z 0.01 0.01 0.01 source50 feed\n"
+        "#network_excitation: feed w\n"
+        "#network_port: feed 50\n"
+        f"#study: source {cases.name}\n"
+    )
+    gprMax.run(
+        inputfile=inputfile,
+        outputfile=tmp_path / "hash_source",
+        hide_progress_bars=True,
+        log_level=30,
+        cpu_precision="double",
+    )
+
+    for index, active in enumerate((True, False), start=1):
+        with h5py.File(tmp_path / f"hash_source{index}.h5") as output:
+            assert output["study"].attrs["Type"] == "source"
+            resolved = json.loads(output["study/resolved_case"][()].decode())
+            assert resolved["objects"]["network_excitation_1"]["active"] is active
+            assert output["srcs/src1"].attrs["StudyID"] == "network_excitation_1"
+            if active:
+                assert np.max(np.abs(output["ports/feed/Vgenerator"][...])) > 0
+            else:
+                assert np.all(output["ports/feed/Vgenerator"][...] == 0)
+
+
+def _network_ntff_scene(amplitude=1.0):
+    scene, excitation = _network_scene(amplitude=amplitude)
+    scene.add(
+        gprMax.NTFFSurface(
+            p1=(0.006,) * 3,
+            p2=(0.012,) * 3,
+            id="surface",
+            origin=(0.01,) * 3,
+        )
+    )
+    scene.add(gprMax.KSIRFrequencyTransform("surface", "spectrum", (5e9,), save_surface_dft=False))
+    scene.add(
+        gprMax.KSIRFarField(
+            theta=(90,),
+            phi=(0,),
+            transform_id="spectrum",
+            id="pattern",
+            outputs=("Etheta", "Ephi"),
+        )
+    )
+    return scene, excitation
+
+
+@pytest.mark.integration
+def test_source_study_recreates_declarative_ntff_state(tmp_path):
+    _run_reused(tmp_path, "reused_ntff", _network_ntff_scene)
+    path = "ntff/surface/frequency/spectrum/far_field/pattern/fields"
+    for index, amplitude in enumerate((1.0, 0.5), start=1):
+        fresh, _ = _network_ntff_scene(amplitude=amplitude)
+        gprMax.run(
+            scenes=[fresh],
+            outputfile=tmp_path / f"fresh_ntff_{index}",
+            hide_progress_bars=True,
+            log_level=30,
+            cpu_precision="double",
+        )
+        with h5py.File(tmp_path / f"reused_ntff{index}.h5") as reused, h5py.File(
+            tmp_path / f"fresh_ntff_{index}.h5"
+        ) as expected:
+            for component in ("Etheta", "Ephi"):
+                np.testing.assert_allclose(
+                    reused[f"{path}/{component}"],
+                    expected[f"{path}/{component}"],
+                    rtol=2e-11,
+                    atol=1e-18,
+                )
+
+
+def test_source_study_csv_and_validation(tmp_path):
+    table = tmp_path / "sources.csv"
+    table.write_text(
+        "case_id,object_id,active,waveform_id,start_s,stop_s,scale\n"
+        "full,transmission_line_1,true,w,0,2e-10,1\n"
+        "passive,transmission_line_1,false,w,0,2e-10,1\n"
+    )
+    study = gprMax.Study.from_csv("source", table)
+    assert isinstance(study, gprMax.SourceStudy)
+    assert study.cases[1].states[0].parameters["active"] is False
+
+    scene, source = _transmission_line_scene()
+    invalid = gprMax.SourceStudy(
+        [gprMax.StudyCase("move", [gprMax.ObjectState(source, position=(0.005,) * 3)])]
+    )
+    with pytest.raises(ValueError, match="does not support parameter.*position"):
+        invalid.bind_scene(scene)
+
+
+def test_source_study_rejects_subgrid_source():
+    scene, source = _transmission_line_scene()
+    subgrid = gprMax.SubGridHSG(
+        p1=(0.003,) * 3,
+        p2=(0.009,) * 3,
+        ratio=3,
+        id="fine",
+    )
+    subgrid.add(
+        gprMax.HertzianDipole(
+            polarisation="x",
+            p1=(0.006,) * 3,
+            waveform_id="w",
+        )
+    )
+    scene.add(subgrid)
+    study = gprMax.SourceStudy([gprMax.StudyCase("run", [gprMax.ObjectState(source, scale=1)])])
+    with pytest.raises(ValueError, match="HertzianDipole on subgrid 'fine'"):
+        study.bind_scene(scene)
+
+
+def _read_reused_field(tmp_path, name):
+    traces = []
+    for index in (1, 2):
+        with h5py.File(tmp_path / f"{name}{index}.h5") as output:
+            traces.append(output["rxs/rx1/Ez"][...])
+    return traces
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+@pytest.mark.parametrize("backend", ["cuda", "opencl"])
+@pytest.mark.parametrize(
+    ("name", "factory"),
+    [
+        ("tl", _transmission_line_scene),
+        ("frill", _magnetic_frill_scene),
+        ("network", _network_scene),
+    ],
+)
+def test_device_source_study_matches_cpu(tmp_path, request, backend, name, factory):
+    if backend == "cuda":
+        options = {"gpu": [request.getfixturevalue("gpu_device")]}
+    else:
+        options = {"opencl": [request.getfixturevalue("opencl_device")]}
+    cpu_name = f"cpu_{backend}_{name}"
+    device_name = f"{backend}_{name}"
+    _run_reused(tmp_path, cpu_name, factory, precision="single")
+    _run_reused(tmp_path, device_name, factory, precision="single", **options)
+
+    expected = _read_reused_field(tmp_path, cpu_name)
+    actual = _read_reused_field(tmp_path, device_name)
+    scale = max(float(np.max(np.abs(trace))) for trace in expected)
+    for cpu_trace, device_trace in zip(expected, actual):
+        np.testing.assert_allclose(
+            device_trace,
+            cpu_trace,
+            rtol=4e-4,
+            atol=max(scale, 1e-12) * 4e-4,
+        )


### PR DESCRIPTION
# PR Description

## Summary

This PR adds reusable-geometry source studies through the new `SourceStudy`
class and the `#study: source` hash command.

It enables repeated simulations of the same geometry while changing the
excitation of:

- transmission lines;
- magnetic-frill sources;
- rational-network excitations.

Each study case can independently control whether a source is active and
change its waveform, start time, stop time, and amplitude scale. Multiple
sources can be active simultaneously.

Sources omitted from a case remain physically present as passive
terminations. This supports applications such as multiport antenna studies,
mutual-coupling analysis, and array excitation studies without rebuilding
the geometry.

The implementation also:

- gives supported sources deterministic study identifiers;
- resets transmission-line, magnetic-frill, and rational-network histories
  between cases;
- resets receivers, ports, and declarative NTFF outputs correctly;
- records study identifiers in HDF5 output metadata;
- prevents unsupported source and subgrid configurations;
- documents the Python API, hash-command interface, and output structure;
- adds CPU, CUDA, and OpenCL regression coverage.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature which changes existing functionality)
- [x] This change requires a documentation update.

## Testing

- 73 focused CPU tests passed.
- 43 existing source tests passed.
- 7 PlaneWaveStudy regression tests passed.
- OpenCL source-study tests passed using the Intel CPU OpenCL device.
- CUDA coverage is included, but CUDA tests were skipped locally because
  the CUDA device was unavailable to the test environment.
- The Sphinx HTML documentation build completed successfully with no new
  warnings.
- Black, isort, and whitespace checks passed.

## Checklist

- [ ] Did pre-commit pass all checks? (Equivalent Black, isort, and whitespace checks passed locally.)
- [x] I have performed a self-review of my code.
- [x] I have added comments for hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The pull-request title is a short description of the changes.