### PR TITLE
Fix geometry construction in subgrids and MPI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,9 @@ jobs:
       - name: Configure Linux MPI transport
         if: runner.os == 'Linux'
         shell: bash
-        run: echo "FI_PROVIDER=shm" >> "$GITHUB_ENV"
+        run: |
+          echo "FI_PROVIDER=shm" >> "$GITHUB_ENV"
+          echo "UCX_TLS=self,sm" >> "$GITHUB_ENV"
 
       - name: Install gprMax and test dependencies
         run: |

--- a/gprMax/cython/geometry_primitives.pyx
+++ b/gprMax/cython/geometry_primitives.pyx
@@ -21,6 +21,7 @@
 import numpy as np
 
 cimport numpy as np
+from libc.math cimport ceil, cos, sin
 
 np.seterr(divide='raise')
 
@@ -40,10 +41,10 @@ from gprMax.utilities.utilities import round_value
 
 
 cpdef bint are_clockwise(
-    float v1x,
-    float v1y,
-    float v2x,
-    float v2y
+    double v1x,
+    double v1y,
+    double v2x,
+    double v2y
 ):
     """Find if vector 2 is clockwise relative to vector 1.
 
@@ -58,9 +59,9 @@ cpdef bint are_clockwise(
 
 
 cpdef bint is_within_radius(
-    float vx,
-    float vy,
-    float radius
+    double vx,
+    double vy,
+    double radius
 ):
     """Check if the point is within a given radius of the centre of the circle.
 
@@ -76,13 +77,13 @@ cpdef bint is_within_radius(
 
 
 cpdef bint is_inside_sector(
-    float px,
-    float py,
-    float ctrx,
-    float ctry,
-    float sectorstartangle,
-    float sectorangle,
-    float radius
+    double px,
+    double py,
+    double ctrx,
+    double ctry,
+    double sectorstartangle,
+    double sectorangle,
+    double radius
 ):
     """For a point to be inside a circular sector, it has to meet the following tests:
         It has to be positioned anti-clockwise from the start "arm" of the sector
@@ -102,12 +103,12 @@ cpdef bint is_inside_sector(
         (boolean)
     """
 
-    cdef float sectorstart1, sectorstart2, sectorend1, sectorend2, relpoint1, relpoint2
+    cdef double sectorstart1, sectorstart2, sectorend1, sectorend2, relpoint1, relpoint2
 
-    sectorstart1 = radius * np.cos(sectorstartangle)
-    sectorstart2 = radius * np.sin(sectorstartangle)
-    sectorend1 = radius * np.cos(sectorstartangle + sectorangle)
-    sectorend2 = radius * np.sin(sectorstartangle + sectorangle)
+    sectorstart1 = radius * cos(sectorstartangle)
+    sectorstart2 = radius * sin(sectorstartangle)
+    sectorend1 = radius * cos(sectorstartangle + sectorangle)
+    sectorend2 = radius * sin(sectorstartangle + sectorangle)
     relpoint1 = px - ctrx
     relpoint2 = py - ctry
 
@@ -482,20 +483,20 @@ cpdef void build_voxel(
 
 
 cpdef void build_triangle(
-    float x1,
-    float y1,
-    float z1,
-    float x2,
-    float y2,
-    float z2,
-    float x3,
-    float y3,
-    float z3,
+    double x1,
+    double y1,
+    double z1,
+    double x2,
+    double y2,
+    double z2,
+    double x3,
+    double y3,
+    double z3,
     str normal,
-    float thickness,
-    float dx,
-    float dy,
-    float dz,
+    double thickness,
+    double dx,
+    double dy,
+    double dz,
     int numID,
     int numIDx,
     int numIDy,
@@ -528,52 +529,44 @@ cpdef void build_triangle(
     """
 
     cdef Py_ssize_t i, j, k
-    cdef int i1, i2, j1, j2, sign, levelcells, thicknesscells
-    cdef float area, s, t
+    cdef int i1, i2, j1, j2, levelcells, thicknesscells
+    cdef int u1, v1, u2, v2, u3, v3
+    cdef double bu, bv, cu, cv, qu, qv, denominator, s, t
 
-    # Calculate a bounding box for the triangle
+    # Work from snapped cell indices and relative coordinates. This avoids
+    # subtracting large absolute floating-point coordinates, so translating an
+    # otherwise identical object into an MPI rank or subgrid cannot change
+    # which cell centres lie inside the triangle.
     if normal == 'x':
-        area = 0.5 * (-z2 * y3 + z1 * (-y2 + y3) + y1 * (z2 - z3) + y2 * z3)
-        i1 = round_value(np.amin([y1, y2, y3]) / dy) - 1
-        i2 = round_value(np.amax([y1, y2, y3]) / dy) + 1
-        j1 = round_value(np.amin([z1, z2, z3]) / dz) - 1
-        j2 = round_value(np.amax([z1, z2, z3]) / dz) + 1
+        u1, u2, u3 = round_value(y1 / dy), round_value(y2 / dy), round_value(y3 / dy)
+        v1, v2, v3 = round_value(z1 / dz), round_value(z2 / dz), round_value(z3 / dz)
+        i1, i2 = min(u1, u2, u3) - 1, max(u1, u2, u3) + 1
+        j1, j2 = min(v1, v2, v3) - 1, max(v1, v2, v3) + 1
         levelcells = round_value(x1 / dx)
         thicknesscells = round_value(thickness / dx)
-
-        # Bound to the size of the grid
-        if i2 > solid.shape[1]:
-            i2 = solid.shape[1]
-        if j2 > solid.shape[2]:
-            j2 = solid.shape[2]
+        bu, bv = (u2 - u1) * dy, (v2 - v1) * dz
+        cu, cv = (u3 - u1) * dy, (v3 - v1) * dz
+        i2, j2 = min(i2, solid.shape[1]), min(j2, solid.shape[2])
     elif normal == 'y':
-        area = 0.5 * (-z2 * x3 + z1 * (-x2 + x3) + x1 * (z2 - z3) + x2 * z3)
-        i1 = round_value(np.amin([x1, x2, x3]) / dx) - 1
-        i2 = round_value(np.amax([x1, x2, x3]) / dx) + 1
-        j1 = round_value(np.amin([z1, z2, z3]) / dz) - 1
-        j2 = round_value(np.amax([z1, z2, z3]) / dz) + 1
+        u1, u2, u3 = round_value(x1 / dx), round_value(x2 / dx), round_value(x3 / dx)
+        v1, v2, v3 = round_value(z1 / dz), round_value(z2 / dz), round_value(z3 / dz)
+        i1, i2 = min(u1, u2, u3) - 1, max(u1, u2, u3) + 1
+        j1, j2 = min(v1, v2, v3) - 1, max(v1, v2, v3) + 1
         levelcells = round_value(y1 /dy)
         thicknesscells = round_value(thickness / dy)
-
-        # Bound to the size of the grid
-        if i2 > solid.shape[0]:
-            i2 = solid.shape[0]
-        if j2 > solid.shape[2]:
-            j2 = solid.shape[2]
+        bu, bv = (u2 - u1) * dx, (v2 - v1) * dz
+        cu, cv = (u3 - u1) * dx, (v3 - v1) * dz
+        i2, j2 = min(i2, solid.shape[0]), min(j2, solid.shape[2])
     elif normal == 'z':
-        area = 0.5 * (-y2 * x3 + y1 * (-x2 + x3) + x1 * (y2 - y3) + x2 * y3)
-        i1 = round_value(np.amin([x1, x2, x3]) / dx) - 1
-        i2 = round_value(np.amax([x1, x2, x3]) / dx) + 1
-        j1 = round_value(np.amin([y1, y2, y3]) / dy) - 1
-        j2 = round_value(np.amax([y1, y2, y3]) / dy) + 1
+        u1, u2, u3 = round_value(x1 / dx), round_value(x2 / dx), round_value(x3 / dx)
+        v1, v2, v3 = round_value(y1 / dy), round_value(y2 / dy), round_value(y3 / dy)
+        i1, i2 = min(u1, u2, u3) - 1, max(u1, u2, u3) + 1
+        j1, j2 = min(v1, v2, v3) - 1, max(v1, v2, v3) + 1
         levelcells = round_value(z1 / dz)
         thicknesscells = round_value(thickness / dz)
-
-        # Bound to the size of the grid
-        if i2 > solid.shape[0]:
-            i2 = solid.shape[0]
-        if j2 > solid.shape[1]:
-            j2 = solid.shape[1]
+        bu, bv = (u2 - u1) * dx, (v2 - v1) * dy
+        cu, cv = (u3 - u1) * dx, (v3 - v1) * dy
+        i2, j2 = min(i2, solid.shape[0]), min(j2, solid.shape[1])
 
     # Bound to the start of the grid
     if i1 < 0:
@@ -581,31 +574,25 @@ cpdef void build_triangle(
     if j1 < 0:
         j1 = 0
 
-    sign = np.sign(area)
+    denominator = bu * cv - bv * cu
+    if denominator == 0:
+        return
 
     for i in range(i1, i2):
         for j in range(j1, j2):
-
-            # Calculate the areas of the 3 triangles defined by the 3 vertices
-            # of the main triangle and the point under test.
             if normal == 'x':
-                ir = (i + 0.5) * dy
-                jr = (j + 0.5) * dz
-                s = sign * (z1 * y3 - y1 * z3 + (z3 - z1) * ir + (y1 - y3) * jr);
-                t = sign * (y1 * z2 - z1 * y2 + (z1 - z2) * ir + (y2 - y1) * jr);
+                qu, qv = (i + 0.5 - u1) * dy, (j + 0.5 - v1) * dz
             elif normal == 'y':
-                ir = (i + 0.5) * dx
-                jr = (j + 0.5) * dz
-                s = sign * (z1 * x3 - x1 * z3 + (z3 - z1) * ir + (x1 - x3) * jr);
-                t = sign * (x1 * z2 - z1 * x2 + (z1 - z2) * ir + (x2 - x1) * jr);
+                qu, qv = (i + 0.5 - u1) * dx, (j + 0.5 - v1) * dz
             elif normal == 'z':
-                ir = (i + 0.5) * dx
-                jr = (j + 0.5) * dy
-                s = sign * (y1 * x3 - x1 * y3 + (y3 - y1) * ir + (x1 - x3) * jr);
-                t = sign * (x1 * y2 - y1 * x2 + (y1 - y2) * ir + (x2 - x1) * jr);
+                qu, qv = (i + 0.5 - u1) * dx, (j + 0.5 - v1) * dy
 
-            # If these conditions are true then point is inside triangle
-            if s > 0 and t > 0 and (s + t) < 2 * area * sign:
+            s = (qu * cv - qv * cu) / denominator
+            t = (bu * qv - bv * qu) / denominator
+
+            # Preserve the historical strict-edge convention: cells whose
+            # centres lie exactly on an edge are not filled.
+            if s > 0 and t > 0 and (s + t) < 1:
                 if thicknesscells == 0:
                     if normal == 'x':
                         build_face_yz(levelcells, i, j, numIDy, numIDz,
@@ -633,17 +620,17 @@ cpdef void build_triangle(
 
 
 cpdef void build_cylindrical_sector(
-    float ctr1,
-    float ctr2,
-    float level,
-    float sectorstartangle,
-    float sectorangle,
-    float radius,
+    double ctr1,
+    double ctr2,
+    double level,
+    double sectorstartangle,
+    double sectorangle,
+    double radius,
     str normal,
-    float thickness,
-    float dx,
-    float dy,
-    float dz,
+    double thickness,
+    double dx,
+    double dy,
+    double dz,
     int numID,
     int numIDx,
     int numIDy,
@@ -683,15 +670,17 @@ cpdef void build_cylindrical_sector(
     """
 
     cdef Py_ssize_t x, y, z
-    cdef int x1, x2, y1, y2, z1, z2, thicknesscells
+    cdef int x1, x2, y1, y2, z1, z2, thicknesscells, ctr1cell, ctr2cell
+    cdef int radiuscells1, radiuscells2
+    cdef double rel1, rel2
 
     if normal == 'x':
         # Angles are defined from zero degrees on the positive y-axis going
         # towards positive z-axis.
-        y1 = round_value((ctr1 - radius)/dy)
-        y2 = round_value((ctr1 + radius)/dy)
-        z1 = round_value((ctr2 - radius)/dz)
-        z2 = round_value((ctr2 + radius)/dz)
+        ctr1cell, ctr2cell = round_value(ctr1 / dy), round_value(ctr2 / dz)
+        radiuscells1, radiuscells2 = <int>ceil(radius / dy), <int>ceil(radius / dz)
+        y1, y2 = ctr1cell - radiuscells1 - 1, ctr1cell + radiuscells1 + 1
+        z1, z2 = ctr2cell - radiuscells2 - 1, ctr2cell + radiuscells2 + 1
         levelcells = round_value(level / dx)
         thicknesscells = round_value(thickness / dx)
 
@@ -707,8 +696,8 @@ cpdef void build_cylindrical_sector(
 
         for y in range(y1, y2):
             for z in range(z1, z2):
-                if is_inside_sector(y * dy + 0.5 * dy, z * dz + 0.5 * dz, ctr1,
-                                    ctr2, sectorstartangle, sectorangle, radius):
+                rel1, rel2 = (y + 0.5 - ctr1cell) * dy, (z + 0.5 - ctr2cell) * dz
+                if is_inside_sector(rel1, rel2, 0, 0, sectorstartangle, sectorangle, radius):
                     if thicknesscells == 0:
                         build_face_yz(levelcells, y, z, numIDy, numIDz,
                                       rigidE, rigidH, ID)
@@ -721,10 +710,10 @@ cpdef void build_cylindrical_sector(
     elif normal == 'y':
         # Angles are defined from zero degrees on the positive x-axis going
         # towards positive z-axis.
-        x1 = round_value((ctr1 - radius)/dx)
-        x2 = round_value((ctr1 + radius)/dx)
-        z1 = round_value((ctr2 - radius)/dz)
-        z2 = round_value((ctr2 + radius)/dz)
+        ctr1cell, ctr2cell = round_value(ctr1 / dx), round_value(ctr2 / dz)
+        radiuscells1, radiuscells2 = <int>ceil(radius / dx), <int>ceil(radius / dz)
+        x1, x2 = ctr1cell - radiuscells1 - 1, ctr1cell + radiuscells1 + 1
+        z1, z2 = ctr2cell - radiuscells2 - 1, ctr2cell + radiuscells2 + 1
         levelcells = round_value(level / dy)
         thicknesscells = round_value(thickness / dy)
 
@@ -740,8 +729,8 @@ cpdef void build_cylindrical_sector(
 
         for x in range(x1, x2):
             for z in range(z1, z2):
-                if is_inside_sector(x * dx + 0.5 * dx, z * dz + 0.5 * dz, ctr1,
-                                    ctr2, sectorstartangle, sectorangle, radius):
+                rel1, rel2 = (x + 0.5 - ctr1cell) * dx, (z + 0.5 - ctr2cell) * dz
+                if is_inside_sector(rel1, rel2, 0, 0, sectorstartangle, sectorangle, radius):
                     if thicknesscells == 0:
                         build_face_xz(x, levelcells, z, numIDx, numIDz,
                                       rigidE, rigidH, ID)
@@ -754,10 +743,10 @@ cpdef void build_cylindrical_sector(
     elif normal == 'z':
         # Angles are defined from zero degrees on the positive x-axis going
         # towards positive y-axis.
-        x1 = round_value((ctr1 - radius)/dx)
-        x2 = round_value((ctr1 + radius)/dx)
-        y1 = round_value((ctr2 - radius)/dy)
-        y2 = round_value((ctr2 + radius)/dy)
+        ctr1cell, ctr2cell = round_value(ctr1 / dx), round_value(ctr2 / dy)
+        radiuscells1, radiuscells2 = <int>ceil(radius / dx), <int>ceil(radius / dy)
+        x1, x2 = ctr1cell - radiuscells1 - 1, ctr1cell + radiuscells1 + 1
+        y1, y2 = ctr2cell - radiuscells2 - 1, ctr2cell + radiuscells2 + 1
         levelcells = round_value(level / dz)
         thicknesscells = round_value(thickness / dz)
 
@@ -773,8 +762,8 @@ cpdef void build_cylindrical_sector(
 
         for x in range(x1, x2):
             for y in range(y1, y2):
-                if is_inside_sector(x * dx + 0.5 * dx, y * dy + 0.5 * dy, ctr1,
-                                    ctr2, sectorstartangle, sectorangle, radius):
+                rel1, rel2 = (x + 0.5 - ctr1cell) * dx, (y + 0.5 - ctr2cell) * dy
+                if is_inside_sector(rel1, rel2, 0, 0, sectorstartangle, sectorangle, radius):
                     if thicknesscells == 0:
                         build_face_xy(x, y, levelcells, numIDx, numIDy,
                                       rigidE, rigidH, ID)
@@ -887,16 +876,16 @@ cpdef void build_box(
 
 
 cpdef void build_cylinder(
-    float x1,
-    float y1,
-    float z1,
-    float x2,
-    float y2,
-    float z2,
-    float r,
-    float dx,
-    float dy,
-    float dz,
+    double x1,
+    double y1,
+    double z1,
+    double x2,
+    double y2,
+    double z2,
+    double r,
+    double dx,
+    double dy,
+    double dz,
     int numID,
     int numIDx,
     int numIDy,
@@ -927,183 +916,51 @@ cpdef void build_cylinder(
     """
 
     cdef Py_ssize_t i, j, k
-    cdef int xs, xf, ys, yf, zs, zf, xc, yc, zc
-    cdef float f1f2mag, f2f1mag, f1ptmag, f2ptmag, dot1, dot2, factor1, factor2
-    cdef float theta1, theta2, distance1, distance2
-    cdef bint build, x_align, y_align, z_align
-    cdef np.ndarray f1f2, f2f1, f1pt, f2pt
+    cdef int xs, xf, ys, yf, zs, zf
+    cdef int ix1, iy1, iz1, ix2, iy2, iz2
+    cdef int rx, ry, rz
+    cdef double ax, ay, az, axis2, qx, qy, qz, projection, t
+    cdef double radial2, radius2
 
-    # Check if cylinder is aligned with an axis
-    x_align = y_align = z_align = 0
-    # x-aligned
-    if (round_value(y1 / dy) == round_value(y2 / dy) and
-        round_value(z1 / dz) == round_value(z2 / dz)):
-        x_align = 1
+    ix1, iy1, iz1 = round_value(x1 / dx), round_value(y1 / dy), round_value(z1 / dz)
+    ix2, iy2, iz2 = round_value(x2 / dx), round_value(y2 / dy), round_value(z2 / dz)
+    ax, ay, az = (ix2 - ix1) * dx, (iy2 - iy1) * dy, (iz2 - iz1) * dz
+    axis2 = ax * ax + ay * ay + az * az
+    if axis2 == 0:
+        return
 
-    # y-aligned
-    elif (round_value(x1 / dx) == round_value(x2 / dx) and
-          round_value(z1 / dz) == round_value(z2 / dz)):
-        y_align = 1
+    rx, ry, rz = <int>ceil(r / dx), <int>ceil(r / dy), <int>ceil(r / dz)
+    xs, xf = max(0, min(ix1, ix2) - rx - 1), min(solid.shape[0], max(ix1, ix2) + rx + 1)
+    ys, yf = max(0, min(iy1, iy2) - ry - 1), min(solid.shape[1], max(iy1, iy2) + ry + 1)
+    zs, zf = max(0, min(iz1, iz2) - rz - 1), min(solid.shape[2], max(iz1, iz2) + rz + 1)
+    radius2 = r * r
 
-    # z-aligned
-    elif (round_value(x1 / dx) == round_value(x2 / dx) and
-          round_value(y1 / dy) == round_value(y2 / dy)):
-        z_align = 1
-
-    # Calculate a bounding box for the cylinder
-    if x1 < x2:
-        if x_align:
-            xs = round_value(x1 / dx)
-            xf = round_value(x2 / dx)
-        else:
-            xs = round_value((x1 - r) / dx) - 1
-            xf = round_value((x2 + r) / dx) + 1
-    else:
-        if x_align:
-            xs = round_value(x2 / dx)
-            xf = round_value(x1 / dx)
-        else:
-            xs = round_value((x2 - r) / dx) - 1
-            xf = round_value((x1 + r) / dx) + 1
-    if y1 < y2:
-        if y_align:
-            ys = round_value(y1 / dy)
-            yf = round_value(y2 / dy)
-        else:
-            ys = round_value((y1 - r) / dy) - 1
-            yf = round_value((y2 + r) / dy) + 1
-    else:
-        if y_align:
-            ys = round_value(y2 / dy)
-            yf = round_value(y1 / dy)
-        else:
-            ys = round_value((y2 - r) / dy) - 1
-            yf = round_value((y1 + r) / dy) + 1
-    if z1 < z2:
-        if z_align:
-            zs = round_value(z1 / dz)
-            zf = round_value(z2 / dz)
-        else:
-            zs = round_value((z1 - r) / dz) - 1
-            zf = round_value((z2 + r) / dz) + 1
-    else:
-        if z_align:
-            zs = round_value(z2 / dz)
-            zf = round_value(z1 / dz)
-        else:
-            zs = round_value((z2 - r) / dz) - 1
-            zf = round_value((z1 + r) / dz) + 1
-
-    # Set bounds to domain if they outside
-    if xs < 0:
-        xs = 0
-    if xf > solid.shape[0]:
-        xf = solid.shape[0]
-    if ys < 0:
-        ys = 0
-    if yf > solid.shape[1]:
-        yf = solid.shape[1]
-    if zs < 0:
-        zs = 0
-    if zf > solid.shape[2]:
-        zf = solid.shape[2]
-
-    # x-aligned cylinder
-    if x_align:
+    for i in range(xs, xf):
         for j in range(ys, yf):
             for k in range(zs, zf):
-                if np.sqrt((j * dy + 0.5 * dy - y1)**2 + (k * dz + 0.5 * dz - z1)**2) <= r:
-                    for i in range(xs, xf):
-                        build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
-                                    averaging, pec_x, pec_y, pec_z,
-                                    solid, rigidE, rigidH, ID)
-    # y-aligned cylinder
-    elif y_align:
-        for i in range(xs, xf):
-            for k in range(zs, zf):
-                if np.sqrt((i * dx + 0.5 * dx - x1)**2 + (k * dz + 0.5 * dz - z1)**2) <= r:
-                    for j in range(ys, yf):
-                        build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
-                                    averaging, pec_x, pec_y, pec_z,
-                                    solid, rigidE, rigidH, ID)
-    # z-aligned cylinder
-    elif z_align:
-        for i in range(xs, xf):
-            for j in range(ys, yf):
-                if np.sqrt((i * dx + 0.5 * dx - x1)**2 + (j * dy + 0.5 * dy - y1)**2) <= r:
-                    for k in range(zs, zf):
-                        build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
-                                    averaging, pec_x, pec_y, pec_z,
-                                    solid, rigidE, rigidH, ID)
-
-    # Not aligned with any axis
-    else:
-        # Vectors between centres of cylinder faces
-        f1f2 = np.array([x2 - x1, y2 - y1, z2 - z1], dtype=np.float32)
-        f2f1 = np.array([x1 - x2, y1 - y2, z1 - z2], dtype=np.float32)
-
-        # Magnitudes
-        f1f2mag = np.sqrt((f1f2*f1f2).sum(axis=0))
-        f2f1mag = np.sqrt((f2f1*f2f1).sum(axis=0))
-
-        for i in range(xs, xf):
-            for j in range(ys, yf):
-                for k in range(zs, zf):
-                    # Build flag - default false, set to True if point is in cylinder
-                    build = 0
-                    # Vector from centre of first cylinder face to test point
-                    f1pt = np.array([i * dx + 0.5 * dx - x1,
-                                     j * dy + 0.5 * dy - y1,
-                                     k * dz + 0.5 * dz - z1], dtype=np.float32)
-                    # Vector from centre of second cylinder face to test point
-                    f2pt = np.array([i * dx + 0.5 * dx - x2,
-                                     j * dy + 0.5 * dy - y2,
-                                     k * dz + 0.5 * dz - z2], dtype=np.float32)
-                    # Magnitudes
-                    f1ptmag = np.sqrt((f1pt*f1pt).sum(axis=0))
-                    f2ptmag = np.sqrt((f2pt*f2pt).sum(axis=0))
-                    # Dot products
-                    dot1 = np.dot(f1f2, f1pt)
-                    dot2 = np.dot(f2f1, f2pt)
-
-                    if f1ptmag == 0 or f2ptmag == 0:
-                        build = 1
-                    else:
-                        factor1 = dot1 / (f1f2mag * f1ptmag)
-                        factor2 = dot2 / (f2f1mag * f2ptmag)
-                        # Catch cases where either factor1 or factor2 are 1
-                        try:
-                            theta1 = np.arccos(factor1)
-                        except FloatingPointError:
-                            theta1 = 0
-                        try:
-                            theta2 = np.arccos(factor2)
-                        except FloatingPointError:
-                            theta2 = 0
-                        distance1 = f1ptmag * np.sin(theta1)
-                        distance2 = f2ptmag * np.sin(theta2)
-                        if ((distance1 <= r or distance2 <= r) and
-                            theta1 <= np.pi/2 and theta2 <= np.pi/2):
-                            build = 1
-
-                    if build:
+                qx, qy, qz = (i + 0.5 - ix1) * dx, (j + 0.5 - iy1) * dy, (k + 0.5 - iz1) * dz
+                projection = qx * ax + qy * ay + qz * az
+                t = projection / axis2
+                if 0 <= t <= 1:
+                    radial2 = qx * qx + qy * qy + qz * qz - projection * projection / axis2
+                    if radial2 <= radius2:
                         build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
                                     averaging, pec_x, pec_y, pec_z,
                                     solid, rigidE, rigidH, ID)
 
 
 cpdef void build_cone(
-    float x1,
-    float y1,
-    float z1,
-    float x2,
-    float y2,
-    float z2,
-    float r1,
-    float r2,
-    float dx,
-    float dy,
-    float dz,
+    double x1,
+    double y1,
+    double z1,
+    double x2,
+    double y2,
+    double z2,
+    double r1,
+    double r2,
+    double dx,
+    double dy,
+    double dz,
     int numID,
     int numIDx,
     int numIDy,
@@ -1135,184 +992,35 @@ cpdef void build_cone(
     """
 
     cdef Py_ssize_t i, j, k
-    cdef int xs, xf, ys, yf, zs, zf, xs_bound, xf_bound, ys_bound, yf_bound, zs_bound, zf_bound
-    cdef float f1f2mag, f2f1mag, f1ptmag, f2ptmag, dot1, dot2, factor1, factor2
-    cdef float theta1, theta2, distance1, distance2, R1, R2
-    cdef float height, distance_axis_1, distance_axis_2
-    cdef bint build, x_align, y_align, z_align
-    cdef np.ndarray f1f2, f2f1, f1pt, f2pt
-    cdef float Rmax
+    cdef int xs, xf, ys, yf, zs, zf
+    cdef int ix1, iy1, iz1, ix2, iy2, iz2
+    cdef int rx, ry, rz
+    cdef double ax, ay, az, axis2, qx, qy, qz, projection, t
+    cdef double radial2, radius, Rmax
 
-    Rmax = np.amax([r1, r2])
+    ix1, iy1, iz1 = round_value(x1 / dx), round_value(y1 / dy), round_value(z1 / dz)
+    ix2, iy2, iz2 = round_value(x2 / dx), round_value(y2 / dy), round_value(z2 / dz)
+    ax, ay, az = (ix2 - ix1) * dx, (iy2 - iy1) * dy, (iz2 - iz1) * dz
+    axis2 = ax * ax + ay * ay + az * az
+    if axis2 == 0:
+        return
 
-    # Check if cone is aligned with an axis
-    x_align = y_align = z_align = 0
-    # x-aligned
-    if (round_value(y1 / dy) == round_value(y2 / dy) and
-        round_value(z1 / dz) == round_value(z2 / dz)):
-        x_align = 1
+    Rmax = max(r1, r2)
+    rx, ry, rz = <int>ceil(Rmax / dx), <int>ceil(Rmax / dy), <int>ceil(Rmax / dz)
+    xs, xf = max(0, min(ix1, ix2) - rx - 1), min(solid.shape[0], max(ix1, ix2) + rx + 1)
+    ys, yf = max(0, min(iy1, iy2) - ry - 1), min(solid.shape[1], max(iy1, iy2) + ry + 1)
+    zs, zf = max(0, min(iz1, iz2) - rz - 1), min(solid.shape[2], max(iz1, iz2) + rz + 1)
 
-    # y-aligned
-    elif (round_value(x1 / dx) == round_value(x2 / dx) and
-          round_value(z1 / dz) == round_value(z2 / dz)):
-        y_align = 1
-
-    # z-aligned
-    elif (round_value(x1 / dx) == round_value(x2 / dx) and
-          round_value(y1 / dy) == round_value(y2 / dy)):
-        z_align = 1
-
-    # Calculate a bounding box for the cone
-    if x1 < x2:
-        if x_align:
-            xs = round_value(x1 / dx)
-            xf = round_value(x2 / dx)
-        else:
-            xs = round_value((x1 - Rmax) / dx) - 1
-            xf = round_value((x2 + Rmax) / dx) + 1
-    else:
-        if x_align:
-            xs = round_value(x2 / dx)
-            xf = round_value(x1 / dx)
-        else:
-            xs = round_value((x2 - Rmax) / dx) - 1
-            xf = round_value((x1 + Rmax) / dx) + 1
-    if y1 < y2:
-        if y_align:
-            ys = round_value(y1 / dy)
-            yf = round_value(y2 / dy)
-        else:
-            ys = round_value((y1 - Rmax) / dy) - 1
-            yf = round_value((y2 + Rmax) / dy) + 1
-    else:
-        if y_align:
-            ys = round_value(y2 / dy)
-            yf = round_value(y1 / dy)
-        else:
-            ys = round_value((y2 - Rmax) / dy) - 1
-            yf = round_value((y1 + Rmax) / dy) + 1
-    if z1 < z2:
-        if z_align:
-            zs = round_value(z1 / dz)
-            zf = round_value(z2 / dz)
-        else:
-            zs = round_value((z1 - Rmax) / dz) - 1
-            zf = round_value((z2 + Rmax) / dz) + 1
-    else:
-        if z_align:
-            zs = round_value(z2 / dz)
-            zf = round_value(z1 / dz)
-        else:
-            zs = round_value((z2 - Rmax) / dz) - 1
-            zf = round_value((z1 + Rmax) / dz) + 1
-
-    xs_bound = xs
-    xf_bound = xf
-    ys_bound = ys
-    yf_bound = yf
-    zs_bound = zs
-    zf_bound = zf
-
-    # Set bounds to domain if they outside
-    if xs_bound < 0:
-        xs_bound = 0
-    if xf_bound > solid.shape[0]:
-        xf_bound = solid.shape[0]
-    if ys_bound < 0:
-        ys_bound = 0
-    if yf_bound > solid.shape[1]:
-        yf_bound = solid.shape[1]
-    if zs_bound < 0:
-        zs_bound = 0
-    if zf_bound > solid.shape[2]:
-        zf_bound = solid.shape[2]
-
-    # x-aligned cone
-    if x_align:
-        for j in range(ys_bound, yf_bound):
-            for k in range(zs_bound, zf_bound):
-                for i in range(xs_bound, xf_bound):
-                    if np.sqrt((j * dy + 0.5 * dy - y1)**2 + (k * dz + 0.5 * dz - z1)**2) <= ((i- xs)/(xf-xs))*(r2-r1) + r1:
-                        build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
-                                    averaging, pec_x, pec_y, pec_z,
-                                    solid, rigidE, rigidH, ID)
-    # y-aligned cone
-    elif y_align:
-        for i in range(xs_bound, xf_bound):
-            for k in range(zs_bound, zf_bound):
-                for j in range(ys_bound, yf_bound):
-                    if np.sqrt((i * dx + 0.5 * dx - x1)**2 + (k * dz + 0.5 * dz - z1)**2) <= ((j-ys)/(yf-ys))*(r2-r1) + r1:
-                        build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
-                                    averaging, pec_x, pec_y, pec_z,
-                                    solid, rigidE, rigidH, ID)
-    # z-aligned cone
-    elif z_align:
-        for i in range(xs_bound, xf_bound):
-            for j in range(ys_bound, yf_bound):
-                for k in range(zs_bound, zf_bound):
-                    if np.sqrt((i * dx + 0.5 * dx - x1)**2 + (j * dy + 0.5 * dy - y1)**2) <= ((k-zs)/(zf-zs))*(r2-r1) + r1:
-                        build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
-                                    averaging, pec_x, pec_y, pec_z,
-                                    solid, rigidE, rigidH, ID)
-
-    # Not aligned with any axis
-    else:
-        # Vectors between centres of cone faces
-        f1f2 = np.array([x2 - x1, y2 - y1, z2 - z1], dtype=np.float32)
-        f2f1 = np.array([x1 - x2, y1 - y2, z1 - z2], dtype=np.float32)
-
-        # Magnitudes
-        f1f2mag = np.sqrt((f1f2*f1f2).sum(axis=0))
-        f2f1mag = np.sqrt((f2f1*f2f1).sum(axis=0))
-
-        height = f1f2mag
-
-        for i in range(xs_bound, xf_bound):
-            for j in range(ys_bound, yf_bound):
-                for k in range(zs_bound, zf_bound):
-                    # Build flag - default false, set to True if point is in cone
-                    build = 0
-                    # Vector from centre of first cone face to test point
-                    f1pt = np.array([i * dx + 0.5 * dx - x1,
-                                     j * dy + 0.5 * dy - y1,
-                                     k * dz + 0.5 * dz - z1], dtype=np.float32)
-                    # Vector from centre of second cone face to test point
-                    f2pt = np.array([i * dx + 0.5 * dx - x2,
-                                     j * dy + 0.5 * dy - y2,
-                                     k * dz + 0.5 * dz - z2], dtype=np.float32)
-                    # Magnitudes
-                    f1ptmag = np.sqrt((f1pt*f1pt).sum(axis=0))
-                    f2ptmag = np.sqrt((f2pt*f2pt).sum(axis=0))
-                    # Dot products
-                    dot1 = np.dot(f1f2, f1pt)
-                    dot2 = np.dot(f2f1, f2pt)
-
-                    if f1ptmag == 0 or f2ptmag == 0:
-                        build = 1
-                    else:
-                        factor1 = dot1 / (f1f2mag * f1ptmag)
-                        factor2 = dot2 / (f2f1mag * f2ptmag)
-                        # Catch cases where either factor1 or factor2 are 1
-                        try:
-                            theta1 = np.arccos(factor1)
-                        except FloatingPointError:
-                            theta1 = 0
-                        try:
-                            theta2 = np.arccos(factor2)
-                        except FloatingPointError:
-                            theta2 = 0
-                        distance1 = f1ptmag * np.sin(theta1)
-                        distance2 = f2ptmag * np.sin(theta2)
-                        distance_axis_1 = f1ptmag * np.cos(theta1)
-                        distance_axis_2 = f2ptmag * np.cos(theta2)
-                        R1 = r1
-                        R2 = r2
-
-                        if ((distance1 <= (distance_axis_1/height)*(R2 - R1) + R1 or distance2 <= (distance_axis_2/height)*(R1 - R2) + R2) and
-                            theta1 <= np.pi/2 and theta2 <= np.pi/2):
-                            build = 1
-
-                    if build:
+    for i in range(xs, xf):
+        for j in range(ys, yf):
+            for k in range(zs, zf):
+                qx, qy, qz = (i + 0.5 - ix1) * dx, (j + 0.5 - iy1) * dy, (k + 0.5 - iz1) * dz
+                projection = qx * ax + qy * ay + qz * az
+                t = projection / axis2
+                if 0 <= t <= 1:
+                    radius = r1 + t * (r2 - r1)
+                    radial2 = qx * qx + qy * qy + qz * qz - projection * projection / axis2
+                    if radial2 <= radius * radius:
                         build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
                                     averaging, pec_x, pec_y, pec_z,
                                     solid, rigidE, rigidH, ID)
@@ -1322,10 +1030,10 @@ cpdef void build_sphere(
     int xc,
     int yc,
     int zc,
-    float r,
-    float dx,
-    float dy,
-    float dz,
+    double r,
+    double dx,
+    double dy,
+    double dz,
     int numID,
     int numIDx,
     int numIDy,
@@ -1355,15 +1063,14 @@ cpdef void build_sphere(
     """
 
     cdef Py_ssize_t i, j, k
-    cdef int xs, xf, ys, yf, zs, zf
+    cdef int xs, xf, ys, yf, zs, zf, rx, ry, rz
+    cdef double qx, qy, qz
 
     # Calculate a bounding box for sphere
-    xs = round_value(((xc * dx) - r) / dx) - 1
-    xf = round_value(((xc * dx) + r) / dx) + 1
-    ys = round_value(((yc * dy) - r) / dy) - 1
-    yf = round_value(((yc * dy) + r) / dy) + 1
-    zs = round_value(((zc * dz) - r) / dz) - 1
-    zf = round_value(((zc * dz) + r) / dz) + 1
+    rx, ry, rz = <int>ceil(r / dx), <int>ceil(r / dy), <int>ceil(r / dz)
+    xs, xf = xc - rx - 1, xc + rx + 1
+    ys, yf = yc - ry - 1, yc + ry + 1
+    zs, zf = zc - rz - 1, zc + rz + 1
 
     # Set bounds to domain if they outside
     if xs < 0:
@@ -1382,9 +1089,8 @@ cpdef void build_sphere(
     for i in range(xs, xf):
         for j in range(ys, yf):
             for k in range(zs, zf):
-                if (np.sqrt((i + 0.5 - xc)**2 * dx**2 +
-                            (j + 0.5 - yc)**2 * dy**2 +
-                            (k + 0.5 - zc)**2 * dz**2) <= r):
+                qx, qy, qz = (i + 0.5 - xc) * dx, (j + 0.5 - yc) * dy, (k + 0.5 - zc) * dz
+                if qx * qx + qy * qy + qz * qz <= r * r:
                     build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
                                 averaging, pec_x, pec_y, pec_z,
                                 solid, rigidE, rigidH, ID)
@@ -1394,12 +1100,12 @@ cpdef void build_ellipsoid(
     int xc,
     int yc,
     int zc,
-    float xr,
-    float yr,
-    float zr,
-    float dx,
-    float dy,
-    float dz,
+    double xr,
+    double yr,
+    double zr,
+    double dx,
+    double dy,
+    double dz,
     int numID,
     int numIDx,
     int numIDy,
@@ -1431,15 +1137,14 @@ cpdef void build_ellipsoid(
     """
 
     cdef Py_ssize_t i, j, k
-    cdef int xs, xf, ys, yf, zs, zf
+    cdef int xs, xf, ys, yf, zs, zf, rxcells, rycells, rzcells
+    cdef double qx, qy, qz
 
-    # Calculate a bounding box for sphere
-    xs = round_value(((xc * dx) - xr) / dx) - 1
-    xf = round_value(((xc * dx) + xr) / dx) + 1
-    ys = round_value(((yc * dy) - yr) / dy) - 1
-    yf = round_value(((yc * dy) + yr) / dy) + 1
-    zs = round_value(((zc * dz) - zr) / dz) - 1
-    zf = round_value(((zc * dz) + zr) / dz) + 1
+    # Calculate an origin-independent bounding box.
+    rxcells, rycells, rzcells = <int>ceil(xr / dx), <int>ceil(yr / dy), <int>ceil(zr / dz)
+    xs, xf = xc - rxcells - 1, xc + rxcells + 1
+    ys, yf = yc - rycells - 1, yc + rycells + 1
+    zs, zf = zc - rzcells - 1, zc + rzcells + 1
 
     # Set bounds to domain if they outside
     if xs < 0:
@@ -1458,9 +1163,8 @@ cpdef void build_ellipsoid(
     for i in range(xs, xf):
         for j in range(ys, yf):
             for k in range(zs, zf):
-                if (((i + 0.5 - xc)**2 * dx**2)/xr**2 +
-                            ((j + 0.5 - yc)**2 * dy**2)/yr**2 +
-                            ((k + 0.5 - zc)**2 * dz**2)/zr**2 <= 1):
+                qx, qy, qz = (i + 0.5 - xc) * dx, (j + 0.5 - yc) * dy, (k + 0.5 - zc) * dz
+                if (qx * qx) / (xr * xr) + (qy * qy) / (yr * yr) + (qz * qz) / (zr * zr) <= 1:
                     build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
                                 averaging, pec_x, pec_y, pec_z,
                                 solid, rigidE, rigidH, ID)

--- a/gprMax/cython/geometry_primitives.pyx
+++ b/gprMax/cython/geometry_primitives.pyx
@@ -531,7 +531,9 @@ cpdef void build_triangle(
     cdef Py_ssize_t i, j, k
     cdef int i1, i2, j1, j2, levelcells, thicknesscells
     cdef int u1, v1, u2, v2, u3, v3
-    cdef double bu, bv, cu, cv, qu, qv, denominator, s, t
+    cdef long long bu, bv, cu, cv, qu2, qv2
+    cdef long long denominator, s_num2, t_num2
+    cdef bint inside
 
     # Work from snapped cell indices and relative coordinates. This avoids
     # subtracting large absolute floating-point coordinates, so translating an
@@ -544,8 +546,6 @@ cpdef void build_triangle(
         j1, j2 = min(v1, v2, v3) - 1, max(v1, v2, v3) + 1
         levelcells = round_value(x1 / dx)
         thicknesscells = round_value(thickness / dx)
-        bu, bv = (u2 - u1) * dy, (v2 - v1) * dz
-        cu, cv = (u3 - u1) * dy, (v3 - v1) * dz
         i2, j2 = min(i2, solid.shape[1]), min(j2, solid.shape[2])
     elif normal == 'y':
         u1, u2, u3 = round_value(x1 / dx), round_value(x2 / dx), round_value(x3 / dx)
@@ -554,8 +554,6 @@ cpdef void build_triangle(
         j1, j2 = min(v1, v2, v3) - 1, max(v1, v2, v3) + 1
         levelcells = round_value(y1 /dy)
         thicknesscells = round_value(thickness / dy)
-        bu, bv = (u2 - u1) * dx, (v2 - v1) * dz
-        cu, cv = (u3 - u1) * dx, (v3 - v1) * dz
         i2, j2 = min(i2, solid.shape[0]), min(j2, solid.shape[2])
     elif normal == 'z':
         u1, u2, u3 = round_value(x1 / dx), round_value(x2 / dx), round_value(x3 / dx)
@@ -564,8 +562,6 @@ cpdef void build_triangle(
         j1, j2 = min(v1, v2, v3) - 1, max(v1, v2, v3) + 1
         levelcells = round_value(z1 / dz)
         thicknesscells = round_value(thickness / dz)
-        bu, bv = (u2 - u1) * dx, (v2 - v1) * dy
-        cu, cv = (u3 - u1) * dx, (v3 - v1) * dy
         i2, j2 = min(i2, solid.shape[0]), min(j2, solid.shape[1])
 
     # Bound to the start of the grid
@@ -574,25 +570,40 @@ cpdef void build_triangle(
     if j1 < 0:
         j1 = 0
 
+    # Barycentric tests are performed entirely in snapped integer grid
+    # coordinates. Scaling either in-plane axis by its cell spacing is an
+    # affine transformation and therefore leaves these coordinates unchanged.
+    # This also makes the zero-area test exact on every compiler/architecture.
+    bu, bv = u2 - u1, v2 - v1
+    cu, cv = u3 - u1, v3 - v1
     denominator = bu * cv - bv * cu
     if denominator == 0:
         return
 
     for i in range(i1, i2):
         for j in range(j1, j2):
-            if normal == 'x':
-                qu, qv = (i + 0.5 - u1) * dy, (j + 0.5 - v1) * dz
-            elif normal == 'y':
-                qu, qv = (i + 0.5 - u1) * dx, (j + 0.5 - v1) * dz
-            elif normal == 'z':
-                qu, qv = (i + 0.5 - u1) * dx, (j + 0.5 - v1) * dy
-
-            s = (qu * cv - qv * cu) / denominator
-            t = (bu * qv - bv * qu) / denominator
+            # Twice the cell-centre offset avoids representing 0.5 in
+            # floating point. Numerators consequently share a denominator of
+            # 2 * ``denominator``.
+            qu2, qv2 = 2 * i + 1 - 2 * u1, 2 * j + 1 - 2 * v1
+            s_num2 = qu2 * cv - qv2 * cu
+            t_num2 = bu * qv2 - bv * qu2
+            if denominator > 0:
+                inside = (
+                    s_num2 > 0
+                    and t_num2 > 0
+                    and s_num2 + t_num2 < 2 * denominator
+                )
+            else:
+                inside = (
+                    s_num2 < 0
+                    and t_num2 < 0
+                    and s_num2 + t_num2 > 2 * denominator
+                )
 
             # Preserve the historical strict-edge convention: cells whose
             # centres lie exactly on an edge are not filled.
-            if s > 0 and t > 0 and (s + t) < 1:
+            if inside:
                 if thicknesscells == 0:
                     if normal == 'x':
                         build_face_yz(levelcells, i, j, numIDy, numIDz,

--- a/gprMax/geometry_outputs/geometry_objects.py
+++ b/gprMax/geometry_outputs/geometry_objects.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
 #                          and Nathan Mannall
 #
 # This file is part of gprMax.
@@ -140,6 +140,41 @@ class MPIGeometryObject(GeometryObject[MPIGrid]):
     def GRID_VIEW_TYPE(self) -> type[MPIGridView]:
         return MPIGridView
 
+    def _merge_negative_rigid_halos(
+        self, output: np.ndarray, grid_array: np.ndarray, tag_base: int
+    ) -> np.ndarray:
+        """Merge rigid flags built in a neighbour's negative cell halo.
+
+        Geometry primitives are built independently on every MPI rank. An
+        object exactly on an internal rank face can therefore set one of the
+        redundant rigid markers in the upper rank's negative halo, while the
+        corresponding cell is written to HDF5 by the lower rank. Component
+        IDs already have node ownership rules; cell-based rigid arrays need
+        this one-plane maximum reduction before their non-overlapping write.
+        """
+        for dimension in range(3):
+            negative, positive = self.grid_view.comm.Shift(dimension, 1)
+            send_plane = None
+            if negative != MPI.PROC_NULL:
+                spatial = [self.grid_view.getter_slice(axis) for axis in range(3)]
+                start = self.grid_view.start[dimension] - self.grid_view.step[dimension]
+                spatial[dimension] = slice(start, start + 1)
+                send_plane = np.ascontiguousarray(grid_array[(..., *spatial)])
+
+            received = self.grid_view.comm.sendrecv(
+                sendobj=send_plane,
+                dest=negative,
+                sendtag=tag_base + dimension,
+                source=positive,
+                recvtag=tag_base + dimension,
+            )
+            if received is not None:
+                target = [slice(None)] * output.ndim
+                target[output.ndim - 3 + dimension] = slice(-1, None)
+                np.maximum(output[tuple(target)], received, out=output[tuple(target)])
+
+        return output
+
     def write_hdf5(self, title: str, pbar: tqdm):
         """Writes a geometry objects file in HDF5 format.
 
@@ -155,6 +190,9 @@ class MPIGeometryObject(GeometryObject[MPIGrid]):
         data = self.grid_view.get_solid().astype(np.int16)
         rigidE = self.grid_view.get_rigidE()
         rigidH = self.grid_view.get_rigidH()
+
+        rigidE = self._merge_negative_rigid_halos(rigidE, self.grid.rigidE, 4100)
+        rigidH = self._merge_negative_rigid_halos(rigidH, self.grid.rigidH, 4200)
 
         ID = self.grid_view.map_to_view_materials(ID)
         data = self.grid_view.map_to_view_materials(data)

--- a/gprMax/geometry_outputs/geometry_objects_read.py
+++ b/gprMax/geometry_outputs/geometry_objects_read.py
@@ -73,10 +73,7 @@ class ReadGeometryObject(AbstractContextManager):
         )
         self.target_invariant_size = target_invariant_size
 
-        if (
-            invariant_axis is not None
-            and self.file_invariant_size != target_invariant_size
-        ):
+        if invariant_axis is not None and self.file_invariant_size != target_invariant_size:
             # Decouple the *write* region's size on this axis from the
             # file's own (read) size - the actual resizing of the read
             # arrays happens in _resize_cell_axis()/_resize_edge_axis(),
@@ -192,6 +189,72 @@ class ReadGeometryObject(AbstractContextManager):
         mapped = self.material_id_map[safe_indices]
         return np.where(data < 0, existing, mapped)
 
+    def _read_spatial_dataset(
+        self,
+        dataset: h5py.Dataset,
+        *,
+        component_axis: bool = False,
+        edge_based: bool = False,
+    ) -> npt.NDArray:
+        """Read exactly the portion of a geometry dataset owned by this rank.
+
+        MPI grid arrays include the negative interface halo when values are
+        assigned, so ``get_3d_read_slice`` is deliberately used rather than
+        the non-overlapping output slice. For 2D TM/TE conversion the array
+        must first be resized globally, after which the same rank-local slice
+        is applied.
+        """
+        mismatch = (
+            self.invariant_axis is not None
+            and self.file_invariant_size != self.target_invariant_size
+        )
+        if mismatch:
+            array = dataset[:]
+            if edge_based:
+                array = self._resize_edge_axis(array, int(component_axis))
+            else:
+                array = self._resize_cell_axis(array, int(component_axis))
+            if isinstance(self.grid_view, MPIGridView):
+                spatial = self.grid_view.get_3d_read_slice(upper_bound_exclusive=not edge_based)
+                return np.ascontiguousarray(array[(..., *spatial)])
+            return array
+
+        if isinstance(self.grid_view, MPIGridView):
+            spatial = self.grid_view.get_3d_read_slice(upper_bound_exclusive=not edge_based)
+            return np.ascontiguousarray(dataset[(..., *spatial)])
+        return dataset[:]
+
+    def _get_assignment_region(
+        self, array: npt.NDArray, *, edge_based: bool = False
+    ) -> npt.NDArray:
+        """Return existing values for the exact region set by ``GridView``.
+
+        This differs from ``get_solid``/``get_ID`` on a non-leading MPI rank:
+        setters include its negative interface halo, which is also present in
+        the geometry file read slice.
+        """
+        assert self.grid_view is not None
+        spatial = tuple(
+            self.grid_view.setter_slice(axis, upper_bound_exclusive=not edge_based)
+            for axis in range(3)
+        )
+        return np.ascontiguousarray(array[(..., *spatial)])
+
+    def get_local_data_start(self) -> Optional[npt.NDArray[np.int32]]:
+        """Return the local cell coordinate corresponding to ``get_data()[0,0,0]``.
+
+        Legacy/external geometry files without rigid and component-ID arrays
+        are rebuilt voxel by voxel. On MPI ranks, the returned data may begin
+        in a negative interface halo rather than at the object's original
+        local start, so the builder must use this matching coordinate.
+        """
+        if self.grid_view is None:
+            return None
+        return np.array(
+            [self.grid_view.setter_slice(axis).start for axis in range(3)],
+            dtype=np.int32,
+        )
+
     def __enter__(self):
         return self
 
@@ -242,21 +305,14 @@ class ReadGeometryObject(AbstractContextManager):
 
         data = self.file_handler["/data"]
         assert isinstance(data, h5py.Dataset)
-        # A full, native-shape read - there is no partial-region reading
-        # support in this class (the read region always equals the file's
-        # own extent), so this is equivalent to the previous grid-view-
-        # sliced read whenever there's no invariant-axis mismatch, and
-        # correctly generalises when there is one (_resize_cell_axis()
-        # below then adapts it to the target's own size).
-        data = data[:]
-        data = self._resize_cell_axis(data, spatial_axis_offset=0)
+        data = self._read_spatial_dataset(data)
 
         # Should be int16 to allow for -1 which indicates background, i.e.
         # don't build anything, but AustinMan/Woman maybe uint16
         if data.dtype != "int16":
             data = data.astype("int16")
 
-        existing = self.grid_view.get_solid()
+        existing = self._get_assignment_region(self.grid_view.grid.solid)
         self.grid_view.set_solid(self._remap(data, existing))
 
     def get_data(self) -> Optional[npt.NDArray[np.int16]]:
@@ -271,8 +327,7 @@ class ReadGeometryObject(AbstractContextManager):
 
         data = self.file_handler["/data"]
         assert isinstance(data, h5py.Dataset)
-        data = data[:]
-        data = self._resize_cell_axis(data, spatial_axis_offset=0)
+        data = self._read_spatial_dataset(data)
 
         # Should be int16 to allow for -1 which indicates background, i.e.
         # don't build anything, but AustinMan/Woman maybe uint16
@@ -291,7 +346,7 @@ class ReadGeometryObject(AbstractContextManager):
         rigidE = self.file_handler["/rigidE"]
         assert isinstance(rigidE, h5py.Dataset)
 
-        rigidE = self._resize_cell_axis(rigidE[:], spatial_axis_offset=1)
+        rigidE = self._read_spatial_dataset(rigidE, component_axis=True)
         self.grid_view.set_rigidE(rigidE)
 
     def read_rigidH(self):
@@ -301,7 +356,7 @@ class ReadGeometryObject(AbstractContextManager):
         rigidH = self.file_handler["/rigidH"]
         assert isinstance(rigidH, h5py.Dataset)
 
-        rigidH = self._resize_cell_axis(rigidH[:], spatial_axis_offset=1)
+        rigidH = self._read_spatial_dataset(rigidH, component_axis=True)
         self.grid_view.set_rigidH(rigidH)
 
     def read_ID(self):
@@ -311,6 +366,6 @@ class ReadGeometryObject(AbstractContextManager):
         ID = self.file_handler["/ID"]
         assert isinstance(ID, h5py.Dataset)
 
-        data = self._resize_edge_axis(ID[:], spatial_axis_offset=1)
-        existing = self.grid_view.get_ID(force_refresh=True)
+        data = self._read_spatial_dataset(ID, component_axis=True, edge_based=True)
+        existing = self._get_assignment_region(self.grid_view.grid.ID, edge_based=True)
         self.grid_view.set_ID(self._remap(data, existing))

--- a/gprMax/user_inputs.py
+++ b/gprMax/user_inputs.py
@@ -349,8 +349,20 @@ class MainGridUserInput(UserInput[GridType]):
         else:
             raise ValueError("Dimension should have value x, y, or z")
 
+        # ``lower_point`` and ``upper_point`` use zero-valued coordinates
+        # outside the requested dimension only as carriers for the scalar
+        # extent. Those placeholder coordinates are not part of the object.
+        # In an offset subgrid they translate to negative local indices, so
+        # passing the whole carrier point to ``within_bounds`` can reject a
+        # valid thickness in an unrelated dimension. Use a valid local anchor
+        # for the transverse coordinates and retain only the requested-axis
+        # coordinate. This also preserves MPIGrid.within_bounds' conversion
+        # back to global coordinates.
+        bounds_point = np.zeros_like(upper_point)
+        bounds_point[index] = upper_point[index]
+
         try:
-            self.grid.within_bounds(upper_point)
+            self.grid.within_bounds(bounds_point)
         except ValueError:
             raise ValueError(
                 f"'{cmd_str}' extends beyond the size of the model in the {dimension} dimension"

--- a/gprMax/user_objects/cmds_geometry/cone.py
+++ b/gprMax/user_objects/cmds_geometry/cone.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
 #                          and Nathan Mannall
 #
 # This file is part of gprMax.
@@ -102,6 +102,11 @@ class Cone(GeometryUserObject):
         x1, y1, z1 = uip.round_to_grid(p1)
         x2, y2, z2 = uip.round_to_grid(p2)
 
+        if (x1, y1, z1) == (x2, y2, z2):
+            message = f"{self.__str__()} the two face centres must occupy different grid points."
+            logger.error(message)
+            raise ValueError(message)
+
         if r1 < 0:
             logger.exception(
                 f"{self.__str__()} the radius of the first face {r1:g} should be a positive value."
@@ -123,7 +128,9 @@ class Cone(GeometryUserObject):
 
         if len(materials) != len(materialsrequested):
             found_ids = {material.ID for material in materials}
-            notfound = [material_id for material_id in materialsrequested if material_id not in found_ids]
+            notfound = [
+                material_id for material_id in materialsrequested if material_id not in found_ids
+            ]
             message = f"{self.__str__()} material(s) {notfound} do not exist"
             logger.error(message)
             raise ValueError(message)

--- a/gprMax/user_objects/cmds_geometry/cylinder.py
+++ b/gprMax/user_objects/cmds_geometry/cylinder.py
@@ -91,15 +91,23 @@ class Cylinder(GeometryUserObject):
         x2, y2, z2 = uip.round_to_grid(p2)
 
         if r <= 0:
-            logger.exception(f"{self.__str__()} the radius {r:g} should be a positive value.")
-            raise ValueError
+            message = f"{self.__str__()} the radius {r:g} should be a positive value."
+            logger.error(message)
+            raise ValueError(message)
+
+        if (x1, y1, z1) == (x2, y2, z2):
+            message = f"{self.__str__()} the two face centres must occupy different grid points."
+            logger.error(message)
+            raise ValueError(message)
 
         # Look up requested materials in existing list of material instances
         materials = [y for x in materialsrequested for y in grid.materials if y.ID == x]
 
         if len(materials) != len(materialsrequested):
             found_ids = {material.ID for material in materials}
-            notfound = [material_id for material_id in materialsrequested if material_id not in found_ids]
+            notfound = [
+                material_id for material_id in materialsrequested if material_id not in found_ids
+            ]
             message = f"{self.__str__()} material(s) {notfound} do not exist"
             logger.error(message)
             raise ValueError(message)

--- a/gprMax/user_objects/cmds_geometry/cylindrical_sector.py
+++ b/gprMax/user_objects/cmds_geometry/cylindrical_sector.py
@@ -169,7 +169,9 @@ class CylindricalSector(GeometryUserObject):
         sectorangle = 2 * np.pi * (end / 360)
 
         if r <= 0:
-            logger.exception(f"{self.__str__()} the radius {r:g} should be a positive value.")
+            message = f"{self.__str__()} the radius {r:g} should be a positive value."
+            logger.error(message)
+            raise ValueError(message)
         if sectorstartangle < 0 or sectorangle <= 0:
             logger.exception(
                 f"{self.__str__()} the starting angle and sector angle should be a positive values."
@@ -186,7 +188,9 @@ class CylindricalSector(GeometryUserObject):
 
         if len(materials) != len(materialsrequested):
             found_ids = {material.ID for material in materials}
-            notfound = [material_id for material_id in materialsrequested if material_id not in found_ids]
+            notfound = [
+                material_id for material_id in materialsrequested if material_id not in found_ids
+            ]
             message = f"{self.__str__()} material(s) {notfound} do not exist"
             logger.error(message)
             raise ValueError(message)

--- a/gprMax/user_objects/cmds_geometry/ellipsoid.py
+++ b/gprMax/user_objects/cmds_geometry/ellipsoid.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
 #                          and Nathan Mannall
 #
 # This file is part of gprMax.
@@ -62,6 +62,14 @@ class Ellipsoid(GeometryUserObject):
             logger.exception(f"{self.__str__()} please specify a point and the three semiaxes.")
             raise
 
+        if xr <= 0 or yr <= 0 or zr <= 0:
+            message = (
+                f"{self.__str__()} the semiaxes ({xr:g}, {yr:g}, {zr:g}) "
+                "should all be positive values."
+            )
+            logger.error(message)
+            raise ValueError(message)
+
         # Check averaging
         try:
             # Try user-specified averaging
@@ -92,7 +100,9 @@ class Ellipsoid(GeometryUserObject):
 
         if len(materials) != len(materialsrequested):
             found_ids = {material.ID for material in materials}
-            notfound = [material_id for material_id in materialsrequested if material_id not in found_ids]
+            notfound = [
+                material_id for material_id in materialsrequested if material_id not in found_ids
+            ]
             message = f"{self.__str__()} material(s) {notfound} do not exist"
             logger.error(message)
             raise ValueError(message)

--- a/gprMax/user_objects/cmds_geometry/geometry_objects_read.py
+++ b/gprMax/user_objects/cmds_geometry/geometry_objects_read.py
@@ -179,7 +179,9 @@ class GeometryObjectsRead(GeometryUserObject):
             with h5py.File(geofile, "r") as check_file:
                 file_invariant_size = check_file["/data"].shape[invariant_axis]
             if file_invariant_size != target_invariant_size:
-                action = "broadcasting" if file_invariant_size < target_invariant_size else "reducing"
+                action = (
+                    "broadcasting" if file_invariant_size < target_invariant_size else "reducing"
+                )
                 logger.info(
                     f"{self.__str__()} imported file has {file_invariant_size} cell(s) on the "
                     f"invariant axis but this model ({mode}) needs {target_invariant_size} - "
@@ -220,17 +222,17 @@ class GeometryObjectsRead(GeometryUserObject):
                 # further offset is needed here.
                 data = f.get_data()
                 if data is not None:
+                    data_start = f.get_local_data_start()
+                    assert data_start is not None
                     averaging = False
-                    is_pec_lookup = np.array(
-                        [m.is_pec for m in grid.materials], dtype=np.uint8
-                    )
+                    is_pec_lookup = np.array([m.is_pec for m in grid.materials], dtype=np.uint8)
                     is_averagable_lookup = np.array(
                         [m.averagable for m in grid.materials], dtype=np.uint8
                     )
                     build_voxels_from_array(
-                        discretised_p1[0],
-                        discretised_p1[1],
-                        discretised_p1[2],
+                        data_start[0],
+                        data_start[1],
+                        data_start[2],
                         0,
                         averaging,
                         is_pec_lookup,

--- a/gprMax/user_objects/cmds_geometry/sphere.py
+++ b/gprMax/user_objects/cmds_geometry/sphere.py
@@ -57,6 +57,11 @@ class Sphere(GeometryUserObject):
             logger.exception(f"{self.__str__()} please specify a point and a radius.")
             raise
 
+        if r <= 0:
+            message = f"{self.__str__()} the radius {r:g} should be a positive value."
+            logger.error(message)
+            raise ValueError(message)
+
         # Check averaging
         try:
             # Try user-specified averaging
@@ -87,7 +92,9 @@ class Sphere(GeometryUserObject):
 
         if len(materials) != len(materialsrequested):
             found_ids = {material.ID for material in materials}
-            notfound = [material_id for material_id in materialsrequested if material_id not in found_ids]
+            notfound = [
+                material_id for material_id in materialsrequested if material_id not in found_ids
+            ]
             message = f"{self.__str__()} material(s) {notfound} do not exist"
             logger.error(message)
             raise ValueError(message)

--- a/gprMax/user_objects/cmds_geometry/triangle.py
+++ b/gprMax/user_objects/cmds_geometry/triangle.py
@@ -112,6 +112,19 @@ class Triangle(RotatableMixin, GeometryUserObject):
 
         # Check whether points are valid against grid
         dp1, dp2, dp3 = uip.check_tri_points(up1, up2, up3, self.__str__())
+
+        # Reject coincident or collinear vertices after discretisation. A
+        # geometrically valid triangle can collapse when its vertices round to
+        # the same grid line, and silently producing an empty object hides that
+        # modelling error.
+        normal_vector = np.cross(dp2 - dp1, dp3 - dp1)
+        if not np.any(normal_vector):
+            message = (
+                f"{self.__str__()} the vertices must define a non-degenerate "
+                "triangle after discretisation."
+            )
+            logger.error(message)
+            raise ValueError(message)
         # Convert points to metres
         x1, y1, z1 = uip.discrete_to_continuous(dp1)
         x2, y2, z2 = uip.discrete_to_continuous(dp2)
@@ -159,7 +172,9 @@ class Triangle(RotatableMixin, GeometryUserObject):
 
         if len(materials) != len(materialsrequested):
             found_ids = {material.ID for material in materials}
-            notfound = [material_id for material_id in materialsrequested if material_id not in found_ids]
+            notfound = [
+                material_id for material_id in materialsrequested if material_id not in found_ids
+            ]
             message = f"{self.__str__()} material(s) {notfound} do not exist"
             logger.error(message)
             raise ValueError(message)

--- a/tests/cmds_geometry/test_degenerate_primitives.py
+++ b/tests/cmds_geometry/test_degenerate_primitives.py
@@ -1,0 +1,96 @@
+"""Regression tests for geometry definitions that collapse after gridding."""
+
+import pytest
+
+import gprMax
+
+
+def _scene():
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(1e-3, 1e-3, 1e-3)))
+    scene.add(gprMax.Domain(p1=(0.02, 0.02, 0.02)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(iterations=1))
+    return scene
+
+
+@pytest.mark.parametrize(
+    "name,geometry,error",
+    [
+        (
+            "sphere",
+            gprMax.Sphere(p1=(0.01, 0.01, 0.01), r=0, material_id="pec"),
+            "radius",
+        ),
+        (
+            "ellipsoid",
+            gprMax.Ellipsoid(
+                p1=(0.01, 0.01, 0.01),
+                xr=0.003,
+                yr=0,
+                zr=0.003,
+                material_id="pec",
+            ),
+            "semiaxes",
+        ),
+        (
+            "cylinder",
+            gprMax.Cylinder(
+                p1=(0.008, 0.008, 0.008),
+                p2=(0.0084, 0.008, 0.008),
+                r=0.002,
+                material_id="pec",
+            ),
+            "different grid points",
+        ),
+        (
+            "cone",
+            gprMax.Cone(
+                p1=(0.008, 0.008, 0.008),
+                p2=(0.0084, 0.008, 0.008),
+                r1=0.001,
+                r2=0.002,
+                material_id="pec",
+            ),
+            "different grid points",
+        ),
+        (
+            "sector",
+            gprMax.CylindricalSector(
+                normal="z",
+                ctr1=0.01,
+                ctr2=0.01,
+                extent1=0.007,
+                extent2=0.012,
+                r=0,
+                start=0,
+                end=90,
+                material_id="pec",
+            ),
+            "radius",
+        ),
+        (
+            "triangle",
+            gprMax.Triangle(
+                p1=(0.005, 0.005, 0.01),
+                p2=(0.008, 0.008, 0.01),
+                p3=(0.011, 0.011, 0.01),
+                thickness=0.002,
+                material_id="pec",
+            ),
+            "non-degenerate triangle",
+        ),
+    ],
+)
+def test_degenerate_geometry_is_rejected(name, geometry, error, tmp_path):
+    scene = _scene()
+    scene.add(geometry)
+
+    with pytest.raises(ValueError, match=error):
+        gprMax.run(
+            scenes=[scene],
+            n=1,
+            geometry_only=True,
+            outputfile=tmp_path / name,
+            hide_progress_bars=True,
+        )

--- a/tests/geometry_primitives/test_build_dispatch.py
+++ b/tests/geometry_primitives/test_build_dispatch.py
@@ -293,7 +293,7 @@ class TestConeBuild:
         cone.build(g)
 
         layer_counts = [np.count_nonzero(g.solid[:, :, k]) for k in range(8)]
-        assert layer_counts == [0, 0, 16, 16, 16, 16, 0, 0]
+        assert layer_counts == [0, 0, 16, 12, 4, 4, 0, 0]
 
     def test_both_radii_zero_raises(self, dispatch_grid):
         g = dispatch_grid()

--- a/tests/geometry_primitives/test_shape_builders.py
+++ b/tests/geometry_primitives/test_shape_builders.py
@@ -571,8 +571,8 @@ class TestBuildCylinder:
 
 class TestBuildCone:
     def test_z_aligned_cone_shrinks_layer_by_layer(self, grid_arrays):
-        # Radius interpolates from 2.5 cells at z-cell 2 to 0.5 cells at
-        # z-cell 6, giving per-layer radii 2.5 / 2.0 / 1.5 / 1.0.
+        # Radius is evaluated at each cell centre, giving per-layer radii
+        # 2.25 / 1.75 / 1.25 / 0.75 cells.
         g = grid_arrays()
         build_cone(
             5 * DL,
@@ -601,12 +601,11 @@ class TestBuildCone:
         )
 
         layer_counts = {k: np.count_nonzero(g.solid[:, :, k]) for k in range(8)}
-        assert layer_counts == {0: 0, 1: 0, 2: 16, 3: 16, 4: 16, 5: 16, 6: 0, 7: 0}
+        assert layer_counts == {0: 0, 1: 0, 2: 16, 3: 12, 4: 4, 5: 4, 6: 0, 7: 0}
         # The widest layer is the full 4x4 block around the axis...
         assert nonzero_set(g.solid[:, :, 2]) == {(i, j) for i in range(3, 7) for j in range(3, 7)}
-        # The narrowest layer is the full 4x4 block (upstream change:
-        # cone radius interpolation now fills all active layers uniformly).
-        assert len(nonzero_set(g.solid[:, :, 5])) == 16
+        # The narrowest layer is the 2x2 block immediately around the axis.
+        assert nonzero_set(g.solid[:, :, 5]) == {(i, j) for i in range(4, 6) for j in range(4, 6)}
 
     def test_equal_radii_reduce_to_a_cylinder(self, grid_arrays):
         r = 1.5 * DL
@@ -739,7 +738,7 @@ class TestBuildCone:
         )
 
         layer_counts = [np.count_nonzero(g.solid[i, :, :]) for i in range(8)]
-        assert layer_counts == [0, 0, 16, 16, 16, 16, 0, 0]
+        assert layer_counts == [0, 0, 16, 12, 4, 4, 0, 0]
 
 
 class TestBuildCylindricalSector:

--- a/tests/geometry_primitives/test_translation_invariance.py
+++ b/tests/geometry_primitives/test_translation_invariance.py
@@ -1,0 +1,162 @@
+"""Origin-invariance tests for curved and planar geometry rasterisers.
+
+MPI ranks and HSG subgrids translate global geometry into a local coordinate
+frame before invoking these shared builders. An integer-cell translation must
+therefore translate the voxel mask exactly, without changing its shape.
+"""
+
+import numpy as np
+import pytest
+
+from gprMax.cython.geometry_primitives import (
+    build_cone,
+    build_cylinder,
+    build_cylindrical_sector,
+    build_ellipsoid,
+    build_sphere,
+    build_triangle,
+)
+
+from .conftest import DL
+
+
+def _material_args(grid):
+    return (
+        1,
+        1,
+        1,
+        1,
+        True,
+        False,
+        False,
+        False,
+        grid.solid,
+        grid.rigidE,
+        grid.rigidH,
+        grid.ID,
+    )
+
+
+def _sphere(grid, shift):
+    build_sphere(12 + shift, 13 + shift, 14 + shift, 3.2 * DL, DL, DL, DL, *_material_args(grid))
+
+
+def _ellipsoid(grid, shift):
+    build_ellipsoid(
+        12 + shift,
+        13 + shift,
+        14 + shift,
+        4.1 * DL,
+        2.7 * DL,
+        3.3 * DL,
+        DL,
+        DL,
+        DL,
+        *_material_args(grid),
+    )
+
+
+def _cylinder(grid, shift):
+    s = shift * DL
+    build_cylinder(
+        8 * DL + s,
+        9 * DL + s,
+        10 * DL + s,
+        18 * DL + s,
+        16 * DL + s,
+        15 * DL + s,
+        2.4 * DL,
+        DL,
+        DL,
+        DL,
+        *_material_args(grid),
+    )
+
+
+def _cone(grid, shift):
+    s = shift * DL
+    build_cone(
+        8 * DL + s,
+        9 * DL + s,
+        10 * DL + s,
+        18 * DL + s,
+        16 * DL + s,
+        15 * DL + s,
+        1.2 * DL,
+        3.1 * DL,
+        DL,
+        DL,
+        DL,
+        *_material_args(grid),
+    )
+
+
+def _triangle(grid, shift):
+    s = shift * DL
+    build_triangle(
+        8 * DL + s,
+        8 * DL + s,
+        12 * DL + s,
+        20 * DL + s,
+        9 * DL + s,
+        12 * DL + s,
+        13 * DL + s,
+        21 * DL + s,
+        12 * DL + s,
+        "z",
+        3 * DL,
+        DL,
+        DL,
+        DL,
+        *_material_args(grid),
+    )
+
+
+def _sector(grid, shift):
+    s = shift * DL
+    build_cylindrical_sector(
+        14 * DL + s,
+        14 * DL + s,
+        10 * DL + s,
+        np.pi / 7,
+        1.4 * np.pi,
+        5.2 * DL,
+        "z",
+        4 * DL,
+        DL,
+        DL,
+        DL,
+        *_material_args(grid),
+    )
+
+
+@pytest.mark.parametrize("builder", [_sphere, _ellipsoid, _cylinder, _cone, _triangle, _sector])
+def test_integer_cell_translation_preserves_voxel_mask(grid_arrays, builder):
+    shift = 29
+    extent = 28
+    base = grid_arrays(70, 70, 70)
+    translated = grid_arrays(70, 70, 70)
+
+    builder(base, 0)
+    builder(translated, shift)
+
+    np.testing.assert_array_equal(
+        base.solid[:extent, :extent, :extent],
+        translated.solid[
+            shift : shift + extent,
+            shift : shift + extent,
+            shift : shift + extent,
+        ],
+    )
+
+
+def test_cone_endpoint_reversal_preserves_geometry_and_radius_assignment(grid_arrays):
+    forward = grid_arrays(32, 32, 32)
+    reverse = grid_arrays(32, 32, 32)
+    p1 = (6 * DL, 12 * DL, 12 * DL)
+    p2 = (22 * DL, 12 * DL, 12 * DL)
+
+    build_cone(*p1, *p2, 1.2 * DL, 4.2 * DL, DL, DL, DL, *_material_args(forward))
+    build_cone(*p2, *p1, 4.2 * DL, 1.2 * DL, DL, DL, DL, *_material_args(reverse))
+
+    np.testing.assert_array_equal(forward.solid, reverse.solid)

--- a/tests/outputs/test_geometry_objects.py
+++ b/tests/outputs/test_geometry_objects.py
@@ -357,7 +357,11 @@ class TestMpiVariant:
         overridden."""
         assert issubclass(MPIGeometryObject, GeometryObject)
         overrides = {n for n in MPIGeometryObject.__dict__ if not n.startswith("__")}
-        assert overrides <= {"GRID_VIEW_TYPE", "write_hdf5"}
+        assert overrides <= {
+            "GRID_VIEW_TYPE",
+            "_merge_negative_rigid_halos",
+            "write_hdf5",
+        }
 
     def test_uses_an_mpi_grid_view(self, make_mpi_grid, make_materials):
         """Expects ``MPIGridView``, so each rank exports its own share."""
@@ -375,6 +379,19 @@ class TestMpiVariant:
         grid.materials = make_materials(2)
         obj = MPIGeometryObject(grid, 0, 0, 0, 8, 8, 8, "mpi")
         assert obj.solidsize == 512 * 4
+
+    def test_rigid_halo_merge_is_part_of_parallel_export(self):
+        """The parallel writer must reconcile redundant rigid markers.
+
+        Actual multi-rank round trips are exercised by the MPI integration
+        suite. Keep a small source-level guard here because ordinary pytest
+        installations commonly use an h5py build without parallel HDF5.
+        """
+        import inspect
+
+        source = inspect.getsource(MPIGeometryObject.write_hdf5)
+        assert "_merge_negative_rigid_halos(rigidE" in source
+        assert "_merge_negative_rigid_halos(rigidH" in source
 
     def test_the_parallel_write_needs_parallel_hdf5(self):
         """Expects ``MPIGeometryObject.write_hdf5`` to open with

--- a/tests/outputs/test_geometry_objects_read.py
+++ b/tests/outputs/test_geometry_objects_read.py
@@ -239,6 +239,15 @@ class TestReadData:
         assert data.shape == (3, 3, 3)
         assert not np.any(g.solid)
 
+    def test_get_data_reports_the_matching_local_start(self, geometry_file, target_grid):
+        """The fallback voxel builder must place the first returned cell at
+        the reader's assignment start (which can differ on an MPI rank)."""
+        g = target_grid()
+        start = np.array([2, 3, 4], dtype=np.int32)
+        with ReadGeometryObject(geometry_file(shape=(3, 3, 3)), g, start, ID_MAP) as r:
+            r.get_data()
+            np.testing.assert_array_equal(r.get_local_data_start(), start)
+
     def test_get_data_applies_the_material_map(self, geometry_file, target_grid):
         """Expects the remapped values — ``get_data`` applies
         ``material_id_map``, unlike the old ``num_existing_materials``

--- a/tests/subgrids/test_thickness_geometry.py
+++ b/tests/subgrids/test_thickness_geometry.py
@@ -1,0 +1,54 @@
+import numpy as np
+
+import gprMax
+
+
+def test_thickness_geometry_builds_in_off_origin_subgrid(tmp_path):
+    """Triangles and sectors must not validate placeholder transverse zeros."""
+    scene = gprMax.Scene()
+    scene.add(gprMax.Domain(p1=(0.09, 0.09, 0.09)))
+    scene.add(gprMax.Discretisation(p1=(0.003, 0.003, 0.003)))
+    scene.add(gprMax.TimeWindow(iterations=1))
+    scene.add(gprMax.PMLThickness(thickness=0))
+
+    subgrid = gprMax.SubGridHSG(
+        p1=(0.03, 0.03, 0.03),
+        p2=(0.06, 0.06, 0.06),
+        ratio=3,
+        id="fine_grid",
+    )
+    subgrid.add(
+        gprMax.Triangle(
+            p1=(0.040, 0.040, 0.045),
+            p2=(0.050, 0.040, 0.045),
+            p3=(0.045, 0.052, 0.045),
+            thickness=0.002,
+            material_id="pec",
+        )
+    )
+    subgrid.add(
+        gprMax.CylindricalSector(
+            normal="z",
+            ctr1=0.045,
+            ctr2=0.045,
+            extent1=0.048,
+            extent2=0.051,
+            r=0.004,
+            start=0,
+            end=180,
+            material_id="pec",
+        )
+    )
+    scene.add(subgrid)
+
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        outputfile=tmp_path / "off_origin_thickness_geometry",
+        geometry_only=True,
+        subgrid=True,
+        hide_progress_bars=True,
+    )
+
+    pec = next(material for material in subgrid.subgrid.materials if material.ID == "pec")
+    assert np.count_nonzero(subgrid.subgrid.solid == pec.numID) > 0

--- a/tests/subgrids/test_thickness_geometry.py
+++ b/tests/subgrids/test_thickness_geometry.py
@@ -47,6 +47,7 @@ def test_thickness_geometry_builds_in_off_origin_subgrid(tmp_path):
         outputfile=tmp_path / "off_origin_thickness_geometry",
         geometry_only=True,
         subgrid=True,
+        autotranslate=True,
         hide_progress_bars=True,
     )
 

--- a/tests/user_inputs/test_thickness.py
+++ b/tests/user_inputs/test_thickness.py
@@ -1,0 +1,125 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from gprMax.user_inputs import MPIUserInput, SubgridUserInput
+
+
+class _BoundsGrid(SimpleNamespace):
+    """Small grid stand-in implementing the normal three-axis bounds check."""
+
+    def within_bounds(self, point):
+        for index, dimension in enumerate("xyz"):
+            if point[index] < 0 or point[index] > self.size[index]:
+                raise ValueError(dimension)
+        return True
+
+
+def _subgrid_input():
+    grid = _BoundsGrid(
+        dl=np.full(3, 1e-3),
+        size=np.full(3, 20, dtype=np.int32),
+        nx=20,
+        ny=20,
+        nz=20,
+        ratio=3,
+        i0=5,
+        j0=7,
+        k0=11,
+        n_boundary_cells_x=4,
+        n_boundary_cells_y=4,
+        n_boundary_cells_z=4,
+    )
+    return SubgridUserInput(grid)
+
+
+def _global_extent(user_input, axis, local_index):
+    grid = user_input.grid
+    origin = (grid.i0, grid.j0, grid.k0)[axis] * grid.ratio
+    boundary = (
+        grid.n_boundary_cells_x,
+        grid.n_boundary_cells_y,
+        grid.n_boundary_cells_z,
+    )[axis]
+    return (origin + local_index - boundary) * grid.dl[axis]
+
+
+@pytest.mark.parametrize(("dimension", "axis"), tuple(zip("xyz", range(3))))
+def test_subgrid_thickness_ignores_transverse_carrier_coordinates(dimension, axis):
+    user_input = _subgrid_input()
+    lower_extent = _global_extent(user_input, axis, local_index=8)
+
+    # Reproduce the old failure condition: the zeros used to carry a scalar
+    # extent translate outside an off-origin subgrid in the other two axes.
+    carrier = np.zeros(3)
+    carrier[axis] = lower_extent
+    translated_carrier = user_input.discretise_point(tuple(carrier))
+    assert np.delete(translated_carrier, axis).max() < 0
+
+    within_grid, local_lower, local_thickness = user_input.check_thickness(
+        dimension,
+        lower_extent,
+        3e-3,
+        "#test_object",
+    )
+
+    assert within_grid
+    assert local_lower == pytest.approx(8e-3)
+    assert local_thickness == pytest.approx(3e-3)
+
+
+@pytest.mark.parametrize(("dimension", "axis"), tuple(zip("xyz", range(3))))
+def test_subgrid_thickness_still_rejects_requested_axis_overflow(dimension, axis):
+    user_input = _subgrid_input()
+    lower_extent = _global_extent(user_input, axis, local_index=18)
+
+    with pytest.raises(
+        ValueError,
+        match=rf"extends beyond the size of the model in the {dimension} dimension",
+    ):
+        user_input.check_thickness(
+            dimension,
+            lower_extent,
+            3e-3,
+            "#test_object",
+        )
+
+
+class _MPIGrid(SimpleNamespace):
+    def global_to_local_coordinate(self, point):
+        return point - self.lower_extent
+
+    def local_to_global_coordinate(self, point):
+        return point + self.lower_extent
+
+    def within_bounds(self, local_point):
+        global_point = self.local_to_global_coordinate(local_point)
+        for index, dimension in enumerate("xyz"):
+            if global_point[index] < 0 or global_point[index] > self.global_size[index]:
+                raise ValueError(dimension)
+        return True
+
+
+@pytest.mark.parametrize(("dimension", "axis"), tuple(zip("xyz", range(3))))
+def test_mpi_thickness_crossing_lower_rank_face_remains_clipped(dimension, axis):
+    lower_extent = np.zeros(3, dtype=np.int32)
+    lower_extent[axis] = 9
+    grid = _MPIGrid(
+        dl=np.ones(3),
+        size=np.full(3, 11, dtype=np.int32),
+        global_size=np.full(3, 30, dtype=np.int32),
+        lower_extent=lower_extent,
+    )
+    user_input = MPIUserInput(grid)
+
+    within_grid, local_lower, local_thickness = user_input.check_thickness(
+        dimension,
+        lower_extent=5,
+        thickness=10,
+        cmd_str="#test_object",
+    )
+
+    assert within_grid
+    assert local_lower == pytest.approx(0)
+    assert local_thickness == pytest.approx(6)


### PR DESCRIPTION
## Summary

Fixes geometry construction and geometry-object I/O across translated HSG subgrids and MPI domain decompositions.

The shared primitive rasterisers now use snapped, origin-independent, double-precision relative coordinates. This prevents an otherwise identical object from changing shape when translated into a subgrid or MPI-local coordinate frame. The cylinder and cone builders use axial projection rather than per-cell trigonometric calculations; this also corrects cone radius interpolation and endpoint reversal.

MPI geometry-object reading now loads only the rank-local slab, including the required negative interface halo. Parallel geometry export reconciles redundant electric and magnetic rigid markers at internal rank faces before writing. Legacy voxel-only geometry files use the matching rank-local insertion origin.

Degenerate spheres, ellipsoids, cylinders, cones, cylindrical sectors, and triangles are now rejected with clear errors instead of silently producing empty/invalid geometry.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update.

## Verification

- Cython extensions build successfully.
- Uniform-grid and equivalent translated HSG models produce identical `solid`, `rigidE`, and `rigidH` arrays.
- Serial and MPI geometry outputs are bit-for-bit identical for X-, Y-, and Z-axis splits and for 2x2x1 and 2x2x2 decompositions (`data`, `ID`, `rigidE`, and `rigidH`).
- Full and legacy voxel-only geometry-object MPI round trips match serial output exactly.
- Integer-cell translation tests cover sphere, ellipsoid, cylinder, cone, triangle, and cylindrical sector.
- `1506 passed, 4 skipped` in the broad geometry/subgrid/output regression suite. The skips require CUDA/pycuda or parallel-HDF5 support in the active pytest environment.

## Checklist

- [ ] Did pre-commit pass all checks? (`pre-commit` is not installed in the active shell; Black/isort formatting and `git diff --check` were run directly.)
- [x] I have performed a self-review of my code.
- [x] I have added comments for my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.
