### PR TITLE
Fix Lorentz and Drude pole validation

### DIFF
--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -343,9 +343,9 @@ where
 
 .. math::
 
-    \beta_p = \sqrt{\omega_p^2 - \delta_p^2} \quad \textrm{and} \quad \gamma_p = \frac{\omega_p^2 \Delta \epsilon_{rp}}{\beta_p},
+    \beta_p = \sqrt{(2\pi f_p)^2 - \delta_p^2} \quad \textrm{and} \quad \gamma_p = \frac{(2\pi f_p)^2 \Delta \epsilon_{rp}}{\beta_p},
 
-where :math:`\Delta \epsilon_{rp} = \epsilon_{rsp} - \epsilon_{r \infty}`, :math:`\epsilon_{rsp}` is the zero-frequency relative permittivity for the pole, :math:`\epsilon_{r \infty}` is the relative permittivity at infinite frequency, :math:`\omega_p` is the frequency (Hertz) of the pole pair, :math:`\delta_p` is the damping coefficient (Hertz) , and :math:`j=\sqrt{-1}`.
+where :math:`\Delta \epsilon_{rp} = \epsilon_{rsp} - \epsilon_{r \infty}`, :math:`\epsilon_{rsp}` is the zero-frequency relative permittivity for the pole, :math:`\epsilon_{r \infty}` is the relative permittivity at infinite frequency, :math:`f_p` is the resonance frequency (Hertz) of the pole pair, :math:`\delta_p` is the damping coefficient (per second), and :math:`j=\sqrt{-1}`. The angular resonance frequency used in the formulation is :math:`\omega_p=2\pi f_p`.
 
 The syntax of the command is:
 
@@ -355,19 +355,19 @@ The syntax of the command is:
 
 * ``i1`` is the number of Lorentz poles.
 * ``f1`` is the difference between the zero-frequency relative permittivity and the relative permittivity at infinite frequency, i.e. :math:`\Delta \epsilon_{rp1} = \epsilon_{rsp1} - \epsilon_{r \infty}` , for the first Lorentz pole.
-* ``f2`` is the frequency (Hertz), :math:`\omega_{p1}`, for the first Lorentz pole.
-* ``f3`` is the damping coefficient (Hertz), :math:`\delta_{p1}`, for the first Lorentz pole.
+* ``f2`` is the resonance frequency (Hertz), :math:`f_{p1}`, for the first Lorentz pole.
+* ``f3`` is the damping coefficient (per second), :math:`\delta_{p1}`, for the first Lorentz pole.
 * ``f4`` is the difference between the zero-frequency relative permittivity and the relative permittivity at infinite frequency, i.e. :math:`\Delta \epsilon_{rp2} = \epsilon_{rsp2} - \epsilon_{r \infty}` , for the second Lorentz pole.
-* ``f5`` is the frequency (Hertz), :math:`\omega_{p2}`, for the second Lorentz pole.
-* ``f6`` is the damping coefficient (Hertz), :math:`\delta_{p2}`, for the second Lorentz pole.
+* ``f5`` is the resonance frequency (Hertz), :math:`f_{p2}`, for the second Lorentz pole.
+* ``f6`` is the damping coefficient (per second), :math:`\delta_{p2}`, for the second Lorentz pole.
 * ...
 * ``str1`` identifies the material to add the dispersive properties to.
 
 .. note::
 
-    * You can continue to add triplets of values for :math:`\Delta \epsilon_{rp}`, :math:`\omega_p` and :math:`\delta_p` for as many Lorentz poles as you have specified with ``i1``.
+    * You can continue to add triplets of values for :math:`\Delta \epsilon_{rp}`, :math:`f_p` and :math:`\delta_p` for as many Lorentz poles as you have specified with ``i1``.
     * The relative permittivity in the ``#material`` command should be given as the relative permittivity at infinite frequency, i.e. :math:`\epsilon_{r \infty}`.
-    * Temporal values associated with pole frequencies and relaxation times should always be greater than the time step :math:`\Delta t` used in the model.
+    * The recursive formulation requires :math:`f_p < 1/\Delta t`, :math:`\delta_p < 1/\Delta t`, and the underdamped condition :math:`\delta_p < 2\pi f_p`. These coefficient limits do not replace the stricter Nyquist and spatial-resolution limits on useful simulation output.
 
 
 #add_dispersion_drude:
@@ -377,9 +377,9 @@ Allows you to add dispersive properties to an already defined ``#material`` base
 
 .. math::
 
-    \chi_p (t) = \frac{\omega_p^2}{\gamma_p} (1-e^{-\gamma_p t}),
+    \chi_p (t) = \frac{(2\pi f_p)^2}{\gamma_p} (1-e^{-\gamma_p t}),
 
-where :math:`\omega_p` is the frequency (Hertz) of the pole, and :math:`\gamma_p` is the inverse of the pole relaxation time (Hertz).
+where :math:`f_p` is the plasma frequency (Hertz) of the pole, :math:`\omega_p=2\pi f_p` is its angular frequency, and :math:`\gamma_p` is the inverse of the pole relaxation time (per second).
 
 The syntax of the command is:
 
@@ -388,17 +388,17 @@ The syntax of the command is:
     #add_dispersion_drude: i1 f1 f2 f3 f4 ... str1
 
 * ``i1`` is the number of Drude poles.
-* ``f1`` is the frequency (Hertz), :math:`\omega_{p1}`, for the first Drude pole.
-* ``f2`` is the inverse of the relaxation time (Hertz), :math:`\gamma_{p1}`, for the first Drude pole.
-* ``f3`` is the frequency (Hertz), :math:`\omega_{p2}`, for the second Drude pole.
-* ``f4`` is the inverse of the relaxation time (Hertz), :math:`\gamma_{p2}` for the second Drude pole.
+* ``f1`` is the plasma frequency (Hertz), :math:`f_{p1}`, for the first Drude pole.
+* ``f2`` is the inverse of the relaxation time (per second), :math:`\gamma_{p1}`, for the first Drude pole.
+* ``f3`` is the plasma frequency (Hertz), :math:`f_{p2}`, for the second Drude pole.
+* ``f4`` is the inverse of the relaxation time (per second), :math:`\gamma_{p2}` for the second Drude pole.
 * ...
 * ``str1`` identifies the material to add the dispersive properties to.
 
 .. note::
 
-    * You can continue to add pairs of values for :math:`\omega_p` and :math:`\gamma_p` for as many Drude poles as you have specified with ``i1``.
-    * Temporal values associated with pole frequencies and relaxation times should always be greater than the time step :math:`\Delta t` used in the model.
+    * You can continue to add pairs of values for :math:`f_p` and :math:`\gamma_p` for as many Drude poles as you have specified with ``i1``.
+    * The recursive formulation requires :math:`f_p < 1/\Delta t` and :math:`\gamma_p < 1/\Delta t`. These coefficient limits do not replace the stricter Nyquist and spatial-resolution limits on useful simulation output.
 
 
 #material_range:

--- a/docs/source/material_databases.rst
+++ b/docs/source/material_databases.rst
@@ -130,6 +130,13 @@ and the general inclusive pole representation used internally by gprMax.
 Field names carry units explicitly; for example a Debye pole uses
 ``relative_permittivity_difference`` and ``relaxation_time_s``. Perfect
 conductors use the ``builtin`` model rather than non-standard JSON infinity.
+Lorentz and Drude resonance or plasma frequencies are specified in hertz,
+whereas their damping and collision coefficients are specified per second.
+The recursive formulation requires pole frequencies below ``1 / dt``; this
+coefficient-construction limit must not be mistaken for the stricter Nyquist
+limit on resolved simulation output. The Lorentz representation is
+underdamped and therefore also requires the damping coefficient to be less
+than ``2 * pi`` times the resonance frequency.
 
 Each selected material records the database ID, database version, entry key,
 canonical entry SHA-256, source path, and whether it came from an official
@@ -145,9 +152,8 @@ trade name. FR-4, soils, concrete, and biological tissues can vary strongly
 with composition, manufacture, moisture, temperature, and frequency. New
 official empirical entries should therefore include traceable citations,
 explicit validity bands and conditions, and fit-quality information for fitted
-dispersion models. The migrated Eccosorb fits are explicitly marked as legacy
-where that information was not retained. A generic engineering estimate must
-be labelled as such rather than presented as a measured vendor grade.
+dispersion models. A generic engineering estimate must be labelled as such
+rather than presented as a measured vendor grade.
 
 Curation workflow
 =================
@@ -196,3 +202,10 @@ The source files are not modified. The converter copies all HDF5 arrays and
 attributes, adds stable material keys, writes JSON, and verifies that every
 non-negative material index is declared. This works with voxel-only v3 files
 and current files containing ``ID``, ``rigidE``, and ``rigidH``.
+
+The converter's array-preservation check is the evidence that a legacy file
+was migrated without changing its geometry. By contrast, regenerating a
+geometry object with a newer gprMax version can legitimately change material
+catalogues or component IDs because of unrelated developments in geometry
+construction and material averaging. Such differences must not be attributed
+to the database format without a separate numerical comparison.

--- a/gprMax/material_database.py
+++ b/gprMax/material_database.py
@@ -32,7 +32,12 @@ import numpy as np
 
 import gprMax.config as config
 from gprMax.grid.fdtd_grid import FDTDGrid
-from gprMax.materials import DispersiveMaterial, Material
+from gprMax.materials import (
+    DispersiveMaterial,
+    Material,
+    validate_drude_pole,
+    validate_lorentz_pole,
+)
 
 SCHEMA_NAME = "gprMax-material-database"
 SCHEMA_VERSION = 1
@@ -562,25 +567,19 @@ def build_material_from_spec(grid: FDTDGrid, spec: MaterialSpec, material_id: st
             result.deltaer = [pole["relative_permittivity_difference"] for pole in spec.poles]
             result.tau = [pole["resonance_frequency_hz"] for pole in spec.poles]
             result.alpha = [pole["damping_coefficient_per_s"] for pole in spec.poles]
-            if any(
-                frequency >= (2.0 * np.pi) / grid.dt
-                or damping >= 1.0 / grid.dt
-                or frequency == damping
-                for frequency, damping in zip(result.tau, result.alpha)
-            ):
-                raise ValueError(
-                    f"Lorentz material '{material_id}' has a pole incompatible with dt={grid.dt:g} s"
-                )
+            for frequency, damping in zip(result.tau, result.alpha):
+                try:
+                    validate_lorentz_pole(frequency, damping, grid.dt)
+                except ValueError as exc:
+                    raise ValueError(f"Lorentz material '{material_id}': {exc}") from exc
         elif spec.model == "drude":
             result.tau = [pole["plasma_frequency_hz"] for pole in spec.poles]
             result.alpha = [pole["collision_frequency_per_s"] for pole in spec.poles]
-            if any(
-                frequency >= (2.0 * np.pi) / grid.dt or collision >= 1.0 / grid.dt
-                for frequency, collision in zip(result.tau, result.alpha)
-            ):
-                raise ValueError(
-                    f"Drude material '{material_id}' has a pole incompatible with dt={grid.dt:g} s"
-                )
+            for frequency, collision in zip(result.tau, result.alpha):
+                try:
+                    validate_drude_pole(frequency, collision, grid.dt)
+                except ValueError as exc:
+                    raise ValueError(f"Drude material '{material_id}': {exc}") from exc
         else:
             result.inclusive_w = [pole["w_per_s"] for pole in spec.poles]
             result.inclusive_q = [pole["q_per_s"] for pole in spec.poles]

--- a/gprMax/materials.py
+++ b/gprMax/materials.py
@@ -26,6 +26,49 @@ import gprMax.config as config
 logger = logging.getLogger(__name__)
 
 
+def validate_lorentz_pole(frequency_hz: float, damping_per_s: float, dt: float) -> None:
+    """Validate a Lorentz pole for the recursive material formulation.
+
+    Lorentz resonance frequencies are supplied in hertz, whereas the
+    coefficient construction uses the angular frequency ``2 * pi * f``.
+    The simple conjugate-pole representation used by gprMax is valid only for
+    an underdamped pole.
+    """
+
+    if frequency_hz <= 0:
+        raise ValueError("Lorentz resonance frequency must be positive")
+    if damping_per_s < 0:
+        raise ValueError("Lorentz damping coefficient must be non-negative")
+    if frequency_hz >= 1.0 / dt:
+        raise ValueError("Lorentz resonance frequency must be below 1 / dt")
+    if damping_per_s >= 1.0 / dt:
+        raise ValueError("Lorentz damping coefficient must be below 1 / dt")
+
+    angular_frequency = 2.0 * np.pi * frequency_hz
+    if damping_per_s >= angular_frequency or np.isclose(
+        damping_per_s,
+        angular_frequency,
+        rtol=1e-12,
+        atol=0.0,
+    ):
+        raise ValueError(
+            "Lorentz damping coefficient must be below 2 * pi * resonance frequency"
+        )
+
+
+def validate_drude_pole(frequency_hz: float, collision_per_s: float, dt: float) -> None:
+    """Validate a Drude pole for the recursive material formulation."""
+
+    if frequency_hz <= 0:
+        raise ValueError("Drude plasma frequency must be positive")
+    if collision_per_s <= 0:
+        raise ValueError("Drude collision frequency must be positive")
+    if frequency_hz >= 1.0 / dt:
+        raise ValueError("Drude plasma frequency must be below 1 / dt")
+    if collision_per_s >= 1.0 / dt:
+        raise ValueError("Drude collision frequency must be below 1 / dt")
+
+
 class Material:
     """Super-class to describe generic, non-dispersive materials,
     their properties and update coefficients.

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -44,6 +44,7 @@ from gprMax.materials import ListMaterial as ListMaterialUser
 from gprMax.materials import Material as MaterialUser
 from gprMax.materials import PeplinskiSoil as PeplinskiSoilUser
 from gprMax.materials import RangeMaterial as RangeMaterialUser
+from gprMax.materials import validate_drude_pole, validate_lorentz_pole
 from gprMax.network_ports import RationalNetworkModel, RationalNetworkTerminal
 from gprMax.pml import CFS, CFSParameter, InternalPMLSpec
 from gprMax.receivers import Rx as RxUser
@@ -3479,8 +3480,8 @@ class AddLorentzDispersion(GridUserObject):
         er_delta: tuple required for difference between zero-frequency relative
                     permittivity and relative permittivity at infinite frequency
                     for each pole.
-        omega: tuple required for frequency (Hz) for each pole.
-        delta: tuple required for damping coefficient (Hz) for each pole.
+        omega: tuple required for resonance frequency (Hz) for each pole.
+        delta: tuple required for damping coefficient (per second) for each pole.
         material_ids: list required of material ids to apply disperive
                         properties.
     """
@@ -3538,24 +3539,17 @@ class AddLorentzDispersion(GridUserObject):
             disp_material.poles = poles
             disp_material.averagable = config.get_model_config().dispersive_averaging
             for i in range(poles):
-                if (
-                    er_delta[i] > 0
-                    and omega[i] < (2.0 * np.pi) / grid.dt
-                    and delta[i] < 1.0 / grid.dt
-                    and omega[i] != delta[i]
-                ):
-                    disp_material.deltaer.append(er_delta[i])
-                    disp_material.tau.append(omega[i])
-                    disp_material.alpha.append(delta[i])
-                else:
-                    logger.exception(
-                        f"{self.params_str()} requires positive "
-                        "values for the permittivity difference "
-                        "and frequencies, and associated times "
-                        "that are greater than the inverse of the time step for "
-                        "the model."
+                if er_delta[i] <= 0:
+                    raise ValueError(
+                        f"{self.params_str()} requires positive relative-permittivity differences"
                     )
-                    raise ValueError
+                try:
+                    validate_lorentz_pole(omega[i], delta[i], grid.dt)
+                except ValueError as exc:
+                    raise ValueError(f"{self.params_str()}: {exc}") from exc
+                disp_material.deltaer.append(er_delta[i])
+                disp_material.tau.append(omega[i])
+                disp_material.alpha.append(delta[i])
             if disp_material.poles > config.get_model_config().materials["maxpoles"]:
                 config.get_model_config().materials["maxpoles"] = disp_material.poles
 
@@ -3568,7 +3562,7 @@ class AddLorentzDispersion(GridUserObject):
                 f"{self.grid_name(grid)}Lorentz disperion added to {disp_material.ID} "
                 f"with delta_eps_r={', '.join(f'{deltaer:4.2f}' for deltaer in disp_material.deltaer)}, "
                 f"omega={', '.join(f'{omega:4.3e}' for omega in disp_material.tau)} Hertz, "
-                f"and delta={', '.join(f'{delta:4.3e}' for delta in disp_material.alpha)} Hertz, created."
+                f"and delta={', '.join(f'{delta:4.3e}' for delta in disp_material.alpha)} per second, created."
             )
 
 
@@ -3582,8 +3576,8 @@ class AddDrudeDispersion(GridUserObject):
 
     Attributes:
         poles: float required for number of Drude poles.
-        omega: tuple required for frequency (Hz) for each pole.
-        alpha: tuple required for inverse of relaxation time (secs) for each pole.
+        omega: tuple required for plasma frequency (Hz) for each pole.
+        alpha: tuple required for inverse of relaxation time (per second) for each pole.
         material_ids: list required of material ids to apply disperive
                         properties.
     """
@@ -3639,17 +3633,12 @@ class AddDrudeDispersion(GridUserObject):
             disp_material.poles = poles
             disp_material.averagable = config.get_model_config().dispersive_averaging
             for i in range(poles):
-                if omega[i] < (2.0 * np.pi) / grid.dt and alpha[i] < 1.0 / grid.dt:
-                    disp_material.tau.append(omega[i])
-                    disp_material.alpha.append(alpha[i])
-                else:
-                    logger.exception(
-                        f"{self.params_str()} requires positive "
-                        + "values for the frequencies, and "
-                        + "associated times that are greater than "
-                        + "the inverse of time step for the model."
-                    )
-                    raise ValueError
+                try:
+                    validate_drude_pole(omega[i], alpha[i], grid.dt)
+                except ValueError as exc:
+                    raise ValueError(f"{self.params_str()}: {exc}") from exc
+                disp_material.tau.append(omega[i])
+                disp_material.alpha.append(alpha[i])
             if disp_material.poles > config.get_model_config().materials["maxpoles"]:
                 config.get_model_config().materials["maxpoles"] = disp_material.poles
 
@@ -3661,7 +3650,7 @@ class AddDrudeDispersion(GridUserObject):
             logger.info(
                 f"{self.grid_name(grid)}Drude disperion added to {disp_material.ID} "
                 f"with omega={', '.join(f'{omega:4.3e}' for omega in disp_material.tau)} Hertz, "
-                f"and alpha={', '.join(f'{alpha:4.3e}' for alpha in disp_material.alpha)} Hertz created."
+                f"and alpha={', '.join(f'{alpha:4.3e}' for alpha in disp_material.alpha)} per second created."
             )
 
 

--- a/tests/materials/test_material_database.py
+++ b/tests/materials/test_material_database.py
@@ -105,6 +105,87 @@ def test_debye_names_physical_quantities_explicitly(tmp_path, fake_grid):
     assert material.tau == [9e-12]
 
 
+@pytest.mark.parametrize("damping_ratio", (1.0, 1.01))
+def test_lorentz_database_rejects_critical_and_overdamped_poles(
+    tmp_path, fake_grid, damping_ratio
+):
+    frequency = 100e9
+    entry = _constant(er=2.0)
+    entry.update(
+        {
+            "model": "lorentz",
+            "poles": [
+                {
+                    "relative_permittivity_difference": 3.5,
+                    "resonance_frequency_hz": frequency,
+                    "damping_coefficient_per_s": damping_ratio * 2.0 * np.pi * frequency,
+                }
+            ],
+        }
+    )
+    (tmp_path / "local.json").write_text(json.dumps(_database({"critical": entry})))
+    spec = load_material_spec("local", "critical", search_directory=tmp_path)
+
+    with pytest.raises(ValueError, match=r"damping coefficient.*2 \* pi"):
+        build_material_from_spec(fake_grid(dt=1e-12), spec, "critical")
+
+
+@pytest.mark.parametrize(
+    "model, frequency_field, rate_field",
+    (
+        ("lorentz", "resonance_frequency_hz", "damping_coefficient_per_s"),
+        ("drude", "plasma_frequency_hz", "collision_frequency_per_s"),
+    ),
+)
+def test_database_pole_frequency_limit_uses_hertz_not_angular_frequency(
+    tmp_path, fake_grid, model, frequency_field, rate_field
+):
+    dt = 1e-12
+    pole = {frequency_field: 1.01 / dt, rate_field: 1e9}
+    if model == "lorentz":
+        pole["relative_permittivity_difference"] = 3.5
+    entry = _constant(er=2.0)
+    entry.update({"model": model, "poles": [pole]})
+    (tmp_path / "local.json").write_text(json.dumps(_database({"too_fast": entry})))
+    spec = load_material_spec("local", "too_fast", search_directory=tmp_path)
+
+    with pytest.raises(ValueError, match=r"frequency must be below 1 / dt"):
+        build_material_from_spec(fake_grid(dt=dt), spec, "too_fast")
+
+
+@pytest.mark.parametrize(
+    "model, pole",
+    (
+        (
+            "lorentz",
+            {
+                "relative_permittivity_difference": 3.5,
+                "resonance_frequency_hz": 0.99e12,
+                "damping_coefficient_per_s": 1e9,
+            },
+        ),
+        (
+            "drude",
+            {
+                "plasma_frequency_hz": 0.99e12,
+                "collision_frequency_per_s": 1e9,
+            },
+        ),
+    ),
+)
+def test_database_pole_frequency_just_below_timestep_limit_is_accepted(
+    tmp_path, fake_grid, model, pole
+):
+    entry = _constant(er=2.0)
+    entry.update({"model": model, "poles": [pole]})
+    (tmp_path / "local.json").write_text(json.dumps(_database({"valid": entry})))
+    spec = load_material_spec("local", "valid", search_directory=tmp_path)
+
+    material = build_material_from_spec(fake_grid(dt=1e-12), spec, "valid")
+
+    assert material.type == model
+
+
 def test_general_poles_round_trip_exactly(tmp_path, fake_grid):
     entry = _constant(er=2.0)
     entry.update(

--- a/tests/user_objects/test_cmds_multiuse.py
+++ b/tests/user_objects/test_cmds_multiuse.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
+from gprMax.materials import Material as RuntimeMaterial
 from gprMax.user_objects.cmds_multiuse import (
     PMLCFS,
     AddDebyeDispersion,
@@ -581,6 +582,35 @@ class TestAddLorentzDispersion:
         assert d.order == 12
         assert d.hash == "#add_dispersion_lorentz"
 
+    def test_build_rejects_critical_pole(self, stub_grid, user_object_config):
+        user_object_config.model_config.dispersive_averaging = True
+        stub_grid.materials.append(RuntimeMaterial(2, "sample"))
+        frequency = 10e9
+        dispersion = AddLorentzDispersion(
+            poles=1,
+            er_delta=(1.0,),
+            omega=(frequency,),
+            delta=(2.0 * np.pi * frequency,),
+            material_ids=["sample"],
+        )
+
+        with pytest.raises(ValueError, match=r"damping coefficient.*2 \* pi"):
+            dispersion.build(stub_grid)
+
+    def test_build_rejects_frequency_at_timestep_limit(self, stub_grid, user_object_config):
+        user_object_config.model_config.dispersive_averaging = True
+        stub_grid.materials.append(RuntimeMaterial(2, "sample"))
+        dispersion = AddLorentzDispersion(
+            poles=1,
+            er_delta=(1.0,),
+            omega=(1.0 / stub_grid.dt,),
+            delta=(1e8,),
+            material_ids=["sample"],
+        )
+
+        with pytest.raises(ValueError, match=r"frequency must be below 1 / dt"):
+            dispersion.build(stub_grid)
+
 
 class TestAddDrudeDispersion:
     def test_constructor_stores_kwargs(self):
@@ -591,6 +621,19 @@ class TestAddDrudeDispersion:
         d = AddDrudeDispersion()
         assert d.order == 13
         assert d.hash == "#add_dispersion_drude"
+
+    def test_build_rejects_frequency_at_timestep_limit(self, stub_grid, user_object_config):
+        user_object_config.model_config.dispersive_averaging = True
+        stub_grid.materials.append(RuntimeMaterial(2, "sample"))
+        dispersion = AddDrudeDispersion(
+            poles=1,
+            omega=(1.0 / stub_grid.dt,),
+            alpha=(1e8,),
+            material_ids=["sample"],
+        )
+
+        with pytest.raises(ValueError, match=r"frequency must be below 1 / dt"):
+            dispersion.build(stub_grid)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- correct the Lorentz critical-damping guard from `f_p == delta_p` to `delta_p < 2*pi*f_p`, rejecting critical and overdamped poles before coefficient construction
- correct Lorentz and Drude pole-frequency timestep checks from the angular-frequency expression `2*pi/dt` to the hertz limit `1/dt`
- share the validation between JSON material databases and the existing hash-command/Python API dispersion paths
- correct Lorentz and Drude equations, units, and timestep-limit explanations in the documentation
- remove the unshipped Eccosorb-database claim and clarify that regenerated geometry-reference drift is not evidence of database-format conversion
- add regression tests at the Lorentz singularity and on both sides of the timestep frequency limit

The `1/dt` check is the recursive coefficient-construction bound. It is not presented as the output Nyquist limit, which remains `1/(2*dt)`.

## Type of change

- [x] Bug fix
- [x] Documentation update

## Testing

- [x] `python -m pytest -m unit -q` — 3564 passed, 5 skipped
- [x] focused material and input-interface tests — 533 passed
- [x] Sphinx HTML build completed successfully; only two pre-existing unused-citation warnings remain
- [x] `git diff --check`

## Checklist

- [x] I have performed a self-review of the code.
- [x] I have added comments and diagnostics for the numerical constraints.
- [x] I have made corresponding documentation changes.
- [x] The changes generate no new documentation warnings.
- [x] The PR title is a short description of the changes.