### PR TITLE
Add semantic tags for voxelised geometry

### DIFF
--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -576,6 +576,44 @@ Object construction functions
 
 Object construction commands are processed in the order they appear in the scene. Therefore space in the model allocated to a specific material using for example the :class:`gprMax.user_objects.cmds_geometry.box.Box` command can be reallocated to another material using the same or any other object construction command. Space in the model can be regarded as a canvas in which objects are introduced and one can be overlaid on top of the other overwriting its properties in order to produce the desired geometry. The object construction commands can therefore be used to create complex shapes and configurations.
 
+Cell-centred geometry tags
+--------------------------
+
+The volumetric commands ``Box``, ``Sphere``, ``Cylinder``, ``Cone``,
+``CylindricalSector``, ``Ellipsoid``, a ``Triangle`` with non-zero thickness,
+and ``FractalBox`` accept the optional keyword ``tag``. A tag is semantic
+metadata independent of the electromagnetic material, for example
+``tag='cranial_bone'``. Reusing the same string on several primitives makes
+them one semantic region without retaining a list of the individual
+primitives.
+
+Tags follow the same ordered overwrite semantics as geometry. A tagged
+primitive writes its tag to every cell it occupies; an untagged primitive
+writes tag ID zero and therefore clears an older tag in its cells. This makes
+constructive geometry work naturally. For example, an untagged free-space
+cylinder drawn inside a tagged material cylinder leaves a tagged shell and an
+untagged hollow interior. A free-space volume may itself be tagged when that
+region is intentionally significant. Dielectric smoothing does not alter tag
+membership.
+
+.. code-block:: python
+
+    scene.add(gprMax.Cylinder(
+        p1=(0.10, 0.10, 0.05), p2=(0.10, 0.10, 0.15),
+        r=0.04, material_id='plastic', tag='container',
+    ))
+    scene.add(gprMax.Cylinder(
+        p1=(0.10, 0.10, 0.05), p2=(0.10, 0.10, 0.15),
+        r=0.03, material_id='free_space',
+    ))
+
+Tag ID zero is permanently reserved for ``untagged``. The model stores one
+compact integer per cell only when at least one tag is present; tag arrays are
+not part of the FDTD field update and are not transferred to accelerators.
+Tags are flat rather than hierarchical. Larger groups such as ``head`` can be
+formed later by selecting several leaf tags such as ``brain``, ``eyes``, and
+``cranial_bone``.
+
 Box
 ---
 .. autoclass:: gprMax.user_objects.cmds_geometry.box.Box
@@ -711,7 +749,7 @@ fractal box by its ID and must be added after it:
     scene.add(gprMax.FractalBox(
         p1=(0, 0, 0), p2=(0.30, 0.20, 0.10),
         frac_dim=1.5, weighting=(1, 1, 1), n_materials=20,
-        mixing_model_id='soil_mix', id='ground', seed=1,
+        mixing_model_id='soil_mix', id='ground', seed=1, tag='soil_layer_1',
     ))
     scene.add(gprMax.AddSurfaceRoughness(
         p1=(0, 0, 0.10), p2=(0.30, 0.20, 0.10),
@@ -741,7 +779,10 @@ Geometry Objects Write
 .. autoclass:: gprMax.user_objects.cmds_output.GeometryObjectsWrite
 
 Geometry views are visualisations. Geometry-object files instead preserve
-material-index geometry for insertion into another model:
+material-index geometry for insertion into another model. If semantic tags
+exist, both outputs also preserve their cell IDs and the ID-to-name table.
+This permits a costly tagged anatomy or geological model to be written once
+and inserted into later simulations without rebuilding it:
 
 .. code-block:: python
 

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -767,11 +767,30 @@ For example to specify a xy oriented plate that is a perfect electric conductor,
 #triangle:
 ----------
 
+.. _geometry-tags-hash:
+
+The volumetric commands ``#triangle`` (non-zero thickness), ``#box``,
+``#sphere``, ``#cylinder``, ``#cylindrical_sector``, ``#cone``,
+``#ellipsoid``, and ``#fractal_box`` accept an optional final positional
+``tag_name`` string. Geometry tags are cell-centred semantic metadata and
+are independent of materials. They follow normal ordered geometry semantics:
+a later tagged volume replaces the older tag in its cells, while a later
+untagged volume clears those cells to tag ID zero. Consequently
+``#cylinder: ... plastic n container`` followed by a smaller untagged
+free-space cylinder creates a tagged hollow shell. The tag must always be the
+last argument. To keep the positional grammar unambiguous and backward
+compatible, hash-command users must explicitly provide the preceding ``y`` or
+``n`` smoothing argument whenever a tag is present. A tagged
+``#fractal_box`` must therefore provide its seed and smoothing arguments
+before the tag. Tags may contain letters, digits, ``_``, ``-``, ``.``, and
+``:``; spaces are not permitted. The Python API does not require an explicit
+smoothing argument when ``tag`` is used.
+
 Allows you to introduce a triangular patch or a triangular prism with specific properties into the model. The patch is just a triangular surface made as a collection of staircased Yee cells, and the triangular prism extends the triangular patch in the direction perpendicular to the plane. The syntax of the command is:
 
 .. code-block:: none
 
-    #triangle: f1 f2 f3 f4 f5 f6 f7 f8 f9 f10 str1 [c1]
+    #triangle: f1 f2 f3 f4 f5 f6 f7 f8 f9 f10 str1 [c1 [tag_name]]
 
 * ``f1 f2 f3`` are the coordinates (x,y,z) of the first apex of the triangle, ``f4 f5 f6`` the coordinates (x,y,z) of the second apex, and ``f7 f8 f9`` the coordinates (x,y,z) of the third apex.
 * ``f10`` is the thickness of the triangular prism. If the thickness is zero then a triangular patch is created.
@@ -787,7 +806,7 @@ Allows you to introduce an orthogonal parallelepiped with specific properties in
 
 .. code-block:: none
 
-    #box: f1 f2 f3 f4 f5 f6 str1 [c1]
+    #box: f1 f2 f3 f4 f5 f6 str1 [c1 [tag_name]]
 
 * ``f1 f2 f3`` are the lower left (x,y,z) coordinates of the parallelepiped, and ``f4 f5 f6`` are the upper right (x,y,z) coordinates of the parallelepiped.
 * ``str1`` is a material identifier that must correspond to material that has already been defined in the input file, or is one of the builtin materials.
@@ -800,7 +819,7 @@ Allows you to introduce a spherical object with specific parameters into the mod
 
 .. code-block:: none
 
-    #sphere: f1 f2 f3 f4 str1 [c1]
+    #sphere: f1 f2 f3 f4 str1 [c1 [tag_name]]
 
 * ``f1 f2 f3`` are the coordinates (x,y,z) of the centre of the sphere.
 * ``f4`` is its radius.
@@ -820,7 +839,7 @@ Allows you to introduce a circular cylinder into the model. The orientation of t
 
 .. code-block:: none
 
-    #cylinder: f1 f2 f3 f4 f5 f6 f7 str1 [c1]
+    #cylinder: f1 f2 f3 f4 f5 f6 f7 str1 [c1 [tag_name]]
 
 * ``f1 f2 f3`` are the coordinates (x,y,z) of the centre of one face of the cylinder, and ``f4 f5 f6`` are the coordinates (x,y,z) of the centre of the other face.
 * ``f7`` is the radius of the cylinder.
@@ -841,7 +860,7 @@ Allows you to introduce a cylindrical sector (shaped like a slice of pie) into t
 
 .. code-block:: none
 
-    #cylindrical_sector: c1 f1 f2 f3 f4 f5 f6 f7 str1 [c1]
+    #cylindrical_sector: c1 f1 f2 f3 f4 f5 f6 f7 str1 [c1 [tag_name]]
 
 * ``c1`` is the direction of the axis of the cylinder from which the sector is defined and can be ``x``, ``y``, or ``z``.
 * ``f1 f2`` are the coordinates of the centre of the cylindrical sector.
@@ -865,7 +884,7 @@ Allows you to introduce a cone into the model. The orientation of the cylinder a
 
 .. code-block:: none
 
-    #cone: f1 f2 f3 f4 f5 f6 f7 f8 str1 [c1]
+    #cone: f1 f2 f3 f4 f5 f6 f7 f8 str1 [c1 [tag_name]]
 
 * ``f1 f2 f3`` are the coordinates (x,y,z) of the centre of the first face of the cone, and ``f4 f5 f6`` are the coordinates (x,y,z) of the centre of the other face.
 * ``f7`` is the radius of the first face of the cone, and ``f8`` is the radius of the other face of the cone.
@@ -885,7 +904,7 @@ Allows you to introduce an ellipsoid into the model. The syntax of the command i
 
 .. code-block:: none
 
-    #ellipsoid: f1 f2 f3 f4 f5 f6 str1 [c1]
+    #ellipsoid: f1 f2 f3 f4 f5 f6 str1 [c1 [tag_name]]
 
 * ``f1 f2 f3`` are the coordinates (x,y,z) of the centre of the ellipsoid.
 * ``f4 f5 f6`` are the coordinates (x,y,z) of the semi-axes of the ellipsoid.
@@ -907,7 +926,7 @@ Allows you to introduce an orthogonal parallelepiped with fractal distributed pr
 
 .. code-block:: none
 
-    #fractal_box: f1 f2 f3 f4 f5 f6 f7 f8 f9 f10 i1 str1 str2 [i2] [c1]
+    #fractal_box: f1 f2 f3 f4 f5 f6 f7 f8 f9 f10 i1 str1 str2 [i2 [c1 [tag_name]]]
 
 * ``f1 f2 f3`` are the lower left (x,y,z) coordinates of the parallelepiped, and ``f4 f5 f6`` are the upper right (x,y,z) coordinates of the parallelepiped.
 * ``f7`` is the fractal dimension which, for an orthogonal parallelepiped, should take values between zero and three.
@@ -1022,7 +1041,7 @@ AustinMan_v2.6_2x2x2_gprmax.h5 AustinMan_v2_6_2mm_materials``.
 #geometry_objects_write:
 ------------------------
 
-Allows you to write geometry generated in a model to file. The file can be read back into gprMax using the ``#geometry_objects_read`` command. This allows complex geometry that can take some time to generate to be saved to file and more quickly imported into subsequent models. Geometry arrays and stable material keys are saved in HDF5 and corresponding material definitions are saved in a versioned ``_materials.json`` database. The syntax of the command is:
+Allows you to write geometry generated in a model to file. The file can be read back into gprMax using the ``#geometry_objects_read`` command. This allows complex geometry that can take some time to generate to be saved to file and more quickly imported into subsequent models. Geometry arrays, cell-centred semantic tags (when present), their ID-to-name table, and stable material keys are saved in HDF5. Corresponding material definitions are saved in a versioned ``_materials.json`` database. The syntax of the command is:
 
 .. code-block:: none
 

--- a/docs/source/output.rst
+++ b/docs/source/output.rst
@@ -1046,6 +1046,15 @@ Geometry files use the open source `Visualization ToolKit (VTK) <http://www.vtk.
 
 The ``#geometry_view:`` command produces either ImageData for a per-cell geometry view, or UnstructuredGrid for a per-cell-edge geometry view. The following are steps to get started with viewing geometry files in Paraview:
 
+If the model contains semantic geometry tags, a normal per-cell geometry view
+also contains the integer cell array ``TagID``. VTKHDF field data stores the
+matching ``geometry_tag_ids`` and ``geometry_tag_names`` arrays; ID zero means
+``untagged``. The tag array records the final voxelised geometry after ordered
+overwrites and is not affected by dielectric smoothing. It is omitted
+entirely for models without tags. Per-cell-edge geometry views do not export
+tags because zero-thickness edge and plate objects do not yet have tag
+semantics.
+
 .. _pv_toolbar:
 
 .. figure:: ../../images_shared/paraview_toolbar.png

--- a/gprMax/cython/geometry_primitives.pyx
+++ b/gprMax/cython/geometry_primitives.pyx
@@ -20,6 +20,7 @@
 
 import numpy as np
 
+cimport cython
 cimport numpy as np
 from libc.math cimport ceil, cos, sin
 
@@ -38,6 +39,29 @@ from gprMax.cython.yee_cell_setget_rigid cimport (
 )
 
 from gprMax.utilities.utilities import round_value
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef inline void set_geometry_tag(
+    np.uint8_t[::1] tag_bytes,
+    int itemsize,
+    Py_ssize_t ny,
+    Py_ssize_t nz,
+    Py_ssize_t i,
+    Py_ssize_t j,
+    Py_ssize_t k,
+    unsigned int tag_id,
+) noexcept nogil:
+    """Write an adaptively sized tag ID to a flattened C-contiguous map."""
+
+    cdef Py_ssize_t offset = ((i * ny + j) * nz + k) * itemsize
+    if itemsize == 1:
+        tag_bytes[offset] = <np.uint8_t>tag_id
+    elif itemsize == 2:
+        (<np.uint16_t*>&tag_bytes[offset])[0] = <np.uint16_t>tag_id
+    else:
+        (<np.uint32_t*>&tag_bytes[offset])[0] = <np.uint32_t>tag_id
 
 
 cpdef bint are_clockwise(
@@ -508,7 +532,9 @@ cpdef void build_triangle(
     np.uint32_t[:, :, ::1] solid,
     np.int8_t[:, :, :, ::1] rigidE,
     np.int8_t[:, :, :, ::1] rigidH,
-    np.uint32_t[:, :, :, ::1] ID
+    np.uint32_t[:, :, :, ::1] ID,
+    object tag_data=None,
+    unsigned int tag_id=0
 ):
     """
     Builds triangles and triangular prisms which sets values in the solid,
@@ -534,6 +560,18 @@ cpdef void build_triangle(
     cdef long long bu, bv, cu, cv, qu2, qv2
     cdef long long denominator, s_num2, t_num2
     cdef bint inside
+    cdef int tag_itemsize = 0
+    cdef np.uint8_t[::1] tag_bytes
+    cdef object tag_array
+
+    if tag_data is not None:
+        tag_array = np.asarray(tag_data)
+        if tag_array.ndim != 3 or not tag_array.flags.c_contiguous:
+            raise ValueError("Geometry tag map must be a C-contiguous 3-D array")
+        if tag_array.dtype not in (np.uint8, np.uint16, np.uint32):
+            raise TypeError("Geometry tag map must use uint8, uint16, or uint32")
+        tag_itemsize = tag_array.itemsize
+        tag_bytes = tag_array.view(np.uint8).reshape(-1)
 
     # Work from snapped cell indices and relative coordinates. This avoids
     # subtracting large absolute floating-point coordinates, so translating an
@@ -620,14 +658,23 @@ cpdef void build_triangle(
                             build_voxel(k, i, j, numID, numIDx, numIDy, numIDz,
                                         averaging, pec_x, pec_y, pec_z,
                                         solid, rigidE, rigidH, ID)
+                            if tag_itemsize:
+                                set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1],
+                                                 solid.shape[2], k, i, j, tag_id)
                         elif normal == 'y':
                             build_voxel(i, k, j, numID, numIDx, numIDy, numIDz,
                                         averaging, pec_x, pec_y, pec_z,
                                         solid, rigidE, rigidH, ID)
+                            if tag_itemsize:
+                                set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1],
+                                                 solid.shape[2], i, k, j, tag_id)
                         elif normal == 'z':
                             build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
                                         averaging, pec_x, pec_y, pec_z,
                                         solid, rigidE, rigidH, ID)
+                            if tag_itemsize:
+                                set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1],
+                                                 solid.shape[2], i, j, k, tag_id)
 
 
 cpdef void build_cylindrical_sector(
@@ -653,7 +700,9 @@ cpdef void build_cylindrical_sector(
     np.uint32_t[:, :, ::1] solid,
     np.int8_t[:, :, :, ::1] rigidE,
     np.int8_t[:, :, :, ::1] rigidH,
-    np.uint32_t[:, :, :, ::1] ID
+    np.uint32_t[:, :, :, ::1] ID,
+    object tag_data=None,
+    unsigned int tag_id=0
 ):
     """
     Builds cylindrical sectors which sets values in the solid, rigid and ID
@@ -684,6 +733,18 @@ cpdef void build_cylindrical_sector(
     cdef int x1, x2, y1, y2, z1, z2, thicknesscells, ctr1cell, ctr2cell
     cdef int radiuscells1, radiuscells2
     cdef double rel1, rel2
+    cdef int tag_itemsize = 0
+    cdef np.uint8_t[::1] tag_bytes
+    cdef object tag_array
+
+    if tag_data is not None:
+        tag_array = np.asarray(tag_data)
+        if tag_array.ndim != 3 or not tag_array.flags.c_contiguous:
+            raise ValueError("Geometry tag map must be a C-contiguous 3-D array")
+        if tag_array.dtype not in (np.uint8, np.uint16, np.uint32):
+            raise TypeError("Geometry tag map must use uint8, uint16, or uint32")
+        tag_itemsize = tag_array.itemsize
+        tag_bytes = tag_array.view(np.uint8).reshape(-1)
 
     if normal == 'x':
         # Angles are defined from zero degrees on the positive y-axis going
@@ -717,6 +778,9 @@ cpdef void build_cylindrical_sector(
                             build_voxel(x, y, z, numID, numIDx, numIDy, numIDz,
                                         averaging, pec_x, pec_y, pec_z,
                                         solid, rigidE, rigidH, ID)
+                            if tag_itemsize:
+                                set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1],
+                                                 solid.shape[2], x, y, z, tag_id)
 
     elif normal == 'y':
         # Angles are defined from zero degrees on the positive x-axis going
@@ -750,6 +814,9 @@ cpdef void build_cylindrical_sector(
                             build_voxel(x, y, z, numID, numIDx, numIDy, numIDz,
                                         averaging, pec_x, pec_y, pec_z,
                                         solid, rigidE, rigidH, ID)
+                            if tag_itemsize:
+                                set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1],
+                                                 solid.shape[2], x, y, z, tag_id)
 
     elif normal == 'z':
         # Angles are defined from zero degrees on the positive x-axis going
@@ -783,6 +850,9 @@ cpdef void build_cylindrical_sector(
                             build_voxel(x, y, z, numID, numIDx, numIDy, numIDz,
                                         averaging, pec_x, pec_y, pec_z,
                                         solid, rigidE, rigidH, ID)
+                            if tag_itemsize:
+                                set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1],
+                                                 solid.shape[2], x, y, z, tag_id)
 
 
 cpdef void build_box(
@@ -803,7 +873,9 @@ cpdef void build_box(
     np.uint32_t[:, :, ::1] solid,
     np.int8_t[:, :, :, ::1] rigidE,
     np.int8_t[:, :, :, ::1] rigidH,
-    np.uint32_t[:, :, :, ::1] ID
+    np.uint32_t[:, :, :, ::1] ID,
+    object tag_data=None,
+    unsigned int tag_id=0
 ):
     """Builds boxes which sets values in the solid, rigid and ID arrays.
 
@@ -818,12 +890,29 @@ cpdef void build_box(
     """
 
     cdef Py_ssize_t i, j, k
+    cdef int tag_itemsize = 0
+    cdef np.uint8_t[::1] tag_bytes
+    cdef object tag_array
+
+    if tag_data is not None:
+        tag_array = np.asarray(tag_data)
+        if tag_array.ndim != 3 or not tag_array.flags.c_contiguous:
+            raise ValueError("Geometry tag map must be a C-contiguous 3-D array")
+        if tag_array.dtype not in (np.uint8, np.uint16, np.uint32):
+            raise TypeError("Geometry tag map must use uint8, uint16, or uint32")
+        if tag_array.shape != (solid.shape[0], solid.shape[1], solid.shape[2]):
+            raise ValueError("Geometry tag map shape must match the solid array")
+        tag_itemsize = tag_array.itemsize
+        tag_bytes = tag_array.view(np.uint8).reshape(-1)
 
     if averaging:
         for i in range(xs, xf):
             for j in range(ys, yf):
                 for k in range(zs, zf):
                     solid[i, j, k] = numID
+                    if tag_itemsize:
+                        set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1], solid.shape[2],
+                                         i, j, k, tag_id)
                     unset_rigid_E(i, j, k, rigidE)
                     unset_rigid_H(i, j, k, rigidH)
     else:
@@ -831,6 +920,9 @@ cpdef void build_box(
             for j in range(ys, yf):
                 for k in range(zs, zf):
                     solid[i, j, k] = numID
+                    if tag_itemsize:
+                        set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1], solid.shape[2],
+                                         i, j, k, tag_id)
                     set_rigid_E(i, j, k, rigidE)
 
         # Each E/H component gets its own full-range loop. Ex/Ey/Ez are
@@ -908,7 +1000,9 @@ cpdef void build_cylinder(
     np.uint32_t[:, :, ::1] solid,
     np.int8_t[:, :, :, ::1] rigidE,
     np.int8_t[:, :, :, ::1] rigidH,
-    np.uint32_t[:, :, :, ::1] ID
+    np.uint32_t[:, :, :, ::1] ID,
+    object tag_data=None,
+    unsigned int tag_id=0
 ):
     """Builds cylinders which sets values in the solid, rigid and ID arrays for
         a Yee voxel.
@@ -932,6 +1026,18 @@ cpdef void build_cylinder(
     cdef int rx, ry, rz
     cdef double ax, ay, az, axis2, qx, qy, qz, projection, t
     cdef double radial2, radius2
+    cdef int tag_itemsize = 0
+    cdef np.uint8_t[::1] tag_bytes
+    cdef object tag_array
+
+    if tag_data is not None:
+        tag_array = np.asarray(tag_data)
+        if tag_array.ndim != 3 or not tag_array.flags.c_contiguous:
+            raise ValueError("Geometry tag map must be a C-contiguous 3-D array")
+        if tag_array.dtype not in (np.uint8, np.uint16, np.uint32):
+            raise TypeError("Geometry tag map must use uint8, uint16, or uint32")
+        tag_itemsize = tag_array.itemsize
+        tag_bytes = tag_array.view(np.uint8).reshape(-1)
 
     ix1, iy1, iz1 = round_value(x1 / dx), round_value(y1 / dy), round_value(z1 / dz)
     ix2, iy2, iz2 = round_value(x2 / dx), round_value(y2 / dy), round_value(z2 / dz)
@@ -958,6 +1064,9 @@ cpdef void build_cylinder(
                         build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
                                     averaging, pec_x, pec_y, pec_z,
                                     solid, rigidE, rigidH, ID)
+                        if tag_itemsize:
+                            set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1],
+                                             solid.shape[2], i, j, k, tag_id)
 
 
 cpdef void build_cone(
@@ -983,7 +1092,9 @@ cpdef void build_cone(
     np.uint32_t[:, :, ::1] solid,
     np.int8_t[:, :, :, ::1] rigidE,
     np.int8_t[:, :, :, ::1] rigidH,
-    np.uint32_t[:, :, :, ::1] ID
+    np.uint32_t[:, :, :, ::1] ID,
+    object tag_data=None,
+    unsigned int tag_id=0
 ):
     """Builds cones which sets values in the solid, rigid and ID arrays for
         a Yee voxel.
@@ -1008,6 +1119,18 @@ cpdef void build_cone(
     cdef int rx, ry, rz
     cdef double ax, ay, az, axis2, qx, qy, qz, projection, t
     cdef double radial2, radius, Rmax
+    cdef int tag_itemsize = 0
+    cdef np.uint8_t[::1] tag_bytes
+    cdef object tag_array
+
+    if tag_data is not None:
+        tag_array = np.asarray(tag_data)
+        if tag_array.ndim != 3 or not tag_array.flags.c_contiguous:
+            raise ValueError("Geometry tag map must be a C-contiguous 3-D array")
+        if tag_array.dtype not in (np.uint8, np.uint16, np.uint32):
+            raise TypeError("Geometry tag map must use uint8, uint16, or uint32")
+        tag_itemsize = tag_array.itemsize
+        tag_bytes = tag_array.view(np.uint8).reshape(-1)
 
     ix1, iy1, iz1 = round_value(x1 / dx), round_value(y1 / dy), round_value(z1 / dz)
     ix2, iy2, iz2 = round_value(x2 / dx), round_value(y2 / dy), round_value(z2 / dz)
@@ -1035,6 +1158,9 @@ cpdef void build_cone(
                         build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
                                     averaging, pec_x, pec_y, pec_z,
                                     solid, rigidE, rigidH, ID)
+                        if tag_itemsize:
+                            set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1],
+                                             solid.shape[2], i, j, k, tag_id)
 
 
 cpdef void build_sphere(
@@ -1056,7 +1182,9 @@ cpdef void build_sphere(
     np.uint32_t[:, :, ::1] solid,
     np.int8_t[:, :, :, ::1] rigidE,
     np.int8_t[:, :, :, ::1] rigidH,
-    np.uint32_t[:, :, :, ::1] ID
+    np.uint32_t[:, :, :, ::1] ID,
+    object tag_data=None,
+    unsigned int tag_id=0
 ):
     """Builds spheres which sets values in the solid, rigid and ID arrays for
         a Yee voxel.
@@ -1076,6 +1204,18 @@ cpdef void build_sphere(
     cdef Py_ssize_t i, j, k
     cdef int xs, xf, ys, yf, zs, zf, rx, ry, rz
     cdef double qx, qy, qz
+    cdef int tag_itemsize = 0
+    cdef np.uint8_t[::1] tag_bytes
+    cdef object tag_array
+
+    if tag_data is not None:
+        tag_array = np.asarray(tag_data)
+        if tag_array.ndim != 3 or not tag_array.flags.c_contiguous:
+            raise ValueError("Geometry tag map must be a C-contiguous 3-D array")
+        if tag_array.dtype not in (np.uint8, np.uint16, np.uint32):
+            raise TypeError("Geometry tag map must use uint8, uint16, or uint32")
+        tag_itemsize = tag_array.itemsize
+        tag_bytes = tag_array.view(np.uint8).reshape(-1)
 
     # Calculate a bounding box for sphere
     rx, ry, rz = <int>ceil(r / dx), <int>ceil(r / dy), <int>ceil(r / dz)
@@ -1105,6 +1245,9 @@ cpdef void build_sphere(
                     build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
                                 averaging, pec_x, pec_y, pec_z,
                                 solid, rigidE, rigidH, ID)
+                    if tag_itemsize:
+                        set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1],
+                                         solid.shape[2], i, j, k, tag_id)
 
 
 cpdef void build_ellipsoid(
@@ -1128,7 +1271,9 @@ cpdef void build_ellipsoid(
     np.uint32_t[:, :, ::1] solid,
     np.int8_t[:, :, :, ::1] rigidE,
     np.int8_t[:, :, :, ::1] rigidH,
-    np.uint32_t[:, :, :, ::1] ID
+    np.uint32_t[:, :, :, ::1] ID,
+    object tag_data=None,
+    unsigned int tag_id=0
 ):
     """Builds ellipsoids which sets values in the solid, rigid and ID arrays for
         a Yee voxel.
@@ -1150,6 +1295,18 @@ cpdef void build_ellipsoid(
     cdef Py_ssize_t i, j, k
     cdef int xs, xf, ys, yf, zs, zf, rxcells, rycells, rzcells
     cdef double qx, qy, qz
+    cdef int tag_itemsize = 0
+    cdef np.uint8_t[::1] tag_bytes
+    cdef object tag_array
+
+    if tag_data is not None:
+        tag_array = np.asarray(tag_data)
+        if tag_array.ndim != 3 or not tag_array.flags.c_contiguous:
+            raise ValueError("Geometry tag map must be a C-contiguous 3-D array")
+        if tag_array.dtype not in (np.uint8, np.uint16, np.uint32):
+            raise TypeError("Geometry tag map must use uint8, uint16, or uint32")
+        tag_itemsize = tag_array.itemsize
+        tag_bytes = tag_array.view(np.uint8).reshape(-1)
 
     # Calculate an origin-independent bounding box.
     rxcells, rycells, rzcells = <int>ceil(xr / dx), <int>ceil(yr / dy), <int>ceil(zr / dz)
@@ -1179,6 +1336,9 @@ cpdef void build_ellipsoid(
                     build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
                                 averaging, pec_x, pec_y, pec_z,
                                 solid, rigidE, rigidH, ID)
+                    if tag_itemsize:
+                        set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1],
+                                         solid.shape[2], i, j, k, tag_id)
 
 
 cpdef void build_voxels_from_array(
@@ -1193,7 +1353,9 @@ cpdef void build_voxels_from_array(
     np.uint32_t[:, :, ::1] solid,
     np.int8_t[:, :, :, ::1] rigidE,
     np.int8_t[:, :, :, ::1] rigidH,
-    np.uint32_t[:, :, :, ::1] ID
+    np.uint32_t[:, :, :, ::1] ID,
+    object tag_data=None,
+    unsigned int tag_id=0
 ):
     """Builds Yee voxels by reading integers from an array.
 
@@ -1222,6 +1384,18 @@ cpdef void build_voxels_from_array(
     cdef Py_ssize_t i, j, k
     cdef int xf, yf, zf, numID
     cdef bint pec, voxel_averaging
+    cdef int tag_itemsize = 0
+    cdef np.uint8_t[::1] tag_bytes
+    cdef object tag_array
+
+    if tag_data is not None:
+        tag_array = np.asarray(tag_data)
+        if tag_array.ndim != 3 or not tag_array.flags.c_contiguous:
+            raise ValueError("Geometry tag map must be a C-contiguous 3-D array")
+        if tag_array.dtype not in (np.uint8, np.uint16, np.uint32):
+            raise TypeError("Geometry tag map must use uint8, uint16, or uint32")
+        tag_itemsize = tag_array.itemsize
+        tag_bytes = tag_array.view(np.uint8).reshape(-1)
 
     # Set bounds to domain if they outside
     if xs < 0:
@@ -1255,6 +1429,9 @@ cpdef void build_voxels_from_array(
                     voxel_averaging = averaging and is_averagable_lookup[numID]
                     build_voxel(i, j, k, numID, numID, numID, numID, voxel_averaging,
                                 pec, pec, pec, solid, rigidE, rigidH, ID)
+                    if tag_itemsize:
+                        set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1], solid.shape[2],
+                                         i, j, k, tag_id)
 
 
 cpdef void build_voxels_from_array_mask(
@@ -1271,7 +1448,11 @@ cpdef void build_voxels_from_array_mask(
     np.uint32_t[:, :, ::1] solid,
     np.int8_t[:, :, :, ::1] rigidE,
     np.int8_t[:, :, :, ::1] rigidH,
-    np.uint32_t[:, :, :, ::1] ID
+    np.uint32_t[:, :, :, ::1] ID,
+    object tag_data=None,
+    unsigned int tag_id=0,
+    unsigned int water_tag_id=0,
+    unsigned int grass_tag_id=0
 ):
     """Builds Yee voxels by reading integers from an array.
 
@@ -1294,6 +1475,18 @@ cpdef void build_voxels_from_array_mask(
     cdef Py_ssize_t i, j, k
     cdef int xf, yf, zf, numID, numIDx, numIDy, numIDz
     cdef bint pec, voxel_averaging
+    cdef int tag_itemsize = 0
+    cdef np.uint8_t[::1] tag_bytes
+    cdef object tag_array
+
+    if tag_data is not None:
+        tag_array = np.asarray(tag_data)
+        if tag_array.ndim != 3 or not tag_array.flags.c_contiguous:
+            raise ValueError("Geometry tag map must be a C-contiguous 3-D array")
+        if tag_array.dtype not in (np.uint8, np.uint16, np.uint32):
+            raise TypeError("Geometry tag map must use uint8, uint16, or uint32")
+        tag_itemsize = tag_array.itemsize
+        tag_bytes = tag_array.view(np.uint8).reshape(-1)
 
     # Set upper bounds
     xf = xs + data.shape[0]
@@ -1309,15 +1502,24 @@ cpdef void build_voxels_from_array_mask(
                     voxel_averaging = averaging and is_averagable_lookup[numID]
                     build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
                                 voxel_averaging, pec, pec, pec, solid, rigidE, rigidH, ID)
+                    if tag_itemsize:
+                        set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1], solid.shape[2],
+                                         i, j, k, tag_id)
                 elif mask[i - xs, j - ys, k - zs] == 2:
                     numID = numIDx = numIDy = numIDz = waternumID
                     pec = is_pec_lookup[numID]
                     voxel_averaging = averaging and is_averagable_lookup[numID]
                     build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
                                 voxel_averaging, pec, pec, pec, solid, rigidE, rigidH, ID)
+                    if tag_itemsize:
+                        set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1], solid.shape[2],
+                                         i, j, k, water_tag_id)
                 elif mask[i - xs, j - ys, k - zs] == 3:
                     numID = numIDx = numIDy = numIDz = grassnumID
                     pec = is_pec_lookup[numID]
                     voxel_averaging = averaging and is_averagable_lookup[numID]
                     build_voxel(i, j, k, numID, numIDx, numIDy, numIDz,
                                 voxel_averaging, pec, pec, pec, solid, rigidE, rigidH, ID)
+                    if tag_itemsize:
+                        set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1], solid.shape[2],
+                                         i, j, k, grass_tag_id)

--- a/gprMax/geometry_outputs/geometry_objects.py
+++ b/gprMax/geometry_outputs/geometry_objects.py
@@ -68,7 +68,16 @@ class GeometryObject(Generic[GridType]):
         self.solidsize = (float)(np.prod(self.grid_view.size) * np.dtype(np.uint32).itemsize)
         self.rigidsize = (float)(18 * np.prod(self.grid_view.size) * np.dtype(np.int8).itemsize)
         self.IDsize = (float)(6 * np.prod(self.grid_view.size + 1) * np.dtype(np.uint32).itemsize)
-        self.datawritesize = self.solidsize + self.rigidsize + self.IDsize
+        self._base_datawritesize = self.solidsize + self.rigidsize + self.IDsize
+
+    @property
+    def datawritesize(self):
+        tag_size = 0
+        if getattr(self.grid, "geometry_tag_map", None) is not None:
+            tag_size = float(
+                np.prod(self.grid_view.size) * self.grid.geometry_tag_map.data.dtype.itemsize
+            )
+        return self._base_datawritesize + tag_size
 
     @property
     def grid(self) -> GridType:
@@ -124,6 +133,11 @@ class GeometryObject(Generic[GridType]):
         data = self.grid_view.get_solid().astype(np.int16)
         rigidE = self.grid_view.get_rigidE()
         rigidH = self.grid_view.get_rigidH()
+        tag_data = (
+            self.grid_view.get_geometry_tags()
+            if getattr(self.grid, "geometry_tag_map", None) is not None
+            else None
+        )
 
         ID = self.grid_view.map_to_view_materials(ID)
         data = self.grid_view.map_to_view_materials(data)
@@ -141,6 +155,15 @@ class GeometryObject(Generic[GridType]):
 
             fdata["/ID"] = ID
             pbar.update(self.IDsize)
+
+            if tag_data is not None:
+                fdata["/tag_data"] = tag_data
+                fdata.create_dataset(
+                    "/tag_names",
+                    data=np.asarray(self.grid.geometry_tag_registry.names, dtype="S"),
+                )
+                fdata.attrs["GeometryTagsSchemaVersion"] = 1
+                pbar.update(tag_data.nbytes)
 
             fdata.create_dataset("/material_keys", data=np.asarray(material_keys, dtype="S"))
             fdata.attrs["MaterialDatabase"] = self.filename_materials.stem
@@ -204,6 +227,11 @@ class MPIGeometryObject(GeometryObject[MPIGrid]):
         data = self.grid_view.get_solid().astype(np.int16)
         rigidE = self.grid_view.get_rigidE()
         rigidH = self.grid_view.get_rigidH()
+        tag_data = (
+            self.grid_view.get_geometry_tags()
+            if getattr(self.grid, "geometry_tag_map", None) is not None
+            else None
+        )
 
         rigidE = self._merge_negative_rigid_halos(rigidE, self.grid.rigidE, 4100)
         rigidH = self._merge_negative_rigid_halos(rigidH, self.grid.rigidH, 4200)
@@ -239,6 +267,19 @@ class MPIGeometryObject(GeometryObject[MPIGrid]):
             )
             dset[:, dset_slice[0], dset_slice[1], dset_slice[2]] = ID
             pbar.update(self.IDsize)
+
+            if tag_data is not None:
+                tag_slice = self.grid_view.get_3d_output_slice()
+                tag_dataset = fdata.create_dataset(
+                    "/tag_data", self.grid_view.global_size, dtype=tag_data.dtype
+                )
+                tag_dataset[tag_slice] = tag_data
+                fdata.create_dataset(
+                    "/tag_names",
+                    data=np.asarray(self.grid.geometry_tag_registry.names, dtype="S"),
+                )
+                fdata.attrs["GeometryTagsSchemaVersion"] = 1
+                pbar.update(tag_data.nbytes)
 
             fdata.create_dataset("/material_keys", data=np.asarray(material_keys, dtype="S"))
             fdata.attrs["MaterialDatabase"] = self.filename_materials.stem

--- a/gprMax/geometry_outputs/geometry_objects_read.py
+++ b/gprMax/geometry_outputs/geometry_objects_read.py
@@ -299,6 +299,38 @@ class ReadGeometryObject(AbstractContextManager):
         rigidH_class = self.file_handler.get("rigidH", getclass=True)
         return rigidE_class == h5py.Dataset and rigidH_class == h5py.Dataset
 
+    def has_tag_data(self) -> bool:
+        return (
+            self.file_handler.get("tag_data", getclass=True) == h5py.Dataset
+            and self.file_handler.get("tag_names", getclass=True) == h5py.Dataset
+        )
+
+    def read_tags(self) -> None:
+        """Import or clear semantic tags wherever the geometry writes cells."""
+
+        if self.grid_view is None or self.grid_view.grid.geometry_tag_map is None:
+            return
+
+        raw_data = self.file_handler["/data"]
+        assert isinstance(raw_data, h5py.Dataset)
+        raw_data = self._read_spatial_dataset(raw_data)
+        existing = self.grid_view.get_geometry_tags()
+
+        if self.has_tag_data():
+            tag_data = self.file_handler["/tag_data"]
+            assert isinstance(tag_data, h5py.Dataset)
+            tag_data = self._read_spatial_dataset(tag_data)
+            raw_names = self.file_handler["/tag_names"][:]
+            names = tuple(
+                value.decode("utf-8") if isinstance(value, bytes) else str(value)
+                for value in raw_names
+            )
+            imported = self.grid_view.grid.geometry_tag_map.remap_file_ids(tag_data, names)
+        else:
+            imported = np.zeros(raw_data.shape, dtype=existing.dtype)
+
+        self.grid_view.set_geometry_tags(np.where(raw_data < 0, existing, imported))
+
     def read_data(self):
         if self.grid_view is None:
             return

--- a/gprMax/geometry_outputs/geometry_view_voxels.py
+++ b/gprMax/geometry_outputs/geometry_view_voxels.py
@@ -39,6 +39,11 @@ class GeometryViewVoxels(GeometryView[GridType]):
         """Prepares data for writing to VTKHDF file."""
 
         self.material_data = self.grid_view.get_solid()
+        self.tag_data = (
+            self.grid_view.get_geometry_tags()
+            if getattr(self.grid, "geometry_tag_map", None) is not None
+            else None
+        )
 
         if isinstance(self.grid, SubGridBaseGrid):
             self.origin = self.grid.local_to_global(self.grid_view.start)
@@ -48,6 +53,8 @@ class GeometryViewVoxels(GeometryView[GridType]):
         self.spacing = self.grid_view.step * self.grid.dl
 
         self.nbytes = self.material_data.nbytes
+        if self.tag_data is not None:
+            self.nbytes += self.tag_data.nbytes
 
         # Write information about any PMLs, sources, receivers
         self.metadata = Metadata(self.grid_view)
@@ -57,6 +64,13 @@ class GeometryViewVoxels(GeometryView[GridType]):
 
         with VtkImageData(self.filename, self.grid_view.size, self.origin, self.spacing) as f:
             f.add_cell_data("Material", self.material_data)
+            if self.tag_data is not None:
+                f.add_cell_data("TagID", self.tag_data)
+                f.add_field_data(
+                    "geometry_tag_ids",
+                    np.arange(len(self.grid.geometry_tag_registry.names), dtype=np.uint32),
+                )
+                f.add_field_data("geometry_tag_names", list(self.grid.geometry_tag_registry.names))
             self.metadata.write_to_vtkhdf(f)
 
 
@@ -73,11 +87,18 @@ class MPIGeometryViewVoxels(GeometryViewVoxels[MPIGrid]):
         assert isinstance(self.grid_view, self.GRID_VIEW_TYPE)
 
         self.material_data = self.grid_view.get_solid()
+        self.tag_data = (
+            self.grid_view.get_geometry_tags()
+            if getattr(self.grid, "geometry_tag_map", None) is not None
+            else None
+        )
 
         self.origin = self.grid_view.global_start * self.grid.dl
         self.spacing = self.grid_view.step * self.grid.dl
 
         self.nbytes = self.material_data.nbytes
+        if self.tag_data is not None:
+            self.nbytes += self.tag_data.nbytes
 
         # Write information about any PMLs, sources, receivers
         self.metadata = MPIMetadata(self.grid_view)
@@ -95,10 +116,20 @@ class MPIGeometryViewVoxels(GeometryViewVoxels[MPIGrid]):
             comm=self.grid_view.comm,
         ) as f:
             f.add_cell_data("Material", self.material_data, self.grid_view.offset)
+            if self.tag_data is not None:
+                f.add_cell_data("TagID", self.tag_data, self.grid_view.offset)
 
         # Write metadata in serial as it contains variable length
         # strings which currently cannot be written by HDF5 using
         # parallel I/O
         if self.grid_view.comm.rank == 0:
             with VtkHdfFile(self.filename, VtkImageData.TYPE, mode="r+") as f:
+                if self.tag_data is not None:
+                    f.add_field_data(
+                        "geometry_tag_ids",
+                        np.arange(len(self.grid.geometry_tag_registry.names), dtype=np.uint32),
+                    )
+                    f.add_field_data(
+                        "geometry_tag_names", list(self.grid.geometry_tag_registry.names)
+                    )
                 self.metadata.write_to_vtkhdf(f)

--- a/gprMax/geometry_outputs/grid_view.py
+++ b/gprMax/geometry_outputs/grid_view.py
@@ -442,6 +442,20 @@ class GridView(Generic[GridType]):
         """
         self.set_array_slice(self.grid.solid, value)
 
+    def get_geometry_tags(self) -> npt.NDArray:
+        """Get cell-centred semantic tag IDs for this view."""
+
+        if getattr(self.grid, "geometry_tag_map", None) is None:
+            raise RuntimeError("This grid has no geometry tag map")
+        return self.get_array_slice(self.grid.geometry_tag_map.data)
+
+    def set_geometry_tags(self, value: npt.NDArray):
+        """Set cell-centred semantic tag IDs for this view."""
+
+        if getattr(self.grid, "geometry_tag_map", None) is None:
+            raise RuntimeError("This grid has no geometry tag map")
+        self.set_array_slice(self.grid.geometry_tag_map.data, value)
+
     def get_rigidE(self) -> npt.NDArray[np.int8]:
         """Get a view of the rigidE array.
 

--- a/gprMax/geometry_tags.py
+++ b/gprMax/geometry_tags.py
@@ -1,0 +1,129 @@
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
+#
+# This file is part of gprMax.
+
+"""Cell-centred semantic tags for voxelised geometry."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import Optional
+
+import numpy as np
+import numpy.typing as npt
+
+
+UNTAGGED_NAME = "untagged"
+_TAG_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]*$")
+
+
+def validate_geometry_tag(tag: Optional[str]) -> Optional[str]:
+    """Validate and normalise a user-facing geometry tag."""
+
+    if tag is None:
+        return None
+    if not isinstance(tag, str):
+        raise TypeError("Geometry tag must be a string or None")
+    if tag == UNTAGGED_NAME:
+        raise ValueError(f"Geometry tag '{UNTAGGED_NAME}' is reserved for tag ID 0")
+    if not _TAG_PATTERN.fullmatch(tag):
+        raise ValueError(
+            "Geometry tag must start with a letter or digit and contain only letters, "
+            "digits, '_', '-', '.', or ':'"
+        )
+    return tag
+
+
+class GeometryTagRegistry:
+    """Maps semantic tag names to compact, deterministic integer IDs."""
+
+    def __init__(self) -> None:
+        self._names = [UNTAGGED_NAME]
+        self._ids = {UNTAGGED_NAME: 0}
+        self._frozen = False
+
+    def register(self, tag: Optional[str]) -> int:
+        tag = validate_geometry_tag(tag)
+        if tag is None:
+            return 0
+        existing = self._ids.get(tag)
+        if existing is not None:
+            return existing
+        if self._frozen:
+            raise RuntimeError(f"Cannot register geometry tag '{tag}' after registry is frozen")
+        tag_id = len(self._names)
+        if tag_id > np.iinfo(np.uint32).max:
+            raise ValueError("Geometry tag count exceeds the uint32 ID range")
+        self._ids[tag] = tag_id
+        self._names.append(tag)
+        return tag_id
+
+    def register_many(self, tags: Iterable[Optional[str]]) -> None:
+        for tag in tags:
+            self.register(tag)
+
+    def freeze(self) -> None:
+        self._frozen = True
+
+    @property
+    def frozen(self) -> bool:
+        return self._frozen
+
+    @property
+    def has_tags(self) -> bool:
+        return len(self._names) > 1
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        return tuple(self._names)
+
+    @property
+    def dtype(self) -> np.dtype:
+        max_id = len(self._names) - 1
+        if max_id <= np.iinfo(np.uint8).max:
+            return np.dtype(np.uint8)
+        if max_id <= np.iinfo(np.uint16).max:
+            return np.dtype(np.uint16)
+        return np.dtype(np.uint32)
+
+    def id_for(self, tag: Optional[str]) -> int:
+        tag = validate_geometry_tag(tag)
+        if tag is None:
+            return 0
+        try:
+            return self._ids[tag]
+        except KeyError as exc:
+            raise KeyError(f"Geometry tag '{tag}' is not registered") from exc
+
+
+class GeometryTagMap:
+    """Dense cell map whose storage type is selected by its registry."""
+
+    def __init__(self, shape: tuple[int, int, int], registry: GeometryTagRegistry) -> None:
+        if not registry.frozen:
+            raise RuntimeError("Geometry tag registry must be frozen before allocating a map")
+        if not registry.has_tags:
+            raise ValueError("A geometry tag map is not required for an empty registry")
+        self.registry = registry
+        self.data = np.zeros(shape, dtype=registry.dtype, order="C")
+
+    @property
+    def nbytes(self) -> int:
+        return self.data.nbytes
+
+    def id_for(self, tag: Optional[str]) -> int:
+        return self.registry.id_for(tag)
+
+    def remap_file_ids(
+        self, values: npt.NDArray[np.integer], file_names: Iterable[str]
+    ) -> npt.NDArray[np.integer]:
+        """Map file-local tag IDs to this map's model-wide IDs."""
+
+        names = tuple(file_names)
+        lookup = np.asarray(
+            [self.registry.id_for(name if index else None) for index, name in enumerate(names)]
+        )
+        if values.size and int(values.max()) >= lookup.size:
+            raise ValueError("Geometry object contains a tag ID absent from its tag-name table")
+        return np.asarray(lookup[values], dtype=self.data.dtype, order="C")

--- a/gprMax/grid/fdtd_grid.py
+++ b/gprMax/grid/fdtd_grid.py
@@ -107,6 +107,10 @@ class FDTDGrid:
         self.rigidE: npt.NDArray[np.int8]
         self.rigidH: npt.NDArray[np.int8]
         self.ID: npt.NDArray[np.uint32]
+        # Optional cell-centred semantic metadata. It is independent of
+        # material IDs and deliberately remains on the host.
+        self.geometry_tag_registry = None
+        self.geometry_tag_map = None
 
         # Update Coefficient Arrays
         self.updatecoeffsE: npt.NDArray[np.float32]
@@ -1593,6 +1597,7 @@ class FDTDGrid:
         """
 
         solidarray = self.nx * self.ny * self.nz * np.dtype(np.uint32).itemsize
+        tagarray = self.geometry_tag_map.nbytes if self.geometry_tag_map is not None else 0
 
         # 12 x rigidE array components + 6 x rigidH array components
         rigidarrays = (12 + 6) * self.nx * self.ny * self.nz * np.dtype(np.int8).itemsize
@@ -1626,7 +1631,7 @@ class FDTDGrid:
                     pmlarrays += (self.nx + 1) * self.ny * v
                     pmlarrays += self.nx * (self.ny + 1) * v
 
-        mem_use = fieldarrays + solidarray + rigidarrays + pmlarrays
+        mem_use = fieldarrays + solidarray + tagarray + rigidarrays + pmlarrays
 
         return mem_use
 

--- a/gprMax/hash_cmds_geometry.py
+++ b/gprMax/hash_cmds_geometry.py
@@ -55,8 +55,8 @@ def _validate_fractal_modifier_targets(geometry):
         tokens for tokens in tokenised if tokens and tokens[0] == "#fractal_box:"
     ]
     for tokens in fractal_box_commands:
-        if len(tokens) not in (14, 15, 16):
-            raise ValueError(f"'{' '.join(tokens)}' requires 13, 14, or 15 parameters")
+        if len(tokens) not in (14, 15, 16, 17):
+            raise ValueError(f"'{' '.join(tokens)}' requires 13 to 16 parameters")
     fractal_box_ids = {tokens[13] for tokens in fractal_box_commands}
     if len(fractal_box_ids) != len(fractal_box_commands):
         raise ValueError("#fractal_box identifiers must be unique")
@@ -96,6 +96,30 @@ def process_geometrycmds(geometry):
 
     for object in geometry:
         tmp = object.split()
+        tag = None
+
+        # Geometry hash commands use positional arguments only. A tag is
+        # accepted only after an explicit y/n smoothing argument. Requiring
+        # that marker keeps all existing isotropic and anisotropic forms
+        # unambiguous and backward compatible.
+        base_lengths = {
+            "#triangle:": 12,
+            "#box:": 8,
+            "#cylinder:": 9,
+            "#cone:": 10,
+            "#cylindrical_sector:": 10,
+            "#sphere:": 6,
+            "#ellipsoid:": 8,
+        }
+        base_length = base_lengths.get(tmp[0])
+        if base_length is not None:
+            if len(tmp) == base_length + 2 and tmp[-2].lower() in {"y", "n"}:
+                tag, tmp = tmp[-1], tmp[:-1]
+
+        # A fractal tag follows the existing seed and y/n smoothing values.
+        elif tmp[0] == "#fractal_box:":
+            if len(tmp) == 17 and tmp[-2].lower() in {"y", "n"}:
+                tag, tmp = tmp[-1], tmp[:-1]
 
         if tmp[0] == "#geometry_objects_read:":
             from .user_objects.cmds_geometry.geometry_objects_read import GeometryObjectsRead
@@ -196,7 +220,10 @@ def process_geometrycmds(geometry):
 
             # Isotropic case with no user specified averaging
             if len(tmp) == 12:
-                triangle = Triangle(p1=p1, p2=p2, p3=p3, thickness=thickness, material_id=tmp[11])
+                triangle = Triangle(
+                    p1=p1, p2=p2, p3=p3, thickness=thickness,
+                    material_id=tmp[11], tag=tag
+                )
 
             # Isotropic case with user specified averaging
             elif len(tmp) == 13:
@@ -207,11 +234,15 @@ def process_geometrycmds(geometry):
                     thickness=thickness,
                     material_id=tmp[11],
                     averaging=tmp[12],
+                    tag=tag,
                 )
 
             # Uniaxial anisotropic case
             elif len(tmp) == 14:
-                triangle = Triangle(p1=p1, p2=p2, p3=p3, thickness=thickness, material_ids=tmp[11:])
+                triangle = Triangle(
+                    p1=p1, p2=p2, p3=p3, thickness=thickness,
+                    material_ids=tmp[11:], tag=tag
+                )
 
             else:
                 logger.exception("'" + " ".join(tmp) + "'" + " too many parameters have been given")
@@ -229,15 +260,15 @@ def process_geometrycmds(geometry):
 
             # Isotropic case with no user specified averaging
             if len(tmp) == 8:
-                box = Box(p1=p1, p2=p2, material_id=tmp[7])
+                box = Box(p1=p1, p2=p2, material_id=tmp[7], tag=tag)
 
             # Isotropic case with user specified averaging
             elif len(tmp) == 9:
-                box = Box(p1=p1, p2=p2, material_id=tmp[7], averaging=tmp[8])
+                box = Box(p1=p1, p2=p2, material_id=tmp[7], averaging=tmp[8], tag=tag)
 
             # Uniaxial anisotropic case
             elif len(tmp) == 10:
-                box = Box(p1=p1, p2=p2, material_ids=tmp[7:])
+                box = Box(p1=p1, p2=p2, material_ids=tmp[7:], tag=tag)
 
             else:
                 logger.exception("'" + " ".join(tmp) + "'" + " too many parameters have been given")
@@ -256,15 +287,17 @@ def process_geometrycmds(geometry):
 
             # Isotropic case with no user specified averaging
             if len(tmp) == 9:
-                cylinder = Cylinder(p1=p1, p2=p2, r=r, material_id=tmp[8])
+                cylinder = Cylinder(p1=p1, p2=p2, r=r, material_id=tmp[8], tag=tag)
 
             # Isotropic case with user specified averaging
             elif len(tmp) == 10:
-                cylinder = Cylinder(p1=p1, p2=p2, r=r, material_id=tmp[8], averaging=tmp[9])
+                cylinder = Cylinder(
+                    p1=p1, p2=p2, r=r, material_id=tmp[8], averaging=tmp[9], tag=tag
+                )
 
             # Uniaxial anisotropic case
             elif len(tmp) == 11:
-                cylinder = Cylinder(p1=p1, p2=p2, r=r, material_ids=tmp[8:])
+                cylinder = Cylinder(p1=p1, p2=p2, r=r, material_ids=tmp[8:], tag=tag)
 
             else:
                 logger.exception("'" + " ".join(tmp) + "'" + " too many parameters have been given")
@@ -284,7 +317,7 @@ def process_geometrycmds(geometry):
 
             # Isotropic case with no user specified averaging
             if len(tmp) == 10:
-                cone = Cone(p1=p1, p2=p2, r1=r1, r2=r2, material_id=tmp[9])
+                cone = Cone(p1=p1, p2=p2, r1=r1, r2=r2, material_id=tmp[9], tag=tag)
 
             # Isotropic case with user specified averaging
             elif len(tmp) == 11:
@@ -295,11 +328,12 @@ def process_geometrycmds(geometry):
                     r2=r2,
                     material_id=tmp[9],
                     averaging=tmp[10],
+                    tag=tag,
                 )
 
             # Uniaxial anisotropic case
             elif len(tmp) == 12:
-                cone = Cone(p1=p1, p2=p2, r1=r1, r2=r2, material_ids=tmp[9:])
+                cone = Cone(p1=p1, p2=p2, r1=r1, r2=r2, material_ids=tmp[9:], tag=tag)
 
             else:
                 logger.exception("'" + " ".join(tmp) + "'" + " too many parameters have been given")
@@ -333,6 +367,7 @@ def process_geometrycmds(geometry):
                     start=start,
                     end=end,
                     material_id=tmp[9],
+                    tag=tag,
                 )
 
             # Isotropic case with user specified averaging
@@ -348,6 +383,7 @@ def process_geometrycmds(geometry):
                     end=end,
                     averaging=tmp[10],
                     material_id=tmp[9],
+                    tag=tag,
                 )
 
             # Uniaxial anisotropic case
@@ -362,6 +398,7 @@ def process_geometrycmds(geometry):
                     start=start,
                     end=end,
                     material_ids=tmp[9:],
+                    tag=tag,
                 )
 
             else:
@@ -380,15 +417,15 @@ def process_geometrycmds(geometry):
 
             # Isotropic case with no user specified averaging
             if len(tmp) == 6:
-                sphere = Sphere(p1=p1, r=r, material_id=tmp[5])
+                sphere = Sphere(p1=p1, r=r, material_id=tmp[5], tag=tag)
 
             # Isotropic case with user specified averaging
             elif len(tmp) == 7:
-                sphere = Sphere(p1=p1, r=r, material_id=tmp[5], averaging=tmp[6])
+                sphere = Sphere(p1=p1, r=r, material_id=tmp[5], averaging=tmp[6], tag=tag)
 
             # Uniaxial anisotropic case
             elif len(tmp) == 8:
-                sphere = Sphere(p1=p1, r=r, material_ids=tmp[5:])
+                sphere = Sphere(p1=p1, r=r, material_ids=tmp[5:], tag=tag)
 
             else:
                 logger.exception("'" + " ".join(tmp) + "'" + " too many parameters have been given")
@@ -408,7 +445,9 @@ def process_geometrycmds(geometry):
 
             # Isotropic case with no user specified averaging
             if len(tmp) == 8:
-                ellipsoid = Ellipsoid(p1=p1, xr=xr, yr=yr, zr=zr, material_id=tmp[7])
+                ellipsoid = Ellipsoid(
+                    p1=p1, xr=xr, yr=yr, zr=zr, material_id=tmp[7], tag=tag
+                )
 
             # Isotropic case with user specified averaging
             elif len(tmp) == 9:
@@ -419,11 +458,14 @@ def process_geometrycmds(geometry):
                     zr=zr,
                     material_id=tmp[7],
                     averaging=tmp[8],
+                    tag=tag,
                 )
 
             # Uniaxial anisotropic case
             elif len(tmp) == 10:
-                ellipsoid = Ellipsoid(p1=p1, xr=xr, yr=yr, zr=zr, material_ids=tmp[7:])
+                ellipsoid = Ellipsoid(
+                    p1=p1, xr=xr, yr=yr, zr=zr, material_ids=tmp[7:], tag=tag
+                )
 
             else:
                 logger.exception("'" + " ".join(tmp) + "'" + " too many parameters have been given")
@@ -457,6 +499,7 @@ def process_geometrycmds(geometry):
                     n_materials=n_materials,
                     mixing_model_id=mixing_model_id,
                     id=ID,
+                    tag=tag,
                 )
             elif len(tmp) == 15:
                 fb = FractalBox(
@@ -468,6 +511,7 @@ def process_geometrycmds(geometry):
                     mixing_model_id=mixing_model_id,
                     id=ID,
                     seed=tmp[14],
+                    tag=tag,
                 )
             elif len(tmp) == 16:
                 fb = FractalBox(
@@ -480,6 +524,7 @@ def process_geometrycmds(geometry):
                     id=ID,
                     seed=tmp[14],
                     averaging=tmp[15],
+                    tag=tag,
                 )
             else:
                 logger.exception("'" + " ".join(tmp) + "'" + " too many parameters have been given")

--- a/gprMax/model.py
+++ b/gprMax/model.py
@@ -55,6 +55,7 @@ class Model:
 
     def __init__(self):
         self.title = ""
+        self.geometry_tag_registry = None
 
         self.dt_mod = 1.0  # Time step stability factor
 

--- a/gprMax/scene.py
+++ b/gprMax/scene.py
@@ -21,6 +21,7 @@ from typing import List, Sequence
 
 import numpy as np
 
+from gprMax.geometry_tags import GeometryTagMap, GeometryTagRegistry
 from gprMax.grid.fdtd_grid import FDTDGrid
 from gprMax.grid.mpi_grid import MPIGrid
 from gprMax.materials import create_built_in_materials
@@ -247,6 +248,41 @@ class Scene:
             self.process_geometry_objects(subgrid_object.children_geometry, subgrid)
             self._build_internal_pml_enclosures(subgrid)
 
+    def initialise_geometry_tags(self, model: Model):
+        """Create one model-wide registry and optional cell maps per grid."""
+
+        registry = GeometryTagRegistry()
+        grid_objects = [(model.G, self.geometry_objects)]
+        grid_objects.extend(
+            (subgrid_object.subgrid, subgrid_object.children_geometry)
+            for subgrid_object in self.subgrid_objects
+        )
+
+        declared_by_grid = []
+        for grid, objects in grid_objects:
+            declared = tuple(
+                tag for obj in objects for tag in obj.declared_geometry_tags()
+            )
+            registry.register_many(declared)
+            declared_by_grid.append((grid, declared))
+
+        registry.freeze()
+        if not registry.has_tags:
+            model.geometry_tag_registry = None
+            for grid, _ in declared_by_grid:
+                grid.geometry_tag_registry = None
+                grid.geometry_tag_map = None
+            return
+
+        model.geometry_tag_registry = registry
+        for grid, declared in declared_by_grid:
+            grid.geometry_tag_registry = registry
+            grid.geometry_tag_map = (
+                GeometryTagMap(tuple(int(value) for value in grid.size), registry)
+                if declared
+                else None
+            )
+
     def create_internal_objects(self, model: Model):
         """Calls the UserObject.build() function in the correct way - API
         presents the user with UserObjects in order to build the internal
@@ -261,6 +297,10 @@ class Scene:
 
         # Process multiple commands
         self.process_multi_use_objects(model)
+
+        # Discover semantic tags, including catalogues stored in imported
+        # geometry, before selecting the compact map dtype.
+        self.initialise_geometry_tags(model)
 
         # Initialise geometry arrays for main and subgrids
         for grid in [model.G] + model.subgrids:

--- a/gprMax/user_objects/cmds_geometry/box.py
+++ b/gprMax/user_objects/cmds_geometry/box.py
@@ -28,7 +28,7 @@ from gprMax.materials import Material
 from gprMax.user_objects.rotatable import RotatableMixin
 from gprMax.user_objects.user_objects import GeometryUserObject
 
-from .cmds_geometry import check_averaging, rotate_2point_object
+from .cmds_geometry import check_averaging, geometry_tag_args, rotate_2point_object
 
 logger = logging.getLogger(__name__)
 
@@ -149,6 +149,7 @@ class Box(RotatableMixin, GeometryUserObject):
                 # Append the new material object to the materials list
                 grid.materials.append(m)
 
+        tag_data, tag_id = geometry_tag_args(grid, self.kwargs.get("tag"))
         build_box(
             xs,
             xf,
@@ -168,6 +169,8 @@ class Box(RotatableMixin, GeometryUserObject):
             grid.rigidE,
             grid.rigidH,
             grid.ID,
+            tag_data,
+            tag_id,
         )
 
         dielectricsmoothing = "on" if averaging else "off"

--- a/gprMax/user_objects/cmds_geometry/cmds_geometry.py
+++ b/gprMax/user_objects/cmds_geometry/cmds_geometry.py
@@ -27,6 +27,17 @@ import gprMax.config as config
 logger = logging.getLogger(__name__)
 
 
+def geometry_tag_args(grid, tag):
+    """Return the optional dense map and compact ID expected by Cython builders."""
+
+    tag_map = getattr(grid, "geometry_tag_map", None)
+    if tag_map is None:
+        if tag is not None:
+            raise RuntimeError(f"Geometry tag '{tag}' was not registered before rasterisation")
+        return None, 0
+    return tag_map.data, tag_map.id_for(tag)
+
+
 def check_averaging(averaging):
     """Check and set material averaging value.
 

--- a/gprMax/user_objects/cmds_geometry/cone.py
+++ b/gprMax/user_objects/cmds_geometry/cone.py
@@ -25,7 +25,7 @@ import gprMax.config as config
 from gprMax.cython.geometry_primitives import build_cone
 from gprMax.grid.fdtd_grid import FDTDGrid
 from gprMax.materials import Material
-from gprMax.user_objects.cmds_geometry.cmds_geometry import check_averaging
+from gprMax.user_objects.cmds_geometry.cmds_geometry import check_averaging, geometry_tag_args
 from gprMax.user_objects.user_objects import GeometryUserObject
 
 logger = logging.getLogger(__name__)
@@ -167,6 +167,7 @@ class Cone(GeometryUserObject):
                 # Append the new material object to the materials list
                 grid.materials.append(m)
 
+        tag_data, tag_id = geometry_tag_args(grid, self.kwargs.get("tag"))
         build_cone(
             x1,
             y1,
@@ -191,6 +192,8 @@ class Cone(GeometryUserObject):
             grid.rigidE,
             grid.rigidH,
             grid.ID,
+            tag_data,
+            tag_id,
         )
 
         dielectricsmoothing = "on" if averaging else "off"

--- a/gprMax/user_objects/cmds_geometry/cylinder.py
+++ b/gprMax/user_objects/cmds_geometry/cylinder.py
@@ -24,7 +24,7 @@ import numpy as np
 from gprMax.cython.geometry_primitives import build_cylinder
 from gprMax.grid.fdtd_grid import FDTDGrid
 from gprMax.materials import Material
-from gprMax.user_objects.cmds_geometry.cmds_geometry import check_averaging
+from gprMax.user_objects.cmds_geometry.cmds_geometry import check_averaging, geometry_tag_args
 from gprMax.user_objects.user_objects import GeometryUserObject
 
 logger = logging.getLogger(__name__)
@@ -144,6 +144,7 @@ class Cylinder(GeometryUserObject):
                 # Append the new material object to the materials list
                 grid.materials.append(m)
 
+        tag_data, tag_id = geometry_tag_args(grid, self.kwargs.get("tag"))
         build_cylinder(
             x1,
             y1,
@@ -167,6 +168,8 @@ class Cylinder(GeometryUserObject):
             grid.rigidE,
             grid.rigidH,
             grid.ID,
+            tag_data,
+            tag_id,
         )
 
         dielectricsmoothing = "on" if averaging else "off"

--- a/gprMax/user_objects/cmds_geometry/cylindrical_sector.py
+++ b/gprMax/user_objects/cmds_geometry/cylindrical_sector.py
@@ -25,7 +25,7 @@ import gprMax.config as config
 from gprMax.cython.geometry_primitives import build_cylindrical_sector
 from gprMax.grid.fdtd_grid import FDTDGrid
 from gprMax.materials import Material
-from gprMax.user_objects.cmds_geometry.cmds_geometry import check_averaging
+from gprMax.user_objects.cmds_geometry.cmds_geometry import check_averaging, geometry_tag_args
 from gprMax.user_objects.user_objects import GeometryUserObject
 
 logger = logging.getLogger(__name__)
@@ -244,6 +244,10 @@ class CylindricalSector(GeometryUserObject):
                 pec_y = materials[1].is_pec
                 pec_z = materials[2].is_pec
 
+        tag = self.kwargs.get("tag")
+        if tag is not None and thickness <= 0:
+            raise ValueError(f"{self.params_str()} a cell-centred tag requires a volumetric sector")
+        tag_data, tag_id = geometry_tag_args(grid, tag)
         build_cylindrical_sector(
             ctr1,
             ctr2,
@@ -268,6 +272,8 @@ class CylindricalSector(GeometryUserObject):
             grid.rigidE,
             grid.rigidH,
             grid.ID,
+            tag_data,
+            tag_id,
         )
 
         if thickness > 0:

--- a/gprMax/user_objects/cmds_geometry/ellipsoid.py
+++ b/gprMax/user_objects/cmds_geometry/ellipsoid.py
@@ -24,7 +24,7 @@ import numpy as np
 from gprMax.cython.geometry_primitives import build_ellipsoid
 from gprMax.grid.fdtd_grid import FDTDGrid
 from gprMax.materials import Material
-from gprMax.user_objects.cmds_geometry.cmds_geometry import check_averaging
+from gprMax.user_objects.cmds_geometry.cmds_geometry import check_averaging, geometry_tag_args
 from gprMax.user_objects.user_objects import GeometryUserObject
 
 logger = logging.getLogger(__name__)
@@ -139,6 +139,7 @@ class Ellipsoid(GeometryUserObject):
                 # Append the new material object to the materials list
                 grid.materials.append(m)
 
+        tag_data, tag_id = geometry_tag_args(grid, self.kwargs.get("tag"))
         build_ellipsoid(
             xc,
             yc,
@@ -161,6 +162,8 @@ class Ellipsoid(GeometryUserObject):
             grid.rigidE,
             grid.rigidH,
             grid.ID,
+            tag_data,
+            tag_id,
         )
 
         dielectricsmoothing = "on" if averaging else "off"

--- a/gprMax/user_objects/cmds_geometry/fractal_box.py
+++ b/gprMax/user_objects/cmds_geometry/fractal_box.py
@@ -25,7 +25,11 @@ import gprMax.config as config
 from gprMax.cython.geometry_primitives import build_voxels_from_array, build_voxels_from_array_mask
 from gprMax.grid.fdtd_grid import FDTDGrid
 from gprMax.materials import ListMaterial
-from gprMax.user_objects.cmds_geometry.cmds_geometry import check_averaging, rotate_2point_object
+from gprMax.user_objects.cmds_geometry.cmds_geometry import (
+    check_averaging,
+    geometry_tag_args,
+    rotate_2point_object,
+)
 from gprMax.user_objects.rotatable import RotatableMixin
 from gprMax.user_objects.user_objects import GeometryUserObject
 
@@ -756,6 +760,7 @@ class FractalBox(RotatableMixin, GeometryUserObject):
                 is_averagable_lookup = np.array(
                     [m.averagable for m in grid.materials], dtype=np.uint8
                 )
+                tag_data, tag_id = geometry_tag_args(grid, self.kwargs.get("tag"))
                 build_voxels_from_array_mask(
                     self.volume.xs,
                     self.volume.ys,
@@ -771,6 +776,10 @@ class FractalBox(RotatableMixin, GeometryUserObject):
                     grid.rigidE,
                     grid.rigidH,
                     grid.ID,
+                    tag_data,
+                    tag_id,
+                    0,
+                    0,
                 )
 
                 # fractalvolume/mask are only needed to build the voxel data
@@ -811,6 +820,7 @@ class FractalBox(RotatableMixin, GeometryUserObject):
                 is_averagable_lookup = np.array(
                     [m.averagable for m in grid.materials], dtype=np.uint8
                 )
+                tag_data, tag_id = geometry_tag_args(grid, self.kwargs.get("tag"))
                 build_voxels_from_array(
                     self.volume.xs,
                     self.volume.ys,
@@ -824,6 +834,8 @@ class FractalBox(RotatableMixin, GeometryUserObject):
                     grid.rigidE,
                     grid.rigidH,
                     grid.ID,
+                    tag_data,
+                    tag_id,
                 )
 
                 # See the comment on the equivalent free in the

--- a/gprMax/user_objects/cmds_geometry/geometry_objects_read.py
+++ b/gprMax/user_objects/cmds_geometry/geometry_objects_read.py
@@ -62,6 +62,36 @@ class GeometryObjectsRead(GeometryUserObject):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self._declared_tags_cache = None
+
+    def _resolve_geofile(self) -> Path:
+        geofile = Path(self.kwargs["geofile"])
+        if not geofile.exists():
+            geofile = Path(config.sim_config.input_file_path.parent, geofile)
+        if not geofile.is_file():
+            raise FileNotFoundError(f"Geometry object file '{geofile}' does not exist")
+        return geofile
+
+    def declared_geometry_tags(self) -> tuple[str, ...]:
+        """Read the compact tag catalogue before destination map allocation."""
+
+        if self._declared_tags_cache is None:
+            geofile = self._resolve_geofile()
+            with h5py.File(geofile, "r") as geometry:
+                if "/tag_names" not in geometry:
+                    self._declared_tags_cache = ()
+                else:
+                    raw_names = geometry["/tag_names"][:]
+                    names = tuple(
+                        value.decode("utf-8") if isinstance(value, bytes) else str(value)
+                        for value in raw_names
+                    )
+                    if not names or names[0] != "untagged":
+                        raise ValueError(
+                            f"Geometry file '{geofile}' has an invalid /tag_names catalogue"
+                        )
+                    self._declared_tags_cache = names[1:]
+        return self._declared_tags_cache
 
     def build(self, grid: FDTDGrid):
         """Creates the object and adds it to the grid."""
@@ -78,11 +108,7 @@ class GeometryObjectsRead(GeometryUserObject):
                 f"{self.params_str()} requires exactly one of material_database or legacy matfile"
             )
 
-        geofile = Path(geofile)
-        if not geofile.exists():
-            geofile = Path(config.sim_config.input_file_path.parent, geofile)
-        if not geofile.is_file():
-            raise FileNotFoundError(f"Geometry object file '{geofile}' does not exist")
+        geofile = self._resolve_geofile()
 
         if material_database is not None:
             material_id_map, material_description = self._build_database_material_map(
@@ -138,6 +164,7 @@ class GeometryObjectsRead(GeometryUserObject):
                 f.read_ID()
                 f.read_rigidE()
                 f.read_rigidH()
+                f.read_tags()
 
                 logger.info(
                     f"{self.grid_name(grid)}Geometry objects from file {geofile}"
@@ -168,6 +195,7 @@ class GeometryObjectsRead(GeometryUserObject):
                         grid.rigidH,
                         grid.ID,
                     )
+                f.read_tags()
                 logger.info(
                     f"{self.grid_name(grid)}Geometry objects from file "
                     f"(voxels only) {geofile} inserted at {p2[0]:g}m, "

--- a/gprMax/user_objects/cmds_geometry/sphere.py
+++ b/gprMax/user_objects/cmds_geometry/sphere.py
@@ -24,7 +24,7 @@ import numpy as np
 from gprMax.cython.geometry_primitives import build_sphere
 from gprMax.grid.fdtd_grid import FDTDGrid
 from gprMax.materials import Material
-from gprMax.user_objects.cmds_geometry.cmds_geometry import check_averaging
+from gprMax.user_objects.cmds_geometry.cmds_geometry import check_averaging, geometry_tag_args
 from gprMax.user_objects.user_objects import GeometryUserObject
 
 logger = logging.getLogger(__name__)
@@ -131,6 +131,7 @@ class Sphere(GeometryUserObject):
                 # Append the new material object to the materials list
                 grid.materials.append(m)
 
+        tag_data, tag_id = geometry_tag_args(grid, self.kwargs.get("tag"))
         build_sphere(
             xc,
             yc,
@@ -151,6 +152,8 @@ class Sphere(GeometryUserObject):
             grid.rigidE,
             grid.rigidH,
             grid.ID,
+            tag_data,
+            tag_id,
         )
 
         dielectricsmoothing = "on" if averaging else "off"

--- a/gprMax/user_objects/cmds_geometry/triangle.py
+++ b/gprMax/user_objects/cmds_geometry/triangle.py
@@ -28,7 +28,7 @@ from gprMax.materials import Material
 from gprMax.user_objects.rotatable import RotatableMixin
 from gprMax.user_objects.user_objects import GeometryUserObject
 
-from .cmds_geometry import check_averaging, rotate_point
+from .cmds_geometry import check_averaging, geometry_tag_args, rotate_point
 
 logger = logging.getLogger(__name__)
 
@@ -229,6 +229,10 @@ class Triangle(RotatableMixin, GeometryUserObject):
                 pec_y = materials[1].is_pec
                 pec_z = materials[2].is_pec
 
+        tag = self.kwargs.get("tag")
+        if tag is not None and thickness <= 0:
+            raise ValueError(f"{self.params_str()} a cell-centred tag requires a volumetric prism")
+        tag_data, tag_id = geometry_tag_args(grid, tag)
         build_triangle(
             x1,
             y1,
@@ -256,6 +260,8 @@ class Triangle(RotatableMixin, GeometryUserObject):
             grid.rigidE,
             grid.rigidH,
             grid.ID,
+            tag_data,
+            tag_id,
         )
 
         p4 = uip.round_to_grid_static_point(up1)

--- a/gprMax/user_objects/user_objects.py
+++ b/gprMax/user_objects/user_objects.py
@@ -174,3 +174,11 @@ class GeometryUserObject(GridUserObject):
         They should be built in the order they were added to the scene.
         """
         return 1
+
+    def declared_geometry_tags(self) -> tuple[str, ...]:
+        """Return semantic tag names that must exist before rasterisation."""
+
+        from gprMax.geometry_tags import validate_geometry_tag
+
+        tag = validate_geometry_tag(self.kwargs.get("tag"))
+        return () if tag is None else (tag,)

--- a/tests/fractals/test_fractal_box.py
+++ b/tests/fractals/test_fractal_box.py
@@ -23,6 +23,7 @@ discretisation.
 import numpy as np
 import pytest
 
+from gprMax.geometry_tags import GeometryTagMap, GeometryTagRegistry
 from gprMax.user_objects.cmds_geometry.add_surface_roughness import AddSurfaceRoughness
 from gprMax.user_objects.cmds_geometry.fractal_box import FractalBox
 
@@ -162,6 +163,26 @@ class TestAveraging:
         add_mixing_model(g)
         make_box(averaging="n").build(g)
         assert g.fractalvolumes[0].averaging is False
+
+
+class TestSemanticTags:
+    def test_final_fractal_shape_is_tagged_without_a_second_geometry_pass(self, fractal_grid):
+        g = fractal_grid()
+        add_mixing_model(g)
+        registry = GeometryTagRegistry()
+        registry.register("geological_layer")
+        registry.freeze()
+        g.geometry_tag_registry = registry
+        g.geometry_tag_map = GeometryTagMap((g.nx, g.ny, g.nz), registry)
+
+        box = make_box(tag="geological_layer")
+        box.build(g)
+        box.build(g)
+
+        occupied = g.solid != 0
+        assert occupied.any()
+        assert np.all(g.geometry_tag_map.data[occupied] == 1)
+        assert np.all(g.geometry_tag_map.data[~occupied] == 0)
 
 
 class TestPreBuildValidation:

--- a/tests/geometry_objects/test_geometry_objects_read.py
+++ b/tests/geometry_objects/test_geometry_objects_read.py
@@ -119,6 +119,49 @@ def test_pec_only_region_round_trips_as_pec(tmp_path, monkeypatch):
     assert materials_by_id["free_space"].type == "builtin"
 
 
+def test_semantic_tags_round_trip_and_are_remapped_by_name(tmp_path, monkeypatch):
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(1e-3, 1e-3, 1e-3)))
+    scene.add(gprMax.Domain(p1=(0.02, 0.02, 0.02)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=1e-12))
+    scene.add(
+        gprMax.Box(
+            p1=(0.004, 0.004, 0.004),
+            p2=(0.012, 0.012, 0.012),
+            material_id="pec",
+            tag="housing",
+        )
+    )
+    scene.add(
+        gprMax.Box(
+            p1=(0.006, 0.006, 0.006),
+            p2=(0.010, 0.010, 0.010),
+            material_id="free_space",
+        )
+    )
+    outdir = tmp_path / "tagged_write"
+    scene.add(
+        gprMax.GeometryObjectsWrite(
+            p1=(0.0, 0.0, 0.0), p2=(0.02, 0.02, 0.02), filename=str(outdir)
+        )
+    )
+    gprMax.run(
+        scenes=[scene], n=1, geometry_only=True, outputfile=outdir, hide_progress_bars=True
+    )
+
+    grid = _read_geometry_and_get_grid(
+        tmp_path,
+        outdir.with_suffix(".h5"),
+        Path(f"{outdir}_materials.json"),
+        monkeypatch,
+    )
+    assert grid.geometry_tag_registry.names == ("untagged", "housing")
+    tags = grid.geometry_tag_map.data
+    assert np.all(tags[4:6, 4:6, 4:6] == 1)
+    assert np.all(tags[6:10, 6:10, 6:10] == 0)
+
+
 def test_pec_pmc_and_custom_material_round_trip_correctly(tmp_path, monkeypatch):
     """General case: PEC, PMC, free_space (background) and a custom
     material all present in the same exported region. Builtins must be

--- a/tests/hash_cmds/test_hash_cmds_geometry.py
+++ b/tests/hash_cmds/test_hash_cmds_geometry.py
@@ -154,6 +154,18 @@ class TestBox:
         with pytest.raises(ValueError):
             process_geometrycmds(["#box: 0 0 0 0.1 0.1 0.1 mx my mz extra"])
 
+    def test_trailing_positional_tag_is_unambiguous_and_preserves_averaging(self):
+        box = process_geometrycmds(
+            ["#box: 0 0 0 0.1 0.1 0.1 m1 n housing"]
+        )[0]
+        assert box.kwargs["averaging"] == "n"
+        assert box.kwargs["tag"] == "housing"
+
+    def test_extra_string_without_explicit_smoothing_retains_legacy_interpretation(self):
+        box = process_geometrycmds(["#box: 0 0 0 0.1 0.1 0.1 m1 housing"])[0]
+        assert box.kwargs["averaging"] == "housing"
+        assert box.kwargs.get("tag") is None
+
 
 # ---------------------------------------------------------------------------
 # Cylinder (9 / 10 / 11)
@@ -343,6 +355,13 @@ class TestFractalBox:
     def test_sixteen_token_with_seed_and_averaging(self):
         objs = process_geometrycmds(["#fractal_box: 0 0 0 0.1 0.1 0.1 1.5 1 1 1 4 mix fb1 42 y"])
         assert objs[0].kwargs["averaging"] == "y"
+
+    def test_positional_tag_after_seed_and_averaging(self):
+        objs = process_geometrycmds(
+            ["#fractal_box: 0 0 0 0.1 0.1 0.1 1.5 1 1 1 4 mix fb1 42 y soil_layer"]
+        )
+        assert objs[0].kwargs["averaging"] == "y"
+        assert objs[0].kwargs["tag"] == "soil_layer"
 
     def test_too_few_tokens_rejected(self):
         with pytest.raises(ValueError):

--- a/tests/outputs/test_geometry_view_voxels.py
+++ b/tests/outputs/test_geometry_view_voxels.py
@@ -25,6 +25,7 @@ import pytest
 
 from gprMax.geometry_outputs.geometry_view_voxels import GeometryViewVoxels, MPIGeometryViewVoxels
 from gprMax.geometry_outputs.geometry_views import GeometryView
+from gprMax.geometry_tags import GeometryTagMap, GeometryTagRegistry
 
 from .conftest import DL, DL_ANISO
 
@@ -215,6 +216,32 @@ class TestWriteVtk:
         view.write_vtk()
         _, data = read_h5(view.filename)
         assert "VTKHDF/CellData/Material" in data
+
+    def test_semantic_tags_and_registry_are_written_when_present(
+        self, make_voxel_view, make_view_grid, read_h5
+    ):
+        grid = make_view_grid(nx=8, ny=8, nz=8)
+        registry = GeometryTagRegistry()
+        registry.register("housing")
+        registry.freeze()
+        grid.geometry_tag_registry = registry
+        grid.geometry_tag_map = GeometryTagMap((8, 8, 8), registry)
+        grid.geometry_tag_map.data[1:3, 1:3, 1:3] = 1
+
+        view = make_voxel_view(grid=grid, stop=(4, 4, 4))
+        view.write_vtk()
+        _, data = read_h5(view.filename)
+
+        assert "VTKHDF/CellData/TagID" in data
+        assert data["VTKHDF/CellData/TagID"].shape == (4, 4, 4)
+        assert "VTKHDF/FieldData/geometry_tag_ids" in data
+        assert "VTKHDF/FieldData/geometry_tag_names" in data
+
+    def test_tag_data_is_absent_when_geometry_has_no_tags(self, make_voxel_view, read_h5):
+        view = make_voxel_view()
+        view.write_vtk()
+        _, data = read_h5(view.filename)
+        assert "VTKHDF/CellData/TagID" not in data
 
     def test_cell_data_is_written_in_zyx_order(self, make_voxel_view, read_h5):
         """Expects the transpose the VTKHDF specification requires, as for

--- a/tests/test_geometry_tags.py
+++ b/tests/test_geometry_tags.py
@@ -1,0 +1,201 @@
+"""Semantic geometry-tag registry and end-to-end voxel semantics."""
+
+import numpy as np
+import pytest
+
+import gprMax
+import gprMax.model as model_mod
+from gprMax.geometry_tags import GeometryTagRegistry, validate_geometry_tag
+
+
+def _capture_grid(monkeypatch):
+    captured = {}
+    original = model_mod.Model.build
+
+    def build(self):
+        original(self)
+        captured["grid"] = self.G
+
+    monkeypatch.setattr(model_mod.Model, "build", build)
+    return captured
+
+
+def _base_scene():
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(1e-3, 1e-3, 1e-3)))
+    scene.add(gprMax.Domain(p1=(0.01, 0.01, 0.01)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=1e-12))
+    return scene
+
+
+def _build(scene, tmp_path, monkeypatch, name="tags"):
+    captured = _capture_grid(monkeypatch)
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        geometry_only=True,
+        outputfile=tmp_path / name,
+        hide_progress_bars=True,
+    )
+    return captured["grid"]
+
+
+@pytest.mark.parametrize("tag", ["", "has space", "slash/tag", "untagged", 7])
+def test_invalid_or_reserved_tags_are_rejected(tag):
+    with pytest.raises((TypeError, ValueError)):
+        validate_geometry_tag(tag)
+
+
+def test_registry_reuses_ids_and_selects_smallest_dtype():
+    registry = GeometryTagRegistry()
+    assert registry.register("housing") == 1
+    assert registry.register("housing") == 1
+    registry.register_many(f"part_{i}" for i in range(1, 255))
+    registry.freeze()
+    assert registry.dtype == np.dtype(np.uint8)
+
+    registry = GeometryTagRegistry()
+    registry.register_many(f"part_{i}" for i in range(256))
+    registry.freeze()
+    assert registry.dtype == np.dtype(np.uint16)
+
+    registry = GeometryTagRegistry()
+    registry.register_many(f"part_{i}" for i in range(65536))
+    registry.freeze()
+    assert registry.dtype == np.dtype(np.uint32)
+
+
+def test_no_tags_means_no_registry_or_map_allocation(tmp_path, monkeypatch):
+    scene = _base_scene()
+    scene.add(gprMax.Box(p1=(0.002, 0.002, 0.002), p2=(0.008, 0.008, 0.008), material_id="pec"))
+    grid = _build(scene, tmp_path, monkeypatch)
+    assert grid.geometry_tag_registry is None
+    assert grid.geometry_tag_map is None
+
+
+def test_final_voxels_follow_tag_overwrite_and_clear_semantics(tmp_path, monkeypatch):
+    scene = _base_scene()
+    scene.add(
+        gprMax.Box(
+            p1=(0.001, 0.001, 0.001),
+            p2=(0.009, 0.009, 0.009),
+            material_id="pec",
+            tag="outer",
+        )
+    )
+    scene.add(
+        gprMax.Box(
+            p1=(0.003, 0.003, 0.003),
+            p2=(0.007, 0.007, 0.007),
+            material_id="free_space",
+        )
+    )
+    scene.add(
+        gprMax.Box(
+            p1=(0.004, 0.004, 0.004),
+            p2=(0.006, 0.006, 0.006),
+            material_id="free_space",
+            tag="void_marker",
+        )
+    )
+    grid = _build(scene, tmp_path, monkeypatch)
+    tags = grid.geometry_tag_map.data
+    outer = grid.geometry_tag_registry.id_for("outer")
+    void = grid.geometry_tag_registry.id_for("void_marker")
+
+    assert np.all(tags[1:3, 1:3, 1:3] == outer)
+    assert np.all(tags[3:4, 3:4, 3:4] == 0)
+    assert np.all(tags[4:6, 4:6, 4:6] == void)
+
+
+def test_same_tag_on_multiple_primitives_uses_one_id(tmp_path, monkeypatch):
+    scene = _base_scene()
+    scene.add(
+        gprMax.Box(
+            p1=(0.001, 0.001, 0.001),
+            p2=(0.003, 0.003, 0.003),
+            material_id="pec",
+            tag="metal",
+        )
+    )
+    scene.add(gprMax.Sphere(p1=(0.007, 0.007, 0.007), r=0.001, material_id="pec", tag="metal"))
+    grid = _build(scene, tmp_path, monkeypatch)
+    assert grid.geometry_tag_registry.names == ("untagged", "metal")
+    assert set(np.unique(grid.geometry_tag_map.data)) == {0, 1}
+
+
+def test_smoothing_does_not_change_cell_centred_tag_membership(tmp_path, monkeypatch):
+    scene = _base_scene()
+    scene.add(
+        gprMax.Box(
+            p1=(0.001, 0.001, 0.001),
+            p2=(0.004, 0.004, 0.004),
+            material_id="free_space",
+            averaging="n",
+            tag="unsmoothed",
+        )
+    )
+    scene.add(
+        gprMax.Box(
+            p1=(0.005, 0.005, 0.005),
+            p2=(0.008, 0.008, 0.008),
+            material_id="free_space",
+            averaging="y",
+            tag="smoothed",
+        )
+    )
+    grid = _build(scene, tmp_path, monkeypatch)
+    tags = grid.geometry_tag_map.data
+    assert np.count_nonzero(tags == grid.geometry_tag_registry.id_for("unsmoothed")) == 27
+    assert np.count_nonzero(tags == grid.geometry_tag_registry.id_for("smoothed")) == 27
+
+
+def test_clipped_tagged_primitive_writes_only_valid_domain_cells(tmp_path, monkeypatch):
+    scene = _base_scene()
+    scene.add(
+        gprMax.Sphere(
+            p1=(0.0, 0.005, 0.005),
+            r=0.003,
+            material_id="pec",
+            tag="clipped_sphere",
+        )
+    )
+    grid = _build(scene, tmp_path, monkeypatch)
+    tags = grid.geometry_tag_map.data
+    assert tags.shape == (10, 10, 10)
+    assert np.count_nonzero(tags) > 0
+    assert np.count_nonzero(tags[:, :2, :2]) == 0
+
+
+def test_geometry_tag_map_is_preserved_across_geometry_fixed_runs(tmp_path, monkeypatch):
+    scene = _base_scene()
+    scene.add(
+        gprMax.Box(
+            p1=(0.002, 0.002, 0.002),
+            p2=(0.008, 0.008, 0.008),
+            material_id="pec",
+            tag="anatomy",
+        )
+    )
+
+    observed = []
+    original = model_mod.Model.build
+
+    def build(self):
+        original(self)
+        observed.append((id(self.G.geometry_tag_map), self.G.geometry_tag_map.data.copy()))
+
+    monkeypatch.setattr(model_mod.Model, "build", build)
+    gprMax.run(
+        scenes=[scene],
+        n=2,
+        geometry_fixed=True,
+        geometry_only=True,
+        outputfile=tmp_path / "geometry_fixed_tags",
+        hide_progress_bars=True,
+    )
+
+    assert len(observed) == 2
+    assert observed[0][0] == observed[1][0]
+    assert np.array_equal(observed[0][1], observed[1][1])


### PR DESCRIPTION
# PR Description


## Summary

Adds optional cell-centred semantic tags to voxelised geometry. Tags identify meaningful regions independently of electromagnetic material IDs, supporting future object-based processing such as tissue-specific SAR calculations.

Tags follow the existing ordered geometry-building semantics:

- tagged geometry writes its tag ID;
- later tagged geometry overwrites the previous tag;
- later untagged geometry clears the tag to ID 0;
- dielectric smoothing does not affect tag membership.

Tag ID 0 is permanently reserved for `untagged`.

## Interfaces

Python API:

```python
gprMax.Box(..., tag="housing")