### PR TITLE
Add SAR output support for HSG subgrids

### DIFF
--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -1406,13 +1406,24 @@ each requested frequency.
 Selected tagged cells that lie in boundary or internal PML regions are
 excluded automatically because PML loss is not physical material absorption.
 
+``SAR`` may be added to a :class:`SubGridHSG` in the same way as other
+subgrid outputs. Fields are transformed using the fine-grid ``dt`` and the
+result is written below ``/subgrids/<subgrid ID>/sar/<output ID>``. The
+normalising source may be on the main grid or the subgrid; its waveform DFT
+uses the timestep of the grid that owns the source. This is useful when a
+main-grid plane wave or antenna illuminates finely resolved tagged tissue.
+Mass averaging is local to the selected subgrid tag volume, so the complete
+tissue region required by an averaging cube should be contained inside the
+subgrid working region.
+
 The default permits output only while the shortest wavelength in any model
 material is sampled by at least ten cells. Use ``spectrum_limit=8`` for a
 lambda/8 criterion. ``spectrum_limit='nyquist'`` is an explicit research
 override: it retains the requested frequencies but does not imply spatial
-accuracy. Three-dimensional CPU, CUDA, OpenCL, and Metal models are supported.
-MPI domain decomposition and SAR regions inside a subgrid are not yet
-supported. See :ref:`sar-output` for the formulation and HDF5 schema.
+accuracy. Three-dimensional CPU, CUDA, OpenCL, and Metal models are supported
+on the main grid. Three-dimensional CPU HSG subgrids are also supported. MPI
+domain decomposition is not yet supported. See :ref:`sar-output` for the
+formulation and HDF5 schema.
 
 Rational-network S11 and input impedance
 -----------------------------------------

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1990,9 +1990,13 @@ wavelength criterion but not the temporal Nyquist check. The default Python
 API criterion is lambda/10, and lambda/8 is requested by supplying ``8``.
 Every material in the selected final tagged cells must have a positive mass
 density. Tagged cells inside boundary or internal PML regions are excluded
-automatically. Three-dimensional CPU, CUDA, OpenCL, and Metal models are
-supported; MPI domain decomposition and SAR regions inside a subgrid are not
-yet supported. See :ref:`sar-output` for the formulation and datasets.
+automatically. Three-dimensional CPU, CUDA, OpenCL, and Metal main-grid models
+and three-dimensional CPU HSG subgrids are supported; MPI domain decomposition
+is not yet supported. A ``#sar`` command inside a subgrid block samples the
+fine grid at its own timestep and writes
+``/subgrids/<subgrid ID>/sar/<output ID>``. Its normalising source may belong
+to the main grid or the subgrid. See :ref:`sar-output` for the formulation and
+datasets.
 
 For port-power normalisation, replace the numeric target amplitude by
 ``incident_power`` or ``accepted_power`` and insert the target power in watts

--- a/docs/source/output.rst
+++ b/docs/source/output.rst
@@ -43,7 +43,8 @@ further groups for each named or numbered output.
 Absorbed power density and specific absorption rate
 ---------------------------------------------------
 
-A requested SAR output adds ``/sar/<id>``. gprMax transforms only the unique
+A requested main-grid SAR output adds ``/sar/<id>``; an output attached to a
+subgrid adds ``/subgrids/<subgrid ID>/sar/<id>``. gprMax transforms only the unique
 Yee electric edges required by the selected tagged cells and only at the
 requested frequencies; it does not store a full time history for every cell.
 The serial CPU solver uses a Cython/OpenMP sparse transform. CUDA, OpenCL, and
@@ -92,6 +93,11 @@ The requested port power is obtained through the same terminal/modal power
 adapter used for antenna gain. Non-positive, non-finite, or invalid port
 powers produce invalid SAR bins rather than unbounded scaling. Frequencies
 below ``SourceFloorDB`` are likewise marked invalid and stored as NaN.
+Source and port normalisation are resolved across the complete model rather
+than only the grid containing the SAR output. Consequently, a source on the
+main grid can illuminate and normalise tagged tissue sampled at every fine
+timestep inside a subgrid. A subgrid port uses the model-wide qualified
+reference ``<subgrid ID>/<port ID>``.
 
 The datasets include ``frequency``, ``cell_indices``, ``tag_id``,
 ``material_id``, ``density``, ``source_spectrum``, ``source_relative_db``,
@@ -99,6 +105,9 @@ The datasets include ``frequency``, ``cell_indices``, ``tag_id``,
 ``limiting_material``, ``absorbed_power_density``, and ``sar``. Each
 ``tags/<name>`` subgroup contains cell count, total mass, absorbed power,
 mass-average SAR, and peak voxel SAR.
+``CellIndexOrigin`` and ``CellCentreOffset`` map the integer
+``cell_indices`` to physical cell-centre positions. ``CellIndexFrame`` is
+``main-grid`` for a normal output and ``subgrid-local`` for an HSG output.
 
 Spatial averaging is not performed by default. This keeps the application-
 neutral local quantities available without imposing a bioelectromagnetic

--- a/gprMax/fields_outputs.py
+++ b/gprMax/fields_outputs.py
@@ -261,7 +261,8 @@ def write_hdf5_outputfile(outputfile: Path, title: str, model):
         sg_frills = [True for sg in model.subgrids if sg.magneticfrillsources]
         sg_ports = [True for sg in model.subgrids if sg.port_monitors]
         sg_eigenmode_ports = [True for sg in model.subgrids if sg.eigenmodeports]
-        if sg_rxs or sg_tls or sg_frills or sg_ports or sg_eigenmode_ports:
+        sg_sar = [True for sg in model.subgrids if getattr(sg, "sar_monitors", ())]
+        if sg_rxs or sg_tls or sg_frills or sg_ports or sg_eigenmode_ports or sg_sar:
             for sg in model.subgrids:
                 grp = f.create_group(f"/subgrids/{sg.name}")
                 write_hd5_data(grp, sg, is_subgrid=True)

--- a/gprMax/model.py
+++ b/gprMax/model.py
@@ -367,19 +367,26 @@ class Model:
             if not self.G.ntff_output_writers:
                 compile_ntff_outputs(self, self.G)
 
+        grids = [self.G] + self.subgrids
+
         # SAR requests use final Yee material IDs and therefore compile only
-        # after the geometry build. Accelerator backends collect the same
-        # sparse edge DFTs on device and download only those compact arrays.
-        if getattr(self.G, "sar_specs", None) and not self.G.sar_monitors:
+        # after the geometry build. Each monitor samples fields on its owning
+        # grid, while source and port normalisation are resolved model-wide.
+        # This lets, for example, a main-grid plane wave illuminate tagged
+        # tissue built and sampled on a fine subgrid.
+        sar_grids = [
+            grid for grid in grids if getattr(grid, "sar_specs", None) and not grid.sar_monitors
+        ]
+        if sar_grids:
             from gprMax.sar import compile_sar_outputs
 
-            compile_sar_outputs(self.G)
+            for grid in sar_grids:
+                compile_sar_outputs(grid, model=self)
 
         logger.info(
             f"Output directory: {config.get_model_config().output_file_path.parent.resolve()}\n"
         )
 
-        grids = [self.G] + self.subgrids
         for grid in grids:
             grid.update_sources_and_recievers()
 
@@ -390,8 +397,9 @@ class Model:
         if config.sim_config.study is not None:
             config.sim_config.study.apply_case(self)
 
-        for monitor in self.G.sar_monitors:
-            monitor.prepare_run(self.G)
+        for grid in grids:
+            for monitor in grid.sar_monitors:
+                monitor.prepare_run()
 
         # Magnetic-frill sources bind the attached thin-wire radius, resolve
         # symmetry, validate the PEC ground plane, and precompute their
@@ -678,8 +686,9 @@ class Model:
         for grid in [self.G] + self.subgrids:
             finalise_transmission_line_ports(grid)
             finalise_magnetic_frill_ports(grid)
-        for monitor in self.G.sar_monitors:
-            monitor.finalise()
+        for grid in grids:
+            for monitor in grid.sar_monitors:
+                monitor.finalise()
 
         if config.sim_config.study is not None:
             config.sim_config.study.collect_case(self)
@@ -689,6 +698,7 @@ class Model:
         sg_tls = [True for sg in self.subgrids if sg.transmissionlines]
         sg_frills = [True for sg in self.subgrids if sg.magneticfrillsources]
         sg_ports = [True for sg in self.subgrids if sg.port_monitors]
+        sg_sar = [True for sg in self.subgrids if sg.sar_monitors]
         ntff_outputs = [
             monitor
             for monitor in self.G.ntff_monitors
@@ -703,6 +713,7 @@ class Model:
             or self.G.magneticfrillsources
             or sg_frills
             or sg_ports
+            or sg_sar
             or ntff_outputs
             or self.G.port_monitors
             or self.G.eigenmodeports

--- a/gprMax/sar.py
+++ b/gprMax/sar.py
@@ -31,6 +31,7 @@ from gprMax.ports import (
     DEFAULT_MINIMUM_WAVELENGTH_CELLS,
     evaluate_port_power_spectrum,
     minimum_wavelength_sampling,
+    model_port_output_registry,
     port_output_registry,
     validate_spectrum_limit,
 )
@@ -38,6 +39,7 @@ from gprMax.sar_averaging import apply_spatial_average_plan, build_spatial_avera
 
 if TYPE_CHECKING:
     from gprMax.grid.fdtd_grid import FDTDGrid
+    from gprMax.model import Model
 
 
 logger = logging.getLogger(__name__)
@@ -193,6 +195,7 @@ class SARMonitor:
         normalisation: str = "waveform",
         port_id: str | None = None,
         target_power: float | None = None,
+        model: "Model | None" = None,
     ) -> None:
         if grid.geometry_tag_map is None or grid.geometry_tag_registry is None:
             raise ValueError("SAR requires at least one tagged volumetric geometry object")
@@ -217,7 +220,12 @@ class SARMonitor:
             "nyquist" if self.spectrum_limit == "nyquist" else "minimum_wavelength_cells"
         )
         self.waveform_id = str(waveform_id)
-        if not any(waveform.ID == self.waveform_id for waveform in grid.waveforms):
+        waveform_grids = (grid,) if model is None else (model.G, *model.subgrids)
+        if not any(
+            waveform.ID == self.waveform_id
+            for waveform_grid in waveform_grids
+            for waveform in waveform_grid.waveforms
+        ):
             raise ValueError(f"SAR references unknown waveform {self.waveform_id!r}")
         self.target_amplitude = float(target_amplitude)
         if not np.isfinite(self.target_amplitude) or self.target_amplitude <= 0:
@@ -347,56 +355,78 @@ class SARMonitor:
         self.grid_shape = (int(grid.nx), int(grid.ny), int(grid.nz))
         self.grid_spacing = (float(grid.dx), float(grid.dy), float(grid.dz))
         self.cell_volume = float(grid.dx * grid.dy * grid.dz)
+        if hasattr(grid, "local_to_global"):
+            self.cell_index_frame = "subgrid-local"
+            self.cell_index_origin = np.asarray(grid.local_to_global((0, 0, 0)), dtype=np.float64)
+        else:
+            self.cell_index_frame = "main-grid"
+            self.cell_index_origin = np.zeros(3, dtype=np.float64)
         self.grid = grid
+        self.model = model
         self._source_samples = np.empty(0, dtype=self.real_dtype)
+        self._source_dt = float(grid.dt)
+        self._source_window = np.empty(0, dtype=self.real_dtype)
         self._spatial_average_plans = None
-        self.prepare_run(grid)
 
-    def _build_source_samples(self, grid: "FDTDGrid") -> npt.NDArray[np.floating]:
-        source_groups = (
-            grid.voltagesources,
-            grid.hertziandipoles,
-            grid.magneticdipoles,
-            grid.transmissionlines,
-            grid.magneticfrillsources,
-            grid.discreteplanewaves,
-        )
-        sources = [
-            source
-            for group in source_groups
-            for source in group
-            if source.waveformID == self.waveform_id
-        ]
-        if not sources:
+    def _model_grids(self):
+        if self.model is None:
+            return (self.grid,)
+        return (self.model.G, *self.model.subgrids)
+
+    def _build_source_samples(self):
+        bindings = []
+        for source_grid in self._model_grids():
+            source_groups = (
+                source_grid.voltagesources,
+                source_grid.hertziandipoles,
+                source_grid.magneticdipoles,
+                source_grid.transmissionlines,
+                source_grid.magneticfrillsources,
+                source_grid.discreteplanewaves,
+            )
+            bindings.extend(
+                (source, source_grid)
+                for group in source_groups
+                for source in group
+                if source.waveformID == self.waveform_id
+            )
+        if not bindings:
             raise ValueError(
                 f"SAR waveform {self.waveform_id!r} is not associated with an active source"
             )
-        active_sources = [source for source in sources if getattr(source, "study_scale", 1.0) != 0]
-        if len(active_sources) != 1:
+        active_bindings = [
+            binding for binding in bindings if getattr(binding[0], "study_scale", 1.0) != 0
+        ]
+        if len(active_bindings) != 1:
             raise ValueError(
                 f"SAR waveform {self.waveform_id!r} must identify exactly one active "
-                f"source; found {len(active_sources)}"
+                f"source across the model; found {len(active_bindings)}"
             )
-        source = active_sources[0]
-        windows = {(float(source.start), float(source.stop))}
-        if len(windows) != 1:
+        source, source_grid = active_bindings[0]
+        start, stop = float(source.start), float(source.stop)
+        waveforms = [item for item in source_grid.waveforms if item.ID == self.waveform_id]
+        if len(waveforms) != 1:
             raise ValueError(
-                "SAR sources sharing the normalising waveform must use the same start and stop"
+                f"SAR waveform {self.waveform_id!r} is not uniquely defined on its source grid"
             )
-        start, stop = next(iter(windows))
-        waveform = next(item for item in grid.waveforms if item.ID == self.waveform_id)
+        waveform = waveforms[0]
         source_scale = float(getattr(source, "study_scale", 1.0))
-        samples = np.zeros(grid.iterations, dtype=self.real_dtype)
-        for iteration in range(grid.iterations):
-            time = iteration * grid.dt
+        samples = np.zeros(source_grid.iterations, dtype=self.real_dtype)
+        for iteration in range(source_grid.iterations):
+            time = iteration * source_grid.dt
             if start <= time < stop:
-                samples[iteration] = source_scale * waveform.calculate_value(time - start, grid.dt)
-        return samples
+                samples[iteration] = source_scale * waveform.calculate_value(
+                    time - start, source_grid.dt
+                )
+        return samples, float(source_grid.dt)
 
-    def prepare_run(self, grid: "FDTDGrid") -> None:
+    def prepare_run(self) -> None:
         """Refresh source normalisation after geometry-fixed study changes."""
 
-        self._source_samples = self._build_source_samples(grid)
+        self._source_samples, self._source_dt = self._build_source_samples()
+        self._source_window = _window(
+            self.window_name, self._source_samples.size, np.dtype(np.float64)
+        )
 
     @property
     def nbytes(self) -> int:
@@ -411,6 +441,7 @@ class SARMonitor:
             + self.density.nbytes
             + self.window.nbytes
             + self._source_samples.nbytes
+            + self._source_window.nbytes
             + sum(plan.nbytes for plan in (self._spatial_average_plans or ()))
         )
 
@@ -474,12 +505,14 @@ class SARMonitor:
     def finalise(self) -> SARResult:
         if self._next_iteration != self.grid_iterations:
             raise RuntimeError("SAR monitor cannot be finalised before every timestep is observed")
+        source_dt = getattr(self, "_source_dt", self.grid_dt)
+        source_window = getattr(self, "_source_window", self.window)
         source_spectrum = np.asarray(
             engineering_dft(
                 self._source_samples,
                 self.frequencies,
-                self.grid_dt,
-                window=self.window,
+                source_dt,
+                window=source_window,
             ),
             dtype=self.complex_dtype,
         )
@@ -505,11 +538,21 @@ class SARMonitor:
                 where=defined,
             )
         else:
-            registry = port_output_registry(self.grid)
-            if self.port_id not in registry:
-                raise ValueError(f"SAR references unknown main-grid port {self.port_id!r}")
+            if getattr(self, "model", None) is None:
+                registry = port_output_registry(self.grid)
+                if self.port_id not in registry:
+                    raise ValueError(f"SAR references unknown model port {self.port_id!r}")
+                output = registry[self.port_id]
+                port_grid = self.grid
+            else:
+                registry = model_port_output_registry(self.model)
+                if self.port_id not in registry:
+                    raise ValueError(f"SAR references unknown model port {self.port_id!r}")
+                binding = registry[self.port_id]
+                output = binding.output
+                port_grid = binding.grid
             spectrum = evaluate_port_power_spectrum(
-                registry[self.port_id], self.grid, self.frequencies, window=self.window_name
+                output, port_grid, self.frequencies, window=self.window_name
             )
             normalising_power = np.asarray(
                 spectrum.incident_power
@@ -637,6 +680,11 @@ class SARMonitor:
         group.attrs["CollectionBackend"] = self.collection_backend
         group.attrs["PMLCellPolicy"] = "excluded"
         group.attrs["ExcludedPMLCellCount"] = self.excluded_pml_cell_count
+        group.attrs["CellIndexFrame"] = self.cell_index_frame
+        group.attrs["CellIndexOrigin"] = self.cell_index_origin
+        group.attrs["CellIndexOriginUnits"] = "m"
+        group.attrs["CellCentreOffset"] = np.asarray(self.grid_spacing) / 2
+        group.attrs["CellCentreOffsetUnits"] = "m"
         group.attrs["SourceFloorDB"] = self.source_floor_db
         group.attrs["SpectrumLimitMode"] = self.spectrum_limit_mode
         group.attrs["MinimumWavelengthCells"] = self.minimum_wavelength_cells
@@ -708,7 +756,7 @@ class SARMonitor:
             tag_group["peak_voxel_sar"] = peak_sar
 
 
-def compile_sar_outputs(grid: "FDTDGrid") -> None:
+def compile_sar_outputs(grid: "FDTDGrid", *, model: "Model | None" = None) -> None:
     """Compile deferred SAR requests after material IDs are available."""
 
     if grid.sar_monitors:
@@ -728,6 +776,7 @@ def compile_sar_outputs(grid: "FDTDGrid") -> None:
             normalisation=spec.normalisation,
             port_id=spec.port_id,
             target_power=spec.target_power,
+            model=model,
         )
         grid.sar_monitors.append(monitor)
         if spec.owner is not None:

--- a/gprMax/subgrids/precursor_nodes.py
+++ b/gprMax/subgrids/precursor_nodes.py
@@ -271,9 +271,6 @@ class PrecursorNodesBase:
             # interpolate over a fine grid
             f_i = self.interpolate_to_sub_grid(f_t, obj[1])
 
-            if np.array_equal(f_i, f_t):
-                raise ValueError
-
             # discard the outer nodes only required for interpolation
             # f = f_i[self.ratio:-self.ratio, self.ratio:-self.ratio]
             f = f_i

--- a/gprMax/subgrids/updates.py
+++ b/gprMax/subgrids/updates.py
@@ -92,6 +92,7 @@ class SubgridUpdater(CPUUpdates[SubGridBaseGrid]):
     def store_outputs(self):
         super().store_outputs(self.iteration)
         super().store_snapshots(self.iteration)
+        super().observe_sar_electric(self.iteration)
 
     def update_electric_sources(self):
         iteration = self.iteration

--- a/gprMax/user_objects/cmds_output.py
+++ b/gprMax/user_objects/cmds_output.py
@@ -494,10 +494,6 @@ class SAR(OutputUserObject):
         return self._monitor.result
 
     def build(self, model: Model, grid: FDTDGrid):
-        if isinstance(grid, SubGridBaseGrid):
-            raise ValueError(f"{self.params_str()} is not yet supported in a subgrid")
-        if grid is not model.G:
-            raise ValueError(f"{self.params_str()} must be attached to the main grid")
         if config.sim_config.mpi:
             raise ValueError(f"{self.params_str()} is not yet supported by the MPI solver")
         if config.sim_config.general["solver"] not in ("cpu", "cuda", "opencl", "metal"):

--- a/tests/outputs/test_sar_subgrid.py
+++ b/tests/outputs/test_sar_subgrid.py
@@ -1,0 +1,269 @@
+"""Frequency-domain SAR output from a fine HSG subgrid."""
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+
+
+def _subgrid_sar_scene(*, source_on_main_grid=False):
+    scene = gprMax.Scene()
+    scene.add(gprMax.Domain(p1=(0.09, 0.09, 0.09)))
+    scene.add(gprMax.Discretisation(p1=(0.003, 0.003, 0.003)))
+    scene.add(gprMax.TimeWindow(time=4e-10))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.OMPThreads(1))
+
+    subgrid = gprMax.SubGridHSG(
+        p1=(0.03, 0.03, 0.03),
+        p2=(0.06, 0.06, 0.06),
+        ratio=3,
+        id="fine_grid",
+    )
+    scene.add(subgrid)
+    subgrid.add(gprMax.Material(er=4, se=0.5, mr=1, sm=0, id="tissue"))
+    subgrid.add(gprMax.MaterialDensity(density=1000, material_ids="tissue"))
+    subgrid.add(
+        gprMax.Box(
+            p1=(0.040, 0.040, 0.040),
+            p2=(0.050, 0.050, 0.050),
+            material_id="tissue",
+            tag="target",
+        )
+    )
+
+    waveform = gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse")
+    source = gprMax.HertzianDipole(
+        p1=(0.045, 0.045, 0.045) if not source_on_main_grid else (0.018, 0.045, 0.045),
+        polarisation="z",
+        waveform_id="pulse",
+    )
+    if source_on_main_grid:
+        scene.add(waveform)
+        scene.add(source)
+    else:
+        subgrid.add(waveform)
+        subgrid.add(source)
+
+    output = gprMax.SAR(
+        frequencies=(5e9,),
+        waveform_id="pulse",
+        tags="target",
+        id="fine_sar",
+        spectrum_limit="nyquist",
+        averaging_masses=(0.001,),
+    )
+    subgrid.add(output)
+    return scene, output
+
+
+def _uniform_fine_sar_scene():
+    scene = gprMax.Scene()
+    scene.add(gprMax.Domain(p1=(0.09, 0.09, 0.09)))
+    scene.add(gprMax.Discretisation(p1=(0.001, 0.001, 0.001)))
+    scene.add(gprMax.TimeWindow(time=4e-10))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.OMPThreads(8))
+    scene.add(gprMax.Material(er=4, se=0.5, mr=1, sm=0, id="tissue"))
+    scene.add(gprMax.MaterialDensity(density=1000, material_ids="tissue"))
+    scene.add(
+        gprMax.Box(
+            p1=(0.040, 0.040, 0.040),
+            p2=(0.050, 0.050, 0.050),
+            material_id="tissue",
+            tag="target",
+        )
+    )
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
+    scene.add(
+        gprMax.HertzianDipole(p1=(0.045, 0.045, 0.045), polarisation="z", waveform_id="pulse")
+    )
+    scene.add(
+        gprMax.SAR(
+            frequencies=(5e9,),
+            waveform_id="pulse",
+            tags="target",
+            id="fine_sar",
+            spectrum_limit="nyquist",
+            averaging_masses=(0.001,),
+        )
+    )
+    return scene
+
+
+def _subgrid_power_normalised_scene():
+    scene = gprMax.Scene()
+    scene.add(gprMax.Domain(p1=(0.09, 0.09, 0.09)))
+    scene.add(gprMax.Discretisation(p1=(0.003, 0.003, 0.003)))
+    scene.add(gprMax.TimeWindow(time=4e-10))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.OMPThreads(1))
+    fine = gprMax.SubGridHSG(p1=(0.03, 0.03, 0.03), p2=(0.06, 0.06, 0.06), ratio=3, id="fine_grid")
+    scene.add(fine)
+    fine.add(gprMax.Material(er=4, se=0.5, mr=1, sm=0, id="tissue"))
+    fine.add(gprMax.MaterialDensity(density=1000, material_ids="tissue"))
+    fine.add(
+        gprMax.Box(
+            p1=(0.040, 0.040, 0.040),
+            p2=(0.050, 0.050, 0.050),
+            material_id="tissue",
+            tag="target",
+        )
+    )
+    fine.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
+    fine.add(
+        gprMax.VoltageSource(
+            p1=(0.045, 0.045, 0.045),
+            polarisation="z",
+            resistance=50,
+            waveform_id="pulse",
+        )
+    )
+    fine.add(gprMax.RxPort(p1=(0.045, 0.045, 0.045), id="feed", spectrum_limit="nyquist"))
+    output = gprMax.SAR(
+        frequencies=(5e9,),
+        waveform_id="pulse",
+        tags="target",
+        id="power_sar",
+        spectrum_limit="nyquist",
+        normalisation="incident_power",
+        port_id="fine_grid/feed",
+        target_power=1.0,
+    )
+    fine.add(output)
+    return scene, output
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("source_on_main_grid", (False, True))
+def test_sar_runs_on_fine_timestep_and_writes_subgrid_group(tmp_path, source_on_main_grid):
+    scene, api_output = _subgrid_sar_scene(source_on_main_grid=source_on_main_grid)
+    output = tmp_path / ("main_source" if source_on_main_grid else "fine_source")
+
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        outputfile=output,
+        subgrid=True,
+        autotranslate=True,
+        hide_progress_bars=True,
+        cpu_precision="single",
+    )
+
+    assert api_output.result.sar.shape[0] == 1
+    assert api_output.result.cell_indices.shape[0] > 0
+    assert np.all(api_output.result.valid)
+    assert np.all(np.isfinite(api_output.result.sar))
+
+    with h5py.File(output.with_suffix(".h5"), "r") as result:
+        assert "sar" not in result
+        fine = result["subgrids/fine_grid"]
+        assert fine.attrs["Iterations"] == 3 * result.attrs["Iterations"]
+        np.testing.assert_allclose(fine.attrs["dx_dy_dz"], (0.001, 0.001, 0.001))
+        sar = fine["sar/fine_sar"]
+        assert sar.attrs["CellIndexFrame"] == "subgrid-local"
+        expected_origin = (
+            np.asarray((0.03, 0.03, 0.03))
+            - np.asarray(
+                (
+                    fine.attrs["is_os_sep"] * fine.attrs["ratio"]
+                    + fine.attrs["pml_separation"]
+                    + fine.attrs["subgrid_pml_thickness"],
+                )
+                * 3
+            )
+            * 0.001
+        )
+        np.testing.assert_allclose(sar.attrs["CellIndexOrigin"], expected_origin)
+        np.testing.assert_allclose(sar.attrs["CellCentreOffset"], (0.0005,) * 3)
+        np.testing.assert_array_equal(sar["cell_indices"], api_output.result.cell_indices)
+        np.testing.assert_allclose(sar["sar"], api_output.result.sar)
+        assert "spatial_average/1g" in sar
+        assert np.isfinite(sar["spatial_average/1g/peak_sar"][0])
+
+
+@pytest.mark.integration
+def test_subgrid_sar_state_is_reset_for_geometry_fixed_runs(tmp_path):
+    scene, _ = _subgrid_sar_scene()
+    output = tmp_path / "reused"
+
+    gprMax.run(
+        scenes=[scene],
+        n=2,
+        geometry_fixed=True,
+        outputfile=output,
+        subgrid=True,
+        autotranslate=True,
+        hide_progress_bars=True,
+        cpu_precision="single",
+    )
+
+    with h5py.File(f"{output}1.h5", "r") as first, h5py.File(f"{output}2.h5", "r") as second:
+        first_sar = first["subgrids/fine_grid/sar/fine_sar/sar"][...]
+        second_sar = second["subgrids/fine_grid/sar/fine_sar/sar"][...]
+        np.testing.assert_allclose(second_sar, first_sar, rtol=2e-6, atol=0)
+
+
+@pytest.mark.integration
+def test_subgrid_sar_agrees_with_uniform_fine_grid(tmp_path):
+    uniform_path = tmp_path / "uniform"
+    subgrid_path = tmp_path / "subgrid"
+    subgrid_scene, _ = _subgrid_sar_scene()
+
+    gprMax.run(
+        scenes=[_uniform_fine_sar_scene()],
+        n=1,
+        outputfile=uniform_path,
+        hide_progress_bars=True,
+        cpu_precision="double",
+    )
+    gprMax.run(
+        scenes=[subgrid_scene],
+        n=1,
+        outputfile=subgrid_path,
+        subgrid=True,
+        autotranslate=True,
+        hide_progress_bars=True,
+        cpu_precision="double",
+    )
+
+    paths = (
+        "tags/target/absorbed_power",
+        "tags/target/mass_average_sar",
+        "tags/target/peak_voxel_sar",
+        "spatial_average/1g/peak_sar",
+    )
+    with h5py.File(uniform_path.with_suffix(".h5"), "r") as uniform, h5py.File(
+        subgrid_path.with_suffix(".h5"), "r"
+    ) as nested:
+        uniform_sar = uniform["sar/fine_sar"]
+        nested_sar = nested["subgrids/fine_grid/sar/fine_sar"]
+        for path in paths:
+            np.testing.assert_allclose(
+                nested_sar[path][...], uniform_sar[path][...], rtol=0.05, atol=0
+            )
+
+
+@pytest.mark.integration
+def test_subgrid_sar_uses_qualified_model_port_for_power_normalisation(tmp_path):
+    scene, api_output = _subgrid_power_normalised_scene()
+    output = tmp_path / "power_normalised"
+
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        outputfile=output,
+        subgrid=True,
+        autotranslate=True,
+        hide_progress_bars=True,
+        cpu_precision="single",
+    )
+
+    assert np.all(api_output.result.valid)
+    assert np.all(np.isfinite(api_output.result.normalising_power))
+    with h5py.File(output.with_suffix(".h5"), "r") as result:
+        sar = result["subgrids/fine_grid/sar/power_sar"]
+        assert sar.attrs["Normalisation"] == "incident_power"
+        assert sar.attrs["PortID"] == "fine_grid/feed"
+        assert np.all(np.isfinite(sar["sar"]))

--- a/tests/outputs/test_sar_subgrid.py
+++ b/tests/outputs/test_sar_subgrid.py
@@ -7,19 +7,22 @@ import pytest
 import gprMax
 
 
-def _subgrid_sar_scene(*, source_on_main_grid=False):
+def _subgrid_sar_scene(
+    *, source_on_main_grid=False, main_spacing=0.003, ratio=3, filtering=True, threads=1
+):
     scene = gprMax.Scene()
     scene.add(gprMax.Domain(p1=(0.09, 0.09, 0.09)))
-    scene.add(gprMax.Discretisation(p1=(0.003, 0.003, 0.003)))
+    scene.add(gprMax.Discretisation(p1=(main_spacing,) * 3))
     scene.add(gprMax.TimeWindow(time=4e-10))
     scene.add(gprMax.PMLThickness(thickness=0))
-    scene.add(gprMax.OMPThreads(1))
+    scene.add(gprMax.OMPThreads(threads))
 
     subgrid = gprMax.SubGridHSG(
         p1=(0.03, 0.03, 0.03),
         p2=(0.06, 0.06, 0.06),
-        ratio=3,
+        ratio=ratio,
         id="fine_grid",
+        filter=filtering,
     )
     scene.add(subgrid)
     subgrid.add(gprMax.Material(er=4, se=0.5, mr=1, sm=0, id="tissue"))
@@ -242,6 +245,66 @@ def test_subgrid_sar_agrees_with_uniform_fine_grid(tmp_path):
         for path in paths:
             np.testing.assert_allclose(
                 nested_sar[path][...], uniform_sar[path][...], rtol=0.05, atol=0
+            )
+
+
+@pytest.mark.integration
+def test_ratio_one_subgrid_sar_matches_identical_uniform_grid(tmp_path):
+    uniform_path = tmp_path / "uniform_ratio_one"
+    subgrid_path = tmp_path / "subgrid_ratio_one"
+    subgrid_scene, _ = _subgrid_sar_scene(main_spacing=0.001, ratio=1, threads=8)
+
+    gprMax.run(
+        scenes=[_uniform_fine_sar_scene()],
+        n=1,
+        outputfile=uniform_path,
+        hide_progress_bars=True,
+        cpu_precision="double",
+    )
+    gprMax.run(
+        scenes=[subgrid_scene],
+        n=1,
+        outputfile=subgrid_path,
+        subgrid=True,
+        autotranslate=True,
+        hide_progress_bars=True,
+        cpu_precision="double",
+    )
+
+    with h5py.File(uniform_path.with_suffix(".h5"), "r") as uniform, h5py.File(
+        subgrid_path.with_suffix(".h5"), "r"
+    ) as nested:
+        uniform_sar = uniform["sar/fine_sar"]
+        nested_sar = nested["subgrids/fine_grid/sar/fine_sar"]
+        uniform_centres = (
+            uniform_sar["cell_indices"][...] * 0.001
+            + uniform_sar.attrs["CellIndexOrigin"]
+            + uniform_sar.attrs["CellCentreOffset"]
+        )
+        nested_centres = (
+            nested_sar["cell_indices"][...] * 0.001
+            + nested_sar.attrs["CellIndexOrigin"]
+            + nested_sar.attrs["CellCentreOffset"]
+        )
+        uniform_order = np.lexsort(uniform_centres.T[::-1])
+        nested_order = np.lexsort(nested_centres.T[::-1])
+
+        np.testing.assert_allclose(
+            nested_centres[nested_order], uniform_centres[uniform_order], rtol=0, atol=1e-15
+        )
+        uniform_cells = uniform_sar["sar"][0][uniform_order]
+        nested_cells = nested_sar["sar"][0][nested_order]
+        cell_delta = nested_cells - uniform_cells
+        assert np.linalg.norm(cell_delta) / np.linalg.norm(uniform_cells) < 1e-7
+        assert np.max(np.abs(cell_delta)) / np.max(uniform_cells) < 1e-7
+        for path in (
+            "tags/target/absorbed_power",
+            "tags/target/mass_average_sar",
+            "tags/target/peak_voxel_sar",
+            "spatial_average/1g/peak_sar",
+        ):
+            np.testing.assert_allclose(
+                nested_sar[path][...], uniform_sar[path][...], rtol=1e-7, atol=0
             )
 
 


### PR DESCRIPTION
# PR Description

## Summary

This PR adds frequency-domain absorbed-power-density and SAR outputs for tagged geometry inside Huygens Surface Grid (HSG) subgrids.

It:

- accumulates the required electric-field DFTs at every fine-grid timestep;
- supports normalising sources located on either the main grid or the subgrid;
- supports model-wide port-power normalisation using qualified subgrid port IDs;
- writes results under `/subgrids/<subgrid ID>/sar/<output ID>`;
- records the coordinate frame, physical origin, and cell-centre offset;
- supports geometry-fixed repeated simulations;
- supports local 1 g/10 g spatial averaging within the tagged subgrid volume;
- removes an obsolete interpolation guard that prevented valid ratio-1 HSG simulations.


## Validation

A uniform 1 mm model was compared with an otherwise identical 1 mm main grid containing a ratio-1 HSG subgrid.

With the standard HSG filter enabled:

- per-cell SAR relative L2 error: `2.61e-9`;
- peak-normalised maximum cell error: `2.56e-9`;
- absorbed-power and mass-average SAR error: `2.66e-9`;
- peak voxel SAR error: `2.56e-9`;
- peak 1 g SAR error: `2.66e-9`.

With filtering disabled, the relative L2 difference was `6.81e-17`.

A second comparison used a uniform 1 mm model and a 3 mm main grid with a ratio-3 HSG subgrid, giving 1 mm resolution in the tagged region. Differences in absorbed power, mass-average SAR, peak voxel SAR, and peak 1 g SAR were between 2.98% and 3.35%, within the 5% regression tolerance.

Test results:

- 84 focused SAR/subgrid tests passed;
- 127 HSG precursor and update tests passed;
- Black, isort, and whitespace checks passed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added comments where the implementation requires explanation.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.