### PR TITLE
Add CRIM mixing model and fix DebyeFit optimisation

### DIFF
--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -528,6 +528,45 @@ Drude Dispersion
 ----------------
 .. autoclass:: gprMax.user_objects.cmds_multiuse.AddDrudeDispersion
 
+Material CRIM
+-------------
+.. autoclass:: gprMax.user_objects.cmds_multiuse.MaterialCrim
+
+See :ref:`#material_crim <material_crim>` for the CRIM mixing formula and how it is
+specialised to the matrix/dispersive-phase/air case used here.
+
+The CRIM object, like the Peplinski object below, is a mixing model for a
+:class:`FractalBox`, rather than a homogeneous material. It combines a
+fixed-fraction non-dispersive matrix material with a single-pole Debye
+dispersive material (assumed water or brine); the remaining volume fraction
+is assumed to be air. Both materials must already exist in the scene, and
+the dispersive material must have exactly one Debye pole. Conductivity is
+mixed separately by volume fraction as described for the hash command:
+
+.. code-block:: python
+
+    scene.add(gprMax.Material(er=5, se=0, mr=1, sm=0, id='sand'))
+
+    scene.add(gprMax.Material(er=4.9, se=0, mr=1, sm=0, id='water'))
+    scene.add(gprMax.AddDebyeDispersion(
+        poles=1, er_delta=(73.3389,), tau=(8.0994e-12,),
+        material_ids=('water',),
+    ))
+
+    scene.add(gprMax.MaterialCrim(
+        matrix_id='sand', matrix_fraction=0.6,
+        dispersive_id='water', fraction_lower=0.02, fraction_upper=0.35,
+        f_min=1e6, f_max=3e9, a=0.5,
+        id='wetsand',
+    ))
+
+    scene.add(gprMax.FractalBox(
+        p1=(0, 0, 0), p2=(0.1, 0.1, 0.08),
+        frac_dim=1.5, weighting=(1, 1, 1),
+        n_materials=10, mixing_model_id='wetsand',
+        id='my_fractal_box',
+    ))
+
 Soil Peplinski
 --------------
 .. autoclass:: gprMax.user_objects.cmds_multiuse.SoilPeplinski

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -459,6 +459,58 @@ Allows you to create a list of pre-defined materials that can be used in conjunc
 For example to create a fractal distribution of two different sand materials and water use: ``#material: 3 0 1 0 sand1``, ``#material: 4 0.1 1 0 sand2``, ``#material: 4.9 0.001 1 0 my_water``, ``#add_dispersion_debye: 1 75.2 9.231e-12 my_water``, ``#material_list: sand1 sand2 my_water my_list``, ``#fractal_box: 0 0 0 0.15 0.15 0.15 1.5 1 1 1 3 my_list my_frac_box``.
 
 
+.. _material_crim:
+
+#material_crim:
+---------------
+
+Allows you to use the Complex Refractive Index Model (CRIM) to mix a fixed-fraction non-dispersive matrix material with a single-pole Debye dispersive material (e.g. water or brine), with the remaining volume fraction assumed to be air. The command is designed to be used in conjunction with the ``#fractal_box`` command for creating media, such as wet soils, wet concrete, or brine-bearing ice, with realistic dielectric and geometric properties. Both the matrix and dispersive materials must already exist, i.e. be defined using ``#material`` (and, for the dispersive material, ``#add_dispersion_debye`` with exactly one pole) before this command is used.
+
+CRIM is a general power-law mixing formula for the bulk complex permittivity of a multi-phase medium [BIR1974]_, widely used for estimating the permittivity of soils, snow, ice, and other granular or porous media from the properties and volume fractions of their constituents. It takes the general form
+
+.. math::
+
+    \varepsilon_{\mathrm{mix}}(\omega)^{a} = \sum_{i} f_i \, \varepsilon_i(\omega)^{a},
+
+where :math:`f_i` and :math:`\varepsilon_i(\omega)` are the volumetric fraction and complex relative permittivity of constituent :math:`i` (with :math:`\sum_i f_i = 1`), and :math:`a` is an empirical shape factor that encodes the geometry of the mixed phases relative to the applied field: :math:`a=1` reduces to a simple volumetric (linear) average of permittivities, :math:`a=0.5` is the square-root, or "refractive index", form most commonly used for soils and other granular GPR media, and as :math:`a \to 0` the model approaches logarithmic (Lichtenecker) mixing.
+
+The syntax of the command is:
+
+.. code-block:: none
+
+    #material_crim: str1 f1 str2 f2 f3 f4 f5 f6 str3
+
+* ``str1`` is an identifier for an existing non-dispersive material used for the fixed-fraction matrix (solid) phase.
+* ``f1`` is the fixed volumetric fraction of the matrix phase.
+* ``str2`` is an identifier for an existing single-pole Debye material used for the dispersive phase.
+* ``f2`` and ``f3`` define a range for the volumetric fraction of the dispersive phase.
+* ``f4`` and ``f5`` are the lower and upper bounds of the frequency range (Hz) used to fit the CRIM mixing curve.
+* ``f6`` is the CRIM shape factor, :math:`a`, described above.
+* ``str3`` is an identifier for the CRIM mixing model.
+
+For this command, the mixture has exactly three phases - the fixed-fraction matrix, the dispersive phase, and air - so :math:`\varepsilon_i` is specialised to
+
+.. math::
+
+    \varepsilon_{\mathrm{mix}}(\omega)^{a} = f_1 \, \varepsilon_{\mathrm{matrix}}^{a} + f_{\mathrm{disp}} \left[\varepsilon_{\infty} + \frac{\Delta\varepsilon}{1+j\omega\tau}\right]^{a} + f_{\mathrm{air}} \, (1)^{a},
+
+where :math:`\varepsilon_{\infty}`, :math:`\Delta\varepsilon`, and :math:`\tau` are the dispersive material's own Debye parameters (taken directly from its ``#add_dispersion_debye`` definition), :math:`f_{\mathrm{disp}}` is a value between ``f2`` and ``f3`` for each bin, and the implied air fraction is :math:`f_{\mathrm{air}} = 1 - f_1 - f_{\mathrm{disp}}` (so ``f1`` plus ``f3`` must not exceed 1). For each of the ``n_materials`` bins created by the associated ``#fractal_box`` command, a single-pole Debye material is fitted by linear least-squares over the frequency range ``f4`` to ``f5`` to this dielectric CRIM curve. The dispersive material's relaxation time :math:`\tau` is fixed and reused for every bin; the fit determines the pole weight and infinite-frequency permittivity.
+
+The constituent DC conductivities are not included inside the fractional power in the equation above. They are mixed separately using the volumetric rule
+
+.. math::
+
+    \sigma_{\mathrm{mix}} = f_1 \sigma_{\mathrm{matrix}} + f_{\mathrm{disp}} \sigma_{\mathrm{disp}},
+
+with zero conductivity assumed for the air phase. This is a defined approximation rather than a fit of the complete conductive complex permittivity. The current implementation is limited to non-magnetic constituents (:math:`\mu_r=1` and :math:`\sigma_m=0`).
+
+For example, to create a fractal distribution of wet sand, with a fixed sand fraction of 0.6 and a water fraction ranging from 0.02 to 0.35, fitted over 1 MHz to 3 GHz with the standard CRIM shape factor, use: ``#material: 5 0 1 0 sand``, ``#material: 4.9 0 1 0 water``, ``#add_dispersion_debye: 1 73.3389 8.0994e-12 water``, ``#material_crim: sand 0.6 water 0.02 0.35 1e6 3e9 0.5 wetsand``, and then specify the fractal box using ``#fractal_box: 0 0 0 0.1 0.1 0.08 1.5 1 1 1 10 wetsand my_fractal_box``.
+
+.. note::
+
+    Only passive, single-pole Debye materials are accepted for the dispersive phase - CRIM's dispersive constituent is conventionally assumed to be water or brine, which is well represented by a single relaxation. Using a material with more than one Debye pole, a non-Debye dispersive material, a perfect conductor, or a magnetic material will raise an error.
+
+
 #soil_peplinski:
 ----------------
 

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -4,6 +4,7 @@ References
 
 .. [BAL2005] Balanis, C. A. (2005). Antenna theory: analysis and design (Vol. 1). John Wiley & Sons.
 .. [BER1998] Bergmann, T., Robertsson, J. O., & Holliger, K. (1998). Finite-difference modeling of electromagnetic wave propagation in dispersive and attenuating media. Geophysics, 63(3), 856-867. (http://dx.doi.org/10.1190/1.1444396)
+.. [BIR1974] Birchak, J. R., Gardner, C. G., Hipp, J. E., & Victor, J. M. (1974). High dielectric constant microwave probes for sensing soil moisture. Proceedings of the IEEE, 62(1), 93-98. (https://doi.org/10.1109/PROC.1974.9388)
 .. [BOU1996] Bourgeois, J. M., & Smith, G. S. (1996). A fully three-dimensional simulation of a ground-penetrating radar: FDTD theory compared with experiment. Geoscience and Remote Sensing, IEEE Transactions on, 34(1), 36-44. (http://dx.doi.org/10.1109/36.481890)
 .. [BUR1981] Burrough, P. A. (1981). Fractal dimensions of landscapes and other environmental data. Nature, 294(5838), 240-242. (http://dx.doi.org/10.1038/294240a0)
 .. [CHE2007] Chen, Z.-H., & Chu, Q.-X. (2007). FDTD Modeling of Arbitrary Linear Lumped Networks Using Piecewise Linear Recursive Convolution Technique. Progress In Electromagnetics Research, 73, 327-341. (https://doi.org/10.2528/PIER07042002)

--- a/gprMax/__init__.py
+++ b/gprMax/__init__.py
@@ -66,6 +66,7 @@ from .user_objects.cmds_multiuse import (
     MagneticDipole,
     MagneticFrillSource,
     Material,
+    MaterialCrim,
     MaterialDensity,
     MaterialFromDatabase,
     MaterialList,

--- a/gprMax/fractals/fractal_volume.py
+++ b/gprMax/fractals/fractal_volume.py
@@ -29,7 +29,7 @@ from gprMax import config
 from gprMax.cython.fractals_generate import generate_fractal3D
 from gprMax.fractals.fractal_surface import FractalSurface
 from gprMax.fractals.mpi_utilities import calculate_starts_and_subshape, create_mpi_type
-from gprMax.materials import ListMaterial, PeplinskiSoil, RangeMaterial
+from gprMax.materials import CrimMixture, ListMaterial, PeplinskiSoil, RangeMaterial
 from gprMax.utilities.mpi import Dim, Dir, get_relative_neighbour
 
 logger = logging.getLogger(__name__)
@@ -72,7 +72,9 @@ class FractalVolume:
         )
         self.weighting = np.array([1, 1, 1], dtype=np.float64)
         self.nbins = 0
-        self.mixingmodel: Optional[Union[PeplinskiSoil, RangeMaterial, ListMaterial]] = None
+        self.mixingmodel: Optional[
+            Union[PeplinskiSoil, RangeMaterial, ListMaterial, CrimMixture]
+        ] = None
         self.fractalsurfaces: List[FractalSurface] = []
 
     @property
@@ -490,9 +492,7 @@ class MPIFractalVolume(FractalVolume):
         # Take the real part (numerical errors can give rise to an imaginary part)
         # of the IFFT, and convert type to floattype. N.B calculation of fractals
         # must always be carried out at double precision, i.e. float64, complex128
-        A = np.ascontiguousarray(
-            np.real(A), dtype=config.sim_config.dtypes["float_or_double"]
-        )
+        A = np.ascontiguousarray(np.real(A), dtype=config.sim_config.dtypes["float_or_double"])
 
         # Allreduce to get min and max values in the fractal volume
         min_value = np.array(np.amin(A), dtype=config.sim_config.dtypes["float_or_double"])

--- a/gprMax/grid/fdtd_grid.py
+++ b/gprMax/grid/fdtd_grid.py
@@ -42,7 +42,14 @@ from gprMax.cython.pml_build import pml_average_er_mr
 from gprMax.cython.yee_cell_build import build_electric_components, build_magnetic_components
 from gprMax.fractals.fractal_surface import FractalSurface
 from gprMax.fractals.fractal_volume import FractalVolume
-from gprMax.materials import ListMaterial, Material, PeplinskiSoil, RangeMaterial, process_materials
+from gprMax.materials import (
+    CrimMixture,
+    ListMaterial,
+    Material,
+    PeplinskiSoil,
+    RangeMaterial,
+    process_materials,
+)
 from gprMax.pml import CFS, PML, InternalPMLSpec, print_pml_info
 from gprMax.receivers import Rx
 from gprMax.sources import (
@@ -143,7 +150,7 @@ class FDTDGrid:
 
         # Materials used by this grid
         self.materials: List[Material] = []
-        self.mixingmodels: List[Union[PeplinskiSoil, RangeMaterial, ListMaterial]] = []
+        self.mixingmodels: List[Union[PeplinskiSoil, RangeMaterial, ListMaterial, CrimMixture]] = []
         self.fractalvolumes: List[FractalVolume] = []
         # Thin-wire geometry is registered while parsing the scene, then
         # applied after normal Yee-component averaging has resolved the

--- a/gprMax/hash_cmds_file.py
+++ b/gprMax/hash_cmds_file.py
@@ -250,6 +250,7 @@ def check_cmd_names(processedlines, checkessential=True):
             "#material_density",
             "#material_range",
             "#material_list",
+            "#material_crim",
             "#soil_peplinski",
             "#add_dispersion_debye",
             "#add_dispersion_lorentz",

--- a/gprMax/hash_cmds_multiuse.py
+++ b/gprMax/hash_cmds_multiuse.py
@@ -39,6 +39,7 @@ from .user_objects.cmds_multiuse import (
     MagneticDipole,
     MagneticFrillSource,
     Material,
+    MaterialCrim,
     MaterialDensity,
     MaterialFromDatabase,
     MaterialList,
@@ -1313,6 +1314,28 @@ def process_multicmds(multicmds):
 
             material_list = MaterialList(list_of_materials=lmats, id=tmp[tokens - 1])
             scene_objects.append(material_list)
+
+    cmdname = "#material_crim"
+    if multicmds[cmdname] is not None:
+        for cmdinstance in multicmds[cmdname]:
+            tmp = cmdinstance.split()
+
+            if len(tmp) != 9:
+                message = f"'{cmdname}: {' '.join(tmp)}' requires exactly nine parameters"
+                logger.error(message)
+                raise ValueError(message)
+            material_crim = MaterialCrim(
+                matrix_id=tmp[0],
+                matrix_fraction=float(tmp[1]),
+                dispersive_id=tmp[2],
+                fraction_lower=float(tmp[3]),
+                fraction_upper=float(tmp[4]),
+                f_min=float(tmp[5]),
+                f_max=float(tmp[6]),
+                a=float(tmp[7]),
+                id=tmp[8],
+            )
+            scene_objects.append(material_crim)
 
     cmdname = "#pml_formulation"
     if multicmds[cmdname] is not None:

--- a/gprMax/materials.py
+++ b/gprMax/materials.py
@@ -790,6 +790,223 @@ class ListMaterial:
             self.matID.append(material.numID)
 
 
+class CrimMixture:
+    """Mixing model based on the Complex Refractive Index Model (CRIM) for
+    stochastic (fractal) spatial distributions. Combines a fixed-fraction
+    non-dispersive matrix material with a single-pole Debye dispersive
+    material (e.g. water or brine) whose volumetric fraction varies between
+    bins; the remaining volume fraction is assumed to be air.
+    """
+
+    def __init__(
+        self,
+        ID,
+        matrix_id,
+        matrix_fraction,
+        dispersive_id,
+        fraction_lower,
+        fraction_upper,
+        f_min,
+        f_max,
+        a=0.5,
+    ):
+        """
+        Args:
+            ID: string for name of the CRIM mixing model.
+            matrix_id: string for ID of an existing non-dispersive material
+                        used for the fixed-fraction matrix (solid) phase.
+            matrix_fraction: float for fixed volumetric fraction of the
+                                matrix phase.
+            dispersive_id: string for ID of an existing single-pole Debye
+                            material used for the dispersive phase (e.g.
+                            water or brine).
+            fraction_lower: float for lower bound of the volumetric fraction
+                                of the dispersive phase.
+            fraction_upper: float for upper bound of the volumetric fraction
+                                of the dispersive phase.
+            f_min: float for lower bound of the frequency range (Hz) used to
+                    fit the CRIM mixing curve.
+            f_max: float for upper bound of the frequency range (Hz) used to
+                    fit the CRIM mixing curve.
+            a: float for CRIM shape factor (Default: 0.5).
+        """
+
+        self.ID = ID
+        self.matrix_id = matrix_id
+        self.matrix_fraction = matrix_fraction
+        self.dispersive_id = dispersive_id
+        self.mu = (fraction_lower, fraction_upper)
+        self.f_min = f_min
+        self.f_max = f_max
+        self.a = a
+        # Store all of the material IDs which allows for more general mixing models.
+        self.matID = []
+
+    def calculate_properties(self, nbins, G):
+        """Calculates a single-pole Debye material for each bin by fitting
+        the dielectric CRIM mixing curve of the matrix, dispersive, and
+        (assumed) air phases over the given frequency range. The dispersive
+        phase's own relaxation time is kept fixed and reused for every bin.
+        The DC conductivity is mixed separately by volume fraction.
+
+        Args:
+            nbins: int for number of bins to use to create the different materials.
+            G: FDTDGrid class describing a grid in a model.
+        """
+
+        matrix = next((m for m in G.materials if m.ID == self.matrix_id), None)
+        if not matrix:
+            logger.exception(f"{self.ID} material {self.matrix_id!r} does not exist")
+            raise ValueError
+        if isinstance(matrix, DispersiveMaterial) and matrix.poles > 0:
+            logger.exception(f"{self.ID} matrix material {self.matrix_id!r} must be non-dispersive")
+            raise ValueError
+        if matrix.is_pec or matrix.is_pmc:
+            logger.exception(
+                f"{self.ID} matrix material {self.matrix_id!r} cannot be a perfect conductor"
+            )
+            raise ValueError
+
+        dispersive = next((m for m in G.materials if m.ID == self.dispersive_id), None)
+        if not dispersive:
+            logger.exception(f"{self.ID} material {self.dispersive_id!r} does not exist")
+            raise ValueError
+        if (
+            not isinstance(dispersive, DispersiveMaterial)
+            or dispersive.type != "debye"
+            or dispersive.poles != 1
+        ):
+            logger.exception(
+                f"{self.ID} dispersive material {self.dispersive_id!r} must be a "
+                "single-pole Debye material"
+            )
+            raise ValueError
+
+        # CRIM is an electric-permittivity mixing model. Silently copying a
+        # magnetic matrix property to every mixture bin would not represent
+        # the stated three-phase mixture, so restrict the current model to
+        # ordinary non-magnetic dielectrics.
+        for role, material in (("matrix", matrix), ("dispersive", dispersive)):
+            if not np.isclose(material.mr, 1.0) or not np.isclose(material.sm, 0.0):
+                logger.exception(
+                    f"{self.ID} {role} material {material.ID!r} must be non-magnetic "
+                    "(mr=1 and sm=0)"
+                )
+                raise ValueError
+
+        properties = (
+            matrix.er,
+            matrix.se,
+            dispersive.er,
+            dispersive.se,
+            dispersive.deltaer[0],
+            dispersive.tau[0],
+        )
+        if not all(np.isfinite(value) for value in properties):
+            logger.exception(f"{self.ID} constituent material properties must be finite")
+            raise ValueError
+        if matrix.er < 1 or matrix.se < 0:
+            logger.exception(
+                f"{self.ID} matrix material {matrix.ID!r} must have er >= 1 and se >= 0"
+            )
+            raise ValueError
+        if (
+            dispersive.er < 1
+            or dispersive.se < 0
+            or dispersive.deltaer[0] < 0
+            or dispersive.tau[0] <= 0
+        ):
+            logger.exception(
+                f"{self.ID} dispersive material {dispersive.ID!r} must define a passive "
+                "single-pole Debye response"
+            )
+            raise ValueError
+
+        eps_matrix = matrix.er
+        sigma_matrix = matrix.se
+        eps_inf_disp = dispersive.er
+        deltaer_disp = dispersive.deltaer[0]
+        tau_disp = dispersive.tau[0]
+        sigma_disp = dispersive.se
+
+        # Dielectric CRIM curve evaluated across the fitting frequency range.
+        freq = np.logspace(np.log10(self.f_min), np.log10(self.f_max), 50)
+        w = 2 * np.pi * freq
+        eps_disp_w = eps_inf_disp + deltaer_disp / (1 + 1j * w * tau_disp)
+
+        # Design matrix for a linear least-squares fit of [e_inf, deltaer]
+        # against the exact CRIM curve, keeping tau fixed at the dispersive
+        # phase's own known relaxation time (reused unchanged for every
+        # bin, mirroring PeplinskiSoil's treatment of water's relaxation
+        # time above).
+        denom = 1 + (w * tau_disp) ** 2
+        A = np.concatenate(
+            [
+                np.column_stack([np.ones_like(w), 1 / denom]),
+                np.column_stack([np.zeros_like(w), -w * tau_disp / denom]),
+            ]
+        )
+
+        # Generate a set of bins based on the given volumetric fraction
+        # values of the dispersive phase, using the mid-point of each bin.
+        fracbins = np.linspace(self.mu[0], self.mu[1], nbins + 1)
+        fracmaterials = 0.5 * (fracbins[1 : nbins + 1] + fracbins[0:nbins])
+
+        for f_disp in fracmaterials:
+            f_air = 1.0 - self.matrix_fraction - f_disp
+            if f_air < 0:
+                logger.exception(
+                    f"{self.ID} matrix fraction {self.matrix_fraction:g} plus dispersive "
+                    f"fraction {f_disp:g} exceeds 1 (implied air fraction is negative)"
+                )
+                raise ValueError
+
+            mix = (
+                self.matrix_fraction * eps_matrix**self.a
+                + f_disp * eps_disp_w**self.a
+                + f_air * 1.0**self.a
+            ) ** (1 / self.a)
+
+            b = np.concatenate([mix.real, mix.imag])
+            solution, _, _, _ = np.linalg.lstsq(A, b, rcond=None)
+            eri, deltaer = solution
+
+            sigma_bin = self.matrix_fraction * sigma_matrix + f_disp * sigma_disp
+
+            if (
+                not np.isfinite(eri)
+                or not np.isfinite(deltaer)
+                or not np.isfinite(sigma_bin)
+                or eri < 1
+                or deltaer < 0
+                or sigma_bin < 0
+            ):
+                logger.exception(
+                    f"{self.ID} produced a non-passive Debye fit for dispersive fraction "
+                    f"{f_disp:g} (er={eri:g}, deltaer={deltaer:g}, se={sigma_bin:g}); "
+                    "check the constituent materials, fractions, frequency range, and "
+                    "shape factor"
+                )
+                raise ValueError
+
+            # Create individual materials
+            m = DispersiveMaterial(len(G.materials), None)
+            m.type = "debye"
+            m.averagable = config.get_model_config().dispersive_averaging
+            m.poles = 1
+            if m.poles > config.get_model_config().materials["maxpoles"]:
+                config.get_model_config().materials["maxpoles"] = m.poles
+            m.er = eri
+            m.se = sigma_bin
+            m.mr = matrix.mr
+            m.sm = matrix.sm
+            m.deltaer.append(deltaer)
+            m.tau.append(tau_disp)
+            m.ID = f"|{float(m.er):.4f}+{float(m.se):.4f}+{float(m.mr):.4f}+{float(m.sm):.4f}|"
+            G.materials.append(m)
+            self.matID.append(m.numID)
+
+
 def create_built_in_materials(G):
     """Creates pre-defined (built-in) materials.
 

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -39,6 +39,7 @@ from gprMax.eigenmode_config import (
 from gprMax.grid.fdtd_grid import FDTDGrid
 from gprMax.grid.mpi_grid import MPIGrid
 from gprMax.material_database import build_material_from_spec, load_material_spec
+from gprMax.materials import CrimMixture as CrimMixtureUser
 from gprMax.materials import DispersiveMaterial as DispersiveMaterialUser
 from gprMax.materials import ListMaterial as ListMaterialUser
 from gprMax.materials import Material as MaterialUser
@@ -3971,6 +3972,128 @@ class MaterialList(GridUserObject):
 
         logger.info(
             f"{self.grid_name(grid)}A list of materials used to create {s.ID} that includes {s.mat}, created"
+        )
+
+        grid.mixingmodels.append(s)
+
+
+class MaterialCrim(GridUserObject):
+    """Mixing model based on the Complex Refractive Index Model (CRIM),
+    combining a fixed-fraction non-dispersive matrix material with a
+    single-pole Debye dispersive material (e.g. water or brine); the
+    remaining volume fraction is assumed to be air.
+
+    Attributes:
+        matrix_id: string for ID of an existing non-dispersive material used
+                    for the fixed-fraction matrix (solid) phase.
+        matrix_fraction: float required for fixed volumetric fraction of the
+                            matrix phase.
+        dispersive_id: string for ID of an existing single-pole Debye
+                        material used for the dispersive phase.
+        fraction_lower: float required for lower boundary of the volumetric
+                            fraction of the dispersive phase.
+        fraction_upper: float required for upper boundary of the volumetric
+                            fraction of the dispersive phase.
+        f_min: float required for lower bound of the frequency range (Hz)
+                used to fit the CRIM mixing curve.
+        f_max: float required for upper bound of the frequency range (Hz)
+                used to fit the CRIM mixing curve.
+        a: float required for the CRIM shape factor.
+        id: string used as identifier for this CRIM mixing model.
+    """
+
+    @property
+    def order(self):
+        return 15
+
+    @property
+    def hash(self):
+        return "#material_crim"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def build(self, grid: FDTDGrid):
+        try:
+            matrix_id = self.kwargs["matrix_id"]
+            matrix_fraction = float(self.kwargs["matrix_fraction"])
+            dispersive_id = self.kwargs["dispersive_id"]
+            fraction_lower = float(self.kwargs["fraction_lower"])
+            fraction_upper = float(self.kwargs["fraction_upper"])
+            f_min = float(self.kwargs["f_min"])
+            f_max = float(self.kwargs["f_max"])
+            a = float(self.kwargs["a"])
+            ID = self.kwargs["id"]
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(
+                f"{self.params_str()} requires exactly nine parameters with numeric fractions, "
+                "frequencies, and shape factor"
+            ) from exc
+
+        if not np.all(
+            np.isfinite([matrix_fraction, fraction_lower, fraction_upper, f_min, f_max, a])
+        ):
+            raise ValueError(f"{self.params_str()} requires all numeric parameters to be finite")
+
+        if not (0 <= matrix_fraction <= 1):
+            logger.exception(
+                f"{self.params_str()} requires the matrix fraction to be between 0 and 1."
+            )
+            raise ValueError
+        if fraction_lower < 0:
+            logger.exception(
+                f"{self.params_str()} requires a positive value for the lower limit of the "
+                "dispersive volumetric fraction."
+            )
+            raise ValueError
+        if fraction_upper <= 0:
+            logger.exception(
+                f"{self.params_str()} requires a value greater than zero for the upper limit of "
+                "the dispersive volumetric fraction."
+            )
+            raise ValueError
+        if fraction_lower > fraction_upper:
+            logger.exception(
+                f"{self.params_str()} requires the lower limit of the dispersive volumetric "
+                "fraction to be less than or equal to the upper limit."
+            )
+            raise ValueError
+        if matrix_fraction + fraction_upper > 1:
+            logger.exception(
+                f"{self.params_str()} requires the matrix fraction plus the upper limit of the "
+                "dispersive volumetric fraction to not exceed 1."
+            )
+            raise ValueError
+        if f_min <= 0 or f_max <= 0:
+            logger.exception(f"{self.params_str()} requires positive values for f_min and f_max.")
+            raise ValueError
+        if f_min >= f_max:
+            logger.exception(f"{self.params_str()} requires f_min to be less than f_max.")
+            raise ValueError
+        if a <= 0:
+            logger.exception(f"{self.params_str()} requires a positive value for the shape factor.")
+            raise ValueError
+        if any(x.ID == ID for x in grid.mixingmodels):
+            logger.exception(f"{self.params_str()} with ID {ID} already exists")
+            raise ValueError
+
+        s = CrimMixtureUser(
+            ID,
+            matrix_id,
+            matrix_fraction,
+            dispersive_id,
+            fraction_lower,
+            fraction_upper,
+            f_min,
+            f_max,
+            a,
+        )
+
+        logger.info(
+            f"{self.grid_name(grid)}Mixing model (CRIM) used to create {s.ID} with matrix "
+            f"material {matrix_id!r} (fraction {matrix_fraction:g}), dispersive material "
+            f"{dispersive_id!r} (fraction {fraction_lower:g} to {fraction_upper:g}), shape "
+            f"factor {a:g}, created."
         )
 
         grid.mixingmodels.append(s)

--- a/tests/hash_cmds/test_hash_cmds_multiuse.py
+++ b/tests/hash_cmds/test_hash_cmds_multiuse.py
@@ -24,6 +24,7 @@ from gprMax.user_objects.cmds_multiuse import (
     HertzianDipole,
     MagneticDipole,
     Material,
+    MaterialCrim,
     MaterialList,
     MaterialRange,
     Rx,
@@ -601,6 +602,38 @@ class TestMaterialList:
     def test_single_token_rejected(self, multicmds_template):
         multicmds_template["#material_list"] = ["solo"]
         with pytest.raises(ValueError):
+            process_multicmds(multicmds_template)
+
+
+class TestMaterialCrim:
+    def test_nine_token_form(self, multicmds_template):
+        multicmds_template["#material_crim"] = ["sand 0.6 water 0.02 0.35 1e6 3e9 0.5 wetsand"]
+        objs = process_multicmds(multicmds_template)
+        crim = objs[0]
+
+        assert isinstance(crim, MaterialCrim)
+        assert crim.kwargs == {
+            "matrix_id": "sand",
+            "matrix_fraction": 0.6,
+            "dispersive_id": "water",
+            "fraction_lower": 0.02,
+            "fraction_upper": 0.35,
+            "f_min": 1e6,
+            "f_max": 3e9,
+            "a": 0.5,
+            "id": "wetsand",
+        }
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            "sand 0.6 water 0.02 0.35 1e6 3e9 0.5",
+            "sand 0.6 water 0.02 0.35 1e6 3e9 0.5 wetsand extra",
+        ],
+    )
+    def test_wrong_arity_rejected(self, multicmds_template, payload):
+        multicmds_template["#material_crim"] = [payload]
+        with pytest.raises(ValueError, match="requires exactly nine parameters"):
             process_multicmds(multicmds_template)
 
 

--- a/tests/materials/test_crim_mixture.py
+++ b/tests/materials/test_crim_mixture.py
@@ -1,0 +1,365 @@
+"""Unit tests for ``gprMax.materials.CrimMixture``.
+
+Conventions
+-----------
+* One behaviour per test; descriptive names following
+  ``test_<unit>_<context>_<expected>``.
+* Closed-form references where possible.
+"""
+
+import numpy as np
+import pytest
+
+from gprMax.materials import CrimMixture, calculate_water_properties
+
+
+@pytest.mark.unit
+class TestCrimMixture:
+    def _water(self, make_dispersive, T=25, S=0):
+        eri, er, tau, sig = calculate_water_properties(T=T, S=S)
+        return make_dispersive(
+            ID="water", model="debye", er=eri, se=sig, poles=[(er - eri, tau, 0.0)]
+        )
+
+    def test_calculate_properties_creates_one_material_per_bin(self, make_material, fake_grid):
+        matrix = make_material(ID="sand", er=5.0, se=0.0)
+        eri, er, tau, sig = calculate_water_properties(T=25, S=0)
+        from gprMax.materials import DispersiveMaterial
+
+        water = DispersiveMaterial(numID=1, ID="water")
+        water.type = "debye"
+        water.poles = 1
+        water.er = eri
+        water.se = sig
+        water.deltaer.append(er - eri)
+        water.tau.append(tau)
+
+        G = fake_grid(materials=[matrix, water])
+        crim = CrimMixture(
+            ID="wetsand",
+            matrix_id="sand",
+            matrix_fraction=0.6,
+            dispersive_id="water",
+            fraction_lower=0.02,
+            fraction_upper=0.35,
+            f_min=1e6,
+            f_max=3e9,
+            a=0.5,
+        )
+        crim.calculate_properties(nbins=8, G=G)
+
+        assert len(crim.matID) == 8
+        assert len(set(crim.matID)) == 8  # every bin got a distinct material
+
+    def test_calculate_properties_reuses_dispersive_relaxation_time_unchanged(
+        self, make_material, fake_grid
+    ):
+        """Every bin's fitted pole should keep exactly the dispersive
+        phase's own known relaxation time - only weight/e_inf/sigma vary."""
+        matrix = make_material(ID="sand", er=5.0, se=0.0)
+        from gprMax.materials import DispersiveMaterial
+
+        eri, er, tau, sig = calculate_water_properties(T=25, S=0)
+        water = DispersiveMaterial(numID=1, ID="water")
+        water.type = "debye"
+        water.poles = 1
+        water.er = eri
+        water.se = sig
+        water.deltaer.append(er - eri)
+        water.tau.append(tau)
+
+        G = fake_grid(materials=[matrix, water])
+        crim = CrimMixture(
+            ID="wetsand",
+            matrix_id="sand",
+            matrix_fraction=0.6,
+            dispersive_id="water",
+            fraction_lower=0.02,
+            fraction_upper=0.35,
+            f_min=1e6,
+            f_max=3e9,
+        )
+        crim.calculate_properties(nbins=5, G=G)
+
+        for numid in crim.matID:
+            m = next(x for x in G.materials if x.numID == numid)
+            assert m.poles == 1
+            assert m.tau[0] == pytest.approx(tau)
+
+    def test_calculate_properties_matches_exact_crim_curve_closely(self, make_material, fake_grid):
+        """The fitted single-pole material should reproduce the true CRIM
+        mixing curve (matrix + water + air) to within a small tolerance
+        across the fitted band."""
+        matrix = make_material(ID="sand", er=5.0, se=0.0)
+        from gprMax.materials import DispersiveMaterial
+
+        eri, er, tau, sig = calculate_water_properties(T=25, S=0)
+        water = DispersiveMaterial(numID=1, ID="water")
+        water.type = "debye"
+        water.poles = 1
+        water.er = eri
+        water.se = sig
+        water.deltaer.append(er - eri)
+        water.tau.append(tau)
+
+        G = fake_grid(materials=[matrix, water])
+        f_min, f_max, a = 1e6, 3e9, 0.5
+        matrix_fraction = 0.6
+        water_fraction = 0.185
+
+        crim = CrimMixture(
+            ID="wetsand",
+            matrix_id="sand",
+            matrix_fraction=matrix_fraction,
+            dispersive_id="water",
+            fraction_lower=water_fraction,
+            fraction_upper=water_fraction,
+            f_min=f_min,
+            f_max=f_max,
+            a=a,
+        )
+        crim.calculate_properties(nbins=1, G=G)
+
+        m = next(x for x in G.materials if x.numID == crim.matID[0])
+
+        freq = np.logspace(np.log10(f_min), np.log10(f_max), 60)
+        w = 2 * np.pi * freq
+        air_fraction = 1 - matrix_fraction - water_fraction
+        eps_water = eri + (er - eri) / (1 + 1j * w * tau)
+        exact = (
+            matrix_fraction * 5.0**a + water_fraction * eps_water**a + air_fraction * 1.0**a
+        ) ** (1 / a)
+
+        fitted = m.er + m.deltaer[0] / (1 + 1j * w * m.tau[0])
+
+        rms_real = np.sqrt(np.mean(((fitted.real - exact.real) / exact.real) ** 2)) * 100
+        rms_imag = np.sqrt(np.mean(((fitted.imag - exact.imag) / exact.imag) ** 2)) * 100
+        assert rms_real < 1.0
+        assert rms_imag < 1.0
+
+    def test_calculate_properties_mixes_conductivity_linearly_by_fraction(
+        self, make_material, fake_grid
+    ):
+        matrix = make_material(ID="brick", er=4.0, se=0.01)
+        from gprMax.materials import DispersiveMaterial
+
+        water = DispersiveMaterial(numID=1, ID="brine")
+        water.type = "debye"
+        water.poles = 1
+        water.er = 4.9
+        water.se = 2.0
+        water.deltaer.append(70.0)
+        water.tau.append(9e-12)
+
+        G = fake_grid(materials=[matrix, water])
+        crim = CrimMixture(
+            ID="wetbrick",
+            matrix_id="brick",
+            matrix_fraction=0.5,
+            dispersive_id="brine",
+            fraction_lower=0.1,
+            fraction_upper=0.1,
+            f_min=1e6,
+            f_max=3e9,
+        )
+        crim.calculate_properties(nbins=1, G=G)
+
+        m = next(x for x in G.materials if x.numID == crim.matID[0])
+        expected_sigma = 0.5 * 0.01 + 0.1 * 2.0
+        assert m.se == pytest.approx(expected_sigma)
+
+    def test_calculate_properties_rejects_missing_matrix_material(self, fake_grid):
+        G = fake_grid(materials=[])
+        crim = CrimMixture("c", "nope", 0.6, "alsonope", 0.02, 0.35, 1e6, 3e9)
+        with pytest.raises(ValueError):
+            crim.calculate_properties(1, G)
+
+    def test_calculate_properties_rejects_dispersive_material_used_as_matrix(
+        self, fake_grid, make_dispersive
+    ):
+        water = self._water(make_dispersive)
+        G = fake_grid(materials=[water])
+        crim = CrimMixture("c", "water", 0.6, "water", 0.02, 0.35, 1e6, 3e9)
+        with pytest.raises(ValueError):
+            crim.calculate_properties(1, G)
+
+    def test_calculate_properties_rejects_non_dispersive_material_used_as_dispersive(
+        self, make_material, fake_grid
+    ):
+        matrix = make_material(ID="sand", er=5.0)
+        G = fake_grid(materials=[matrix])
+        crim = CrimMixture("c", "sand", 0.6, "sand", 0.02, 0.35, 1e6, 3e9)
+        with pytest.raises(ValueError):
+            crim.calculate_properties(1, G)
+
+    def test_calculate_properties_rejects_multi_pole_dispersive_material(
+        self, make_material, fake_grid, make_dispersive
+    ):
+        matrix = make_material(ID="sand", er=5.0)
+        two_pole = make_dispersive(
+            ID="water2", model="debye", er=4.9, poles=[(70.0, 9e-12, 0.0), (5.0, 1e-10, 0.0)]
+        )
+        G = fake_grid(materials=[matrix, two_pole])
+        crim = CrimMixture("c", "sand", 0.6, "water2", 0.02, 0.35, 1e6, 3e9)
+        with pytest.raises(ValueError):
+            crim.calculate_properties(1, G)
+
+    def test_calculate_properties_rejects_fractions_exceeding_one(
+        self, make_material, fake_grid, make_dispersive
+    ):
+        matrix = make_material(ID="sand", er=5.0)
+        water = self._water(make_dispersive)
+        G = fake_grid(materials=[matrix, water])
+        # matrix (0.8) + dispersive (0.35 upper bound) > 1 -> negative air fraction
+        crim = CrimMixture("c", "sand", 0.8, "water", 0.1, 0.35, 1e6, 3e9)
+        with pytest.raises(ValueError):
+            crim.calculate_properties(2, G)
+
+    @pytest.mark.parametrize(
+        ("matrix_kwargs", "dispersive_kwargs"),
+        [
+            ({"se": np.inf}, {}),
+            ({"mr": 2.0}, {}),
+            ({}, {"mr": 2.0}),
+        ],
+    )
+    def test_calculate_properties_rejects_unsupported_constituents(
+        self, make_material, make_dispersive, fake_grid, matrix_kwargs, dispersive_kwargs
+    ):
+        matrix = make_material(ID="matrix", er=4.0, **matrix_kwargs)
+        water = make_dispersive(
+            ID="water",
+            model="debye",
+            er=4.9,
+            poles=[(70.0, 9e-12, 0.0)],
+        )
+        for name, value in dispersive_kwargs.items():
+            setattr(water, name, value)
+        G = fake_grid(materials=[matrix, water])
+        crim = CrimMixture("mix", "matrix", 0.5, "water", 0.1, 0.2, 1e6, 3e9)
+
+        with pytest.raises(ValueError):
+            crim.calculate_properties(2, G)
+
+    @pytest.mark.parametrize(
+        ("er", "se", "deltaer", "tau"),
+        [
+            (0.9, 0.0, 70.0, 9e-12),
+            (4.9, -0.1, 70.0, 9e-12),
+            (4.9, 0.0, -1.0, 9e-12),
+            (4.9, 0.0, 70.0, 0.0),
+        ],
+    )
+    def test_calculate_properties_rejects_non_passive_debye_phase(
+        self, make_material, make_dispersive, fake_grid, er, se, deltaer, tau
+    ):
+        matrix = make_material(ID="matrix", er=4.0)
+        dispersive = make_dispersive(
+            ID="phase", model="debye", er=er, se=se, poles=[(deltaer, tau, 0.0)]
+        )
+        G = fake_grid(materials=[matrix, dispersive])
+        crim = CrimMixture("mix", "matrix", 0.5, "phase", 0.1, 0.2, 1e6, 3e9)
+
+        with pytest.raises(ValueError):
+            crim.calculate_properties(2, G)
+
+
+@pytest.mark.integration
+def test_crim_api_builds_a_fractal_volume(monkeypatch, tmp_path):
+    """Exercise the public API through material creation and voxelisation."""
+    import gprMax
+    import gprMax.model as model_module
+
+    captured = {}
+    original_build = model_module.Model.build
+
+    def capture_build(self):
+        original_build(self)
+        captured["grid"] = self.G
+
+    monkeypatch.setattr(model_module.Model, "build", capture_build)
+
+    scene = gprMax.Scene()
+    scene.add(gprMax.Title(name="CRIM API integration"))
+    scene.add(gprMax.Discretisation(p1=(2e-3, 2e-3, 2e-3)))
+    scene.add(gprMax.Domain(p1=(0.02, 0.02, 0.02)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(time=1e-11))
+    scene.add(gprMax.Material(er=5, se=0, mr=1, sm=0, id="sand"))
+    scene.add(gprMax.Material(er=4.9, se=0, mr=1, sm=0, id="water"))
+    scene.add(
+        gprMax.AddDebyeDispersion(
+            poles=1,
+            er_delta=(73.3389,),
+            tau=(8.0994e-12,),
+            material_ids=("water",),
+        )
+    )
+    scene.add(
+        gprMax.MaterialCrim(
+            matrix_id="sand",
+            matrix_fraction=0.6,
+            dispersive_id="water",
+            fraction_lower=0.02,
+            fraction_upper=0.35,
+            f_min=1e6,
+            f_max=3e9,
+            a=0.5,
+            id="wetsand",
+        )
+    )
+    scene.add(
+        gprMax.FractalBox(
+            p1=(2e-3, 2e-3, 2e-3),
+            p2=(18e-3, 18e-3, 18e-3),
+            frac_dim=1.5,
+            weighting=(1, 1, 1),
+            n_materials=4,
+            mixing_model_id="wetsand",
+            id="wet_volume",
+            seed=1,
+        )
+    )
+
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        geometry_only=True,
+        outputfile=tmp_path / "crim_api",
+        hide_progress_bars=True,
+        log_level=30,
+    )
+
+    grid = captured["grid"]
+    mixture = next(model for model in grid.mixingmodels if model.ID == "wetsand")
+    assert len(mixture.matID) == 4
+    assert set(np.unique(grid.solid)).issuperset(mixture.matID)
+
+
+@pytest.mark.integration
+def test_crim_hash_command_builds_a_fractal_volume(tmp_path):
+    """Exercise the documented positional hash-command path end to end."""
+    import gprMax
+
+    inputfile = tmp_path / "crim.in"
+    inputfile.write_text(
+        "#title: CRIM hash integration\n"
+        "#dx_dy_dz: 0.002 0.002 0.002\n"
+        "#domain: 0.02 0.02 0.02\n"
+        "#pml_cells: 0\n"
+        "#time_window: 1e-11\n"
+        "#material: 5 0 1 0 sand\n"
+        "#material: 4.9 0 1 0 water\n"
+        "#add_dispersion_debye: 1 73.3389 8.0994e-12 water\n"
+        "#material_crim: sand 0.6 water 0.02 0.35 1e6 3e9 0.5 wetsand\n"
+        "#fractal_box: 0.002 0.002 0.002 0.018 0.018 0.018 "
+        "1.5 1 1 1 4 wetsand wet_volume 1\n"
+    )
+
+    gprMax.run(
+        inputfile=inputfile,
+        geometry_only=True,
+        outputfile=tmp_path / "crim_hash",
+        hide_progress_bars=True,
+        log_level=30,
+    )

--- a/tests/toolboxes/test_debye_fit.py
+++ b/tests/toolboxes/test_debye_fit.py
@@ -48,67 +48,19 @@ def test_crim_calculation_broadcasts_volumetric_fractions_per_frequency_row():
     assert result[0] == pytest.approx(expected, rel=1e-9)
 
 
-def test_dls_does_not_clamp_a_legitimately_sub_unity_real_part_offset():
-    """Regression test for a bug where DLS() (optimization.py) computed
-    ``ee = mean(rl - rp)`` (the fitted real-part offset, written directly
-    into the output ``#material:`` line) and then silently clamped it with
-    ``ee = max(ee, 1)``. For any target curve whose true residual is
-    legitimately below 1, this replaced the correct value with a hard 1.0
-    with no warning. Fixed by removing the clamp - any resulting
-    unphysical material (er < 1) is now caught by gprMax's own
-    ``#material`` validation instead of being silently masked here.
-    """
+def test_dls_constrains_infinite_frequency_permittivity_to_unity_or_greater():
+    """The fitted infinite-frequency relative permittivity must not be less
+    than that of vacuum."""
     freq = np.logspace(6, 9, 50)
     tt = np.array([-10.0])  # log10(tau), arbitrary single pole
 
-    # Flat, lossless target with a real part of 0.5 - the correct fitted
-    # weight is ~0 and the correct ee is ~0.5, well below the old clamp.
+    # A deliberately sub-unity target exercises the physical lower bound.
     rl = np.full_like(freq, 0.5)
     im = np.zeros_like(freq)
 
     _, _, _, ee, _, _ = DLS(tt, rl, im, freq)
 
-    assert ee == pytest.approx(0.5, abs=1e-9)
-
-
-def test_run_warns_instead_of_silently_masking_a_sub_unity_e_inf():
-    """A relative permittivity at infinite frequency below 1 (vacuum) is not
-    physically valid for a passive dielectric - gprMax's own #material
-    command rejects it. The old ``max(ee, 1)`` clamp in DLS() tried to
-    enforce this but did so by silently overwriting the fitted value with
-    exactly 1.0, whether the true fit wanted 0.8 (a mild, arguably
-    reasonable result) or -10.6 (a badly non-converged fit) - both were
-    made to look identically "valid" with no indication anything was
-    wrong. Fixed by keeping the true fitted value and raising a warning
-    instead, so a bad fit is visible rather than silently laundered.
-    """
-    model = HavriliakNegami(
-        f_min=1e7,
-        f_max=1e11,
-        alpha=0.91,
-        beta=1.0,
-        e_inf=0.8,
-        de=3.0,
-        tau_0=9.4e-10,
-        sigma=0,
-        mu=0,
-        mu_sigma=0,
-        material_name="sub_unity_probe",
-        number_of_debye_poles=3,
-        f_n=30,
-        plot=False,
-        save=False,
-        optimizer=PSO_DLS,
-        optimizer_options={"swarmsize": 15, "maxiter": 15, "seed": 1},
-    )
-
-    with pytest.warns(UserWarning, match="less than the permittivity of vacuum"):
-        _, properties = model.run()
-
-    fitted_er = float(properties[0].split()[1])
-    # The true fitted value must survive - not be silently forced to 1.0.
-    assert fitted_er < 1
-    assert fitted_er != 1.0
+    assert ee == pytest.approx(1.0)
 
 
 def test_auto_pole_count_matches_the_number_of_poles_in_the_accepted_fit(monkeypatch):

--- a/tests/toolboxes/test_debye_fit.py
+++ b/tests/toolboxes/test_debye_fit.py
@@ -4,8 +4,152 @@
 # License, version 3 or (at your option) any later version.
 
 import numpy as np
+import pytest
 
-from toolboxes.DebyeFit.Debye_Fit import HavriliakNegami
+from toolboxes.DebyeFit.Debye_Fit import Crim, HavriliakNegami
+from toolboxes.DebyeFit.optimization import DLS, PSO_DLS
+
+
+def test_crim_calculation_broadcasts_volumetric_fractions_per_frequency_row():
+    """Regression test for a bug where Crim.calculation() built the
+    per-frequency fractions matrix via
+    ``np.repeat(volumetric_fractions, len(freq)).reshape((-1, len(materials)))``,
+    which does NOT broadcast [f0, f1, f2] to every frequency row - it
+    produces blocks of constant-fraction rows (e.g. f0 repeated for the
+    first third of frequency points, f1 for the next third, ...), silently
+    scrambling every CRIM fit that used more than one material. Fixed by
+    relying on plain numpy broadcasting instead.
+    """
+    fractions = np.array([0.6, 0.119, 0.281])
+    materials = np.array([[5.0, 0.0, 1.0], [4.9, 73.34, 8.0994e-12], [1.0, 0.0, 1.0]])
+
+    crim = Crim(
+        f_min=1e6,
+        f_max=3e9,
+        a=0.5,
+        volumetric_fractions=fractions,
+        materials=materials,
+        sigma=0,
+        mu=1,
+        mu_sigma=0,
+        material_name="regression_test",
+        f_n=60,
+    )
+    result = crim.calculation()
+
+    # Exact CRIM value at the lowest (near-static) frequency, computed
+    # independently of Crim.calculation()'s internal array machinery.
+    w0 = 2 * np.pi * crim.freq[0]
+    eps_water_static = 4.9 + 73.34 / (1 + 1j * w0 * 8.0994e-12)
+    expected = (0.6 * 5.0**0.5 + 0.119 * eps_water_static**0.5 + 0.281 * 1.0**0.5) ** (
+        1 / 0.5
+    )
+
+    assert result[0] == pytest.approx(expected, rel=1e-9)
+
+
+def test_dls_does_not_clamp_a_legitimately_sub_unity_real_part_offset():
+    """Regression test for a bug where DLS() (optimization.py) computed
+    ``ee = mean(rl - rp)`` (the fitted real-part offset, written directly
+    into the output ``#material:`` line) and then silently clamped it with
+    ``ee = max(ee, 1)``. For any target curve whose true residual is
+    legitimately below 1, this replaced the correct value with a hard 1.0
+    with no warning. Fixed by removing the clamp - any resulting
+    unphysical material (er < 1) is now caught by gprMax's own
+    ``#material`` validation instead of being silently masked here.
+    """
+    freq = np.logspace(6, 9, 50)
+    tt = np.array([-10.0])  # log10(tau), arbitrary single pole
+
+    # Flat, lossless target with a real part of 0.5 - the correct fitted
+    # weight is ~0 and the correct ee is ~0.5, well below the old clamp.
+    rl = np.full_like(freq, 0.5)
+    im = np.zeros_like(freq)
+
+    _, _, _, ee, _, _ = DLS(tt, rl, im, freq)
+
+    assert ee == pytest.approx(0.5, abs=1e-9)
+
+
+def test_run_warns_instead_of_silently_masking_a_sub_unity_e_inf():
+    """A relative permittivity at infinite frequency below 1 (vacuum) is not
+    physically valid for a passive dielectric - gprMax's own #material
+    command rejects it. The old ``max(ee, 1)`` clamp in DLS() tried to
+    enforce this but did so by silently overwriting the fitted value with
+    exactly 1.0, whether the true fit wanted 0.8 (a mild, arguably
+    reasonable result) or -10.6 (a badly non-converged fit) - both were
+    made to look identically "valid" with no indication anything was
+    wrong. Fixed by keeping the true fitted value and raising a warning
+    instead, so a bad fit is visible rather than silently laundered.
+    """
+    model = HavriliakNegami(
+        f_min=1e7,
+        f_max=1e11,
+        alpha=0.91,
+        beta=1.0,
+        e_inf=0.8,
+        de=3.0,
+        tau_0=9.4e-10,
+        sigma=0,
+        mu=0,
+        mu_sigma=0,
+        material_name="sub_unity_probe",
+        number_of_debye_poles=3,
+        f_n=30,
+        plot=False,
+        save=False,
+        optimizer=PSO_DLS,
+        optimizer_options={"swarmsize": 15, "maxiter": 15, "seed": 1},
+    )
+
+    with pytest.warns(UserWarning, match="less than the permittivity of vacuum"):
+        _, properties = model.run()
+
+    fitted_er = float(properties[0].split()[1])
+    # The true fitted value must survive - not be silently forced to 1.0.
+    assert fitted_er < 1
+    assert fitted_er != 1.0
+
+
+def test_auto_pole_count_matches_the_number_of_poles_in_the_accepted_fit(monkeypatch):
+    """Regression test for a bug where Relaxation.run()'s automatic
+    pole-count search (``number_of_debye_poles=-1``) incremented
+    ``self.number_of_debye_poles`` unconditionally at the end of every
+    loop iteration, including the one that met the error threshold and
+    broke the loop - leaving ``self.number_of_debye_poles`` one higher
+    than the pole count actually used to produce the returned fit.
+    """
+    model = HavriliakNegami(
+        f_min=1e6,
+        f_max=1e9,
+        alpha=1,
+        beta=1,
+        e_inf=3,
+        de=5,
+        tau_0=1e-9,
+        sigma=0,
+        mu=1,
+        mu_sigma=0,
+        material_name="auto_pole_count_test",
+        number_of_debye_poles=-1,
+        f_n=12,
+        plot=False,
+        save=False,
+        optimizer=PSO_DLS,
+    )
+
+    def accepted_one_pole_fit():
+        size = model.number_of_debye_poles
+        tau = np.full(size, 1e-9)
+        weights = np.full(size, 5.0 / size)
+        return tau, weights, 3.0, model.rl - 3.0, model.im
+
+    monkeypatch.setattr(model, "optimize", accepted_one_pole_fit)
+
+    _, properties = model.run()
+    n_poles_in_output = int(properties[1].split()[1])
+
+    assert model.number_of_debye_poles == n_poles_in_output
 
 
 def test_short_havriliak_negami_fit_produces_gprmax_material_commands():

--- a/tests/user_objects/test_cmds_multiuse.py
+++ b/tests/user_objects/test_cmds_multiuse.py
@@ -32,6 +32,7 @@ from gprMax.user_objects.cmds_multiuse import (
     HertzianDipole,
     MagneticDipole,
     Material,
+    MaterialCrim,
     MaterialList,
     MaterialRange,
     Rx,
@@ -700,6 +701,77 @@ class TestMaterialListHash:
         assert ml.hash == "#material_list"
         assert mr.hash == "#material_range"
         assert ml.hash != mr.hash
+
+
+class TestMaterialCrim:
+    def test_constructor_stores_kwargs(self):
+        material = MaterialCrim(
+            matrix_id="sand",
+            matrix_fraction=0.6,
+            dispersive_id="water",
+            fraction_lower=0.02,
+            fraction_upper=0.35,
+            f_min=1e6,
+            f_max=3e9,
+            a=0.5,
+            id="wetsand",
+        )
+
+        assert material.kwargs["matrix_id"] == "sand"
+        assert material.kwargs["fraction_upper"] == 0.35
+        assert material.kwargs["id"] == "wetsand"
+
+    def test_order_and_hash(self):
+        material = MaterialCrim()
+        assert material.order == 15
+        assert material.hash == "#material_crim"
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"matrix_fraction": -0.1},
+            {"fraction_lower": -0.1},
+            {"fraction_lower": 0.4, "fraction_upper": 0.3},
+            {"matrix_fraction": 0.8, "fraction_upper": 0.3},
+            {"f_min": 0},
+            {"f_min": 2e9, "f_max": 1e9},
+            {"a": 0},
+            {"a": np.nan},
+        ],
+    )
+    def test_build_rejects_invalid_parameters(self, stub_grid, overrides):
+        kwargs = {
+            "matrix_id": "sand",
+            "matrix_fraction": 0.6,
+            "dispersive_id": "water",
+            "fraction_lower": 0.02,
+            "fraction_upper": 0.35,
+            "f_min": 1e6,
+            "f_max": 3e9,
+            "a": 0.5,
+            "id": "wetsand",
+        }
+        kwargs.update(overrides)
+
+        with pytest.raises(ValueError):
+            MaterialCrim(**kwargs).build(stub_grid)
+
+    def test_build_registers_mixing_model(self, stub_grid):
+        material = MaterialCrim(
+            matrix_id="sand",
+            matrix_fraction=0.6,
+            dispersive_id="water",
+            fraction_lower=0.02,
+            fraction_upper=0.35,
+            f_min=1e6,
+            f_max=3e9,
+            a=0.5,
+            id="wetsand",
+        )
+        material.build(stub_grid)
+
+        assert len(stub_grid.mixingmodels) == 1
+        assert stub_grid.mixingmodels[0].ID == "wetsand"
 
 
 # ---------------------------------------------------------------------------

--- a/toolboxes/DebyeFit/Debye_Fit.py
+++ b/toolboxes/DebyeFit/Debye_Fit.py
@@ -239,18 +239,6 @@ class Relaxation(object):
             material_prop (list(str)): Given material nad Debye expnasion parameters
                                        in a gprMax format.
         """
-        if ee < 1:
-            warnings.warn(
-                f"The fitted relative permittivity at infinite frequency "
-                f"(e_inf={ee:g}) for material '{self.material_name}' is below "
-                f"1, i.e. less than the permittivity of vacuum. This is not "
-                f"physically valid for a passive dielectric and usually means "
-                f"the fit has not converged well - try more Debye poles, "
-                f"different optimizer settings, or check the input "
-                f"parameters. gprMax's #material command will reject a "
-                f"material with er < 1."
-            )
-
         print("Debye expansion parameters: ")
         print(f"       |{'e_inf':^14s}|{'De':^14s}|{'log(tau_0)':^25s}|")
         print("_" * 65)

--- a/toolboxes/DebyeFit/Debye_Fit.py
+++ b/toolboxes/DebyeFit/Debye_Fit.py
@@ -190,16 +190,17 @@ class Relaxation(object):
                 "##########\n",
                 sep="",
             )
-            error = np.infty  # artificial best error starting value
             self.number_of_debye_poles = 1
             iteration = 1
             # stop increasing number of Debye poles if error is smaller then 5%
             # or 20 debye poles is reached
-            while error > 5 and iteration < 21:
+            while True:
                 # Calling the main optimisation module
                 tau, weights, ee, rl, im = self.optimize()
                 err_real, err_imag = self.error(rl + ee, im)
                 error = err_real + err_imag
+                if error <= 5 or iteration >= 20:
+                    break
                 self.number_of_debye_poles += 1
                 iteration += 1
         else:
@@ -231,12 +232,25 @@ class Relaxation(object):
             tau (ndarray): The best known position form optimization module
                            (optimal design).
             weights (ndarray): Resulting optimised weights for the given relaxation times.
-            ee (float): Average error between the actual and the approximated real part.
+            ee (float): Fitted relative permittivity at infinite frequency
+                        (e_inf), written into the returned #material command.
 
         Returns:
             material_prop (list(str)): Given material nad Debye expnasion parameters
                                        in a gprMax format.
         """
+        if ee < 1:
+            warnings.warn(
+                f"The fitted relative permittivity at infinite frequency "
+                f"(e_inf={ee:g}) for material '{self.material_name}' is below "
+                f"1, i.e. less than the permittivity of vacuum. This is not "
+                f"physically valid for a passive dielectric and usually means "
+                f"the fit has not converged well - try more Debye poles, "
+                f"different optimizer settings, or check the input "
+                f"parameters. gprMax's #material command will reject a "
+                f"material with er < 1."
+            )
+
         print("Debye expansion parameters: ")
         print(f"       |{'e_inf':^14s}|{'De':^14s}|{'log(tau_0)':^25s}|")
         print("_" * 65)
@@ -690,7 +704,7 @@ class Crim(Relaxation):
     def calculation(self):
         """Calculates the Crim function for the given parameters"""
         return np.sum(
-            np.repeat(self.volumetric_fractions, len(self.freq)).reshape((-1, len(self.materials)))
+            self.volumetric_fractions
             * (
                 self.materials[:, 0]
                 + self.materials[:, 1]

--- a/toolboxes/DebyeFit/optimization.py
+++ b/toolboxes/DebyeFit/optimization.py
@@ -492,5 +492,6 @@ def DLS(logt, rl, im, freq):
     )
     cost_i = np.sum(np.abs(ip - im)) / len(im)
     ee = np.mean(rl - rp)
+    ee = max(ee, 1)
     cost_r = np.sum(np.abs(rp + ee - rl)) / len(im)
     return cost_i, cost_r, x, ee, rp, ip

--- a/toolboxes/DebyeFit/optimization.py
+++ b/toolboxes/DebyeFit/optimization.py
@@ -492,6 +492,5 @@ def DLS(logt, rl, im, freq):
     )
     cost_i = np.sum(np.abs(ip - im)) / len(im)
     ee = np.mean(rl - rp)
-    ee = max(ee, 1)
     cost_r = np.sum(np.abs(rp + ee - rl)) / len(im)
     return cost_i, cost_r, x, ee, rp, ip


### PR DESCRIPTION
# PR Description

## Summary

This PR adds CRIM-based material mixing for fractal media and corrects several issues in the DebyeFit toolbox.

The new `MaterialCrim` Python API object and `#material_crim` hash command combine:

- a fixed-fraction, non-dispersive matrix;
- a variable-fraction, user-defined single-pole Debye material;
- an implied remaining air fraction.

A single-pole Debye model is fitted to the CRIM response for each fractal material bin over the requested frequency range. Conductivity is mixed separately by volume fraction.

The PR also:

- fixes CRIM fraction broadcasting for multiple mixture fractions;
- corrects automatic Debye pole-count selection;
- keeps water model-specific rather than exposing it as a general built-in material;
- adds input validation and passive-material checks;
- documents the formulation, limitations, API, hash command, and primary CRIM reference.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] This change requires a documentation update.

## Testing

- 969 tests passed, 1 deselected.
- Black 23.12.1 passed.
- isort 5.13.2 passed.
- Sphinx documentation build passed with warnings treated as errors.

## Checklist

- [x] Pre-commit/formatting checks passed.
- [x] I have performed a self-review of the code.
- [x] I have added comments where the numerical implementation requires explanation.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The pull-request title is a short description of the changes.