### PR TITLE
Unify voltage-source excitation and port outputs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Set up MPI runtime
         uses: mpi4py/setup-mpi@v1
-        timeout-minutes: 5
+        timeout-minutes: 15
         with:
           mpi: ${{ matrix.mpi }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,17 +51,17 @@ jobs:
           cache-dependency-path: requirements.txt
 
       - name: Set up MPI runtime
+        if: runner.os != 'Linux'
         uses: mpi4py/setup-mpi@v1
         timeout-minutes: 15
         with:
           mpi: ${{ matrix.mpi }}
 
-      - name: Configure Linux MPI transport
+      - name: Set up Open MPI runtime on Linux
         if: runner.os == 'Linux'
-        shell: bash
         run: |
-          echo "FI_PROVIDER=shm" >> "$GITHUB_ENV"
-          echo "UCX_TLS=self,sm" >> "$GITHUB_ENV"
+          python -m pip install openmpi==5.0.10
+          mpiexec --version
 
       - name: Install gprMax and test dependencies
         run: |

--- a/docs/source/comparisons_analytical.rst
+++ b/docs/source/comparisons_analytical.rst
@@ -803,7 +803,7 @@ Power-normalisation consistency
 
 The :download:`power-normalisation driver
 <../../testing/validation/validate_sar_power_normalisation.py>` exercises an
-actual voltage source and ``RxPort`` through the complete solver and output
+actual voltage source and its automatic port through the complete solver and output
 path. Requesting 4 W rather than 1 W incident power multiplies every SAR value
 by four exactly. Normalising the same fields to accepted rather than incident
 power agrees with the independently evaluated port-power ratio to

--- a/docs/source/comparisons_numerical.rst
+++ b/docs/source/comparisons_numerical.rst
@@ -183,7 +183,7 @@ currents, MATLAB MoM remains the relevant full-wave inter-code comparison.
 Native port-output comparison
 =============================
 
-An additional :download:`RxPort study
+An additional :download:`voltage-port study
 <../../testing/other_codes/matlab_mom/rx_port_comparison/README.md>` uses the
 production ``/ports`` HDF5 datasets directly for the dipole, bow tie,
 monopole, and patch. It is deliberately distinct from cases that reconstruct

--- a/docs/source/examples_antennas.rst
+++ b/docs/source/examples_antennas.rst
@@ -20,9 +20,9 @@ dipole in free space. The balanced antenna is 150 mm long and has a one-cell,
     :language: none
     :linenos:
 
-The antenna is excited by a one-cell, 50 Ohm resistive voltage source. The
-coincident ``#rx_port`` associates the feed with an output port called
-``feed``. gprMax samples the total gap voltage during the solve and, after the
+The antenna is excited by a one-cell, 50 Ohm resistive voltage source whose
+optional ID names the automatic output port ``feed``. gprMax samples the total
+gap voltage during the solve and, after the
 time loop, directly calculates the complex reflection coefficient, input
 impedance, and input admittance. The effective Yee-edge gap capacitance and
 background conductance are removed from the reported terminal quantities.
@@ -30,7 +30,7 @@ Users do not need to reconstruct S11 from voltage and current histories.
 
 The Gaussian waveform has a nominal frequency of 1 GHz. The 60 ns time window
 provides a native FFT-bin spacing of approximately 16.7 MHz. The default
-``#rx_port`` spectrum is limited by the model's lambda/10 mesh criterion and
+voltage-source port spectrum is limited by the model's lambda/10 mesh criterion and
 also carries per-frequency validity masks based on source bandwidth and the
 terminal reconstruction. These masks should be applied when plotting.
 

--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -263,23 +263,21 @@ rebuilding the antenna geometry. Every finite-resistance
 :class:`gprMax.VoltageSource` remains on its original electric edge in every
 case. Exactly one source is driven, while omitted sources have zero generator
 voltage but retain their resistance and therefore act as passive matched
-terminations. Every source must have a coincident, uniquely named
-:class:`gprMax.RxPort`.
+terminations. Every source automatically owns a port monitor and must have a
+unique ``id``.
 
 .. code-block:: python
 
     port1_source = gprMax.VoltageSource(
         p1=(0.040, 0.050, 0.030), polarisation='z', resistance=50,
-        waveform_id='pulse'
+        waveform_id='pulse', id='port1'
     )
     port2_source = gprMax.VoltageSource(
         p1=(0.060, 0.050, 0.030), polarisation='z', resistance=50,
-        waveform_id='pulse'
+        waveform_id='pulse', id='port2'
     )
     scene.add(port1_source)
     scene.add(port2_source)
-    scene.add(gprMax.RxPort(p1=(0.040, 0.050, 0.030), id='port1'))
-    scene.add(gprMax.RxPort(p1=(0.060, 0.050, 0.030), id='port2'))
 
     study = gprMax.PortStudy([
         gprMax.StudyCase('drive_port1', [
@@ -1125,8 +1123,8 @@ Every transmission-line source automatically writes its incident and terminal
 voltage/current histories together with ``frequency``, ``S11``, ``Zin``, and
 ``Yin`` beneath ``/tls/tlN`` in the model HDF5 output. ``Zin`` is derived from
 the voltage-wave S11 result; ``Zin_current`` is an independent, stagger-aware
-current-wave check. An additional :class:`RxPort` is only needed for a
-resistive voltage source, not for a transmission line. See
+current-wave check. Voltage and transmission-line sources both own their
+terminal outputs, so no separate receiver-port object is required. See
 :ref:`Simulation Output <output>` for the equations and validity masks.
 
 Magnetic Frill Source
@@ -1313,33 +1311,33 @@ Receiver Array
 
 Voltage-source S11 and input impedance
 --------------------------------------
-.. autoclass:: gprMax.user_objects.cmds_output.RxPort
-
-``RxPort`` binds to one single-Yee-edge ``VoltageSource`` at the same
-discretised coordinate. It creates the necessary field monitors automatically
-and calculates corrected complex ``S11``, ``Zin``, and ``Yin`` after the
-solve. A finite-resistance source uses its resistance as the reference
-impedance:
+Every 3-D single-Yee-edge :class:`gprMax.VoltageSource` owns the necessary
+hidden field monitor and calculates corrected complex ``S11``, ``Zin``, and
+``Yin`` after the solve. A finite-resistance source uses its physical
+resistance as the reference impedance:
 
 .. code-block:: python
 
-    port = gprMax.RxPort(
+    port = gprMax.VoltageSource(
         p1=(0.050, 0.050, 0.020),
+        polarisation='z',
+        resistance=50,
+        waveform_id='source_wave',
         id='feed',
         spectrum_limit=10,
     )
     scene.add(port)
 
 The default ``spectrum_limit=10`` retains frequencies having at least ten
-cells per shortest material wavelength. Because optional hash-command
-arguments are positional, an ``id`` is required when the Python object uses a
-non-default spectrum limit. A research run can explicitly request all native
-non-negative FFT bins while retaining the normal validity metadata:
+cells per shortest material wavelength. A research run can explicitly request
+all native non-negative FFT bins while retaining the normal validity metadata:
 
 .. code-block:: python
 
-    scene.add(gprMax.RxPort(
+    scene.add(gprMax.VoltageSource(
         p1=(0.050, 0.050, 0.020),
+        polarisation='z', resistance=50,
+        waveform_id='source_wave',
         id='feed_full',
         spectrum_limit='nyquist',
     ))
@@ -1355,13 +1353,9 @@ defaults to 50 Ohms and can be changed on the source:
         polarisation='z',
         resistance=0,
         waveform_id='source_wave',
+        id='ideal_feed',
         reference_impedance=50,
     ))
-    hard_port = gprMax.RxPort(
-        p1=(0.050, 0.050, 0.020),
-        id='ideal_feed',
-    )
-    scene.add(hard_port)
 
 After ``gprMax.run`` completes, ``port.result`` provides the same numerical
 arrays that are stored under ``/ports/feed`` in the model HDF5 file. For a
@@ -1369,14 +1363,21 @@ hard source, gprMax obtains terminal current from the surrounding magnetic-
 field loop and accounts explicitly for the half-step phase difference from
 the integer-time voltage during transformation.
 
-``RxPort`` also supports domain-decomposed MPI CPU models. The owning rank
+A finite-resistance source on a dispersive edge includes the background
+material's complete complex permittivity in the Yee-gap correction. A hard
+source on a dispersive edge is not yet supported because its sampled
+Ampere-loop current requires the discrete polarisation-current contribution
+to be separated explicitly.
+
+The automatic voltage-source port also supports domain-decomposed MPI CPU
+models. The owning rank
 stores the voltage history; hard-source current loops may cross internal rank
 faces because magnetic halos are synchronised before sampling. Histories are
 gathered and transformed once on the coordinator rank, while ``port.result``
 is rebound to that final result for Python API use.
 
-An ``RxPort`` may also be placed inside a ``SubGridHSG``. Add the waveform,
-voltage source, and port to the same subgrid object; the port is then sampled
+The source may also be placed inside a ``SubGridHSG``. Add the waveform and
+voltage source to the subgrid object; the port is then sampled
 using that subgrid's finer spatial and temporal discretisation. With
 ``autotranslate=True``, the port and source use the same global physical
 coordinate:
@@ -1390,15 +1391,12 @@ coordinate:
         p1=(0.090, 0.070, 0.060),
         polarisation='z', resistance=50,
         waveform_id='feed_wave',
+        id='fine_feed',
     ))
-    fine_port = gprMax.RxPort(
-        p1=(0.090, 0.070, 0.060), id='fine_feed'
-    )
-    subgrid.add(fine_port)
 
 The result is stored at
-``/subgrids/<subgrid ID>/ports/<port ID>``. The source and port must belong to
-the same grid object so that their discretised coordinates, material edge,
+``/subgrids/<subgrid ID>/ports/<port ID>``. The source belongs to the owning
+grid object, so its discretised coordinate, material edge,
 ``dl``, and ``dt`` are unambiguous.
 
 Specific absorption rate (SAR)
@@ -1731,7 +1729,7 @@ Main-grid port IDs are used directly. A subgrid port is qualified by its
 subgrid ID, for example ``fine_grid/feed``, ``fine_grid/tl1``, or
 ``fine_grid/frill1``. Its voltage and current spectra are transformed with the
 owning subgrid's finer time step.
-For voltage sources, use the ID of the coincident :class:`RxPort`; automatic
+For voltage sources, use the source's ``id`` (or its automatic ``portN`` ID); automatic
 transmission-line and magnetic-frill IDs are ``tl1``, ... and ``frill1``, ...
 respectively. An eigenmode source is ``portN`` for its explicit port index;
 an eigenmode receiver uses its configured ID. Eigenmode transform

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1357,20 +1357,40 @@ Allows you to introduce a voltage source at an electric field location. It can b
 
 .. code-block:: none
 
-    #voltage_source: c1 f1 f2 f3 f4 str1 [f5 f6 [f7]]
+    #voltage_source: c1 f1 f2 f3 f4 str1 [f5 f6 [f7 | str2 str3 [f7]]]
 
 * ``c1`` is the polarisation of the source and can be ``x``, ``y``, or ``z``.
 * ``f1 f2 f3`` are the coordinates (x,y,z) of the source in the model.
 * ``f4`` is the internal resistance of the voltage source in Ohms. If ``f4`` is set to zero then the voltage source is a hard source. That means it prescribes the value of the electric field component. If the waveform becomes zero then the source is perfectly reflecting.
 * ``f5 f6`` are optional parameters. ``f5`` is a time delay in starting the source. ``f6`` is a time to remove the source. If the time window is longer than the source removal time then the source will stop after the source removal time. If the source removal time is longer than the time window then the source will be active for the entire time window. If ``f5 f6`` are omitted the source will start at the beginning of time window and stop at the end of the time window.
-* ``f7`` is the optional positive wave-reference impedance in Ohms used by a coincident ``#rx_port``. A hard source defaults to 50 Ohms. For a finite-resistance source, ``f7`` must equal ``f4``. In the positional hash syntax, ``f5`` and ``f6`` must be supplied before ``f7``; the Python API does not have this restriction.
+* ``str2`` is an optional port/output identifier. ``str3`` is then required
+  and is either the minimum cells per shortest material wavelength (default
+  10) or ``nyquist`` for every native non-negative FFT bin. Because hash
+  arguments are positional, ``f5`` and ``f6`` must be supplied before these
+  port options. If omitted, ``port1``, ``port2``, and so on are assigned.
+* ``f7`` is the optional positive wave-reference impedance in Ohms for a hard
+  source only; it is always the final positional value. A hard source defaults
+  to 50 Ohms. A finite-resistance source uses ``f4`` and must not supply
+  ``f7``.
 * ``str1`` is the identifier of the waveform that should be used with the source.
+
+Every 3-D voltage source automatically stores its terminal voltage and
+frequency-domain ``S11``, ``Zin``, and ``Yin``. No separate receiver-port
+command is required. For example:
+
+.. code-block:: none
+
+    #voltage_source: z 0.050 0.050 0.020 50 source_wave 0 10e-9 feed 10
+    #voltage_source: z 0.060 0.050 0.020 0 source_wave 0 10e-9 ideal_feed nyquist 75
 
 For example, to specify a y directed voltage source with an internal resistance of 50 Ohms, an amplitude of five, and a 1.2 GHz centre frequency Gaussian waveform use: ``#waveform: gaussian 5 1.2e9 my_gauss_pulse`` and ``#voltage_source: y 0.05 0.05 0.05 50 my_gauss_pulse``.
 
 .. note::
 
     * Where a resistive voltage source is placed at a location that is not free space, the conductivity (determined from the resistance) of the voltage source will be added to the underlying conductivity of the existing material at that location. For example, if a resistive voltage source of 50 Ohms is placed at a location where the material has a relative permittivity of 4 and conductivity of 0.1 S/m, the conductivity of that cell edge will become 0.12 S/m.
+    * A finite-resistance source on a dispersive edge includes the complete
+      complex background permittivity in its Yee-gap correction. A hard source
+      on a dispersive edge is not yet supported.
 
 #transmission_line:
 -------------------
@@ -1393,7 +1413,7 @@ automatically after the simulation. The line resistance is used as the S11
 reference impedance; ``Zin`` is derived from S11, while an independently
 de-embedded current result is saved as ``Zin_current`` for verification. The
 frequency axis, validity masks, and lambda/10 mesh limit are stored with the
-results. No separate ``#rx_port`` command is required for a transmission-line
+results. No separate receiver-port command is required for a transmission-line
 source. The complete schema and equations are documented in the
 :ref:`Simulation Output <output>` section.
 
@@ -1424,7 +1444,7 @@ field deposit is applied by its owning rank. The syntax is:
 
 .. code-block:: none
 
-    #magnetic_frill_source: c1 f1 f2 f3 f4 str1 [f5 f6]
+    #magnetic_frill_source: c1 f1 f2 f3 f4 str1 [str2 | f5 f6 [str2]]
 
 * ``c1`` is the polarisation of the source and can be ``x``, ``y``, or ``z``
   - the antenna axis the source drives current along, following the same
@@ -1440,6 +1460,10 @@ field deposit is applied by its owning rank. The syntax is:
   waveform starts and a time at which that waveform stops. They gate only the
   incident wave; the coaxial terminal relation remains connected for the rest
   of the simulation so that late antenna reflections are treated correctly.
+* ``str2`` is an optional spectrum limit: either a numeric minimum number of
+  cells per shortest material wavelength or ``nyquist``. It may follow the
+  base command directly, or follow ``f5 f6`` when start and stop times are
+  supplied. The default is 10.
 
 The source must be co-located with a Yee edge of a ``#thin_wire`` of the same
 orientation. gprMax obtains the inner-conductor radius :math:`a`
@@ -1561,9 +1585,8 @@ Time histories of incident and total voltage (:math:`V_\mathrm{inc}`,
 :math:`V_\mathrm{ab}`) and total current (:math:`I_\mathrm{tot}`) are saved to
 the output file, along with automatically-calculated S11, input impedance, and
 input admittance, following the same conventions as ``#transmission_line``. No
-separate ``#rx_port`` command is required. If ``#rx_port`` is placed at the
-same position it does not create a second, independent measurement - it can
-only override the automatic output's spectrum limit. The complete schema and
+separate receiver-port command is required. Supply the optional
+``spectrum_limit`` directly on the magnetic-frill source when needed. The complete schema and
 equations are documented in the :ref:`Simulation Output <output>` section.
 
 For example, a z-directed, 0.1 mm radius inner conductor driven through a
@@ -1889,49 +1912,32 @@ Provides a simple method of defining multiple output points in the model. The sy
 * ``f1 f2 f3`` are the lower left (x,y,z) coordinates of the output line/rectangle/volume, and ``f4 f5 f6`` are the upper right (x,y,z) coordinates of the output line/rectangle/volume.
 * ``f7 f8 f9`` are the increments (x,y,z) which define the number of output points in each direction. ``f7``, ``f8``, or  ``f9`` can be set to zero to prevent any output points in a particular direction. Otherwise, the minimum value of ``f7`` is :math:`\Delta x`, the minimum value of ``f8`` is :math:`\Delta y`, and the minimum value of ``f9`` is :math:`\Delta z`.
 
-#rx_port:
----------
+Automatic voltage-source port output
+------------------------------------
 
-Calculates the complex reflection coefficient and input impedance of a
-single-cell voltage-source port. The output point must coincide
-exactly with one ``#voltage_source`` after both positions have been resolved to
-the Yee grid. A separate ``#rx`` command is not required. The syntax is:
-
-.. code-block:: none
-
-    #rx_port: f1 f2 f3 [str1 [str2]]
-
-* ``f1 f2 f3`` are the source coordinates (x,y,z).
-* ``str1`` is the optional port/output identifier. If omitted, ``port1``,
-  ``port2``, and so on are generated.
-* ``str2`` is the optional spectrum limit. A number specifies the minimum
-  cells per shortest material wavelength; the default is 10. The keyword
-  ``nyquist`` requests every native non-negative FFT bin for research and
-  diagnostic use.
-
-The voltage source supplies the reference impedance :math:`Z_0`. For example:
+Every 3-D ``#voltage_source`` automatically calculates the complex reflection
+coefficient and input impedance of its single-cell feed edge. The hidden field
+monitor is placed at the source coordinate; a separate ``#rx`` command is not
+required. Two representative forms are:
 
 .. code-block:: none
 
-    #voltage_source: z 0.050 0.050 0.020 50 source_wave
-    #rx_port: 0.050 0.050 0.020 feed
-    #rx_port: 0.050 0.050 0.020 feed nyquist
-    #voltage_source: z 0.060 0.050 0.020 0 source_wave
-    #rx_port: 0.060 0.050 0.020 ideal_feed
-    # Custom 75 Ohm hard-source reference; start/stop precede it positionally
-    #voltage_source: z 0.070 0.050 0.020 0 source_wave 0 10e-9 75
-    #rx_port: 0.070 0.050 0.020 ideal_feed_75
+    #voltage_source: z 0.050 0.050 0.020 50 source_wave 0 10e-9 feed 10
+    #voltage_source: z 0.060 0.050 0.020 0 source_wave 0 10e-9 ideal_feed nyquist 75
 
-``#rx_port`` is supported in domain-decomposed MPI CPU models. The source and
+The automatic port is supported in domain-decomposed MPI CPU models. The source and
 its internal field monitor belong to one rank; for a hard source, magnetic
 halos are synchronised before the next current sample so an Ampere loop may
 cross an internal rank face or corner. Port histories are gathered and the
 frequency-domain quantities are calculated once on the coordinator rank.
 
+Finite-resistance sources on dispersive edges use the complete complex
+background permittivity in the Yee-gap correction. Hard sources on dispersive
+edges are not yet supported.
 
 For a finite-resistance source, the voltage-source resistance is the
-reference impedance :math:`Z_0`; a hard source defaults to 50 Ohms unless
-``f7`` is supplied. At the source plane, the known generator
+reference impedance :math:`Z_0`; a hard source defaults to 50 Ohms unless the
+final optional reference-impedance value is supplied. At the source plane, the known generator
 spectrum :math:`V_g` and sampled total gap voltage :math:`V` give
 
 .. math::
@@ -2278,7 +2284,7 @@ future selective-output support and is currently rejected rather than
 silently ignored.
 
 For a ``port`` study, every ``#voltage_source`` must have finite, non-zero
-resistance and a coincident ``#rx_port`` with a unique ID. The CSV must contain
+resistance and a unique automatic port ID. The CSV must contain
 one case for every voltage source and drive exactly one source in each case.
 Omitted sources retain their fixed source resistance but receive a zero
 generator waveform, so they behave as passive matched terminations. For
@@ -2328,7 +2334,7 @@ of the CSV source.
 
     GPR studies support top-level ``#hertzian_dipole``,
     ``#magnetic_dipole``, and ``#rx`` objects; port studies additionally
-    support finite-resistance ``#voltage_source``/``#rx_port`` pairs;
+    support finite-resistance ``#voltage_source`` ports;
     eigenmode studies support ``#eigenmode_port``, ``#eigenmode_excitation``,
     and ``#virtual_waveguide``. MPI domain decomposition, task farming, plane
     waves, transmission lines, and rational/frill ports remain excluded from
@@ -2626,7 +2632,8 @@ calculated:
 
     #ksir_antenna_ports: transform_id port_id1 [port_id2 ...]
 
-For a voltage source, ``port_id`` is the ID of the coincident ``#rx_port``.
+For a voltage source, ``port_id`` is the source's optional ID, or its
+automatically assigned ``portN`` ID.
 Transmission-line and magnetic-frill sources provide automatic port IDs
 ``tl1``, ``tl2``, ... and ``frill1``, ``frill2``, ... respectively, in source
 creation order. The association is not required for electric or magnetic far
@@ -2641,14 +2648,13 @@ commands ``#ntff_frequency``, ``#ntff_far_field`` or
 ``#ntff_far_field_array``, and ``#ntff_antenna_ports`` instead.
 
 A port on a subgrid is named as ``subgrid_id/port_id``. For example,
-``fine_grid/feed`` identifies an ``#rx_port`` called ``feed`` on subgrid
+``fine_grid/feed`` identifies a voltage source called ``feed`` on subgrid
 ``fine_grid``; automatic source ports use forms such as ``fine_grid/tl1`` and
 ``fine_grid/frill1``. Main-grid IDs remain unqualified. Each subgrid port is
 post-processed using its owning grid's finer spatial and temporal steps.
 
 The listed set must include **every** physical voltage, transmission-line, and
-magnetic-frill port in the model. Every voltage source must therefore have a
-coincident ``#rx_port``. This requirement makes the net accepted power
+magnetic-frill port in the model. This requirement makes the net accepted power
 unambiguous in coupled multiport antennas. A source whose waveform amplitude is
 zero is still a terminated physical port: list it normally. It has zero
 incident power, but coupling from driven ports can make its accepted power
@@ -2660,10 +2666,9 @@ Gain normalisation currently requires the transform to use the
 plane-wave sources cannot be mixed with a port-normalised antenna result,
 because their input power is not represented by this port set.
 The normal per-port wavelength-sampling limit also applies to gain validity.
-For a voltage-source port, an explicit ``nyquist`` research override on its
-``#rx_port`` retains the full temporal band, including spatially
-under-resolved values, as it does for S11 and impedance. A coincident
-``#rx_port`` can apply the same override to a magnetic-frill output.
+For a voltage-source or magnetic-frill port, an explicit ``nyquist`` research
+override on the source retains the full temporal band, including spatially
+under-resolved values, as it does for S11 and impedance.
 
 For example, a two-element array with one driven and one terminated element
 uses:
@@ -2672,10 +2677,8 @@ uses:
 
     #waveform: ricker 1 1e9 driven
     #waveform: ricker 0 1e9 terminated
-    #voltage_source: z 0.045 0.050 0.050 50 driven
-    #voltage_source: z 0.055 0.050 0.050 50 terminated
-    #rx_port: 0.045 0.050 0.050 element1
-    #rx_port: 0.055 0.050 0.050 element2
+    #voltage_source: z 0.045 0.050 0.050 50 driven 0 10e-9 element1 10
+    #voltage_source: z 0.055 0.050 0.050 50 terminated 0 10e-9 element2 10
     #ksir_frequency: radiation_surface antenna_band 0.8e9 1.0e9 1.2e9 rectangular
     #ksir_antenna_ports: antenna_band element1 element2
     #ksir_far_field_array: 0 180 2 0 360 2 antenna_band pattern gain realized_gain

--- a/docs/source/output.rst
+++ b/docs/source/output.rst
@@ -642,8 +642,8 @@ Transmission-line S11 and impedance output
 -------------------------------------------
 
 S11, input impedance, and input admittance are generated automatically for
-every transmission-line source; no ``#rx_port`` command or additional
-receiver is required. With the real line resistance :math:`Z_0` as the
+every transmission-line source; no additional receiver is required. With the
+real line resistance :math:`Z_0` as the
 reference impedance, the primary results are
 
 .. math::
@@ -693,7 +693,7 @@ Magnetic-frill-source S11 and impedance output
 
 S11, input impedance, and input admittance are generated automatically for
 every ``#magnetic_frill_source``, exactly as for a transmission line; no
-``#rx_port`` command or additional receiver is required (the electric field
+additional receiver is required (the electric field
 component along the polarisation axis is identically zero at the feed point
 by construction, so no field sample is possible there in the first place).
 Main-grid results are stored at ``/frills/frillN``. A Python API frill inside
@@ -727,10 +727,8 @@ histories satisfy
 
     V_\mathrm{ab}=2V_\mathrm{inc}-Z_0 I_\mathrm{tot}.
 
-If ``#rx_port`` is placed at the same feed point, it does not create a
-second, independent measurement (unlike its role with ``#voltage_source``);
-it can only override the ``spectrum_limit`` of this always-on automatic
-output.
+Set ``spectrum_limit`` directly on the magnetic-frill source when a limit
+other than the default lambda/10 band is required.
 
 Rational-network port output
 ----------------------------
@@ -801,8 +799,9 @@ and space increments.
 Voltage-source S11 and impedance output
 ---------------------------------------
 
-The ``#rx_port`` command and ``RxPort`` Python object write one group per
-main-grid port at ``/ports/<port ID>``. A port added to a Python API subgrid is
+Every 3-D ``#voltage_source`` or ``VoltageSource`` Python object writes one
+source-owned group per main-grid port at ``/ports/<port ID>``. A source added
+to a Python API subgrid is
 stored at ``/subgrids/<subgrid ID>/ports/<port ID>`` and uses the owning
 subgrid's spatial step, time step, iteration count, material edge, and field
 histories. For a finite-resistance source, its resistance is the reference
@@ -823,6 +822,22 @@ background capacitance and conductance before reporting ``S11``, ``Zin``, and
     Z_\mathrm{in}=Z_0\frac{1+S_{11}}{1-S_{11}},
     \qquad
     Y_\mathrm{in}=\frac{1-S_{11}}{Z_0(1+S_{11})}.
+
+For a finite-resistance source in a dispersive background, the shunt
+admittance uses the material's complete complex relative permittivity,
+including every Debye, Lorentz, Drude, or inclusive pole,
+
+.. math::
+
+    \widetilde{\omega}=\frac{2}{\Delta t}
+    \tan\!\left(\frac{\omega\Delta t}{2}\right),
+    \qquad
+    Y_\mathrm{gap}=j\widetilde{\omega}\varepsilon_0
+    \varepsilon_r(\widetilde{\omega})\frac{A}{\Delta l}.
+
+This reduces to :math:`G_\mathrm{bg}+j\widetilde{\omega}C_\mathrm{gap}`
+for a nondispersive conductive material. Hard voltage ports use their sampled
+Ampere-loop current and are not yet supported on dispersive source edges.
 
 Important attributes include:
 

--- a/examples/antennas/wire_dipole/antenna_wire_dipole_fs.in
+++ b/examples/antennas/wire_dipole/antenna_wire_dipole_fs.in
@@ -9,8 +9,7 @@
 #edge: 0.025 0.025 0.025 0.025 0.025 0.175 pec
 #edge: 0.025 0.025 0.100 0.025 0.025 0.101 free_space
 
-## RxPort must coincide exactly with the single-edge voltage source.
-#voltage_source: z 0.025 0.025 0.100 50 mypulse
-#rx_port: 0.025 0.025 0.100 feed
+## The voltage source automatically owns port output called "feed".
+#voltage_source: z 0.025 0.025 0.100 50 mypulse 0 60e-9 feed 10
 
 #geometry_view: 0.020 0.020 0.020 0.030 0.030 0.180 0.001 0.001 0.001 antenna_wire_dipole_fs f

--- a/examples/antennas/wire_dipole/antenna_wire_dipole_fs.py
+++ b/examples/antennas/wire_dipole/antenna_wire_dipole_fs.py
@@ -1,6 +1,6 @@
 """Half-wavelength wire dipole excited by a one-cell voltage-source port.
 
-The coincident ``RxPort`` calculates and stores frequency, corrected complex
+The source-owned port calculates and stores frequency, corrected complex
 S11, input impedance, and input admittance under ``/ports/feed`` in the model
 HDF5 output. No post-processing of source voltage and current is required.
 """
@@ -37,9 +37,9 @@ scene.add(
         polarisation="z",
         resistance=50,
         waveform_id="mypulse",
+        id="feed",
     )
 )
-scene.add(gprMax.RxPort(p1=(0.025, 0.025, 0.100), id="feed"))
 scene.add(
     gprMax.GeometryView(
         p1=(0.020, 0.020, 0.020),

--- a/examples/antennas/wire_dipole/antenna_wire_dipole_pattern.in
+++ b/examples/antennas/wire_dipole/antenna_wire_dipole_pattern.in
@@ -10,9 +10,8 @@
 #edge: 0.040 0.040 0.035 0.040 0.040 0.185 pec
 #edge: 0.040 0.040 0.110 0.040 0.040 0.111 free_space
 
-## The receiver port must coincide with the one-cell voltage source.
-#voltage_source: z 0.040 0.040 0.110 50 dipole_pulse
-#rx_port: 0.040 0.040 0.110 feed
+## The voltage source automatically owns port output called "feed".
+#voltage_source: z 0.040 0.040 0.110 50 dipole_pulse 0 40e-9 feed 10
 
 ## Closed equivalent-current surface and 950 MHz full-sphere output.
 #ntff_surface: 0.018 0.018 0.020 0.062 0.062 0.200 dipole_surface

--- a/examples/antennas/wire_dipole/antenna_wire_dipole_pattern.py
+++ b/examples/antennas/wire_dipole/antenna_wire_dipole_pattern.py
@@ -51,9 +51,9 @@ def build_scene():
             polarisation="z",
             resistance=50,
             waveform_id="dipole_pulse",
+            id="feed",
         )
     )
-    scene.add(gprMax.RxPort(p1=feed, id="feed"))
 
     scene.add(
         gprMax.NTFFSurface(

--- a/examples/antennas/wire_dipole/antenna_wire_dipole_transmission_line.py
+++ b/examples/antennas/wire_dipole/antenna_wire_dipole_transmission_line.py
@@ -1,7 +1,7 @@
 """Half-wavelength wire dipole using the legacy transmission-line feed.
 
 The canonical ``antenna_wire_dipole_fs`` example uses a voltage source with an
-``RxPort``. This alternative is retained for users who specifically need the
+the automatic voltage-source port. This alternative is retained for users who specifically need the
 one-dimensional line histories or its independent current-wave checks.
 """
 

--- a/examples/jupyter-notebooks/notebook_helpers.py
+++ b/examples/jupyter-notebooks/notebook_helpers.py
@@ -75,7 +75,7 @@ def ensure_bscan(force=False, traces=60):
 
 
 def ensure_port_demo(force=False):
-    """Run a compact voltage-source/RxPort model for plotting demonstrations."""
+    """Run a compact voltage-source-port model for plotting demonstrations."""
 
     output = OUTPUT_DIR / "wire_dipole_port_demo.h5"
     if force or not output.exists():
@@ -105,8 +105,8 @@ def ensure_port_demo(force=False):
                 polarisation="z",
                 resistance=50,
                 waveform_id="pulse",
+                id="feed",
             )
         )
-        scene.add(gprMax.RxPort(p1=(0.04, 0.04, 0.04), id="feed"))
         gprMax.run(scenes=[scene], outputfile=output, n=1, hide_progress_bars=True)
     return output

--- a/examples/jupyter-notebooks/plot_port.ipynb
+++ b/examples/jupyter-notebooks/plot_port.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "The ``toolboxes.Plotting.plot_port`` module reads the authoritative terminal quantities stored by gprMax. It discovers voltage-source ports, rational-network ports, transmission lines, magnetic-frill ports, and ports in subgrids. Depending on the port type, the output can contain complex $S_{11}$, input impedance and admittance, validity diagnostics, and available voltage and current histories and spectra. The plotting tool never recalculates these quantities from raw receiver fields.\n",
     "\n",
-    "The model must contain an ``RxPort`` at exactly the same position as a compatible source, or use a source such as a transmission line which stores its port result directly. Useful command-line options include:\n",
+    "A voltage source owns its port result directly, as do transmission-line and magnetic-frill sources. Useful command-line options include:\n",
     "\n",
     "* ``--list-ports`` lists all terminal-output groups in the file.\n",
     "* ``--port`` selects a port by ID or complete HDF5 path and may be repeated. All ports are plotted by default.\n",

--- a/gprMax/__init__.py
+++ b/gprMax/__init__.py
@@ -85,7 +85,6 @@ from .user_objects.cmds_multiuse import (
     Waveform,
 )
 from .user_objects.cmds_output import (
-    Radiometry,
     SAR,
     GeometryObjectsWrite,
     GeometryView,
@@ -107,7 +106,7 @@ from .user_objects.cmds_output import (
     NTFFSurface,
     NTFFTimeFarField,
     NTFFTimeFarFieldArray,
-    RxPort,
+    Radiometry,
     Snapshot,
 )
 from .user_objects.cmds_singleuse import (

--- a/gprMax/hash_cmds_file.py
+++ b/gprMax/hash_cmds_file.py
@@ -270,7 +270,6 @@ def check_cmd_names(processedlines, checkessential=True):
             "#excitation_file",
             "#rx",
             "#rx_array",
-            "#rx_port",
             "#sar",
             "#radiometry",
             "#network_port",

--- a/gprMax/hash_cmds_multiuse.py
+++ b/gprMax/hash_cmds_multiuse.py
@@ -58,7 +58,6 @@ from .user_objects.cmds_multiuse import (
     Waveform,
 )
 from .user_objects.cmds_output import (
-    Radiometry,
     SAR,
     GeometryObjectsWrite,
     GeometryView,
@@ -80,7 +79,7 @@ from .user_objects.cmds_output import (
     NTFFSurface,
     NTFFTimeFarField,
     NTFFTimeFarFieldArray,
-    RxPort,
+    Radiometry,
     Snapshot,
 )
 from .user_objects.cmds_singleuse import PMLFormulation
@@ -201,7 +200,12 @@ def process_multicmds(multicmds):
                     resistance=float(tmp[4]),
                     waveform_id=tmp[5],
                 )
-            elif len(tmp) in (8, 9):
+            elif len(tmp) in (8, 9, 10, 11):
+                spectrum_limit = 10
+                port_id = None
+                if len(tmp) >= 10:
+                    port_id = tmp[8]
+                    spectrum_limit = "nyquist" if tmp[9].lower() == "nyquist" else float(tmp[9])
                 voltage_source = VoltageSource(
                     polarisation=tmp[0].lower(),
                     p1=(float(tmp[1]), float(tmp[2]), float(tmp[3])),
@@ -209,7 +213,13 @@ def process_multicmds(multicmds):
                     waveform_id=tmp[5],
                     start=float(tmp[6]),
                     stop=float(tmp[7]),
-                    reference_impedance=float(tmp[8]) if len(tmp) == 9 else None,
+                    id=port_id,
+                    spectrum_limit=spectrum_limit,
+                    reference_impedance=(
+                        float(tmp[8])
+                        if len(tmp) == 9
+                        else (float(tmp[10]) if len(tmp) == 11 else None)
+                    ),
                 )
             else:
                 logger.exception(
@@ -218,7 +228,7 @@ def process_multicmds(multicmds):
                     + ": "
                     + " ".join(tmp)
                     + "'"
-                    + " requires six, eight, or nine parameters"
+                    + " requires six, eight, nine, ten, or eleven parameters"
                 )
                 raise ValueError
 
@@ -334,14 +344,19 @@ def process_multicmds(multicmds):
     if multicmds[cmdname] is not None:
         for cmdinstance in multicmds[cmdname]:
             tmp = cmdinstance.split()
-            if len(tmp) == 6:
+            if len(tmp) in (6, 7):
                 frill = MagneticFrillSource(
                     polarisation=tmp[0],
                     p1=(float(tmp[1]), float(tmp[2]), float(tmp[3])),
                     zcoax=float(tmp[4]),
                     waveform_id=tmp[5],
+                    spectrum_limit=(
+                        ("nyquist" if tmp[6].lower() == "nyquist" else float(tmp[6]))
+                        if len(tmp) == 7
+                        else 10
+                    ),
                 )
-            elif len(tmp) == 8:
+            elif len(tmp) in (8, 9):
                 frill = MagneticFrillSource(
                     polarisation=tmp[0],
                     p1=(float(tmp[1]), float(tmp[2]), float(tmp[3])),
@@ -349,11 +364,17 @@ def process_multicmds(multicmds):
                     waveform_id=tmp[5],
                     start=float(tmp[6]),
                     stop=float(tmp[7]),
+                    spectrum_limit=(
+                        ("nyquist" if tmp[8].lower() == "nyquist" else float(tmp[8]))
+                        if len(tmp) == 9
+                        else 10
+                    ),
                 )
             else:
                 raise ValueError(
-                    f"'{cmdname}: {cmdinstance}' requires six parameters, "
-                    "or eight parameters when start and stop times are supplied"
+                    f"'{cmdname}: {cmdinstance}' requires six parameters, optionally "
+                    "followed by a spectrum limit, or eight parameters when start and "
+                    "stop times are supplied, optionally followed by a spectrum limit"
                 )
 
             scene_objects.append(frill)
@@ -650,30 +671,6 @@ def process_multicmds(multicmds):
 
             rx_array = RxArray(p1=p1, p2=p2, dl=dl)
             scene_objects.append(rx_array)
-
-    cmdname = "#rx_port"
-    if multicmds[cmdname] is not None:
-        for cmdinstance in multicmds[cmdname]:
-            tokens = cmdinstance.split()
-            if len(tokens) < 3 or len(tokens) > 5:
-                raise ValueError(
-                    f"'{cmdname}: {cmdinstance}' requires three coordinates, "
-                    "an optional ID and spectrum limit"
-                )
-            kwargs = {}
-            if len(tokens) >= 4:
-                kwargs["id"] = tokens[3]
-            if len(tokens) >= 5:
-                try:
-                    kwargs["spectrum_limit"] = float(tokens[4])
-                except ValueError:
-                    kwargs["spectrum_limit"] = tokens[4].lower()
-            scene_objects.append(
-                RxPort(
-                    p1=tuple(float(value) for value in tokens[:3]),
-                    **kwargs,
-                )
-            )
 
     cmdname = "#network_port"
     if multicmds[cmdname] is not None:

--- a/gprMax/mpi_model.py
+++ b/gprMax/mpi_model.py
@@ -284,35 +284,12 @@ class MPIModel(Model):
                 finalise_transmission_line_ports(self.G)
                 prepare_magnetic_frill_ports(self.G)
                 finalise_magnetic_frill_ports(self.G)
-                self._rebind_mpi_frill_port_owners()
                 if sar_payloads is not None:
                     for monitor, payloads in zip(self.G.sar_monitors, sar_payloads):
                         monitor.finalise_mpi(payloads, self.G.global_size)
                 write_hdf5_outputfile(
                     config.get_model_config().output_file_path_ext, self.title, self
                 )
-
-    def _rebind_mpi_frill_port_owners(self) -> None:
-        """Reconnect coordinator-side ``RxPort.result`` to gathered frills."""
-
-        dl = np.asarray((self.G.dx, self.G.dy, self.G.dz), dtype=np.float64)
-        for owner in self.G.mpi_port_output_owners.values():
-            if getattr(owner, "_monitor", None) is not None:
-                continue
-            if not hasattr(owner, "_frill_source"):
-                continue
-            coordinate = np.rint(np.asarray(owner.point, dtype=np.float64) / dl).astype(np.int32)
-            sources = [
-                source
-                for source in self.G.magneticfrillsources
-                if np.array_equal(source.coord, coordinate)
-            ]
-            if len(sources) != 1:
-                raise RuntimeError(
-                    f"RxPort at {tuple(owner.point)} could not uniquely rebind its MPI "
-                    f"magnetic frill ({len(sources)} source(s))"
-                )
-            owner._frill_source = sources[0]
 
     def _create_grid(self) -> MPIGrid:
         cart_comm = MPI.COMM_WORLD.Create_cart(config.sim_config.mpi)

--- a/gprMax/ntff/interface.py
+++ b/gprMax/ntff/interface.py
@@ -1873,7 +1873,7 @@ def compile_ntff_outputs(model, grid) -> Optional[NTFFCompiledOutputs]:
         ]
         if unmonitored_voltage_sources:
             raise ValueError(
-                "antenna gain requires an #rx_port for every voltage source; "
+                "antenna gain requires an automatic port output for every voltage source; "
                 f"found {len(unmonitored_voltage_sources)} unmonitored source(s)"
             )
 

--- a/gprMax/ports.py
+++ b/gprMax/ports.py
@@ -170,6 +170,53 @@ def _hard_source_gap_admittance(output, frequency, dt, complex_dtype):
     )
 
 
+def _finite_source_gap_admittance(output, frequency, dt, complex_dtype):
+    """Return the background Yee-gap admittance for a resistive source.
+
+    Nondispersive media retain the original bilinear-frequency expression.
+    For a dispersive background, evaluate the material's complete complex
+    permittivity at that same warped frequency. This includes its physical
+    conductivity and every Debye, Lorentz, Drude, or inclusive pole without
+    requiring an additional time-domain current history.
+    """
+
+    frequency = np.asarray(frequency, dtype=np.float64)
+    omega_discrete = (2 / dt) * np.tan(np.pi * frequency * dt)
+    nyquist = np.isclose(
+        frequency * dt,
+        0.5,
+        rtol=0,
+        atol=4 * np.finfo(np.float64).eps,
+    )
+    if not output.background_is_dispersive:
+        admittance = np.asarray(
+            output.background_conductance + 1j * omega_discrete * output.gap_capacitance,
+            dtype=complex_dtype,
+        )
+        # The bilinear frequency is singular at the exact Nyquist bin. Keep
+        # the research frequency axis, but mark this one correction undefined
+        # instead of allowing its enormous floating-point approximation to
+        # influence validity at independent, lower-frequency bins.
+        admittance[nyquist] = np.nan + 1j * np.nan
+        return admittance
+
+    admittance = np.empty(frequency.shape, dtype=np.complex128)
+    zero = frequency == 0
+    admittance[zero] = output.background_conductance
+    positive = ~zero
+    if np.any(positive):
+        effective_frequency = omega_discrete[positive] / (2 * np.pi)
+        epsilon_r = np.asarray(
+            output.background_material.calculate_er(effective_frequency),
+            dtype=np.complex128,
+        )
+        admittance[positive] = (
+            1j * omega_discrete[positive] * config.sim_config.em_consts["e0"] * epsilon_r * output.area / output.dl
+        )
+    admittance[nyquist] = np.nan + 1j * np.nan
+    return np.asarray(admittance, dtype=complex_dtype)
+
+
 def evaluate_port_power_spectrum(
     output,
     grid: "FDTDGrid",
@@ -214,21 +261,15 @@ def evaluate_port_power_spectrum(
         if incident_modal.shape != outgoing_modal.shape:
             raise ValueError(f"eigenmode port {output.output_id!r} has inconsistent modal arrays")
         if incident_modal.shape != (len(output.mode_indices), frequency.size):
-            raise ValueError(
-                f"eigenmode port {output.output_id!r} has inconsistent modal dimensions"
-            )
+            raise ValueError(f"eigenmode port {output.output_id!r} has inconsistent modal dimensions")
         if power_matrix.shape != (
             frequency.size,
             len(output.mode_indices),
             len(output.mode_indices),
         ):
-            raise ValueError(
-                f"eigenmode port {output.output_id!r} has an inconsistent power matrix"
-            )
+            raise ValueError(f"eigenmode port {output.output_id!r} has an inconsistent power matrix")
         if cross_power_matrix.shape != power_matrix.shape:
-            raise ValueError(
-                f"eigenmode port {output.output_id!r} has an inconsistent cross-power matrix"
-            )
+            raise ValueError(f"eigenmode port {output.output_id!r} has an inconsistent cross-power matrix")
 
         accepted_power = np.zeros(frequency.shape, dtype=real_dtype)
         incident_power = np.zeros(frequency.shape, dtype=real_dtype)
@@ -252,20 +293,13 @@ def evaluate_port_power_spectrum(
                 or not np.all(result_valid[physical_modes, frequency_index])
             ):
                 continue
-            if (
-                excitation_position is not None
-                and not power_wave_valid[frequency_index, excitation_position]
-            ):
+            if excitation_position is not None and not power_wave_valid[frequency_index, excitation_position]:
                 continue
 
             incident = incident_modal[physical_modes, frequency_index]
             outgoing = outgoing_modal[physical_modes, frequency_index]
-            physical_power_matrix = power_matrix[frequency_index][
-                np.ix_(physical_modes, physical_modes)
-            ]
-            physical_cross_power_matrix = cross_power_matrix[frequency_index][
-                np.ix_(physical_modes, physical_modes)
-            ]
+            physical_power_matrix = power_matrix[frequency_index][np.ix_(physical_modes, physical_modes)]
+            physical_cross_power_matrix = cross_power_matrix[frequency_index][np.ix_(physical_modes, physical_modes)]
             if not (
                 np.all(np.isfinite(incident))
                 and np.all(np.isfinite(outgoing))
@@ -284,9 +318,7 @@ def evaluate_port_power_spectrum(
             )
             incident_value = 0.0
             if excitation_position is not None:
-                local_excitation_position = int(
-                    np.flatnonzero(physical_modes == excitation_position)[0]
-                )
+                local_excitation_position = int(np.flatnonzero(physical_modes == excitation_position)[0])
                 excitation_amplitude = incident[local_excitation_position]
                 incident_value = np.real(
                     np.conj(excitation_amplitude)
@@ -551,13 +583,8 @@ def model_port_ids(model: "Model") -> tuple[str, ...]:
     references = []
     for grid in (model.G, *model.subgrids):
         local_ids = [monitor.output_id for monitor in getattr(grid, "port_monitors", ())]
-        local_ids.extend(
-            f"tl{index}" for index, _ in enumerate(getattr(grid, "transmissionlines", ()), start=1)
-        )
-        local_ids.extend(
-            f"frill{index}"
-            for index, _ in enumerate(getattr(grid, "magneticfrillsources", ()), start=1)
-        )
+        local_ids.extend(f"tl{index}" for index, _ in enumerate(getattr(grid, "transmissionlines", ()), start=1))
+        local_ids.extend(f"frill{index}" for index, _ in enumerate(getattr(grid, "magneticfrillsources", ()), start=1))
         local_ids.extend(monitor.output_id for monitor in getattr(grid, "eigenmodeports", ()))
         if len(set(local_ids)) != len(local_ids):
             location = "main grid" if grid is model.G else f"subgrid {grid.name!r}"
@@ -601,8 +628,7 @@ def validate_spectrum_limit(value) -> SpectrumLimit:
         raise ValueError("spectrum_limit must be a finite number or 'nyquist'")
     if value < MINIMUM_PHYSICAL_WAVELENGTH_CELLS:
         raise ValueError(
-            "numeric spectrum_limit must be at least "
-            f"{MINIMUM_PHYSICAL_WAVELENGTH_CELLS:g} cells per wavelength"
+            "numeric spectrum_limit must be at least " f"{MINIMUM_PHYSICAL_WAVELENGTH_CELLS:g} cells per wavelength"
         )
     return value
 
@@ -644,14 +670,10 @@ def _complex_relative_permittivity(material, frequencies):
     if not np.any(positive):
         return values
     if hasattr(material, "poles"):
-        values[positive] = np.asarray(
-            material.calculate_er(frequencies[positive]), dtype=np.complex128
-        )
+        values[positive] = np.asarray(material.calculate_er(frequencies[positive]), dtype=np.complex128)
     else:
         omega = 2 * np.pi * frequencies[positive]
-        values[positive] = material.er + material.se / (
-            1j * omega * config.sim_config.em_consts["e0"]
-        )
+        values[positive] = material.er + material.se / (1j * omega * config.sim_config.em_consts["e0"])
     return values
 
 
@@ -664,9 +686,7 @@ def _complex_relative_permeability(material, frequencies):
     positive = ~zero
     if np.any(positive):
         omega = 2 * np.pi * frequencies[positive]
-        values[positive] = material.mr + material.sm / (
-            1j * omega * config.sim_config.em_consts["m0"]
-        )
+        values[positive] = material.mr + material.sm / (1j * omega * config.sim_config.em_consts["m0"])
     return values
 
 
@@ -737,8 +757,12 @@ def _safe_complex_divide(numerator, denominator, complex_dtype):
     denominator = np.asarray(denominator, dtype=complex_dtype)
     magnitude = np.abs(denominator)
     finite_denominator = np.isfinite(denominator)
-    scale = float(np.max(magnitude[finite_denominator], initial=0.0))
-    threshold = np.finfo(np.empty((), dtype=complex_dtype).real.dtype).eps * scale
+    # Every element is an independent frequency/port quotient. A global
+    # maximum is unsuitable here: one very large (for example near-Nyquist)
+    # denominator can otherwise invalidate ordinary O(1) denominators at all
+    # other frequencies. Retain every finite, representable research value;
+    # source/mesh reliability is described by separate validity masks.
+    threshold = np.finfo(np.empty((), dtype=complex_dtype).real.dtype).tiny
     defined = finite_denominator & (magnitude > threshold)
     result = np.full(numerator.shape, np.nan + 1j * np.nan, dtype=complex_dtype)
     np.divide(numerator, denominator, out=result, where=defined)
@@ -909,23 +933,15 @@ class RationalNetworkPortOutput:
         self.result: Optional[RationalNetworkPortResult] = None
         self.prepared = False
         self.minimum_wavelength_cells = (
-            DEFAULT_MINIMUM_WAVELENGTH_CELLS
-            if self.spectrum_limit == "nyquist"
-            else float(self.spectrum_limit)
+            DEFAULT_MINIMUM_WAVELENGTH_CELLS if self.spectrum_limit == "nyquist" else float(self.spectrum_limit)
         )
-        self.spectrum_limit_mode = (
-            "nyquist" if self.spectrum_limit == "nyquist" else "minimum_wavelength_cells"
-        )
+        self.spectrum_limit_mode = "nyquist" if self.spectrum_limit == "nyquist" else "minimum_wavelength_cells"
         self.incident_floor_db = DEFAULT_INCIDENT_FLOOR_DB
 
     def rebind_after_mpi_gather(self, grid: "FDTDGrid") -> None:
         """Reconnect the gathered output to its coordinator-side terminal."""
 
-        terminals = [
-            terminal
-            for terminal in getattr(grid, "networkterminals", ())
-            if terminal.ID == self.output_id
-        ]
+        terminals = [terminal for terminal in getattr(grid, "networkterminals", ()) if terminal.ID == self.output_id]
         if len(terminals) != 1:
             raise RuntimeError(
                 f"NetworkPort {self.output_id!r} could not uniquely rebind its MPI "
@@ -945,23 +961,16 @@ class RationalNetworkPortOutput:
         if not self.terminal.prepared:
             self.terminal.prepare(grid)
         if not np.isfinite(self.reference_impedance) or self.reference_impedance <= 0:
-            raise ValueError(
-                f"network port {self.output_id!r} requires a finite, positive reference impedance"
-            )
+            raise ValueError(f"network port {self.output_id!r} requires a finite, positive reference impedance")
         if grid.iterations < 2:
             raise ValueError(f"network port {self.output_id!r} requires at least two iterations")
 
         self.dl = float(self.terminal.dl)
         self.area = float(self.terminal.area)
-        self.background_relative_permittivity = float(
-            self.terminal.background_relative_permittivity
-        )
+        self.background_relative_permittivity = float(self.terminal.background_relative_permittivity)
         self.background_conductivity = float(self.terminal.background_conductivity)
         self.gap_capacitance = (
-            config.sim_config.em_consts["e0"]
-            * self.background_relative_permittivity
-            * self.area
-            / self.dl
+            config.sim_config.em_consts["e0"] * self.background_relative_permittivity * self.area / self.dl
         )
         self.background_conductance = self.background_conductivity * self.area / self.dl
 
@@ -976,9 +985,7 @@ class RationalNetworkPortOutput:
         else:
             last_mesh_index = full_frequency.size - 1
             limiting_index = last_mesh_index
-        self._frequency_slice = (
-            slice(None) if self.spectrum_limit_mode == "nyquist" else slice(0, last_mesh_index + 1)
-        )
+        self._frequency_slice = slice(None) if self.spectrum_limit_mode == "nyquist" else slice(0, last_mesh_index + 1)
         self._full_cells_per_wavelength = cells
         self._full_mesh_valid = mesh_valid_full
         self.nyquist_frequency = float(1 / (2 * grid.dt))
@@ -987,9 +994,7 @@ class RationalNetworkPortOutput:
         self.independent_frequency_resolution = float(1 / (grid.iterations * grid.dt))
         self.dt = float(grid.dt)
         if hasattr(grid, "local_to_global"):
-            self.source_position = np.asarray(
-                grid.local_to_global(self.terminal.coord), dtype=np.float64
-            )
+            self.source_position = np.asarray(grid.local_to_global(self.terminal.coord), dtype=np.float64)
         else:
             self.source_position = np.asarray(
                 self.terminal.coord * np.asarray((grid.dx, grid.dy, grid.dz)),
@@ -1018,13 +1023,9 @@ class RationalNetworkPortOutput:
             dtype=real_dtype,
         )
 
-        frequency_full, total_voltage_full = engineering_rfft(
-            total_voltage, grid.dt, time_offset=0.5 * grid.dt
-        )
+        frequency_full, total_voltage_full = engineering_rfft(total_voltage, grid.dt, time_offset=0.5 * grid.dt)
         _, generator_full = engineering_rfft(generator_voltage, grid.dt, time_offset=0.5 * grid.dt)
-        _, network_current_full = engineering_rfft(
-            network_current, grid.dt, time_offset=0.5 * grid.dt
-        )
+        _, network_current_full = engineering_rfft(network_current, grid.dt, time_offset=0.5 * grid.dt)
         selection = self._frequency_slice
         frequency = frequency_full[selection]
         total_spectrum = total_voltage_full[selection]
@@ -1070,9 +1071,7 @@ class RationalNetworkPortOutput:
             else np.zeros(frequency.shape, dtype=bool)
         )
         mesh_valid = np.asarray(self._full_mesh_valid[selection], dtype=bool)
-        cells_per_wavelength = np.asarray(
-            self._full_cells_per_wavelength[selection], dtype=real_dtype
-        )
+        cells_per_wavelength = np.asarray(self._full_cells_per_wavelength[selection], dtype=real_dtype)
         nyquist = np.isclose(
             frequency,
             1 / (2 * grid.dt),
@@ -1162,9 +1161,7 @@ class RationalNetworkPortOutput:
         group.attrs["NyquistFrequency"] = self.nyquist_frequency
         group.attrs["LimitingMaterial"] = self.limiting_material
         group.attrs["IndependentFrequencyResolution"] = self.independent_frequency_resolution
-        group.attrs["FrequencyRange"] = np.asarray(
-            (result.frequency[0], result.frequency[-1]), dtype=real_dtype
-        )
+        group.attrs["FrequencyRange"] = np.asarray((result.frequency[0], result.frequency[-1]), dtype=real_dtype)
         valid_indices = np.flatnonzero(result.valid_s11)
         valid_range = (
             (result.frequency[valid_indices[0]], result.frequency[valid_indices[-1]])
@@ -1177,12 +1174,8 @@ class RationalNetworkPortOutput:
         group.attrs["forward_transform_sign"] = FORWARD_TRANSFORM_KERNEL
         group.attrs["real_dtype"] = real_dtype.name
         group.attrs["complex_dtype"] = complex_dtype.name
-        group.create_dataset(
-            "poles", data=np.asarray(self.terminal.model.poles, dtype=complex_dtype)
-        )
-        group.create_dataset(
-            "residues", data=np.asarray(self.terminal.model.residues, dtype=complex_dtype)
-        )
+        group.create_dataset("poles", data=np.asarray(self.terminal.model.poles, dtype=complex_dtype))
+        group.create_dataset("residues", data=np.asarray(self.terminal.model.residues, dtype=complex_dtype))
         datasets = {
             "time": result.time,
             "Vgenerator": result.generator_voltage,
@@ -1237,13 +1230,9 @@ class VoltageSourcePortMonitor:
         self.prepared = False
 
         self.minimum_wavelength_cells = (
-            DEFAULT_MINIMUM_WAVELENGTH_CELLS
-            if spectrum_limit == "nyquist"
-            else float(spectrum_limit)
+            DEFAULT_MINIMUM_WAVELENGTH_CELLS if spectrum_limit == "nyquist" else float(spectrum_limit)
         )
-        self.spectrum_limit_mode = (
-            "nyquist" if spectrum_limit == "nyquist" else "minimum_wavelength_cells"
-        )
+        self.spectrum_limit_mode = "nyquist" if spectrum_limit == "nyquist" else "minimum_wavelength_cells"
         self.incident_floor_db = DEFAULT_INCIDENT_FLOOR_DB
 
     @property
@@ -1272,18 +1261,16 @@ class VoltageSourcePortMonitor:
         receivers = [
             receiver
             for receiver in grid.rxs
-            if getattr(receiver, "internal", False)
-            and getattr(receiver, "port_id", None) == self.output_id
+            if getattr(receiver, "internal", False) and getattr(receiver, "port_id", None) == self.output_id
         ]
         sources = [
             source
             for source in grid.voltagesources
-            if source.polarisation == self.source.polarisation
-            and np.array_equal(source.coord, self.source.coord)
+            if source.polarisation == self.source.polarisation and np.array_equal(source.coord, self.source.coord)
         ]
         if len(receivers) != 1 or len(sources) != 1:
             raise RuntimeError(
-                f"RxPort {self.output_id!r} could not uniquely rebind its MPI "
+                f"Voltage-source port {self.output_id!r} could not uniquely rebind its MPI "
                 f"receiver/source ({len(receivers)} receiver(s), {len(sources)} source(s))"
             )
         self.receiver = receivers[0]
@@ -1309,9 +1296,9 @@ class VoltageSourcePortMonitor:
         """Validate the built Yee edge and calculate fixed port parameters."""
 
         if grid.iterations < 2:
-            raise ValueError(f"RxPort {self.output_id!r} requires at least two iterations")
+            raise ValueError(f"Voltage-source port {self.output_id!r} requires at least two iterations")
         if not np.array_equal(self.receiver.coord, self.source.coord):
-            raise ValueError(f"RxPort {self.output_id!r} receiver is no longer source-bound")
+            raise ValueError(f"Voltage-source port {self.output_id!r} receiver is no longer source-bound")
         self.hard_source = self.source.resistance == 0
         if self.hard_source:
             component_id = f"E{self.source.polarisation}"
@@ -1334,28 +1321,29 @@ class VoltageSourcePortMonitor:
             self.source.background_is_dispersive = hasattr(material, "poles")
             self.source.source_material_numID = material_num_id
         elif getattr(self.source, "background_material_numID", None) is None:
-            raise ValueError(f"RxPort {self.output_id!r} source material was not constructed")
-        if getattr(self.source, "background_is_dispersive", False):
+            raise ValueError(f"Voltage-source port {self.output_id!r} source material was not constructed")
+        self.background_is_dispersive = bool(getattr(self.source, "background_is_dispersive", False))
+        self.background_material = next(
+            item for item in grid.materials if item.numID == int(self.source.background_material_numID)
+        )
+        if self.hard_source and self.background_is_dispersive:
             raise ValueError(
-                f"RxPort {self.output_id!r} does not yet support a dispersive material "
-                "on the voltage-source edge"
+                f"Voltage-source port {self.output_id!r} does not yet support a hard source "
+                "on a dispersive material edge"
             )
 
         self.dl, self.area = self._edge_geometry(grid)
         self.reference_impedance = float(self.source.reference_impedance)
         if not np.isfinite(self.reference_impedance) or self.reference_impedance <= 0:
             raise ValueError(
-                f"RxPort {self.output_id!r} requires a finite, positive " "reference impedance"
+                f"Voltage-source port {self.output_id!r} requires a finite, positive " "reference impedance"
             )
         self.background_relative_permittivity = float(self.source.background_er)
         self.background_conductivity = float(self.source.background_se)
         if not np.isfinite(self.background_conductivity):
-            raise ValueError(f"RxPort {self.output_id!r} cannot use a voltage source on a PEC edge")
+            raise ValueError(f"Voltage-source port {self.output_id!r} cannot use a voltage source on a PEC edge")
         self.gap_capacitance = (
-            config.sim_config.em_consts["e0"]
-            * self.background_relative_permittivity
-            * self.area
-            / self.dl
+            config.sim_config.em_consts["e0"] * self.background_relative_permittivity * self.area / self.dl
         )
         self.background_conductance = self.background_conductivity * self.area / self.dl
 
@@ -1363,9 +1351,7 @@ class VoltageSourcePortMonitor:
         source_material = grid.materials[source_material_id]
         dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
         if not self.hard_source:
-            added_conductance = (
-                (float(source_material.se) - self.background_conductivity) * self.area / self.dl
-            )
+            added_conductance = (float(source_material.se) - self.background_conductivity) * self.area / self.dl
             tolerance = 64 * np.finfo(dtype).eps
             if not np.isclose(
                 added_conductance,
@@ -1374,19 +1360,15 @@ class VoltageSourcePortMonitor:
                 atol=tolerance / self.reference_impedance,
             ):
                 raise ValueError(
-                    f"RxPort {self.output_id!r} source-edge conductance is inconsistent "
+                    f"Voltage-source port {self.output_id!r} source-edge conductance is inconsistent "
                     "with its source resistance"
                 )
             if not np.isfinite(grid.updatecoeffsE[source_material_id, 4]) or np.isclose(
                 grid.updatecoeffsE[source_material_id, 4], 0
             ):
-                raise ValueError(
-                    f"RxPort {self.output_id!r} source is on an inactive electric edge"
-                )
+                raise ValueError(f"Voltage-source port {self.output_id!r} source is on an inactive electric edge")
         elif f"I{self.source.polarisation}" not in self.receiver.outputs:
-            raise ValueError(
-                f"RxPort {self.output_id!r} hard source has no terminal-current samples"
-            )
+            raise ValueError(f"Voltage-source port {self.output_id!r} hard source has no terminal-current samples")
 
         nsamples = grid.iterations - 1
         self.aligned_samples = nsamples
@@ -1412,7 +1394,7 @@ class VoltageSourcePortMonitor:
             self._frequency_slice = slice(None)
             log = logger.warning
             message = (
-                f"RxPort {self.output_id!r}: full native spectrum 0--"
+                f"Voltage-source port {self.output_id!r}: full native spectrum 0--"
                 f"{full_frequency[-1]:g} Hz requested (Nyquist research override); "
                 f"advisory lambda/{self.minimum_wavelength_cells:g} limit "
                 f"{self.mesh_frequency_limit:g} Hz in material "
@@ -1422,7 +1404,7 @@ class VoltageSourcePortMonitor:
             self._frequency_slice = slice(0, last_mesh_index + 1)
             log = logger.info
             message = (
-                f"RxPort {self.output_id!r}: spectrum 0--"
+                f"Voltage-source port {self.output_id!r}: spectrum 0--"
                 f"{self.mesh_frequency_limit:g} Hz, lambda/"
                 f"{self.minimum_wavelength_cells:g} mesh limit in material "
                 f"{self.limiting_material!r}; native df "
@@ -1441,29 +1423,23 @@ class VoltageSourcePortMonitor:
         if self.hard_source:
             return self._finalise_hard_source(grid)
         if not np.array_equal(self.receiver.coord, self.source.coord):
-            raise RuntimeError(f"RxPort {self.output_id!r} receiver moved away from its source")
+            raise RuntimeError(f"Voltage-source port {self.output_id!r} receiver moved away from its source")
 
         real_dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
         complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
         electric = np.asarray(self.receiver.outputs[self.component], dtype=real_dtype)
         if electric.size != grid.iterations:
-            raise RuntimeError(f"RxPort {self.output_id!r} receiver history has the wrong length")
+            raise RuntimeError(f"Voltage-source port {self.output_id!r} receiver history has the wrong length")
 
         integer_voltage = np.asarray(-self.dl * electric, dtype=real_dtype)
-        total_voltage = np.asarray(
-            0.5 * (integer_voltage[:-1] + integer_voltage[1:]), dtype=real_dtype
-        )
-        generator_voltage = np.asarray(
-            self.source.waveformvalues_halfdt[: total_voltage.size], dtype=real_dtype
-        )
+        total_voltage = np.asarray(0.5 * (integer_voltage[:-1] + integer_voltage[1:]), dtype=real_dtype)
+        generator_voltage = np.asarray(self.source.waveformvalues_halfdt[: total_voltage.size], dtype=real_dtype)
         time = np.asarray(
             (np.arange(total_voltage.size, dtype=real_dtype) + real_dtype.type(0.5)) * grid.dt,
             dtype=real_dtype,
         )
 
-        frequency_full, total_spectrum_full = engineering_rfft(
-            total_voltage, grid.dt, time_offset=0.5 * grid.dt
-        )
+        frequency_full, total_spectrum_full = engineering_rfft(total_voltage, grid.dt, time_offset=0.5 * grid.dt)
         generator_frequency, generator_spectrum_full = engineering_rfft(
             generator_voltage, grid.dt, time_offset=0.5 * grid.dt
         )
@@ -1476,9 +1452,7 @@ class VoltageSourcePortMonitor:
         generator_spectrum = generator_spectrum_full[selection]
         incident_spectrum = np.asarray(0.5 * generator_spectrum, dtype=complex_dtype)
         reflected_source = np.asarray(total_spectrum - incident_spectrum, dtype=complex_dtype)
-        s11_source, source_defined = _safe_complex_divide(
-            reflected_source, incident_spectrum, complex_dtype
-        )
+        s11_source, source_defined = _safe_complex_divide(reflected_source, incident_spectrum, complex_dtype)
 
         incident_magnitude = np.abs(incident_spectrum)
         incident_peak = float(np.max(incident_magnitude, initial=0.0))
@@ -1490,18 +1464,18 @@ class VoltageSourcePortMonitor:
             )
         source_valid = source_defined & (incident_relative_db >= self.incident_floor_db)
 
-        omega_discrete = (2 / grid.dt) * np.tan(np.pi * frequency * grid.dt)
+        gap_admittance = _finite_source_gap_admittance(
+            self,
+            frequency,
+            grid.dt,
+            complex_dtype,
+        )
         gap_correction = np.asarray(
-            self.reference_impedance
-            * (self.background_conductance + 1j * omega_discrete * self.gap_capacitance),
+            self.reference_impedance * gap_admittance,
             dtype=complex_dtype,
         )
-        s11, gap_correction_valid = correct_s11_for_parallel_gap(
-            s11_source, gap_correction, complex_dtype
-        )
-        exact_nyquist_included = (
-            self.aligned_samples % 2 == 0 and frequency.size == frequency_full.size
-        )
+        s11, gap_correction_valid = correct_s11_for_parallel_gap(s11_source, gap_correction, complex_dtype)
+        exact_nyquist_included = self.aligned_samples % 2 == 0 and frequency.size == frequency_full.size
         if self.gap_capacitance != 0 and exact_nyquist_included:
             gap_correction_valid[-1] = False
             s11[-1] = np.nan + 1j * np.nan
@@ -1511,9 +1485,7 @@ class VoltageSourcePortMonitor:
         yin, yin_defined = admittance_from_s11(s11, self.reference_impedance, complex_dtype)
 
         mesh_valid = np.asarray(self._full_mesh_valid[selection], dtype=bool)
-        cells_per_wavelength = np.asarray(
-            self._full_cells_per_wavelength[selection], dtype=real_dtype
-        )
+        cells_per_wavelength = np.asarray(self._full_cells_per_wavelength[selection], dtype=real_dtype)
         valid_s11 = mesh_valid & source_valid & gap_correction_valid
         valid_zin = valid_s11 & zin_defined
         valid_yin = valid_s11 & yin_defined
@@ -1529,13 +1501,13 @@ class VoltageSourcePortMonitor:
             tail_relative_db = float("nan")
         if np.isfinite(tail_relative_db) and tail_relative_db > -40:
             logger.warning(
-                f"RxPort {self.output_id!r}: the final 5% of the voltage trace "
+                f"Voltage-source port {self.output_id!r}: the final 5% of the voltage trace "
                 f"reaches {tail_relative_db:.1f} dB relative to its peak; spectral "
                 "leakage may be significant."
             )
         if np.isfinite(tail_relative_db) and tail_relative_db > -40:
             logger.warning(
-                f"RxPort {self.output_id!r}: the final 5% of the voltage trace "
+                f"Voltage-source port {self.output_id!r}: the final 5% of the voltage trace "
                 f"reaches {tail_relative_db:.1f} dB relative to its peak; spectral "
                 "leakage may be significant."
             )
@@ -1576,14 +1548,14 @@ class VoltageSourcePortMonitor:
         """Derive a delta-gap port from prescribed voltage and loop current."""
 
         if not np.array_equal(self.receiver.coord, self.source.coord):
-            raise RuntimeError(f"RxPort {self.output_id!r} receiver moved away from its source")
+            raise RuntimeError(f"Voltage-source port {self.output_id!r} receiver moved away from its source")
 
         real_dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
         complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
         electric = np.asarray(self.receiver.outputs[self.component], dtype=real_dtype)
         loop_half = self._hard_loop_current_history(real_dtype)
         if electric.size != grid.iterations or loop_half.size != grid.iterations:
-            raise RuntimeError(f"RxPort {self.output_id!r} receiver history has the wrong length")
+            raise RuntimeError(f"Voltage-source port {self.output_id!r} receiver history has the wrong length")
 
         # At receiver-storage index m, E is at m*dt and H is at
         # (m-1/2)*dt. Drop the unexcited initial fields so each retained pair
@@ -1625,9 +1597,7 @@ class VoltageSourcePortMonitor:
             grid.dt,
             complex_dtype,
         )
-        terminal_current = np.asarray(
-            loop_spectrum - gap_admittance * total_spectrum, dtype=complex_dtype
-        )
+        terminal_current = np.asarray(loop_spectrum - gap_admittance * total_spectrum, dtype=complex_dtype)
 
         incident_source = np.asarray(
             0.5 * (total_spectrum + self.reference_impedance * loop_spectrum),
@@ -1645,15 +1615,9 @@ class VoltageSourcePortMonitor:
             0.5 * (total_spectrum - self.reference_impedance * terminal_current),
             dtype=complex_dtype,
         )
-        s11_source, source_plane_defined = _safe_complex_divide(
-            reflected_source, incident_source, complex_dtype
-        )
-        s11, terminal_wave_defined = _safe_complex_divide(
-            reflected_terminal, incident_spectrum, complex_dtype
-        )
-        zin_source, zin_source_defined = _safe_complex_divide(
-            total_spectrum, loop_spectrum, complex_dtype
-        )
+        s11_source, source_plane_defined = _safe_complex_divide(reflected_source, incident_source, complex_dtype)
+        s11, terminal_wave_defined = _safe_complex_divide(reflected_terminal, incident_spectrum, complex_dtype)
+        zin_source, zin_source_defined = _safe_complex_divide(total_spectrum, loop_spectrum, complex_dtype)
         zin, zin_defined = _safe_complex_divide(total_spectrum, terminal_current, complex_dtype)
         yin, yin_defined = _safe_complex_divide(terminal_current, total_spectrum, complex_dtype)
 
@@ -1672,9 +1636,7 @@ class VoltageSourcePortMonitor:
         gap_correction_valid = np.ones(frequency.shape, dtype=bool)
 
         mesh_valid = np.asarray(self._full_mesh_valid[selection], dtype=bool)
-        cells_per_wavelength = np.asarray(
-            self._full_cells_per_wavelength[selection], dtype=real_dtype
-        )
+        cells_per_wavelength = np.asarray(self._full_cells_per_wavelength[selection], dtype=real_dtype)
         source_plane_valid = source_plane_defined & zin_source_defined
         valid_s11 = mesh_valid & source_valid & gap_correction_valid
         valid_zin = valid_s11 & zin_defined
@@ -1724,7 +1686,7 @@ class VoltageSourcePortMonitor:
         """Write the finalised port result beneath ``/ports/<ID>``."""
 
         if self.result is None:
-            raise RuntimeError(f"RxPort {self.output_id!r} has not been finalised")
+            raise RuntimeError(f"Voltage-source port {self.output_id!r} has not been finalised")
         result = self.result
         ports_group = base_group.require_group("ports")
         group = ports_group.create_group(self.output_id)
@@ -1748,9 +1710,7 @@ class VoltageSourcePortMonitor:
         group.attrs["GapCapacitance"] = self.gap_capacitance
         group.attrs["BackgroundConductance"] = self.background_conductance
         group.attrs["GapCorrection"] = "discrete_parallel_admittance"
-        group.attrs["TimeSampleOffset"] = (
-            self.hard_voltage_time_offset if self.hard_source else 0.5 * self.dt
-        )
+        group.attrs["TimeSampleOffset"] = self.hard_voltage_time_offset if self.hard_source else 0.5 * self.dt
         if self.hard_source:
             group.attrs["CurrentTimeSampleOffset"] = self.hard_current_time_offset
             group.attrs["CurrentTimeAlignment"] = "explicit_fft_half_step_phase"
@@ -1762,9 +1722,7 @@ class VoltageSourcePortMonitor:
         group.attrs["MeshFrequencyLimit"] = self.mesh_frequency_limit
         group.attrs["LimitingMaterial"] = self.limiting_material
         group.attrs["IndependentFrequencyResolution"] = self.independent_frequency_resolution
-        group.attrs["FrequencyRange"] = np.asarray(
-            (result.frequency[0], result.frequency[-1]), dtype=real_dtype
-        )
+        group.attrs["FrequencyRange"] = np.asarray((result.frequency[0], result.frequency[-1]), dtype=real_dtype)
         valid_indices = np.flatnonzero(result.valid_s11)
         valid_range = (
             (result.frequency[valid_indices[0]], result.frequency[valid_indices[-1]])
@@ -1819,9 +1777,7 @@ class VoltageSourcePortMonitor:
 
         self.grid_dl = np.asarray((grid.dx, grid.dy, grid.dz), dtype=np.float64)
         if hasattr(grid, "local_to_global"):
-            self.source_position = np.asarray(
-                grid.local_to_global(self.source.coord), dtype=np.float64
-            )
+            self.source_position = np.asarray(grid.local_to_global(self.source.coord), dtype=np.float64)
         else:
             self.source_position = np.asarray(self.source.coord * self.grid_dl, dtype=np.float64)
         self.dt = float(grid.dt)
@@ -1882,13 +1838,9 @@ class TransmissionLinePortOutput:
         self.result: Optional[TransmissionLinePortResult] = None
         self.prepared = False
         self.minimum_wavelength_cells = (
-            DEFAULT_MINIMUM_WAVELENGTH_CELLS
-            if self.spectrum_limit == "nyquist"
-            else float(self.spectrum_limit)
+            DEFAULT_MINIMUM_WAVELENGTH_CELLS if self.spectrum_limit == "nyquist" else float(self.spectrum_limit)
         )
-        self.spectrum_limit_mode = (
-            "nyquist" if self.spectrum_limit == "nyquist" else "minimum_wavelength_cells"
-        )
+        self.spectrum_limit_mode = "nyquist" if self.spectrum_limit == "nyquist" else "minimum_wavelength_cells"
         self.incident_floor_db = DEFAULT_INCIDENT_FLOOR_DB
 
     @property
@@ -1899,9 +1851,7 @@ class TransmissionLinePortOutput:
         """Calculate the native frequency axis and mesh-valid output band."""
 
         if grid.iterations < 2:
-            raise ValueError(
-                f"Transmission line {self.output_id!r} requires at least two iterations"
-            )
+            raise ValueError(f"Transmission line {self.output_id!r} requires at least two iterations")
         if not np.isfinite(self.source.resistance) or self.source.resistance <= 0:
             raise ValueError(f"Transmission line {self.output_id!r} has an invalid resistance")
         if not np.isfinite(self.source.dl) or self.source.dl <= 0:
@@ -1979,26 +1929,18 @@ class TransmissionLinePortOutput:
         for name in ("Vinc", "Iinc", "Vtotal", "Itotal"):
             values = np.asarray(getattr(self.source, name), dtype=real_dtype)
             if values.ndim != 1 or values.size < self.nsamples:
-                raise RuntimeError(
-                    f"Transmission line {self.output_id!r} {name} history has " "the wrong length"
-                )
+                raise RuntimeError(f"Transmission line {self.output_id!r} {name} history has " "the wrong length")
             values = values[: self.nsamples]
             if not np.all(np.isfinite(values)):
-                raise RuntimeError(
-                    f"Transmission line {self.output_id!r} {name} history is not finite"
-                )
+                raise RuntimeError(f"Transmission line {self.output_id!r} {name} history is not finite")
             histories[name] = values
 
         frequency_full, incident_voltage_full = engineering_rfft(histories["Vinc"], grid.dt)
         _, total_voltage_full = engineering_rfft(histories["Vtotal"], grid.dt)
         # Index n stores I at (n - 1/2) dt. Applying the physical sample-time
         # offset here preserves all N samples and the voltage FFT grid.
-        _, incident_current_full = engineering_rfft(
-            histories["Iinc"], grid.dt, time_offset=-0.5 * grid.dt
-        )
-        _, total_current_full = engineering_rfft(
-            histories["Itotal"], grid.dt, time_offset=-0.5 * grid.dt
-        )
+        _, incident_current_full = engineering_rfft(histories["Iinc"], grid.dt, time_offset=-0.5 * grid.dt)
+        _, total_current_full = engineering_rfft(histories["Itotal"], grid.dt, time_offset=-0.5 * grid.dt)
 
         selection = self._frequency_slice
         frequency = frequency_full[selection]
@@ -2007,9 +1949,7 @@ class TransmissionLinePortOutput:
         incident_current = incident_current_full[selection]
         total_current = total_current_full[selection]
         reflected_voltage = np.asarray(total_voltage - incident_voltage, dtype=complex_dtype)
-        s11, source_defined = _safe_complex_divide(
-            reflected_voltage, incident_voltage, complex_dtype
-        )
+        s11, source_defined = _safe_complex_divide(reflected_voltage, incident_voltage, complex_dtype)
 
         incident_magnitude = np.abs(incident_voltage)
         incident_peak = float(np.max(incident_magnitude, initial=0.0))
@@ -2035,28 +1975,21 @@ class TransmissionLinePortOutput:
         reflected_from_current = np.full(frequency.shape, np.nan + 1j * np.nan, dtype=complex_dtype)
         inverse_half_cell_phase = np.conj(half_cell_phase)
         reflected_from_current[line_propagation_valid] = (
-            incident_voltage[line_propagation_valid]
-            * inverse_half_cell_phase[line_propagation_valid]
+            incident_voltage[line_propagation_valid] * inverse_half_cell_phase[line_propagation_valid]
             - self.reference_impedance * total_current[line_propagation_valid]
         ) * inverse_half_cell_phase[line_propagation_valid]
-        s11_current, s11_current_defined = _safe_complex_divide(
-            reflected_from_current, incident_voltage, complex_dtype
-        )
+        s11_current, s11_current_defined = _safe_complex_divide(reflected_from_current, incident_voltage, complex_dtype)
         terminal_current = np.asarray(
             (incident_voltage - reflected_from_current) / self.reference_impedance,
             dtype=complex_dtype,
         )
-        terminal_voltage_current = np.asarray(
-            incident_voltage + reflected_from_current, dtype=complex_dtype
-        )
+        terminal_voltage_current = np.asarray(incident_voltage + reflected_from_current, dtype=complex_dtype)
         zin_current, zin_current_defined = _safe_complex_divide(
             terminal_voltage_current, terminal_current, complex_dtype
         )
 
         mesh_valid = np.asarray(self._full_mesh_valid[selection], dtype=bool)
-        cells_per_wavelength = np.asarray(
-            self._full_cells_per_wavelength[selection], dtype=real_dtype
-        )
+        cells_per_wavelength = np.asarray(self._full_cells_per_wavelength[selection], dtype=real_dtype)
         valid_s11 = mesh_valid & source_valid
         valid_zin = valid_s11 & zin_defined
         valid_yin = valid_s11 & yin_defined
@@ -2141,9 +2074,7 @@ class TransmissionLinePortOutput:
         group.attrs["MeshFrequencyLimit"] = self.mesh_frequency_limit
         group.attrs["LimitingMaterial"] = self.limiting_material
         group.attrs["IndependentFrequencyResolution"] = self.independent_frequency_resolution
-        group.attrs["FrequencyRange"] = np.asarray(
-            (result.frequency[0], result.frequency[-1]), dtype=real_dtype
-        )
+        group.attrs["FrequencyRange"] = np.asarray((result.frequency[0], result.frequency[-1]), dtype=real_dtype)
         valid_indices = np.flatnonzero(result.valid_s11)
         valid_range = (
             (result.frequency[valid_indices[0]], result.frequency[valid_indices[-1]])
@@ -2215,25 +2146,6 @@ def finalise_transmission_line_ports(grid: "FDTDGrid") -> None:
 
 
 @dataclass(frozen=True)
-class RxPortOverride:
-    """Marker left on a ``MagneticFrillSource`` by ``RxPort.build()``.
-
-    Unlike a voltage source, a magnetic-frill source's S11/Zin/Yin output is
-    always on (built by ``prepare_magnetic_frill_ports`` regardless of
-    whether ``#rx_port`` is present) - so ``#rx_port`` paired with this
-    source type does not create a second, independent monitor. It only
-    overrides the ``spectrum_limit`` of that always-on output, consumed once
-    ``prepare_magnetic_frill_ports`` constructs the real
-    ``MagneticFrillPortOutput`` object (which does not exist yet at the point
-    ``RxPort.build()`` itself runs - see ``gprMax/model.py``'s build
-    sequencing).
-    """
-
-    spectrum_limit: SpectrumLimit
-    owner: object
-
-
-@dataclass(frozen=True)
 class MagneticFrillPortResult:
     """Final time- and frequency-domain result for one magnetic-frill source."""
 
@@ -2279,13 +2191,9 @@ class MagneticFrillPortOutput:
         self.result: Optional[MagneticFrillPortResult] = None
         self.prepared = False
         self.minimum_wavelength_cells = (
-            DEFAULT_MINIMUM_WAVELENGTH_CELLS
-            if self.spectrum_limit == "nyquist"
-            else float(self.spectrum_limit)
+            DEFAULT_MINIMUM_WAVELENGTH_CELLS if self.spectrum_limit == "nyquist" else float(self.spectrum_limit)
         )
-        self.spectrum_limit_mode = (
-            "nyquist" if self.spectrum_limit == "nyquist" else "minimum_wavelength_cells"
-        )
+        self.spectrum_limit_mode = "nyquist" if self.spectrum_limit == "nyquist" else "minimum_wavelength_cells"
         self.incident_floor_db = DEFAULT_INCIDENT_FLOOR_DB
 
     @property
@@ -2296,9 +2204,7 @@ class MagneticFrillPortOutput:
         """Calculate the native frequency axis and mesh-valid output band."""
 
         if grid.iterations < 2:
-            raise ValueError(
-                f"Magnetic frill source {self.output_id!r} requires at least two iterations"
-            )
+            raise ValueError(f"Magnetic frill source {self.output_id!r} requires at least two iterations")
         if not np.isfinite(self.source.Z0) or self.source.Z0 <= 0:
             raise ValueError(f"Magnetic frill source {self.output_id!r} has an invalid Z0")
 
@@ -2358,29 +2264,18 @@ class MagneticFrillPortOutput:
         for name in ("Vinc", "Vtotal", "Itot"):
             values = np.asarray(getattr(self.source, name), dtype=real_dtype)
             if values.ndim != 1 or values.size < self.nsamples:
-                raise RuntimeError(
-                    f"Magnetic frill source {self.output_id!r} {name} history "
-                    "has the wrong length"
-                )
+                raise RuntimeError(f"Magnetic frill source {self.output_id!r} {name} history " "has the wrong length")
             values = values[: self.nsamples]
             if not np.all(np.isfinite(values)):
-                raise RuntimeError(
-                    f"Magnetic frill source {self.output_id!r} {name} history is not finite"
-                )
+                raise RuntimeError(f"Magnetic frill source {self.output_id!r} {name} history is not finite")
             histories[name] = values
 
         # Hyun equations (9)-(11): voltage is at integer time and Itot is
         # averaged from the adjacent magnetic half steps to the same time.
         time_offset = 0.0
-        frequency_full, incident_voltage_full = engineering_rfft(
-            histories["Vinc"], grid.dt, time_offset=time_offset
-        )
-        _, total_voltage_full = engineering_rfft(
-            histories["Vtotal"], grid.dt, time_offset=time_offset
-        )
-        _, total_current_full = engineering_rfft(
-            histories["Itot"], grid.dt, time_offset=time_offset
-        )
+        frequency_full, incident_voltage_full = engineering_rfft(histories["Vinc"], grid.dt, time_offset=time_offset)
+        _, total_voltage_full = engineering_rfft(histories["Vtotal"], grid.dt, time_offset=time_offset)
+        _, total_current_full = engineering_rfft(histories["Itot"], grid.dt, time_offset=time_offset)
 
         selection = self._frequency_slice
         frequency = frequency_full[selection]
@@ -2388,9 +2283,7 @@ class MagneticFrillPortOutput:
         total_voltage = total_voltage_full[selection]
         total_current = total_current_full[selection]
         reflected_voltage = np.asarray(total_voltage - incident_voltage, dtype=complex_dtype)
-        s11, source_defined = _safe_complex_divide(
-            reflected_voltage, incident_voltage, complex_dtype
-        )
+        s11, source_defined = _safe_complex_divide(reflected_voltage, incident_voltage, complex_dtype)
 
         incident_magnitude = np.abs(incident_voltage)
         incident_peak = float(np.max(incident_magnitude, initial=0.0))
@@ -2407,9 +2300,7 @@ class MagneticFrillPortOutput:
         yin, yin_defined = admittance_from_s11(s11, self.reference_impedance, complex_dtype)
 
         mesh_valid = np.asarray(self._full_mesh_valid[selection], dtype=bool)
-        cells_per_wavelength = np.asarray(
-            self._full_cells_per_wavelength[selection], dtype=real_dtype
-        )
+        cells_per_wavelength = np.asarray(self._full_cells_per_wavelength[selection], dtype=real_dtype)
         valid_s11 = mesh_valid & source_valid
         valid_zin = valid_s11 & zin_defined
         valid_yin = valid_s11 & yin_defined
@@ -2475,9 +2366,7 @@ class MagneticFrillPortOutput:
         group.attrs["MeshFrequencyLimit"] = self.mesh_frequency_limit
         group.attrs["LimitingMaterial"] = self.limiting_material
         group.attrs["IndependentFrequencyResolution"] = self.independent_frequency_resolution
-        group.attrs["FrequencyRange"] = np.asarray(
-            (result.frequency[0], result.frequency[-1]), dtype=real_dtype
-        )
+        group.attrs["FrequencyRange"] = np.asarray((result.frequency[0], result.frequency[-1]), dtype=real_dtype)
         valid_indices = np.flatnonzero(result.valid_s11)
         valid_range = (
             (result.frequency[valid_indices[0]], result.frequency[valid_indices[-1]])
@@ -2519,16 +2408,11 @@ def prepare_magnetic_frill_ports(grid: "FDTDGrid") -> None:
     for index, source in enumerate(grid.magneticfrillsources, start=1):
         output = getattr(source, "port_output", None)
         if output is None:
-            override = getattr(source, "_rx_port_override", None)
-            if override is not None:
-                output = MagneticFrillPortOutput(
-                    source,
-                    index,
-                    spectrum_limit=override.spectrum_limit,
-                    owner=override.owner,
-                )
-            else:
-                output = MagneticFrillPortOutput(source, index)
+            output = MagneticFrillPortOutput(
+                source,
+                index,
+                spectrum_limit=getattr(source, "spectrum_limit", DEFAULT_MINIMUM_WAVELENGTH_CELLS),
+            )
             source.port_output = output
         else:
             output.source_index = index

--- a/gprMax/sources.py
+++ b/gprMax/sources.py
@@ -2462,10 +2462,13 @@ class VoltageSource(Source):
     def __init__(self):
         super().__init__()
         self.resistance = None
-        # Wave-reference impedance used by a coincident RxPort. For a
-        # finite-resistance source it is the Thevenin resistance; for a hard
-        # source it defaults to 50 Ohms unless explicitly overridden.
+        # Wave-reference impedance used by the automatic source-owned port.
+        # For a finite-resistance source it is the Thevenin resistance; for a
+        # hard source it defaults to 50 Ohms unless explicitly overridden.
         self.reference_impedance = None
+        self.port_id = None
+        self.spectrum_limit = None
+        self.port_output = None
         # Preserved when create_material() replaces the selected electric-edge
         # material with a copy carrying the source resistance. Port outputs
         # need the pre-source values to remove the numerical Yee-gap

--- a/gprMax/studies.py
+++ b/gprMax/studies.py
@@ -313,7 +313,7 @@ class Study:
         ):
             raise ValueError(
                 "VoltageSource reuse is available through PortStudy so its fixed terminal "
-                "resistance and source-bound RxPort are validated together."
+                "resistance and automatic source-owned port are validated together."
             )
         for object_type, prefix in supported:
             index = 0
@@ -1197,7 +1197,6 @@ class PortStudy(Study):
 
         super().bind_scene(scene)
         from gprMax.user_objects.cmds_multiuse import HertzianDipole, MagneticDipole, VoltageSource
-        from gprMax.user_objects.cmds_output import RxPort
 
         other_sources = [
             study_id
@@ -1223,15 +1222,6 @@ class PortStudy(Study):
                     f"PortStudy source '{study_id}' must have a finite resistance greater "
                     "than zero; hard voltage sources are not matched passive ports."
                 )
-
-        rx_ports = [
-            user_object for user_object in scene.output_objects if isinstance(user_object, RxPort)
-        ]
-        if len(rx_ports) != len(voltage_ids):
-            raise ValueError(
-                "PortStudy requires exactly one RxPort at every VoltageSource; found "
-                f"{len(rx_ports)} RxPort object(s) for {len(voltage_ids)} source(s)."
-            )
 
         drive_ids: list[str] = []
         for case in self.cases:
@@ -1295,14 +1285,16 @@ class PortStudy(Study):
             study_id = getattr(monitor.source, "study_id", None)
             if study_id in voltage_ids:
                 if study_id in monitors:
-                    raise ValueError(f"PortStudy source '{study_id}' has more than one RxPort.")
+                    raise ValueError(
+                        f"PortStudy source '{study_id}' has more than one port monitor."
+                    )
                 monitors[study_id] = monitor
         if set(monitors) != set(voltage_ids):
             missing = ", ".join(study_id for study_id in voltage_ids if study_id not in monitors)
-            raise ValueError(f"PortStudy has no source-bound RxPort for: {missing}.")
+            raise ValueError(f"PortStudy has no source-owned port output for: {missing}.")
         port_ids = tuple(monitors[study_id].output_id for study_id in voltage_ids)
         if len(port_ids) != len(set(port_ids)):
-            raise ValueError("PortStudy RxPort output IDs must be unique.")
+            raise ValueError("PortStudy voltage-source port IDs must be unique.")
         self._port_source_ids = voltage_ids
         self._port_ids = port_ids
         self._port_monitors = monitors
@@ -1318,14 +1310,16 @@ class PortStudy(Study):
         ordered = [self._port_monitors[study_id] for study_id in self._port_source_ids]
         results = [monitor.result for monitor in ordered]
         if any(result is None for result in results):
-            raise RuntimeError("PortStudy results were collected before every RxPort finalised.")
+            raise RuntimeError(
+                "PortStudy results were collected before every voltage-source port finalised."
+            )
 
         frequency = np.asarray(results[0].frequency)
         for port_id, result in zip(self._port_ids[1:], results[1:]):
             if not np.array_equal(result.frequency, frequency):
                 raise ValueError(
                     f"PortStudy port '{port_id}' has a different frequency axis; use the "
-                    "same spectrum_limit for every RxPort."
+                    "same spectrum_limit for every voltage-source port."
                 )
 
         complex_dtype = np.dtype(config.sim_config.dtypes["complex"])

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -68,6 +68,41 @@ from gprMax.waveforms import Waveform as WaveformUser
 
 logger = logging.getLogger(__name__)
 
+# Keep this module importable before ``gprMax.ports``: that module imports the
+# NTFF package, whose public interface in turn imports the port evaluators.
+# The local value is the public default used by the port layer.
+DEFAULT_PORT_SPECTRUM_LIMIT = 10.0
+
+
+def _reserve_voltage_port_output_id(
+    grid: FDTDGrid, requested: Optional[str], owner: GridUserObject
+) -> str:
+    """Reserve a voltage-port ID, including consistently on every MPI rank."""
+
+    mpi_registry = bool(getattr(config.sim_config, "mpi", None)) or not hasattr(
+        grid, "port_monitors"
+    )
+    if mpi_registry:
+        used = grid.mpi_port_output_ids
+    else:
+        used = [monitor.output_id for monitor in grid.port_monitors]
+    if requested is None:
+        index = 1
+        while f"port{index}" in used:
+            index += 1
+        output_id = f"port{index}"
+    else:
+        from gprMax.ntff.interface import validate_identifier
+
+        validate_identifier("voltage-source port ID", requested)
+        output_id = requested
+    if output_id in used:
+        raise ValueError(f"port output ID {output_id!r} is already in use.")
+    if mpi_registry:
+        used.append(output_id)
+        grid.mpi_port_output_owners[output_id] = owner
+    return output_id
+
 
 def _require_complete_source_time_window(user_object, start, stop):
     """Require conventional source start/stop limits to be supplied together."""
@@ -556,9 +591,13 @@ class VoltageSource(RotatableMixin, GridUserObject):
         waveform_id: string required for identifier of waveform used with source.
         start: float optional to delay start time (secs) of source.
         stop: float optional to time (secs) to remove source.
+        id: optional HDF5 port identifier. If omitted, ``portN`` is assigned.
+        spectrum_limit: minimum cells per shortest material wavelength
+            (default 10), or ``"nyquist"`` for the full research spectrum.
         reference_impedance: float optional wave-reference impedance (Ohms)
-            for a hard source. The default is 50 Ohms. For a finite-
-            resistance source it must equal the source resistance.
+            for a hard source. The default is 50 Ohms. This final argument
+            is not accepted for a finite-resistance source, whose physical
+            resistance is also its wave-reference impedance.
     """
 
     @property
@@ -577,17 +616,27 @@ class VoltageSource(RotatableMixin, GridUserObject):
         waveform_id: str,
         start: Optional[float] = None,
         stop: Optional[float] = None,
+        id: Optional[str] = None,
+        spectrum_limit=DEFAULT_PORT_SPECTRUM_LIMIT,
         reference_impedance: Optional[float] = None,
     ):
-        super().__init__(
+        from gprMax.ports import validate_spectrum_limit
+
+        spectrum_limit = validate_spectrum_limit(spectrum_limit)
+        kwargs = dict(
             polarisation=polarisation,
             p1=p1,
             resistance=resistance,
             waveform_id=waveform_id,
             start=start,
             stop=stop,
-            reference_impedance=reference_impedance,
         )
+        if id is not None or spectrum_limit != DEFAULT_PORT_SPECTRUM_LIMIT:
+            kwargs["id"] = id
+            kwargs["spectrum_limit"] = spectrum_limit
+        if reference_impedance is not None:
+            kwargs["reference_impedance"] = reference_impedance
+        super().__init__(**kwargs)
 
         self.point = p1
         self.polarisation = polarisation
@@ -595,7 +644,22 @@ class VoltageSource(RotatableMixin, GridUserObject):
         self.waveform_id = waveform_id
         self.start = start
         self.stop = stop
+        self.id = id
+        self.spectrum_limit = spectrum_limit
         self.reference_impedance = reference_impedance
+        self._source = None
+        self._monitor = None
+
+    @property
+    def result(self):
+        """Return the automatic port result after the model has solved."""
+
+        if self._monitor is None or self._monitor.result is None:
+            raise RuntimeError(
+                "VoltageSource port result is not available until a supported "
+                "3-D model has solved"
+            )
+        return self._monitor.result
 
     def _do_rotate(self, grid: FDTDGrid):
         """Performs rotation."""
@@ -671,11 +735,21 @@ class VoltageSource(RotatableMixin, GridUserObject):
                 raise ValueError(
                     f"{self.params_str()} reference impedance must be finite and positive."
                 )
-            if self.resistance > 0 and not np.isclose(self.reference_impedance, self.resistance):
+            if self.resistance > 0:
                 raise ValueError(
-                    f"{self.params_str()} reference impedance must equal the finite "
-                    "source resistance."
+                    f"{self.params_str()} reference impedance is only valid for a "
+                    "zero-resistance hard source; a finite source uses its resistance."
                 )
+        if self.id is not None:
+            from gprMax.ntff.interface import validate_identifier
+
+            validate_identifier("voltage-source port ID", self.id)
+        if self.spectrum_limit != "nyquist" and self.spectrum_limit < DEFAULT_PORT_SPECTRUM_LIMIT:
+            logger.warning(
+                f"{self.params_str()} requests only {self.spectrum_limit:g} cells "
+                "per shortest material wavelength; values below 10 may have "
+                "significant spatial-dispersion error."
+            )
 
         # Check if there is a waveformID in the waveforms list
         if not any(x.ID == self.waveform_id for x in grid.waveforms):
@@ -717,6 +791,8 @@ class VoltageSource(RotatableMixin, GridUserObject):
             if self.reference_impedance is not None
             else (50.0 if self.resistance == 0 else float(self.resistance))
         )
+        voltage_source.port_id = getattr(self, "_port_output_id", None)
+        voltage_source.spectrum_limit = self.spectrum_limit
         voltage_source.waveformID = self.waveform_id
 
         if self.start is None or self.stop is None:
@@ -729,6 +805,59 @@ class VoltageSource(RotatableMixin, GridUserObject):
         voltage_source.calculate_waveform_values(grid)
 
         return voltage_source
+
+    def _create_port_monitor(
+        self,
+        grid: FDTDGrid,
+        voltage_source: VoltageSourceUser,
+        coord: npt.NDArray[np.int32],
+        output_id: str,
+    ) -> None:
+        """Attach the source-owned terminal sampler and spectral monitor."""
+
+        from gprMax.ports import VoltageSourcePortMonitor
+
+        if grid.within_pml(coord):
+            raise ValueError(f"{self.params_str()} cannot be placed inside a PML.")
+
+        receiver = RxUser()
+        receiver.ID = f"_voltage_port_{output_id}"
+        receiver.coord = np.asarray(coord, dtype=np.int32).copy()
+        receiver.coordorigin = receiver.coord.copy()
+        real_dtype = config.sim_config.dtypes["float_or_double"]
+        receiver.outputs[f"E{voltage_source.polarisation}"] = np.zeros(
+            grid.iterations, dtype=real_dtype
+        )
+        receiver.internal = True
+        receiver.source_bound = True
+        receiver.port_id = output_id
+        grid.add_receiver(receiver)
+
+        if voltage_source.resistance == 0:
+            transverse_axes = {
+                "x": (1, 2),
+                "y": (0, 2),
+                "z": (0, 1),
+            }[voltage_source.polarisation]
+            if any(coord[axis] == 0 for axis in transverse_axes):
+                raise ValueError(
+                    f"{self.params_str()} cannot calculate a hard-source current "
+                    "loop on a domain-minimum transverse boundary"
+                )
+            receiver.outputs[f"I{voltage_source.polarisation}"] = np.zeros(
+                grid.iterations, dtype=real_dtype
+            )
+
+        monitor = VoltageSourcePortMonitor(
+            output_id,
+            voltage_source,
+            receiver,
+            self.spectrum_limit,
+            owner=self,
+        )
+        grid.port_monitors.append(monitor)
+        voltage_source.port_output = monitor
+        self._monitor = monitor
 
     def _log(self, grid: FDTDGrid, voltage_source: VoltageSourceUser, x: float, y: float, z: float):
         if self.start is None or self.stop is None:
@@ -753,10 +882,27 @@ class VoltageSource(RotatableMixin, GridUserObject):
         self.point = uip.resolve_inf_point(self.point)
         point_within_grid, discretised_point = uip.check_src_rx_point(self.point, self.params_str())
 
+        # Every MPI rank parses the same scene. Reserve the public ID before
+        # reducing the point object to its owning rank so automatic IDs remain
+        # globally deterministic.
+        if config.sim_config.mpi and config.get_model_config().mode == "3D":
+            self._port_output_id = _reserve_voltage_port_output_id(grid, self.id, self)
+
         if point_within_grid:
             self._validate_parameters(grid, discretised_point)
             voltage_source = self._create_voltage_source(grid, discretised_point)
             grid.add_source(voltage_source)
+            self._source = voltage_source
+            if config.get_model_config().mode == "3D":
+                if not config.sim_config.mpi:
+                    self._port_output_id = _reserve_voltage_port_output_id(grid, self.id, self)
+                    voltage_source.port_id = self._port_output_id
+                self._create_port_monitor(
+                    grid,
+                    voltage_source,
+                    discretised_point,
+                    self._port_output_id,
+                )
             position = uip.round_to_grid_static_point(self.point)
             self._log(grid, voltage_source, *position)
 
@@ -1308,6 +1454,8 @@ class MagneticFrillSource(RotatableMixin, GridUserObject):
         start: float optional delay before the incident waveform starts (secs).
         stop: float optional time at which the incident waveform stops (secs).
             The coaxial terminal relation remains active afterwards.
+        spectrum_limit: minimum cells per shortest material wavelength
+            (default 10), or ``"nyquist"`` for the full research spectrum.
     """
 
     @property
@@ -1326,8 +1474,12 @@ class MagneticFrillSource(RotatableMixin, GridUserObject):
         waveform_id: str,
         start: Optional[float] = None,
         stop: Optional[float] = None,
+        spectrum_limit=DEFAULT_PORT_SPECTRUM_LIMIT,
     ):
-        super().__init__(
+        from gprMax.ports import validate_spectrum_limit
+
+        spectrum_limit = validate_spectrum_limit(spectrum_limit)
+        kwargs = dict(
             polarisation=polarisation,
             p1=p1,
             zcoax=zcoax,
@@ -1335,6 +1487,9 @@ class MagneticFrillSource(RotatableMixin, GridUserObject):
             start=start,
             stop=stop,
         )
+        if spectrum_limit != DEFAULT_PORT_SPECTRUM_LIMIT:
+            kwargs["spectrum_limit"] = spectrum_limit
+        super().__init__(**kwargs)
 
         self.point = p1
         self.polarisation = polarisation
@@ -1342,6 +1497,7 @@ class MagneticFrillSource(RotatableMixin, GridUserObject):
         self.waveform_id = waveform_id
         self.start = start
         self.stop = stop
+        self.spectrum_limit = spectrum_limit
 
     def _do_rotate(self, grid: FDTDGrid):
         """Performs rotation."""
@@ -1439,6 +1595,7 @@ class MagneticFrillSource(RotatableMixin, GridUserObject):
         f.study_id = getattr(self, "_study_id", None)
         f.Z0 = self.zcoax
         f.waveformID = self.waveform_id
+        f.spectrum_limit = self.spectrum_limit
 
         if self.start is None or self.stop is None:
             f.start = 0

--- a/gprMax/user_objects/cmds_output.py
+++ b/gprMax/user_objects/cmds_output.py
@@ -51,268 +51,15 @@ from gprMax.ports import (
     DEFAULT_INCIDENT_FLOOR_DB,
     DEFAULT_MINIMUM_WAVELENGTH_CELLS,
     RationalNetworkPortOutput,
-    RxPortOverride,
-    VoltageSourcePortMonitor,
     validate_spectrum_limit,
 )
-from gprMax.receivers import Rx as RxUser
 from gprMax.sar import RadiometrySpec, SARSpec
 from gprMax.snapshots import Snapshot as SnapshotUser
-from gprMax.sources import MagneticFrillSource
 from gprMax.subgrids.grid import SubGridBaseGrid
 from gprMax.user_objects.user_objects import OutputUserObject
 from gprMax.utilities.utilities import round_int
 
 logger = logging.getLogger(__name__)
-
-
-def _reserve_mpi_port_output_id(
-    grid: FDTDGrid, requested: Optional[str], owner: OutputUserObject
-) -> str:
-    """Reserve one output ID consistently while every MPI rank parses the scene."""
-
-    used = grid.mpi_port_output_ids
-    if requested is None:
-        index = 1
-        while f"port{index}" in used:
-            index += 1
-        output_id = f"port{index}"
-    else:
-        validate_identifier("port output ID", requested)
-        output_id = requested
-    if output_id in used:
-        raise ValueError(f"port output ID {output_id!r} is already in use.")
-    used.append(output_id)
-    grid.mpi_port_output_owners[output_id] = owner
-    return output_id
-
-
-class RxPort(OutputUserObject):
-    """Calculate S11 and input impedance at a one-edge voltage source.
-
-    A finite-resistance source uses its Thevenin wave separation. A zero-
-    resistance hard source uses the sampled gap voltage and an Ampere-loop
-    terminal current. The voltage source owns the wave-reference impedance.
-
-    Attributes:
-        p1: Position of the voltage source in metres.
-        id: Optional HDF5 port identifier.
-        spectrum_limit: Minimum cells per shortest material wavelength
-            (default 10), or ``"nyquist"`` for the full research spectrum.
-    """
-
-    @property
-    def order(self):
-        return 16
-
-    @property
-    def hash(self):
-        return "#rx_port"
-
-    def __init__(
-        self,
-        p1: Tuple[float, float, float],
-        id: Optional[str] = None,
-        spectrum_limit=DEFAULT_MINIMUM_WAVELENGTH_CELLS,
-    ):
-        spectrum_limit = validate_spectrum_limit(spectrum_limit)
-        if id is None and spectrum_limit != DEFAULT_MINIMUM_WAVELENGTH_CELLS:
-            raise ValueError(
-                "RxPort requires an ID before a non-default spectrum_limit so "
-                "the object has an unambiguous positional hash representation"
-            )
-        kwargs = dict(p1=p1, id=id)
-        if spectrum_limit != DEFAULT_MINIMUM_WAVELENGTH_CELLS:
-            kwargs["spectrum_limit"] = spectrum_limit
-        super().__init__(**kwargs)
-        self.point = p1
-        self.ID = id
-        self.spectrum_limit = spectrum_limit
-        self._monitor = None
-        # Set instead of _monitor when this RxPort ends up paired with a
-        # MagneticFrillSource - its port_output object does not exist yet at
-        # build() time (see build() below), so `result` must resolve it
-        # lazily rather than caching a reference that doesn't exist yet.
-        self._frill_source = None
-
-    @property
-    def result(self):
-        if self._monitor is not None:
-            if self._monitor.result is None:
-                raise RuntimeError("RxPort result is not available until the model has solved")
-            return self._monitor.result
-        if self._frill_source is not None:
-            port_output = getattr(self._frill_source, "port_output", None)
-            if port_output is None or port_output.result is None:
-                raise RuntimeError("RxPort result is not available until the model has solved")
-            return port_output.result
-        raise RuntimeError("RxPort result is not available until the model has solved")
-
-    def _validate_context(self, grid):
-        if config.sim_config.args.geometry_fixed and getattr(
-            config.sim_config.study, "type", None
-        ) not in (
-            "port",
-            "source",
-        ):
-            raise ValueError(
-                f"{self.params_str()} does not support geometry-fixed runs outside a "
-                "PortStudy or SourceStudy."
-            )
-        if config.get_model_config().mode != "3D":
-            raise ValueError(f"{self.params_str()} currently supports only 3-D models.")
-        if config.sim_config.general["solver"] not in ("cpu", "cuda", "opencl", "metal"):
-            raise ValueError(f"{self.params_str()} supports CPU, CUDA, OpenCL, and Metal solvers.")
-
-    def build(self, model: Model, grid: FDTDGrid):
-        self._validate_context(grid)
-        mpi_output_id = (
-            _reserve_mpi_port_output_id(grid, self.ID, self) if config.sim_config.mpi else None
-        )
-        uip = self._create_uip(grid)
-        self.point = uip.resolve_inf_point(self.point)
-        point_within_grid, coord = uip.check_src_rx_point(self.point, self.params_str())
-        if not point_within_grid:
-            return
-
-        voltage_candidates = [
-            source for source in grid.voltagesources if np.array_equal(source.coord, coord)
-        ]
-        frill_candidates = [
-            source for source in grid.magneticfrillsources if np.array_equal(source.coord, coord)
-        ]
-        candidates = voltage_candidates + frill_candidates
-        if len(candidates) != 1:
-            raise ValueError(
-                f"{self.params_str()} requires exactly one voltage source or "
-                "magnetic frill source at grid position "
-                f"{tuple(int(value) for value in coord)}; found {len(candidates)}"
-            )
-        source = candidates[0]
-        if grid.within_pml(coord):
-            raise ValueError(f"{self.params_str()} cannot be placed inside a PML.")
-
-        if isinstance(source, MagneticFrillSource):
-            self._build_for_frill_source(grid, source, coord, uip)
-            return
-
-        if not np.isfinite(source.resistance) or source.resistance < 0:
-            raise ValueError(
-                f"{self.params_str()} requires a finite, non-negative voltage-source resistance"
-            )
-        if any(monitor.source is source for monitor in grid.port_monitors):
-            raise ValueError(f"{self.params_str()} source already has an RxPort output.")
-
-        if self.ID is None:
-            if mpi_output_id is not None:
-                output_id = mpi_output_id
-            else:
-                used = {monitor.output_id for monitor in grid.port_monitors}
-                index = 1
-                while f"port{index}" in used:
-                    index += 1
-                output_id = f"port{index}"
-        else:
-            if mpi_output_id is not None:
-                output_id = mpi_output_id
-            else:
-                validate_identifier("RxPort ID", self.ID)
-                output_id = self.ID
-        if any(monitor.output_id == output_id for monitor in grid.port_monitors):
-            raise ValueError(f"{self.params_str()} output ID is already in use.")
-
-        if (
-            self.spectrum_limit != "nyquist"
-            and self.spectrum_limit < DEFAULT_MINIMUM_WAVELENGTH_CELLS
-        ):
-            logger.warning(
-                f"{self.params_str()} requests only {self.spectrum_limit:g} cells "
-                "per shortest material wavelength; values below 10 may have "
-                "significant spatial-dispersion error."
-            )
-
-        receiver = RxUser()
-        receiver.ID = f"_rx_port_{output_id}"
-        receiver.coord = np.asarray(coord, dtype=np.int32).copy()
-        receiver.coordorigin = receiver.coord.copy()
-        real_dtype = config.sim_config.dtypes["float_or_double"]
-        receiver.outputs[f"E{source.polarisation}"] = np.zeros(grid.iterations, dtype=real_dtype)
-        receiver.internal = True
-        receiver.source_bound = True
-        receiver.port_id = output_id
-        grid.add_receiver(receiver)
-
-        if source.resistance == 0:
-            transverse_axes = {
-                "x": (1, 2),
-                "y": (0, 2),
-                "z": (0, 1),
-            }[source.polarisation]
-            if any(coord[axis] == 0 for axis in transverse_axes):
-                raise ValueError(
-                    f"{self.params_str()} cannot calculate a hard-source current "
-                    "loop on a domain-minimum transverse boundary"
-                )
-            # CPU and device solvers store the identical requested-only
-            # Ampere-loop component at the magnetic half step.
-            receiver.outputs[f"I{source.polarisation}"] = np.zeros(
-                grid.iterations, dtype=real_dtype
-            )
-
-        monitor = VoltageSourcePortMonitor(
-            output_id,
-            source,
-            receiver,
-            self.spectrum_limit,
-            owner=self,
-        )
-        grid.port_monitors.append(monitor)
-        self._monitor = monitor
-        position = uip.round_to_grid_static_point(self.point)
-        logger.info(
-            f"RxPort {output_id!r} bound to the "
-            f"{source.polarisation}-polarised voltage source at "
-            f"{position[0]:g}m, {position[1]:g}m, {position[2]:g}m, "
-            f"reference impedance {source.reference_impedance:g} Ohms."
-        )
-
-    def _build_for_frill_source(self, grid: FDTDGrid, source, coord, uip):
-        """Bind to a MagneticFrillSource's always-on automatic port output.
-
-        Unlike a voltage source, a magnetic frill source's S11/Zin/Yin output
-        is calculated automatically regardless of #rx_port (see
-        prepare_magnetic_frill_ports() in gprMax/ports.py) - so this does not
-        create a second, independent monitor. It can only override that
-        output's spectrum_limit, via a deferred marker consumed once the
-        real port_output object is constructed (it does not exist yet at
-        this point in the build sequence - see gprMax/model.py).
-
-        RxPort.__init__ requires an id whenever spectrum_limit is
-        non-default (for an unambiguous positional hash representation) -
-        that id is accepted here but not used to name anything: the
-        automatic output already has a fixed 'frillN' identifier regardless
-        of what #rx_port is called.
-        """
-        if getattr(source, "_rx_port_override", None) is not None:
-            raise ValueError(f"{self.params_str()} source already has an RxPort output.")
-
-        if (
-            self.spectrum_limit != "nyquist"
-            and self.spectrum_limit < DEFAULT_MINIMUM_WAVELENGTH_CELLS
-        ):
-            logger.warning(
-                f"{self.params_str()} requests only {self.spectrum_limit:g} cells "
-                "per shortest material wavelength; values below 10 may have "
-                "significant spatial-dispersion error."
-            )
-
-        source._rx_port_override = RxPortOverride(spectrum_limit=self.spectrum_limit, owner=self)
-        self._frill_source = source
-        position = uip.round_to_grid_static_point(self.point)
-        logger.info(
-            f"RxPort spectrum_limit override bound to the magnetic frill "
-            f"source at {position[0]:g}m, {position[1]:g}m, {position[2]:g}m."
-        )
 
 
 class NetworkPort(OutputUserObject):
@@ -1761,7 +1508,7 @@ class KSIRAntennaPorts(OutputUserObject):
         transform_id: ID of a rectangular-window
             :class:`KSIRFrequencyTransform`.
         port_ids: IDs of every physical antenna port. Voltage-source IDs come
-            from coincident :class:`RxPort` objects. Transmission-line and
+            directly from the source (explicit or automatic). Transmission-line and
             magnetic-frill sources use their automatic ``tlN`` and ``frillN``
             IDs. A port on a subgrid is referenced as
             ``<subgrid ID>/<local port ID>``. Eigenmode sources are not
@@ -1774,8 +1521,8 @@ class KSIRAntennaPorts(OutputUserObject):
 
     @property
     def order(self):
-        # RxPort objects use order 16. Building afterwards makes their public
-        # IDs available irrespective of input-file or Scene insertion order.
+        # Port definitions are finalised after source objects have reserved
+        # their public IDs.
         return 17
 
     @property

--- a/testing/backend_consistency/rx_port/README.md
+++ b/testing/backend_consistency/rx_port/README.md
@@ -1,4 +1,4 @@
-# CUDA `RxPort` consistency check
+# CUDA voltage-port consistency check
 
 This suite checks invariance to excitation amplitude, reference impedance,
 and x/y/z orientation, as well as single/double precision agreement and

--- a/testing/backend_consistency/rx_port/check_rx_port_gpu_invariance.py
+++ b/testing/backend_consistency/rx_port/check_rx_port_gpu_invariance.py
@@ -1,4 +1,4 @@
-"""Check RxPort consistency and precision through the CUDA/HDF5 path."""
+"""Check voltage-port consistency and precision through the CUDA/HDF5 path."""
 
 import argparse
 import json
@@ -58,7 +58,7 @@ def build_scene(case):
     """Build one rotated 150 mm, one-edge-feed thin-wire dipole."""
 
     scene = gprMax.Scene()
-    scene.add(gprMax.Title(name=f"RxPort GPU invariance: {case.name}"))
+    scene.add(gprMax.Title(name=f"Voltage-port GPU invariance: {case.name}"))
     scene.add(gprMax.Discretisation(p1=(DL, DL, DL)))
     scene.add(gprMax.Domain(p1=DOMAIN))
     scene.add(gprMax.TimeWindow(time=TIME_WINDOW))
@@ -93,9 +93,9 @@ def build_scene(case):
             polarisation=case.polarisation,
             resistance=case.resistance,
             waveform_id="pulse",
+            id="feed",
         )
     )
-    scene.add(gprMax.RxPort(p1=feed, id="feed"))
     return scene
 
 
@@ -266,7 +266,7 @@ def create_plot(frequency, valid, single, double):
         axis.set_xlabel("Frequency [GHz]")
         axis.grid(True, alpha=0.25)
         axis.legend(fontsize=8)
-    fig.suptitle("RxPort CUDA invariance and precision checks")
+    fig.suptitle("Voltage-port CUDA invariance and precision checks")
     fig.tight_layout()
     output = RESULTS_DIR / "rx_port_gpu_invariance.png"
     fig.savefig(output, dpi=220, bbox_inches="tight")

--- a/testing/other_codes/matlab_mom/antenna_dipole_fs/dipole_antenna_gprmax.py
+++ b/testing/other_codes/matlab_mom/antenna_dipole_fs/dipole_antenna_gprmax.py
@@ -84,9 +84,9 @@ def build_scene():
             polarisation="z",
             resistance=PORT_REFERENCE_IMPEDANCE,
             waveform_id="pulse",
+            id="dipole_feed",
         )
     )
-    scene.add(gprMax.RxPort(p1=feed_position, id="dipole_feed"))
     # Iz is the Ampere contour integral around this z-directed Yee edge. The
     # CPU solver can store Iz directly, but device receivers currently expose
     # only E and H. These three receivers save the four H samples needed to

--- a/testing/other_codes/matlab_mom/antenna_helix_fs/helix_antenna_gprmax.py
+++ b/testing/other_codes/matlab_mom/antenna_helix_fs/helix_antenna_gprmax.py
@@ -134,16 +134,19 @@ def build_scene(source_mode="resistive"):
         CENTRE_Y,
         GROUND_Z,
     )
+    source_kwargs = {}
+    if source_mode != "resistive":
+        source_kwargs["reference_impedance"] = PORT_REFERENCE_IMPEDANCE
     scene.add(
         gprMax.VoltageSource(
             p1=feed_position,
             polarisation="z",
             resistance=(PORT_REFERENCE_IMPEDANCE if source_mode == "resistive" else 0),
             waveform_id="pulse",
-            reference_impedance=PORT_REFERENCE_IMPEDANCE,
+            id="helix_feed",
+            **source_kwargs,
         )
     )
-    scene.add(gprMax.RxPort(p1=feed_position, id="helix_feed"))
 
     scene.add(
         gprMax.NTFFSurface(

--- a/testing/other_codes/matlab_mom/antenna_patch_fs/README.md
+++ b/testing/other_codes/matlab_mom/antenna_patch_fs/README.md
@@ -228,7 +228,7 @@ the FDTD/MoM antenna-model comparison rather than the NTFF formulation.
 ## Full-sphere gain
 
 `patch_antenna_3d_gain.py` uses the standard-mesh single 50 Ohm gap feed and
-the native `RxPort`/`KSIRAntennaPorts` power normalisation. It evaluates a 2
+the native voltage-port/`KSIRAntennaPorts` power normalisation. It evaluates a 2
 degree full-sphere `KSIRFarFieldArray` at 2.37 GHz and reads the persisted gain
 and directivity datasets back from HDF5. Radiation intensity, realized gain,
 radiation efficiency, and total efficiency are retained as well. The script

--- a/testing/other_codes/matlab_mom/antenna_patch_fs/patch_antenna_3d_gain.py
+++ b/testing/other_codes/matlab_mom/antenna_patch_fs/patch_antenna_3d_gain.py
@@ -28,9 +28,8 @@ def build_gain_scene():
 
     patch._configure_mesh("standard")
     scene, _ = patch.build_scene(feed_mode="single", mesh_mode="standard")
-    _, feed_position = patch._feed_edges("single")[0]
-    scene.add(gprMax.RxPort(p1=feed_position, id="patch_feed"))
-    scene.add(gprMax.KSIRAntennaPorts("patch_spectrum", ("patch_feed",)))
+    feed_port_id, _ = patch._feed_edges("single")[0]
+    scene.add(gprMax.KSIRAntennaPorts("patch_spectrum", (feed_port_id,)))
     scene.add(
         gprMax.KSIRFarFieldArray(
             theta_start=0,

--- a/testing/other_codes/matlab_mom/antenna_patch_fs/patch_antenna_gprmax.py
+++ b/testing/other_codes/matlab_mom/antenna_patch_fs/patch_antenna_gprmax.py
@@ -275,6 +275,7 @@ def build_scene(
                     polarisation="z",
                     resistance=source_resistance,
                     waveform_id="pulse",
+                    id=receiver_id,
                 )
             )
             # Ez on the driven edge is the total port field. Keeping these as

--- a/testing/other_codes/matlab_mom/rx_port_comparison/README.md
+++ b/testing/other_codes/matlab_mom/rx_port_comparison/README.md
@@ -1,4 +1,4 @@
-# Production `RxPort` comparison with MATLAB antennas
+# Source-owned voltage-port comparison with MATLAB antennas
 
 This comparison uses the production gprMax `/ports/feed` HDF5 datasets; it
 does not reconstruct current from surrounding magnetic-field receivers. Four

--- a/testing/other_codes/matlab_mom/rx_port_comparison/compare_rx_port_matlab_antennas.py
+++ b/testing/other_codes/matlab_mom/rx_port_comparison/compare_rx_port_matlab_antennas.py
@@ -1,4 +1,4 @@
-"""Compare production RxPort output with MATLAB Antenna Toolbox models."""
+"""Compare source-owned voltage-port output with MATLAB Antenna Toolbox models."""
 
 import argparse
 import csv
@@ -146,7 +146,7 @@ def build_dipole_scene():
     case = CASES["dipole"]
     scene = _common_scene(
         case,
-        "RxPort MATLAB comparison: 150 mm grid dipole",
+        "Voltage-port MATLAB comparison: 150 mm grid dipole",
         (0.180, 0.180, 0.220),
     )
     wire_x = 0.090
@@ -177,9 +177,9 @@ def build_dipole_scene():
             polarisation="z",
             resistance=case.reference_impedance,
             waveform_id="pulse",
+            id="feed",
         )
     )
-    scene.add(gprMax.RxPort(p1=feed, id="feed"))
     return scene
 
 
@@ -190,7 +190,7 @@ def build_bowtie_scene():
     case = CASES["bowtie"]
     scene = _common_scene(
         case,
-        "RxPort MATLAB comparison: triangular bow-tie",
+        "Voltage-port MATLAB comparison: triangular bow-tie",
         (0.160, 0.160, 0.080),
     )
     feed_x = 0.080
@@ -245,9 +245,9 @@ def build_bowtie_scene():
             polarisation="x",
             resistance=case.reference_impedance,
             waveform_id="pulse",
+            id="feed",
         )
     )
-    scene.add(gprMax.RxPort(p1=feed, id="feed"))
     return scene
 
 
@@ -258,7 +258,7 @@ def build_monopole_scene():
     dl = MONOPOLE_DL
     scene = _common_scene(
         case,
-        "RxPort MATLAB comparison: finite-ground monopole",
+        "Voltage-port MATLAB comparison: finite-ground monopole",
         (0.250, 0.250, 0.250),
     )
     wire_x = 0.125
@@ -285,9 +285,9 @@ def build_monopole_scene():
             polarisation="z",
             resistance=case.reference_impedance,
             waveform_id="pulse",
+            id="feed",
         )
     )
-    scene.add(gprMax.RxPort(p1=feed, id="feed"))
     return scene
 
 
@@ -298,7 +298,7 @@ def build_patch_scene():
     domain = (0.120, 0.100, 120 * PATCH_DZ)
     scene = _common_scene(
         case,
-        "RxPort MATLAB comparison: single-feed rectangular patch",
+        "Voltage-port MATLAB comparison: single-feed rectangular patch",
         domain,
     )
     centre_x = domain[0] / 2
@@ -336,9 +336,9 @@ def build_patch_scene():
             polarisation="z",
             resistance=case.reference_impedance,
             waveform_id="pulse",
+            id="feed",
         )
     )
-    scene.add(gprMax.RxPort(p1=feed, id="feed"))
     return scene
 
 
@@ -604,7 +604,7 @@ def create_plots(results):
             color=colours["gprmax"],
             marker="o",
             markersize=3.5,
-            label="gprMax RxPort corrected",
+            label="gprMax voltage port",
         )
         axes_s11[row, 0].plot(
             frequency_ghz,
@@ -631,7 +631,7 @@ def create_plots(results):
             color=colours["gprmax"],
             marker="o",
             markersize=3.5,
-            label="gprMax RxPort corrected",
+            label="gprMax voltage port",
         )
         axes_s11[row, 1].plot(
             frequency_ghz,
@@ -686,7 +686,7 @@ def create_plots(results):
                 axis.grid(True, alpha=0.25)
                 axis.legend(fontsize=8)
 
-    fig_s11.suptitle("Production gprMax RxPort versus MATLAB Antenna Toolbox", fontsize=14)
+    fig_s11.suptitle("gprMax voltage ports versus MATLAB Antenna Toolbox", fontsize=14)
     fig_s11.tight_layout()
     s11_path = RESULTS_DIR / "rx_port_matlab_comparison.png"
     fig_s11.savefig(s11_path, dpi=220, bbox_inches="tight")

--- a/testing/validation/validate_sar_power_normalisation.py
+++ b/testing/validation/validate_sar_power_normalisation.py
@@ -3,7 +3,7 @@
 This is an end-to-end production-path consistency validation rather than an
 independent electromagnetic reference problem. It checks the quadratic field
 scaling and the relationship between incident- and accepted-power normalized
-SAR using an actual voltage source and :class:`RxPort` output.
+SAR using an actual voltage source and its source-owned port output.
 """
 
 from __future__ import annotations
@@ -44,9 +44,9 @@ def build_scene():
             polarisation="z",
             resistance=50,
             waveform_id="pulse",
+            id="feed",
         )
     )
-    scene.add(gprMax.RxPort(p1=(0.012, 0.012, 0.012), id="feed"))
     outputs = {}
     for output_id, normalisation, power in (
         ("incident_1W", "incident_power", 1.0),

--- a/tests/cmds_multiuse/test_magnetic_frill_source.py
+++ b/tests/cmds_multiuse/test_magnetic_frill_source.py
@@ -6,7 +6,7 @@ Covers: user-object parameter validation (fast, monkeypatched-grid unit
 tests, mirroring tests/cmds_multiuse/test_metal_gpu_restriction_gaps.py's
 style), finalise_setup()'s build-time geometry/symmetry/PML checks, a full
 CPU solve with sane HDF5 output, PEC box/plate ground planes, symmetry-plane
-placement, RxPort pairing, Hyun's terminal identity, and invariance of the
+placement, automatic port output, Hyun's terminal identity, and invariance of the
 feed-cell self-admittance under symmetry completion.
 
 The deeper physics validation ladder (open/short/matched-load analytic
@@ -85,8 +85,7 @@ def test_hash_command_builds_api_object(
     "command",
     [
         "#magnetic_frill_source: z 0.01 0.02 0.03 50",
-        "#magnetic_frill_source: z 0.01 0.02 0.03 50 w 1e-10",
-        "#magnetic_frill_source: z 0.01 0.02 0.03 50 w 1e-10 2e-10 extra",
+        "#magnetic_frill_source: z 0.01 0.02 0.03 50 w 1e-10 2e-10 10 extra",
     ],
 )
 def test_hash_command_rejects_invalid_parameter_count(command):
@@ -565,15 +564,18 @@ def test_zcoax_changes_reflection(tmp_path):
     assert not np.allclose(vtot_a, vtot_b)
 
 
-def test_rx_port_override_sets_marker_and_spectrum_limit(tmp_path):
+def test_source_sets_automatic_port_spectrum_limit(tmp_path):
     scene = _base_scene()
     scene.add(
         gprMax.MagneticFrillSource(
-            p1=(0.01, 0.01, 0.0), polarisation="z", zcoax=50, waveform_id="w"
+            p1=(0.01, 0.01, 0.0),
+            polarisation="z",
+            zcoax=50,
+            waveform_id="w",
+            spectrum_limit=5,
         )
     )
-    scene.add(gprMax.RxPort(p1=(0.01, 0.01, 0.0), id="override", spectrum_limit=5))
-    outputfile = tmp_path / "frill_rxport"
+    outputfile = tmp_path / "frill_spectrum_limit"
     gprMax.run(
         scenes=[scene],
         n=1,
@@ -586,37 +588,18 @@ def test_rx_port_override_sets_marker_and_spectrum_limit(tmp_path):
         assert grp.attrs["MinimumWavelengthCells"] == 5
 
 
-def test_rx_port_duplicate_rejected(tmp_path):
+def test_frill_automatic_port_keeps_fixed_identifier(tmp_path):
     scene = _base_scene()
     scene.add(
         gprMax.MagneticFrillSource(
-            p1=(0.01, 0.01, 0.0), polarisation="z", zcoax=50, waveform_id="w"
+            p1=(0.01, 0.01, 0.0),
+            polarisation="z",
+            zcoax=50,
+            waveform_id="w",
+            spectrum_limit=5,
         )
     )
-    scene.add(gprMax.RxPort(p1=(0.01, 0.01, 0.0)))
-    scene.add(gprMax.RxPort(p1=(0.01, 0.01, 0.0), id="second"))
-    with pytest.raises(ValueError, match="already has an RxPort"):
-        gprMax.run(
-            scenes=[scene],
-            n=1,
-            geometry_only=False,
-            outputfile=tmp_path / "frill_rxport_dup",
-            hide_progress_bars=True,
-        )
-
-
-def test_rx_port_id_ignored_for_frill_source(tmp_path):
-    """An id is accepted (RxPort.__init__ requires one whenever
-    spectrum_limit is non-default) but not used to name anything - the
-    automatic output keeps its fixed 'frillN' identifier regardless."""
-    scene = _base_scene()
-    scene.add(
-        gprMax.MagneticFrillSource(
-            p1=(0.01, 0.01, 0.0), polarisation="z", zcoax=50, waveform_id="w"
-        )
-    )
-    scene.add(gprMax.RxPort(p1=(0.01, 0.01, 0.0), id="named", spectrum_limit=5))
-    outputfile = tmp_path / "frill_rxport_id"
+    outputfile = tmp_path / "frill_port_id"
     gprMax.run(
         scenes=[scene],
         n=1,
@@ -626,4 +609,3 @@ def test_rx_port_id_ignored_for_frill_source(tmp_path):
     )
     with h5py.File(str(outputfile) + ".h5", "r") as f:
         assert "frills/frill1" in f
-        assert "named" not in f.get("ports", {})

--- a/tests/ntff/test_cuda_reusable_interface.py
+++ b/tests/ntff/test_cuda_reusable_interface.py
@@ -74,9 +74,9 @@ def _antenna_scene():
             p1=(0.04, 0.04, 0.04),
             resistance=50,
             waveform_id="pulse",
+            id="feed",
         )
     )
-    scene.add(gprMax.RxPort(p1=(0.04, 0.04, 0.04), id="feed"))
     scene.add(
         gprMax.NTFFSurface(
             p1=(0.028, 0.028, 0.028),
@@ -140,11 +140,7 @@ def _equivalent_current_time_scene():
     scene.add(gprMax.TimeWindow(time=3e-10))
     scene.add(gprMax.PMLThickness(thickness=3))
     scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
-    scene.add(
-        gprMax.HertzianDipole(
-            polarisation="z", p1=(0.04, 0.04, 0.04), waveform_id="pulse"
-        )
-    )
+    scene.add(gprMax.HertzianDipole(polarisation="z", p1=(0.04, 0.04, 0.04), waveform_id="pulse"))
     scene.add(
         gprMax.NTFFSurface(
             p1=(0.028, 0.028, 0.028),
@@ -168,9 +164,7 @@ def _equivalent_current_time_scene():
     "precision,rtol",
     [("single", 3e-4), ("double", 2e-11)],
 )
-def test_cuda_equivalent_current_time_far_fields_match_cpu(
-    tmp_path, gpu_device, precision, rtol
-):
+def test_cuda_equivalent_current_time_far_fields_match_cpu(tmp_path, gpu_device, precision, rtol):
     cpu_scene, cpu_far = _equivalent_current_time_scene()
     cuda_scene, cuda_far = _equivalent_current_time_scene()
     gprMax.run(
@@ -189,8 +183,7 @@ def test_cuda_equivalent_current_time_far_fields_match_cpu(
 
     assert_allclose(cuda_far.result.times, cpu_far.result.times, rtol=0, atol=0)
     field_scale = max(
-        np.max(np.abs(cpu_far.result.fields[component]))
-        for component in ("Etheta", "Ephi")
+        np.max(np.abs(cpu_far.result.fields[component])) for component in ("Etheta", "Ephi")
     )
     assert field_scale > 0
     for component in ("Etheta", "Ephi"):

--- a/tests/ntff/test_hash_command.py
+++ b/tests/ntff/test_hash_command.py
@@ -478,8 +478,7 @@ def test_antenna_metrics_run_from_single_voltage_port(tmp_path):
         "#time_window: 4e-10\n"
         "#pml_cells: 3\n"
         "#waveform: ricker 1 5e9 pulse\n"
-        "#voltage_source: z 0.04 0.04 0.04 50 pulse\n"
-        "#rx_port: 0.04 0.04 0.04 feed\n"
+        "#voltage_source: z 0.04 0.04 0.04 50 pulse 0 4e-10 feed 10\n"
         "#ntff_surface: 0.028 0.028 0.028 0.052 0.052 0.052 surf\n"
         "#ksir_frequency: surf band 5e9 rectangular\n"
         "#ksir_antenna_ports: band feed\n"
@@ -501,7 +500,10 @@ def test_antenna_metrics_run_from_single_voltage_port(tmp_path):
         group = output["ntff/surf/frequency/band/far_field/broadside"]
         assert group.attrs["radiation_quadrature_theta_order"] >= 12
         assert group.attrs["radiation_quadrature_phi_order"] >= 24
-        assert group.attrs["maximum_directivity_sampling"] == "full-sphere quadrature plus requested directions"
+        assert (
+            group.attrs["maximum_directivity_sampling"]
+            == "full-sphere quadrature plus requested directions"
+        )
         assert group["port_power/port_ids"].asstr()[...].tolist() == ["feed"]
         assert group["port_power/incident_voltage_per_port"].shape == (1, 1)
         assert group["port_power/terminal_voltage_per_port"].shape == (1, 1)
@@ -584,10 +586,8 @@ def test_multiport_gain_keeps_zero_amplitude_port_in_power_balance(tmp_path):
         "#pml_cells: 3\n"
         "#waveform: ricker 1 5e9 driven\n"
         "#waveform: ricker 0 5e9 terminated\n"
-        "#voltage_source: z 0.036 0.04 0.04 50 driven\n"
-        "#voltage_source: z 0.044 0.04 0.04 50 terminated\n"
-        "#rx_port: 0.036 0.04 0.04 element1\n"
-        "#rx_port: 0.044 0.04 0.04 element2\n"
+        "#voltage_source: z 0.036 0.04 0.04 50 driven 0 4e-10 element1 10\n"
+        "#voltage_source: z 0.044 0.04 0.04 50 terminated 0 4e-10 element2 10\n"
         "#ntff_surface: 0.024 0.028 0.028 0.056 0.052 0.052 surf\n"
         "#ksir_frequency: surf band 5e9 rectangular\n"
         "#ksir_antenna_ports: band element1 element2\n"

--- a/tests/ntff/test_subgrid_ksir_tfsf_integration.py
+++ b/tests/ntff/test_subgrid_ksir_tfsf_integration.py
@@ -34,11 +34,6 @@ def test_antenna_metrics_use_subgrid_port_and_time_step(tmp_path):
             polarisation="z",
             resistance=50,
             waveform_id="pulse",
-        )
-    )
-    subgrid.add(
-        gprMax.RxPort(
-            p1=source_position,
             id="feed",
             spectrum_limit="nyquist",
         )

--- a/tests/ntff/test_validation_guards.py
+++ b/tests/ntff/test_validation_guards.py
@@ -41,7 +41,8 @@ def test_eigenmode_source_is_incompatible_with_ramahi_ksir():
 
     with pytest.raises(
         ValueError,
-        match="eigenmode sources cannot be used with the Ramahi/KSIR.*" "equivalent-current Huygens NTFF",
+        match="eigenmode sources cannot be used with the Ramahi/KSIR.*"
+        "equivalent-current Huygens NTFF",
     ):
         compile_ntff_outputs(model, grid)
 
@@ -88,7 +89,9 @@ def test_reusable_interface_rejects_geometry_fixed_up_front(tmp_path):
 def test_reusable_surface_rejects_localised_source_outside(tmp_path, source_type):
     scene = _base_scene()
     if source_type == "hertzian":
-        source = gprMax.HertzianDipole(polarisation="z", p1=(0.032, 0.02, 0.02), waveform_id="pulse")
+        source = gprMax.HertzianDipole(
+            polarisation="z", p1=(0.032, 0.02, 0.02), waveform_id="pulse"
+        )
         expected = "HertzianDipole"
     else:
         source = gprMax.VoltageSource(
@@ -182,7 +185,9 @@ def test_reusable_surface_rejects_eigenmode_injection_plane_outside():
 def test_reusable_frequency_rejects_above_nyquist(tmp_path):
     scene = _base_scene()
     scene.add(gprMax.NTFFSurface(p1=SURFACE_LOWER, p2=SURFACE_UPPER, id="surface"))
-    scene.add(gprMax.KSIRFrequencyTransform(surface_id="surface", id="spectrum", frequencies=(1e15,)))
+    scene.add(
+        gprMax.KSIRFrequencyTransform(surface_id="surface", id="spectrum", frequencies=(1e15,))
+    )
 
     with pytest.raises(ValueError, match="Nyquist limit"):
         gprMax.run(
@@ -216,7 +221,9 @@ def test_tfsf_correction_stencil_requires_one_cell_clearance():
 
     monitor = Monitor()
     clear_surfaces = {
-        component: closure.apply_quadrature(build_component_surface(component, (5, 5, 5), (15, 15, 15), spacing, shape))
+        component: closure.apply_quadrature(
+            build_component_surface(component, (5, 5, 5), (15, 15, 15), spacing, shape)
+        )
         for component in COMPONENTS
     }
     _associate_plane_wave(
@@ -231,7 +238,9 @@ def test_tfsf_correction_stencil_requires_one_cell_clearance():
     assert monitor.association[2] == 0
 
     touching_surface = {
-        "Ez": closure.apply_quadrature(build_component_surface("Ez", (7, 5, 5), (15, 15, 15), spacing, shape))
+        "Ez": closure.apply_quadrature(
+            build_component_surface("Ez", (7, 5, 5), (15, 15, 15), spacing, shape)
+        )
     }
     with pytest.raises(ValueError, match="TFSF correction stencil"):
         _associate_plane_wave(
@@ -246,24 +255,26 @@ def test_tfsf_correction_stencil_requires_one_cell_clearance():
 
 def test_exact_receiver_validation_uses_full_patch_support():
     closure = ResolvedKSIRClosure("closed", (), (), True, True)
-    surface = build_component_surface("Ez", (5, 5, 5), (15, 15, 15), (0.01, 0.01, 0.01), (25, 25, 25))
+    surface = build_component_surface(
+        "Ez", (5, 5, 5), (15, 15, 15), (0.01, 0.01, 0.01), (25, 25, 25)
+    )
 
     with pytest.raises(ValueError, match="strictly outside"):
         _validate_external_points(np.asarray(((0.046, 0.1, 0.1),)), {"Ez": surface}, closure)
 
 
 def _antenna_gain_input(*, window="rectangular", association=None, extra_source=""):
-    association_command = "" if association is None else f"#ksir_antenna_ports: band {association}\n"
+    association_command = (
+        "" if association is None else f"#ksir_antenna_ports: band {association}\n"
+    )
     return (
         "#domain: 0.04 0.04 0.04\n"
         "#dx_dy_dz: 0.002 0.002 0.002\n"
         "#time_window: 1e-10\n"
         "#pml_cells: 2\n"
         "#waveform: ricker 1 5e9 pulse\n"
-        "#voltage_source: z 0.018 0.02 0.02 50 pulse\n"
-        "#voltage_source: z 0.022 0.02 0.02 50 pulse\n"
-        "#rx_port: 0.018 0.02 0.02 feed1\n"
-        "#rx_port: 0.022 0.02 0.02 feed2\n"
+        "#voltage_source: z 0.018 0.02 0.02 50 pulse 0 1e-10 feed1 10\n"
+        "#voltage_source: z 0.022 0.02 0.02 50 pulse 0 1e-10 feed2 10\n"
         f"{extra_source}"
         "#ntff_surface: 0.012 0.012 0.012 0.028 0.028 0.028 surface\n"
         f"#ksir_frequency: surface band 5e9 {window}\n"

--- a/tests/outputs/test_radiometry.py
+++ b/tests/outputs/test_radiometry.py
@@ -121,7 +121,10 @@ def test_radiometry_does_not_require_material_density(tmp_path):
 
 def test_radiometry_port_weighting_is_independent_of_requested_power(tmp_path):
     scene = _lossy_scene()
-    scene.add(gprMax.RxPort(p1=(0.012, 0.012, 0.012), id="feed"))
+    voltage_source = next(
+        item for item in scene.grid_objects if isinstance(item, gprMax.VoltageSource)
+    )
+    voltage_source.id = "feed"
     one_watt = gprMax.Radiometry(
         frequencies=(1e9,),
         tags="target",
@@ -180,9 +183,7 @@ def test_radiometry_state_is_reset_for_geometry_fixed_runs(tmp_path):
         hide_progress_bars=True,
     )
 
-    with h5py.File(f"{filename}1.h5", "r") as first, h5py.File(
-        f"{filename}2.h5", "r"
-    ) as second:
+    with h5py.File(f"{filename}1.h5", "r") as first, h5py.File(f"{filename}2.h5", "r") as second:
         np.testing.assert_array_equal(
             first["radiometry/reused/normalised_absorption_density"][...],
             second["radiometry/reused/normalised_absorption_density"][...],

--- a/tests/outputs/test_sar.py
+++ b/tests/outputs/test_sar.py
@@ -486,7 +486,10 @@ def test_sar_real_port_power_normalisation_scales_with_target_power(tmp_path):
     one_watt.port_id = "feed"
     one_watt.target_power = 1.0
     one_watt.waveform_id = None
-    scene.add(gprMax.RxPort(p1=(0.012, 0.012, 0.012), id="feed"))
+    voltage_source = next(
+        item for item in scene.grid_objects if isinstance(item, gprMax.VoltageSource)
+    )
+    voltage_source.id = "feed"
     four_watt = SAR(
         frequencies=one_watt.frequencies,
         tags="target",

--- a/tests/outputs/test_sar_subgrid.py
+++ b/tests/outputs/test_sar_subgrid.py
@@ -121,9 +121,10 @@ def _subgrid_power_normalised_scene():
             polarisation="z",
             resistance=50,
             waveform_id="pulse",
+            id="feed",
+            spectrum_limit="nyquist",
         )
     )
-    fine.add(gprMax.RxPort(p1=(0.045, 0.045, 0.045), id="feed", spectrum_limit="nyquist"))
     output = gprMax.SAR(
         frequencies=(5e9,),
         waveform_id="pulse",

--- a/tests/ports/test_integration.py
+++ b/tests/ports/test_integration.py
@@ -1,4 +1,4 @@
-"""Small CPU integration tests for RxPort HDF5 output."""
+"""Small CPU integration tests for automatic voltage-source port output."""
 
 import h5py
 import numpy as np
@@ -58,22 +58,17 @@ def _scene(
                 material_id="remote_debye",
             )
         )
-    scene.add(
-        gprMax.VoltageSource(
-            p1=(0.01, 0.01, 0.01),
-            polarisation=polarisation,
-            resistance=resistance,
-            waveform_id="pulse",
-            reference_impedance=reference_impedance,
-        )
-    )
-    port = gprMax.RxPort(
+    source = gprMax.VoltageSource(
         p1=(0.01, 0.01, 0.01),
+        polarisation=polarisation,
+        resistance=resistance,
+        waveform_id="pulse",
         id="feed",
         spectrum_limit=spectrum_limit,
+        reference_impedance=reference_impedance,
     )
-    scene.add(port)
-    return scene, port
+    scene.add(source)
+    return scene, source
 
 
 def _run(
@@ -155,9 +150,15 @@ def test_nyquist_research_mode_retains_full_native_axis_and_validity_masks(tmp_p
         assert port.attrs["SpectrumLimitMode"] == "nyquist"
         assert frequency.size == expected_bins
         assert frequency[-1] > port.attrs["MeshFrequencyLimit"]
-        assert not port["mesh_valid"][...].astype(bool)[-1]
+        source_valid = port["source_valid"][...].astype(bool)
+        mesh_valid = port["mesh_valid"][...].astype(bool)
+        gap_valid = port["gap_correction_valid"][...].astype(bool)
+        assert not mesh_valid[-1]
+        resolved = source_valid & mesh_valid
+        assert resolved.any()
+        assert gap_valid[resolved].all()
         if (iterations - 1) % 2 == 0:
-            assert not port["gap_correction_valid"][...].astype(bool)[-1]
+            assert not gap_valid[-1]
             assert np.isnan(port["S11"][...][-1])
         np.testing.assert_allclose(port.attrs["FrequencyRange"], (frequency[0], frequency[-1]))
         for dataset in (
@@ -241,12 +242,8 @@ def test_hard_source_port_uses_phase_aligned_ampere_current(tmp_path, polarisati
         assert port.attrs["PortMode"] == "hard_delta_gap"
         assert port.attrs["ReferenceImpedance"] == 50
         assert port.attrs["ReferenceImpedanceSource"] == "voltage_source"
-        assert port.attrs["TimeSampleOffset"] == pytest.approx(
-            output.attrs["dt"]
-        )
-        assert port.attrs["CurrentTimeSampleOffset"] == pytest.approx(
-            0.5 * output.attrs["dt"]
-        )
+        assert port.attrs["TimeSampleOffset"] == pytest.approx(output.attrs["dt"])
+        assert port.attrs["CurrentTimeSampleOffset"] == pytest.approx(0.5 * output.attrs["dt"])
         assert port.attrs["CurrentTimeAlignment"] == "explicit_fft_half_step_phase"
         assert port["Iloop"].shape == port["time"].shape
         assert port["time_current"].shape == port["time"].shape
@@ -255,8 +252,7 @@ def test_hard_source_port_uses_phase_aligned_ampere_current(tmp_path, polarisati
         assert valid.any()
         np.testing.assert_allclose(
             port["Zin"][...][valid],
-            port["Vtotal_spectrum"][...][valid]
-            / port["Iterminal_spectrum"][...][valid],
+            port["Vtotal_spectrum"][...][valid] / port["Iterminal_spectrum"][...][valid],
             rtol=2e-5,
             atol=2e-5,
         )

--- a/tests/ports/test_mpi_port_gather.py
+++ b/tests/ports/test_mpi_port_gather.py
@@ -2,9 +2,8 @@ from types import SimpleNamespace
 
 import numpy as np
 
-from gprMax.mpi_model import MPIModel
 from gprMax.ports import RationalNetworkPortOutput, VoltageSourcePortMonitor
-from gprMax.user_objects.cmds_output import _reserve_mpi_port_output_id
+from gprMax.user_objects.cmds_multiuse import _reserve_voltage_port_output_id
 
 
 def test_mpi_port_id_reservation_keeps_coordinator_owner():
@@ -12,8 +11,8 @@ def test_mpi_port_id_reservation_keeps_coordinator_owner():
     first = SimpleNamespace()
     second = SimpleNamespace()
 
-    assert _reserve_mpi_port_output_id(grid, None, first) == "port1"
-    assert _reserve_mpi_port_output_id(grid, "feed", second) == "feed"
+    assert _reserve_voltage_port_output_id(grid, None, first) == "port1"
+    assert _reserve_voltage_port_output_id(grid, "feed", second) == "feed"
     assert grid.mpi_port_output_owners == {"port1": first, "feed": second}
 
 
@@ -54,24 +53,3 @@ def test_network_port_rebind_uses_gathered_global_terminal():
     assert monitor.source is terminal
     assert terminal.output is monitor
     np.testing.assert_allclose(monitor.source_position, (0.4, 1.0, 1.8))
-
-
-def test_frill_rx_port_owner_rebinds_to_gathered_source():
-    owner = SimpleNamespace(
-        _monitor=None,
-        _frill_source=None,
-        point=(0.008, 0.009, 0.010),
-    )
-    source = SimpleNamespace(coord=np.asarray((8, 9, 10), dtype=np.int32))
-    model = MPIModel.__new__(MPIModel)
-    model.G = SimpleNamespace(
-        dx=0.001,
-        dy=0.001,
-        dz=0.001,
-        mpi_port_output_owners={"override": owner},
-        magneticfrillsources=[source],
-    )
-
-    model._rebind_mpi_frill_port_owners()
-
-    assert owner._frill_source is source

--- a/tests/ports/test_port_hash_command.py
+++ b/tests/ports/test_port_hash_command.py
@@ -1,9 +1,8 @@
-"""Hash-command coverage for the positional RxPort interface."""
+"""Hash-command coverage for automatic voltage-source ports."""
 
 import pytest
 
 from gprMax.hash_cmds_file import get_user_objects
-from gprMax.user_objects.cmds_output import RxPort
 from gprMax.user_objects.cmds_multiuse import VoltageSource
 
 
@@ -14,46 +13,53 @@ def _parse(command):
 @pytest.mark.parametrize(
     "command, output_id, spectrum_limit",
     [
-        ("#rx_port: 0.1 0.2 0.3", None, 10),
-        ("#rx_port: 0.1 0.2 0.3 feed", "feed", 10),
-        ("#rx_port: 0.1 0.2 0.3 feed 15", "feed", 15),
-        ("#rx_port: 0.1 0.2 0.3 feed nyquist", "feed", "nyquist"),
+        ("#voltage_source: z 0.1 0.2 0.3 50 pulse", None, 10),
+        ("#voltage_source: z 0.1 0.2 0.3 50 pulse 0 1e-9 feed 15", "feed", 15),
+        (
+            "#voltage_source: z 0.1 0.2 0.3 50 pulse 0 1e-9 feed nyquist",
+            "feed",
+            "nyquist",
+        ),
     ],
 )
-def test_rx_port_positional_forms(command, output_id, spectrum_limit):
+def test_voltage_source_port_positional_forms(command, output_id, spectrum_limit):
     objects = _parse(command)
 
     assert len(objects) == 1
-    assert isinstance(objects[0], RxPort)
-    assert objects[0].ID == output_id
+    assert isinstance(objects[0], VoltageSource)
+    assert objects[0].id == output_id
     assert objects[0].spectrum_limit == spectrum_limit
 
 
 @pytest.mark.parametrize(
     "command",
     [
-        "#rx_port: 0.1 0.2",
-        "#rx_port: 0.1 0.2 0.3 feed 10 50",
-        "#rx_port: 0.1 0.2 0.3 feed full",
-        "#rx_port: 0.1 0.2 0.3 feed 2",
-        "#rx_port: 0.1 0.2 0.3 feed nan",
+        "#voltage_source: z 0.1 0.2 0.3 50 pulse 0 1e-9 feed full",
+        "#voltage_source: z 0.1 0.2 0.3 50 pulse 0 1e-9 feed 2",
+        "#voltage_source: z 0.1 0.2 0.3 50 pulse 0 1e-9 feed nan",
     ],
 )
-def test_rx_port_rejects_malformed_spectrum_limit(command):
+def test_voltage_source_rejects_malformed_spectrum_limit(command):
     with pytest.raises(ValueError):
         _parse(command)
 
 
-def test_nondefault_api_limit_requires_id_for_positional_round_trip():
-    with pytest.raises(ValueError, match="requires an ID"):
-        RxPort((0.1, 0.2, 0.3), spectrum_limit="nyquist")
-
-
 def test_voltage_source_hash_accepts_reference_impedance_after_start_stop():
-    objects = _parse(
-        "#voltage_source: z 0.1 0.2 0.3 0 pulse 0 1e-9 75"
-    )
+    objects = _parse("#voltage_source: z 0.1 0.2 0.3 0 pulse 0 1e-9 75")
 
     assert len(objects) == 1
     assert isinstance(objects[0], VoltageSource)
     assert objects[0].reference_impedance == 75
+
+
+def test_voltage_source_hash_keeps_reference_impedance_last_with_port_options():
+    objects = _parse("#voltage_source: z 0.1 0.2 0.3 0 pulse 0 1e-9 feed nyquist 75")
+
+    assert objects[0].id == "feed"
+    assert objects[0].spectrum_limit == "nyquist"
+    assert objects[0].reference_impedance == 75
+
+
+def test_removed_rx_port_hash_command_is_rejected():
+    with pytest.raises(SyntaxError):
+        _parse("#rx_port: 0.1 0.2 0.3")

--- a/tests/ports/test_port_study.py
+++ b/tests/ports/test_port_study.py
@@ -26,10 +26,10 @@ def _two_port_scene(active_port=None, resistances=(50, 50)):
             polarisation="z",
             resistance=resistance,
             waveform_id=waveform_id,
+            id=f"p{index}",
         )
         sources.append(source)
         scene.add(source)
-        scene.add(gprMax.RxPort(p1=(x, 0.012, 0.012), id=f"p{index}"))
     return scene, sources
 
 
@@ -289,10 +289,8 @@ def test_hash_port_study_runs_and_writes_complete_smatrix(tmp_path):
         "#pml_cells: 2\n"
         "#time_window: 4e-10\n"
         "#waveform: ricker 1 5e9 pulse\n"
-        "#voltage_source: z 0.010 0.012 0.012 50 pulse\n"
-        "#voltage_source: z 0.014 0.012 0.012 50 pulse\n"
-        "#rx_port: 0.010 0.012 0.012 p1\n"
-        "#rx_port: 0.014 0.012 0.012 p2\n"
+        "#voltage_source: z 0.010 0.012 0.012 50 pulse 0 4e-10 p1 10\n"
+        "#voltage_source: z 0.014 0.012 0.012 50 pulse 0 4e-10 p2 10\n"
         f"#study: port {cases.name}\n"
     )
 

--- a/tests/ports/test_rational_network.py
+++ b/tests/ports/test_rational_network.py
@@ -215,10 +215,10 @@ def _scene(use_network):
         )
         scene.add(gprMax.NetworkExcitation("feed", "pulse"))
         port = gprMax.NetworkPort("feed", reference_impedance=50)
+        scene.add(port)
     else:
-        scene.add(gprMax.VoltageSource((0.01, 0.01, 0.01), "z", 50, "pulse"))
-        port = gprMax.RxPort((0.01, 0.01, 0.01), id="feed")
-    scene.add(port)
+        port = gprMax.VoltageSource((0.01, 0.01, 0.01), "z", 50, "pulse", id="feed")
+        scene.add(port)
     scene.add(gprMax.Rx((0.012, 0.01, 0.01), id="field"))
     return scene, port
 

--- a/tests/ports/test_subgrid_integration.py
+++ b/tests/ports/test_subgrid_integration.py
@@ -29,21 +29,16 @@ def subgrid_port_result(tmp_path_factory):
     )
     scene.add(subgrid)
     subgrid.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
-    subgrid.add(
-        gprMax.VoltageSource(
-            p1=source_position,
-            polarisation="z",
-            resistance=0,
-            waveform_id="pulse",
-            reference_impedance=50,
-        )
-    )
-    port = gprMax.RxPort(
+    source = gprMax.VoltageSource(
         p1=source_position,
+        polarisation="z",
+        resistance=0,
+        waveform_id="pulse",
         id="feed",
         spectrum_limit="nyquist",
+        reference_impedance=50,
     )
-    subgrid.add(port)
+    subgrid.add(source)
 
     gprMax.run(
         scenes=[scene],
@@ -53,7 +48,7 @@ def subgrid_port_result(tmp_path_factory):
         autotranslate=True,
         hide_progress_bars=True,
     )
-    return output.with_suffix(".h5"), port, source_position
+    return output.with_suffix(".h5"), source, source_position
 
 
 def test_subgrid_port_uses_owning_grid_and_returns_api_result(subgrid_port_result):

--- a/tests/ports/test_validation.py
+++ b/tests/ports/test_validation.py
@@ -1,4 +1,4 @@
-"""Build-time validation for the initial single-edge RxPort interface."""
+"""Build-time validation for source-owned voltage-port outputs."""
 
 import pytest
 
@@ -26,20 +26,14 @@ def _run_geometry(scene, tmp_path, name, **kwargs):
     )
 
 
-def test_port_requires_exactly_one_colocated_voltage_source(tmp_path):
-    scene = _base_scene()
-    scene.add(gprMax.RxPort((0.01, 0.01, 0.01), id="feed"))
-
-    with pytest.raises(ValueError, match="exactly one voltage source.*found 0"):
-        _run_geometry(scene, tmp_path, "no_source")
-
-
 def test_hard_voltage_source_defaults_to_50_ohm_reference_impedance(tmp_path):
     scene = _base_scene()
-    scene.add(gprMax.VoltageSource((0.01, 0.01, 0.01), "z", 0, "pulse"))
-    scene.add(gprMax.RxPort((0.01, 0.01, 0.01), id="feed"))
+    source = gprMax.VoltageSource((0.01, 0.01, 0.01), "z", 0, "pulse")
+    scene.add(source)
 
     _run_geometry(scene, tmp_path, "hard_source")
+    assert source._source.reference_impedance == 50
+    assert source._monitor.output_id == "port1"
 
 
 def test_port_rejects_reference_impedance_different_from_finite_resistance(tmp_path):
@@ -53,29 +47,27 @@ def test_port_rejects_reference_impedance_different_from_finite_resistance(tmp_p
             reference_impedance=75,
         )
     )
-    scene.add(gprMax.RxPort((0.01, 0.01, 0.01), id="feed"))
-
-    with pytest.raises(ValueError, match="must equal the finite source resistance"):
+    with pytest.raises(ValueError, match="only valid for a zero-resistance hard source"):
         _run_geometry(scene, tmp_path, "finite_reference_mismatch")
 
 
-def test_port_rejects_ambiguous_colocated_sources(tmp_path):
+def test_colocated_sources_get_independent_automatic_ports(tmp_path):
+    scene = _base_scene()
+    first = gprMax.VoltageSource((0.01, 0.01, 0.01), "z", 50, "pulse")
+    second = gprMax.VoltageSource((0.01, 0.01, 0.01), "x", 50, "pulse")
+    scene.add(first)
+    scene.add(second)
+
+    _run_geometry(scene, tmp_path, "colocated_sources")
+    assert first._monitor.output_id == "port1"
+    assert second._monitor.output_id == "port2"
+
+
+def test_port_supports_geometry_fixed_first_run(tmp_path):
     scene = _base_scene()
     scene.add(gprMax.VoltageSource((0.01, 0.01, 0.01), "z", 50, "pulse"))
-    scene.add(gprMax.VoltageSource((0.01, 0.01, 0.01), "x", 50, "pulse"))
-    scene.add(gprMax.RxPort((0.01, 0.01, 0.01), id="feed"))
 
-    with pytest.raises(ValueError, match="exactly one voltage source.*found 2"):
-        _run_geometry(scene, tmp_path, "ambiguous_source")
-
-
-def test_port_rejects_geometry_fixed_even_for_first_run(tmp_path):
-    scene = _base_scene()
-    scene.add(gprMax.VoltageSource((0.01, 0.01, 0.01), "z", 50, "pulse"))
-    scene.add(gprMax.RxPort((0.01, 0.01, 0.01), id="feed"))
-
-    with pytest.raises(ValueError, match="does not support geometry-fixed"):
-        _run_geometry(scene, tmp_path, "geometry_fixed", geometry_fixed=True)
+    _run_geometry(scene, tmp_path, "geometry_fixed", geometry_fixed=True)
 
 
 def test_port_rejects_voltage_source_on_pec_edge(tmp_path):
@@ -88,23 +80,21 @@ def test_port_rejects_voltage_source_on_pec_edge(tmp_path):
         )
     )
     scene.add(gprMax.VoltageSource((0.01, 0.01, 0.01), "z", 50, "pulse"))
-    scene.add(gprMax.RxPort((0.01, 0.01, 0.01), id="feed"))
 
     with pytest.raises(ValueError, match="voltage source on a PEC edge"):
         _run_geometry(scene, tmp_path, "pec_source")
 
 
-def test_port_rejects_second_monitor_on_same_source(tmp_path):
+def test_port_rejects_duplicate_explicit_ids(tmp_path):
     scene = _base_scene()
-    scene.add(gprMax.VoltageSource((0.01, 0.01, 0.01), "z", 50, "pulse"))
-    scene.add(gprMax.RxPort((0.01, 0.01, 0.01), id="feed1"))
-    scene.add(gprMax.RxPort((0.01, 0.01, 0.01), id="feed2"))
+    scene.add(gprMax.VoltageSource((0.008, 0.01, 0.01), "z", 50, "pulse", id="feed"))
+    scene.add(gprMax.VoltageSource((0.012, 0.01, 0.01), "z", 50, "pulse", id="feed"))
 
-    with pytest.raises(ValueError, match="source already has an RxPort output"):
+    with pytest.raises(ValueError, match="port output ID 'feed' is already in use"):
         _run_geometry(scene, tmp_path, "duplicate_source")
 
 
-def test_port_rejects_dispersive_material_on_source_edge(tmp_path):
+def test_finite_resistance_port_accepts_dispersive_material_on_source_edge(tmp_path):
     scene = _base_scene()
     scene.add(gprMax.Material(er=4, se=0, mr=1, sm=0, id="dispersive"))
     scene.add(
@@ -122,8 +112,8 @@ def test_port_rejects_dispersive_material_on_source_edge(tmp_path):
             material_id="dispersive",
         )
     )
-    scene.add(gprMax.VoltageSource((0.01, 0.01, 0.01), "z", 50, "pulse"))
-    scene.add(gprMax.RxPort((0.01, 0.01, 0.01), id="feed"))
+    source = gprMax.VoltageSource((0.01, 0.01, 0.01), "z", 50, "pulse")
+    scene.add(source)
 
-    with pytest.raises(ValueError, match="dispersive material"):
-        _run_geometry(scene, tmp_path, "dispersive_source")
+    _run_geometry(scene, tmp_path, "dispersive_source")
+    assert source._monitor.background_is_dispersive

--- a/tests/ports/test_voltage_source_port.py
+++ b/tests/ports/test_voltage_source_port.py
@@ -9,6 +9,8 @@ import gprMax.config as config
 from gprMax.materials import Material
 from gprMax.ntff.conventions import engineering_dft
 from gprMax.ports import (
+    _finite_source_gap_admittance,
+    _safe_complex_divide,
     admittance_from_s11,
     correct_s11_for_parallel_gap,
     engineering_rfft,
@@ -81,6 +83,45 @@ def test_gap_deembedding_recovers_known_load_and_impedance(port_config):
     assert admittance_valid.all()
     np.testing.assert_allclose(corrected_impedance, antenna_impedance, rtol=1e-13)
     np.testing.assert_allclose(corrected_admittance, 1 / antenna_impedance, rtol=1e-13)
+
+
+def test_dispersive_gap_admittance_uses_complete_complex_permittivity(port_config):
+    dt = 1e-11
+    frequency = np.asarray([0.0, 2e9, 8e9])
+    area = 2e-6
+    dl = 1e-3
+    conductivity = 0.2
+    epsilon0 = config.sim_config.em_consts["e0"]
+
+    def calculate_er(values):
+        omega = 2 * np.pi * np.asarray(values)
+        return 3.5 + 5 / (1 + 1j * omega * 8e-11) + conductivity / (1j * omega * epsilon0)
+
+    output = SimpleNamespace(
+        background_is_dispersive=True,
+        background_material=SimpleNamespace(calculate_er=calculate_er),
+        background_conductance=conductivity * area / dl,
+        area=area,
+        dl=dl,
+    )
+    actual = _finite_source_gap_admittance(output, frequency, dt, np.complex128)
+
+    omega_discrete = (2 / dt) * np.tan(np.pi * frequency[1:] * dt)
+    expected = np.empty(frequency.shape, dtype=np.complex128)
+    expected[0] = conductivity * area / dl
+    expected[1:] = 1j * omega_discrete * epsilon0 * calculate_er(omega_discrete / (2 * np.pi)) * area / dl
+    np.testing.assert_allclose(actual, expected, rtol=1e-13, atol=1e-18)
+
+
+def test_safe_complex_divide_keeps_independent_frequency_bins(port_config):
+    numerator = np.asarray([1 + 0j, 1 + 0j, 1 + 0j], dtype=np.complex64)
+    denominator = np.asarray([1 + 0j, 1e30 + 0j, 0 + 0j], dtype=np.complex64)
+
+    result, valid = _safe_complex_divide(numerator, denominator, np.complex64)
+
+    np.testing.assert_array_equal(valid, (True, True, False))
+    np.testing.assert_allclose(result[:2], (1, 1e-30), rtol=1e-6)
+    assert np.isnan(result[2])
 
 
 def test_open_and_short_keep_s11_valid_but_mask_singular_secondary_quantity(port_config):


### PR DESCRIPTION
# PR Description

This PR integrates voltage-port monitoring directly into `VoltageSource`, removing the need for a separate `RxPort` object.

### Main changes

- Automatically creates port output for every 3-D voltage source.
- Provides `S11`, `Zin`, `Yin`, voltage, and validity information through:
  - the source object's `.result` attribute;
  - the `/ports/<source_id>` HDF5 output group.
- Uses the physical source resistance as the reference impedance for finite-resistance sources.
- Uses 50 Ω by default for hard voltage sources, with an optional reference-impedance argument.
- Calculates hard-source terminal current from the phase-aligned Ampère-loop magnetic fields.
- Supports finite-resistance sources on dispersive material edges.
- Corrects finite-source results for gap capacitance, conductivity, and dispersive admittance.
- Marks the exact bilinear-transform Nyquist singularity invalid without affecting other frequency bins.
- Updates `PortStudy`, MPI collection, subgrid handling, NTFF antenna metrics, SAR/radiometry normalisation, examples, and documentation.
- Adds direct spectrum-limit control to magnetic-frill sources.
- Removes the separate Python `RxPort` object and `#rx_port` hash command.

### Validation

- Full non-GPU/non-slow suite:
  - 5585 passed
  - 18 skipped
  - 94 deselected
- CPU/CUDA two-port complex S-matrix parity passed.
- CPU/CUDA antenna-metric parity passed.
- Finite-source amplitude, orientation, precision, passivity, and impedance-renormalisation checks passed.
- Hard-source CPU/CUDA parity passed for x, y, and z orientations.
- CPU/CUDA dispersive Debye source-edge comparison passed.
- OpenCL port-study parity passed.
- Documentation builds successfully.
- Black, isort, and whitespace checks pass.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (removes the separate recent `RxPort` interface)
- [x] This change requires a documentation update.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added comments for the numerically sensitive parts.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of the changes.
