### PR TITLE
Support simultaneous eigenmode excitation for array studies

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: pytest-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cpu-tests:
     name: CPU tests
@@ -29,12 +33,15 @@ jobs:
           cache: pip
           cache-dependency-path: requirements.txt
 
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libopenmpi-dev
+      - name: Install Open MPI runtime
+        timeout-minutes: 5
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install openmpi==5.0.10
+          mpiexec --version
 
       - name: Install gprMax and test dependencies
         run: |
-          python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
           python -m pip install --editable .
 

--- a/docs/source/eigenmode_port.rst
+++ b/docs/source/eigenmode_port.rst
@@ -8,12 +8,13 @@ Eigenmode Ports and S-parameter Analysis
 
 Eigenmode excitation launches a solved waveguide mode instead of prescribing
 one field component. One shared ``#eigenmode_band`` defines the DFT bins and
-``#eigenmode_port`` defines every active or passive reference plane. At most
-one ``#eigenmode_excitation`` may select the launched port and mode. It may be
-omitted only when every port has a passive ``#virtual_waveguide``; that
-passive-only form writes raw modal spectra but no S matrix. A single active
-time-domain run can therefore produce multimode S-parameters and, when the
-device radiates, directivity, gain, and realized gain.
+``#eigenmode_port`` defines every active or passive reference plane. One
+``#eigenmode_excitation`` produces one S-matrix column. Several excitation
+commands may instead drive a deliberate array state with independent modal
+amplitudes, phases, or delays; that run writes incident and outgoing modal
+waves, but does not label them as S-parameters. Excitation may be omitted only
+when every port has a passive ``#virtual_waveguide``; that passive-only form
+also writes raw modal spectra but no S matrix.
 
 Start with the three examples
 =============================
@@ -137,9 +138,10 @@ between them.
 
 The optional trailing ``y`` or ``n`` on a port command controls only that
 port's modal-field figures. A trailing ``y`` or ``n`` on
-``#eigenmode_excitation`` independently controls the single waveform/spectrum
-figure. If omitted, both diagnostics are enabled for geometry-only runs and
-disabled for normal full runs.
+``#eigenmode_excitation`` independently controls its waveform/spectrum figure.
+With several drives, filenames include ``_PortN_ModeM``. If omitted, both
+diagnostics are enabled for geometry-only runs and disabled for normal full
+runs.
 
 Run the simulation and plot S-parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -218,6 +220,50 @@ synthesizes the selected source from the cached phase-aligned modal basis. It
 does not repeat the FDFD solves. This works when the complete eigenmode setup
 belongs either to the main grid or to one HSG subgrid; ports from different
 grids cannot be combined in one modal study.
+
+Drive several ports or modes together
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use repeated excitation commands for a prescribed array or multimode state:
+
+.. code-block:: none
+
+   #eigenmode_excitation: 1 1 auto 1 0 0
+   #eigenmode_excitation: 2 1 auto 0.70710678 90 0
+
+Every drive must use the same base waveform. A physical port is solved and
+monitored once even when more than one of its modes is driven. The complex
+spectral multiplier for drive :math:`q` is
+
+.. math::
+
+   d_q(f) = A_q \exp\!\left(j\phi_q\right)
+            \exp\!\left(-j2\pi f\tau_q\right),
+
+where :math:`A_q` is the amplitude, :math:`\phi_q` is the constant phase, and
+:math:`\tau_q` is a true time delay. A constant phase is normally used for a
+phase-steered array at its design frequency; a non-zero delay gives the
+frequency-linear phase required for true-time-delay steering. In the Python
+API, ``power=P`` may replace ``amplitude=A`` and uses :math:`A=\sqrt{P}``.
+Because every modal profile is power-normalized, :math:`P` is the relative
+per-frequency incident-power scale applied to the common waveform spectrum;
+it is not the time-integrated energy of the finite pulse.
+
+The superposed response is a driven state, not a column of the independently
+excited S matrix. Its HDF5 port groups retain ``incident`` and ``outgoing``
+waves and record ``ResponseType=driven``, ``ExcitationModes``, drive
+amplitudes, powers, phases, delays, and waveform IDs. They deliberately omit
+``S`` and no ``*_sparameters.csv`` is written. Use ``EigenmodeStudy`` when the
+complete S matrix is required, then apply arbitrary weights to that matrix or
+to separately stored embedded far-field responses in post-processing.
+
+An NTFF transform may also be evaluated directly for the simultaneous state.
+Its fields, pattern, and directivity are those of the coherent superposition.
+When every physical port is associated with the transform, incident power is
+summed over the driven modal subspaces using the full modal power matrices,
+including off-diagonal cross terms; net accepted power is summed over all
+active and passive ports. Gain and realized gain therefore describe that
+particular driven state, not an embedded element or an S-matrix column.
 
 The per-case files identify their input port and mode. The aggregate
 ``<output>_study.h5`` stores the complete matrix using
@@ -587,11 +633,12 @@ transverse cell centres for this diagnostic only. Check the expected
 polarisation, symmetry, confinement, conducting-boundary behaviour, and mode
 order. The final optional ``y`` or ``n`` on an eigenmode-port command forces or
 suppresses only that port's modal-field plots. The independent final ``y`` or
-``n`` on ``#eigenmode_excitation`` controls the single waveform/DFT figure. If
+``n`` on ``#eigenmode_excitation`` controls that drive's waveform/DFT figure. If
 either flag is omitted, geometry-only runs write the corresponding diagnostic
 and normal full simulations do not.
 
-The single excitation also writes ``<input>_EigenmodeExcitation.png``. Its left
+One excitation also writes ``<input>_EigenmodeExcitation.png``. With multiple
+drives the filename includes ``_PortN_ModeM``. Its left
 subplot shows the exact sampled injection waveform. Its right subplot shows
 the surrounding zero-padded positive-frequency spectrum, overlays the source
 DFT evaluated at the ports' exact common frequency bins, and shades the port
@@ -1995,14 +2042,16 @@ per-cell Python work occurs during time stepping.
 Modal Receivers, Direct DFT, and S-parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Exactly one global band and zero or one excitation must exist whenever modal
-ports are used. The excitation may be omitted only when every port is a
-passive virtual guide; that form writes raw modal spectra but no S matrix.
-Every ``EigenmodePort`` is a passive monitor at its reference plane; the
-selected excitation port additionally applies the TF/SF source. Port
-indices are one-based and unique, and each port carries an explicit tuple of
-monitored mode indices. The excitation selects one of the modes listed by its
-port. All ports accumulate the common DFT bins from ``EigenmodeBand``.
+Exactly one global band and zero or more distinct port/mode excitations may
+exist whenever modal ports are used. Excitation may be omitted only when every
+port is a passive virtual guide; that form writes raw modal spectra but no S
+matrix. Every ``EigenmodePort`` owns one monitor at its reference plane; each
+selected excitation additionally applies a TF/SF source. Port indices are
+one-based and unique, and each port carries an explicit tuple of monitored
+mode indices. Every excitation selects one of the modes listed by its port.
+All ports accumulate the common DFT bins from ``EigenmodeBand``. Exactly one
+active channel permits S-parameter normalization; a simultaneous driven state
+retains its decomposed waves without constructing S.
 Automatic ports share one candidate-frequency list, but tracking, retained
 source/reference masks, and fallback policies are resolved independently for
 each port and mode. Ports with explicit anchors retain their individually
@@ -2164,14 +2213,25 @@ mode subspace. All off-diagonal terms within that subspace are retained, but
 generalized-only rows and columns are excluded. An invalid propagating mode
 invalidates the accepted-power result rather than being silently omitted.
 
-The externally driven incident power contains only the excitation mode at the
-single source. Passive modal receivers have zero generator incident power,
-but their signed accepted power remains in the multiport balance used for
-gain. This distinction makes realized gain use launched source power while
-gain uses the net power accepted by the radiating structure. The power
-adapter applies the power-normalization and power-matrix masks, so generalized
-below-cutoff coefficients do not enter gain, accepted-power, or energy-balance
-normalization.
+For active port :math:`p`, let :math:`D_p` select its explicitly driven modes.
+The externally driven incident power is
+
+.. math::
+
+   P_{\mathrm{inc}}
+     = \sum_{p\,\mathrm{active}}
+       \operatorname{Re}\!\left\{
+       a_{p,D_p}^{\mathrm{H}}W_{p,D_pD_p}a_{p,D_p}\right\}.
+
+Thus a one-channel run retains the previous single-mode definition, while a
+simultaneous multimode run keeps the cross terms between non-orthogonal driven
+modes on the same physical port. Passive modal receivers have zero generator
+incident power, but their signed accepted power remains in the multiport
+balance used for gain. This distinction makes realized gain use launched
+source power while gain uses the net power accepted by the radiating
+structure. The power adapter applies the power-normalization and power-matrix
+masks, so generalized below-cutoff coefficients do not enter gain,
+accepted-power, or energy-balance normalization.
 
 Understanding Lossy-Mode Results
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -937,9 +937,11 @@ Eigenmode band, ports, excitation, and virtual guides
 .. autoclass:: gprMax.user_objects.cmds_multiuse.EigenmodeExcitation
 
 An eigenmode model has one shared frequency band, one or more independently
-configured ports, and zero or one excitation. The excitation can be omitted
-when every port is a passive virtual guide; that form writes raw modal spectra
-but no S matrix. Ports do not repeat the DFT range or waveform:
+configured ports, and zero or more modal drives. One drive produces one
+S-parameter column. Multiple drives produce a prescribed driven response,
+not an S matrix. Excitation can be omitted when every port is a passive
+virtual guide; that form writes raw modal spectra but no S matrix. Ports do
+not repeat the DFT range or waveform:
 
 .. code-block:: python
 
@@ -964,6 +966,21 @@ but no S matrix. Ports do not repeat the DFT range or waveform:
     ))
     scene.add(gprMax.EigenmodeExcitation(
         port=1, mode=1, waveform='auto', plot_waveform=True,
+    ))
+
+For simultaneous excitation, add further distinct port/mode channels using
+the same base waveform. ``power`` and ``amplitude`` are mutually exclusive;
+``power=P`` applies amplitude :math:`\sqrt{P}`:
+
+.. code-block:: python
+
+    scene.add(gprMax.EigenmodeExcitation(
+        port=1, mode=1, waveform='auto', power=1,
+        phase_deg=0, delay_s=0,
+    ))
+    scene.add(gprMax.EigenmodeExcitation(
+        port=2, mode=1, waveform='auto', power=0.5,
+        phase_deg=90, delay_s=0,
     ))
 
 To terminate either reference plane inside the model, attach a virtual guide
@@ -1001,10 +1018,11 @@ supplied instead. gprMax checks its exact sampled spectrum, warns and discards
 significant DC/Nyquist bins, and rejects more than one percent power outside
 the declared band. Use a band-limited waveform, or select ``waveform='auto'``
 to synthesize one automatically for a finite frequency band.
-``plot_waveform`` independently controls the single excitation waveform/DFT
-figure. ``True`` writes it, ``False`` suppresses it, and the default ``None``
-writes it only for geometry-only runs. Each port's ``plot_fields`` setting
-continues to control only that port's modal-field figures.
+``plot_waveform`` independently controls each excitation waveform/DFT figure.
+``True`` writes it, ``False`` suppresses it, and the default ``None`` writes it
+only for geometry-only runs. Multi-drive filenames include the port and mode.
+Each port's ``plot_fields`` setting continues to control only that port's
+modal-field figures.
 
 Severe tracking mismatch between explicit multiple anchors is an error that
 recommends one explicit anchor. With automatic anchors, a failure confined to

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1728,8 +1728,8 @@ band once guarantees identical DFT bins at every port.
 ----------------
 
 Defines an active or passive modal reference plane. The same command is used
-for every port; ``#eigenmode_excitation`` separately selects the one active
-port and mode.
+for every port; one or more ``#eigenmode_excitation`` commands select active
+port/mode channels.
 
 .. code-block:: none
 
@@ -1776,13 +1776,14 @@ per mode.
 #eigenmode_excitation:
 ----------------------
 
-Optionally selects the single active port and mode after the band and ports
-have been defined. Omit this command only when every port is a passive virtual
-guide; such a model writes raw modal spectra but no S matrix:
+Selects one active port and mode after the band and ports have been defined.
+Repeat the command to drive several distinct port/mode channels. Omit it only
+when every port is a passive virtual guide; such a model writes raw modal
+spectra but no S matrix:
 
 .. code-block:: none
 
-    #eigenmode_excitation: i1 i2 [str1] [f1] [c1]
+    #eigenmode_excitation: i1 i2 [str1] [f1] [f2] [f3] [c1]
 
 * ``i1`` is an existing port number.
 * ``i2`` is one of that port's monitored mode indices.
@@ -1797,7 +1798,11 @@ guide; such a model writes raw modal spectra but no S matrix:
   are discarded with a warning. More than one percent spectral power outside
   the requested band remains an error. Use a band-limited waveform, or select
   ``auto`` to synthesize one automatically for a finite frequency band.
-* ``f1`` is an optional amplitude scale and is valid only with ``auto``.
+* ``f1`` is an optional non-zero amplitude scale. All simultaneous drives
+  must use the same base waveform.
+* ``f2`` is an optional constant phase in degrees. It defaults to zero.
+* ``f3`` is an optional true time delay :math:`\tau` in seconds. It defaults
+  to zero and applies :math:`\exp(-j2\pi f\tau)`.
 * ``c1`` optionally controls the waveform/DFT plot: ``y`` always writes it and
   ``n`` always suppresses it. If omitted, geometry-only runs write the plot and
   normal runs do not. The flag may follow ``i2`` directly when the default
@@ -1808,6 +1813,18 @@ A complete excitation for the ports above is:
 .. code-block:: none
 
     #eigenmode_excitation: 1 1 auto y
+
+For a simultaneous two-port state, for example:
+
+.. code-block:: none
+
+    #eigenmode_excitation: 1 1 auto 1 0 0 n
+    #eigenmode_excitation: 2 1 auto 0.5 90 0 n
+
+Exactly one active channel produces an S-parameter column. With two or more
+active channels, gprMax stores the driven incident/outgoing modal waves and
+drive metadata but does not create ``S`` datasets or an S-parameter CSV. Use
+an eigenmode study for the independently excited complete S matrix.
 
 A single-frequency band cannot use the automatic finite-band pulse. Supply a
 matching continuous waveform and one explicit modal anchor instead.

--- a/docs/source/output.rst
+++ b/docs/source/output.rst
@@ -921,10 +921,10 @@ stored below ``/subgrids/<subgrid ID>/eigenmode_ports/portN`` and uses that
 grid's fine ``dx_dy_dz``, ``dt``, and iteration count. ``frequency`` contains
 the direct-DFT bins.
 ``incident`` and ``outgoing`` have shape ``(nmodes, nfrequencies)``, with
-rows ordered by the one-based ``ModeIndices`` attribute. ``S`` is the outgoing
-coefficient divided by the excited source-mode incident coefficient, so the
-source group contains modal S11 and other groups contain S21, S31, and modal
-conversion terms.
+rows ordered by the one-based ``ModeIndices`` attribute. With exactly one
+active channel, ``S`` is the outgoing coefficient divided by that source-mode
+incident coefficient, so the source group contains modal S11 and other groups
+contain S21, S31, and modal-conversion terms.
 
 Each mode has two audited anchor banks. ``anchor_mode_valid`` selects the
 propagating, one-watt profiles used by TF/SF source synthesis and real-power
@@ -991,6 +991,15 @@ When every eigenmode port has a passive virtual waveguide and no
 ``incident`` and ``outgoing`` modal spectra. No ``S`` datasets or
 ``<output>_sparameters.csv`` file are written because there is no active
 incident spectrum by which to normalize them.
+
+When two or more modal channels are excited simultaneously, the groups also
+contain the raw ``incident`` and ``outgoing`` spectra and have
+``ResponseType=driven``. Source groups record ``ExcitationModes``,
+``DriveAmplitudes``, ``DrivePowers``, ``DrivePhasesDegrees``, ``DriveDelays``,
+and ``DriveWaveformIDs``. No ``S`` datasets or S-parameter CSV are written:
+normalizing a superposed response by one incident channel would not be an
+independently excited S-matrix column. Use an ``EigenmodeStudy`` for that
+matrix.
 
 .. _output-ntff:
 

--- a/gprMax/eigenmode_ports.py
+++ b/gprMax/eigenmode_ports.py
@@ -311,6 +311,11 @@ class EigenmodePortMonitor:
         self.excitation_mode_index = (
             None if excitation_mode_index is None else int(excitation_mode_index)
         )
+        self.excitation_mode_indices = (
+            () if self.excitation_mode_index is None else (self.excitation_mode_index,)
+        )
+        self.drive_metadata = ()
+        self.response_type = "passive"
         # A TF/SF source must sample H on its total-field side. A passive port
         # uses the upstream half-cell, where either side is physically
         # equivalent in the absence of a field discontinuity.
@@ -356,6 +361,27 @@ class EigenmodePortMonitor:
         self.s_generalized_valid = None
         self.s_power_wave_valid = None
 
+    def set_drive_metadata(self, drives):
+        """Record all active modal drives represented by this physical port."""
+
+        self.drive_metadata = tuple(
+            {
+                "mode": int(drive.mode_index),
+                "waveform_id": str(drive.waveform.ID),
+                "amplitude": float(drive.amplitude),
+                "power": float(drive.power),
+                "phase_deg": float(drive.phase_deg),
+                "delay_s": float(drive.delay_s),
+            }
+            for drive in drives
+        )
+        self.excitation_mode_indices = tuple(metadata["mode"] for metadata in self.drive_metadata)
+        self.excitation_mode_index = (
+            self.excitation_mode_indices[0] if len(self.excitation_mode_indices) == 1 else None
+        )
+        self.is_source = bool(self.drive_metadata)
+        self.response_type = "driven" if self.is_source else "passive"
+
     @property
     def output_id(self):
         """Public port identifier used by antenna-power associations."""
@@ -369,12 +395,15 @@ class EigenmodePortMonitor:
             raise ValueError("Eigenmode port mode indices must be unique.")
         if self.port_index < 1:
             raise ValueError("Eigenmode port indices must be one-based positive integers.")
-        if self.is_source and self.excitation_mode_index not in self.mode_indices:
+        if self.is_source and (
+            not self.excitation_mode_indices
+            or any(mode not in self.mode_indices for mode in self.excitation_mode_indices)
+        ):
             raise ValueError(
-                "The source excitation mode must be included in its monitored mode indices."
+                "Every source excitation mode must be included in its monitored mode indices."
             )
-        if not self.is_source and self.excitation_mode_index is not None:
-            raise ValueError("A passive eigenmode port cannot have an excitation mode.")
+        if not self.is_source and self.excitation_mode_indices:
+            raise ValueError("A passive eigenmode port cannot have excitation modes.")
         if self.dft_points < 1:
             raise ValueError("Eigenmode port DFT points must be at least one.")
         if not np.isfinite(self.dft_start) or not np.isfinite(self.dft_stop):
@@ -899,6 +928,7 @@ class EigenmodePortMonitor:
         self.s_valid = None
         self.s_generalized_valid = None
         self.s_power_wave_valid = None
+        self.response_type = "driven" if self.is_source else "passive"
 
     def finalise(self, grid):
         nf, nm = self.electric_dft.shape
@@ -1002,6 +1032,31 @@ class EigenmodePortMonitor:
         group.attrs["IsSource"] = self.is_source
         if self.excitation_mode_index is not None:
             group.attrs["ExcitationMode"] = self.excitation_mode_index
+        excitation_modes = getattr(
+            self,
+            "excitation_mode_indices",
+            () if self.excitation_mode_index is None else (self.excitation_mode_index,),
+        )
+        drive_metadata = getattr(self, "drive_metadata", ())
+        if excitation_modes:
+            group.attrs["ExcitationModes"] = excitation_modes
+        if drive_metadata:
+            group.attrs["DriveAmplitudes"] = tuple(drive["amplitude"] for drive in drive_metadata)
+            group.attrs["DrivePowers"] = tuple(drive["power"] for drive in drive_metadata)
+            group.attrs["DrivePhasesDegrees"] = tuple(
+                drive["phase_deg"] for drive in drive_metadata
+            )
+            group.attrs["DriveDelays"] = tuple(drive["delay_s"] for drive in drive_metadata)
+            group.attrs["DriveWaveformIDs"] = tuple(
+                drive["waveform_id"] for drive in drive_metadata
+            )
+        group.attrs["ResponseType"] = getattr(
+            self,
+            "response_type",
+            "s_parameter_column"
+            if self.s_parameters is not None
+            else ("driven" if self.is_source else "passive"),
+        )
         group.attrs["Direction"] = self.owner.direction
         group.attrs["Normal"] = self.owner.normal
         group.attrs["ModeIndices"] = self.mode_indices
@@ -1052,14 +1107,29 @@ def finalise_eigenmode_ports(grid):
     # Their incident/outgoing power waves are still meaningful and are written
     # to HDF5, but an S matrix cannot be normalised without an active source.
     if not sources:
+        for port in grid.eigenmodeports:
+            port.response_type = "passive"
         return None
-    if len(sources) > 1:
-        raise ValueError(
-            "Eigenmode S-parameters require one and only one active eigenmode source; "
-            f"found {len(sources)}."
-        )
+
+    def excitation_modes(port):
+        modes = getattr(port, "excitation_mode_indices", None)
+        if modes is not None:
+            return tuple(modes)
+        mode = getattr(port, "excitation_mode_index", None)
+        return () if mode is None else (mode,)
+
+    drive_count = sum(len(excitation_modes(port)) for port in sources)
+    # A simultaneous driven state is not an S-matrix column. Preserve its
+    # decomposed incident/outgoing waves and drive metadata without inventing
+    # an ambiguous normalization.
+    if drive_count != 1:
+        for port in grid.eigenmodeports:
+            port.response_type = "driven"
+        return None
 
     source = sources[0]
+    for port in grid.eigenmodeports:
+        port.response_type = "s_parameter_column"
     for port in grid.eigenmodeports:
         if not np.array_equal(port.result.frequency, source.result.frequency):
             raise ValueError("All eigenmode ports must use identical DFT frequency bins.")

--- a/gprMax/grid/fdtd_grid.py
+++ b/gprMax/grid/fdtd_grid.py
@@ -179,6 +179,10 @@ class FDTDGrid:
         self.discreteplanewaves: List[DiscretePlaneWave] = []
         self.eigenmodeband = None
         self.eigenmodeportdefs = {}
+        # User-level modal drives. A physical port is still represented by one
+        # runtime owner/monitor even when several modes or ports are driven.
+        self.eigenmodeexcitations = []
+        # Retained as the single-excitation alias used by EigenmodeStudy.
         self.eigenmodeexcitation = None
         self.eigenmodesources: List[EigenmodeSource] = []
         self.eigenmodereceivers: List[EigenmodeReceiver] = []
@@ -1257,17 +1261,21 @@ class FDTDGrid:
         """Process eigenmode sources and receivers after Yee IDs have been built."""
         if self.eigenmodeportdefs and self.eigenmodeband is None:
             raise ValueError("Eigenmode ports require exactly one EigenmodeBand.")
-        if self.eigenmodeportdefs and self.eigenmodeexcitation is None:
+        if self.eigenmodeportdefs and not self.eigenmodeexcitations:
             if set(self.eigenmodeportdefs) != set(self.virtual_waveguide_specs):
                 raise ValueError(
-                    "Eigenmode ports require exactly one EigenmodeExcitation, unless "
+                    "Eigenmode ports require at least one EigenmodeExcitation, unless "
                     "every port has a passive VirtualWaveguide."
                 )
             from gprMax.user_objects.cmds_multiuse import build_passive_virtual_eigenmode_ports
 
             build_passive_virtual_eigenmode_ports(self)
+        elif self.eigenmodeportdefs and not (self.eigenmodesources or self.eigenmodereceivers):
+            from gprMax.user_objects.cmds_multiuse import build_eigenmode_runtime_ports
+
+            build_eigenmode_runtime_ports(self)
         source_count = len(self.eigenmodesources)
-        expected_sources = 0 if self.eigenmodeexcitation is None else 1
+        expected_sources = len({excitation.port_index for excitation in self.eigenmodeexcitations})
         if (source_count or self.eigenmodereceivers) and source_count != expected_sources:
             raise ValueError(
                 f"Eigenmode ports require {expected_sources} eigenmode source(s) on "

--- a/gprMax/hash_cmds_multiuse.py
+++ b/gprMax/hash_cmds_multiuse.py
@@ -431,11 +431,6 @@ def process_multicmds(multicmds):
             "Eigenmode ports require exactly one #eigenmode_band command; "
             f"found {len(eigenmode_band_cmds)}."
         )
-    if eigenmode_port_cmds and len(eigenmode_excitation_cmds) > 1:
-        raise ValueError(
-            "Eigenmode ports allow at most one #eigenmode_excitation command; "
-            f"found {len(eigenmode_excitation_cmds)}."
-        )
     if eigenmode_excitation_cmds and not eigenmode_port_cmds:
         raise ValueError("#eigenmode_excitation requires at least one #eigenmode_port.")
     if virtual_waveguide_cmds and not eigenmode_port_cmds:
@@ -445,7 +440,7 @@ def process_multicmds(multicmds):
         virtual_numbers = {int(command.split()[0]) for command in virtual_waveguide_cmds}
         if port_numbers != virtual_numbers:
             raise ValueError(
-                "Eigenmode ports require exactly one #eigenmode_excitation, unless "
+                "Eigenmode ports require at least one #eigenmode_excitation, unless "
                 "every port has a passive #virtual_waveguide."
             )
 
@@ -524,15 +519,20 @@ def process_multicmds(multicmds):
         if tmp and tmp[-1].lower() in ("y", "n"):
             plot_waveform = tmp[-1].lower() == "y"
             tmp = tmp[:-1]
-        if len(tmp) not in (2, 3, 4):
+        if len(tmp) not in (2, 3, 4, 5, 6):
             raise ValueError(
-                "#eigenmode_excitation requires port mode " "[auto|waveform_id] [amplitude] [y|n]."
+                "#eigenmode_excitation requires port mode [auto|waveform_id] "
+                "[amplitude] [phase_deg] [delay_s] [y|n]."
             )
         kwargs = {"port": int(tmp[0]), "mode": int(tmp[1])}
         if len(tmp) >= 3:
             kwargs["waveform"] = tmp[2]
-        if len(tmp) == 4:
+        if len(tmp) >= 4:
             kwargs["amplitude"] = float(tmp[3])
+        if len(tmp) >= 5:
+            kwargs["phase_deg"] = float(tmp[4])
+        if len(tmp) == 6:
+            kwargs["delay_s"] = float(tmp[5])
         if plot_waveform is not None:
             kwargs["plot_waveform"] = plot_waveform
         scene_objects.append(EigenmodeExcitation(**kwargs))

--- a/gprMax/model.py
+++ b/gprMax/model.py
@@ -565,7 +565,11 @@ class Model:
             from gprMax.studies import EigenmodeStudy
 
             if not isinstance(config.sim_config.study, EigenmodeStudy) and any(
-                grid.eigenmodesources or grid.eigenmodereceivers or grid.virtual_waveguide_specs
+                grid.eigenmodeportdefs
+                or grid.eigenmodeexcitations
+                or grid.eigenmodesources
+                or grid.eigenmodereceivers
+                or grid.virtual_waveguide_specs
                 for grid in grids
             ):
                 raise ValueError(

--- a/gprMax/ports.py
+++ b/gprMax/ports.py
@@ -211,7 +211,12 @@ def _finite_source_gap_admittance(output, frequency, dt, complex_dtype):
             dtype=np.complex128,
         )
         admittance[positive] = (
-            1j * omega_discrete[positive] * config.sim_config.em_consts["e0"] * epsilon_r * output.area / output.dl
+            1j
+            * omega_discrete[positive]
+            * config.sim_config.em_consts["e0"]
+            * epsilon_r
+            * output.area
+            / output.dl
         )
     admittance[nyquist] = np.nan + 1j * np.nan
     return np.asarray(admittance, dtype=complex_dtype)
@@ -261,21 +266,40 @@ def evaluate_port_power_spectrum(
         if incident_modal.shape != outgoing_modal.shape:
             raise ValueError(f"eigenmode port {output.output_id!r} has inconsistent modal arrays")
         if incident_modal.shape != (len(output.mode_indices), frequency.size):
-            raise ValueError(f"eigenmode port {output.output_id!r} has inconsistent modal dimensions")
+            raise ValueError(
+                f"eigenmode port {output.output_id!r} has inconsistent modal dimensions"
+            )
         if power_matrix.shape != (
             frequency.size,
             len(output.mode_indices),
             len(output.mode_indices),
         ):
-            raise ValueError(f"eigenmode port {output.output_id!r} has an inconsistent power matrix")
+            raise ValueError(
+                f"eigenmode port {output.output_id!r} has an inconsistent power matrix"
+            )
         if cross_power_matrix.shape != power_matrix.shape:
-            raise ValueError(f"eigenmode port {output.output_id!r} has an inconsistent cross-power matrix")
+            raise ValueError(
+                f"eigenmode port {output.output_id!r} has an inconsistent cross-power matrix"
+            )
 
         accepted_power = np.zeros(frequency.shape, dtype=real_dtype)
         incident_power = np.zeros(frequency.shape, dtype=real_dtype)
-        excitation_position = None
+        excitation_positions = np.empty(0, dtype=np.intp)
         if output.is_source:
-            excitation_position = output.mode_indices.index(output.excitation_mode_index)
+            excitation_modes = getattr(output, "excitation_mode_indices", None)
+            if excitation_modes is None:
+                excitation_mode = getattr(output, "excitation_mode_index", None)
+                excitation_modes = () if excitation_mode is None else (excitation_mode,)
+            try:
+                excitation_positions = np.asarray(
+                    [output.mode_indices.index(mode) for mode in excitation_modes],
+                    dtype=np.intp,
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    f"eigenmode port {output.output_id!r} has a driven mode that is "
+                    "not included in its monitored mode indices"
+                ) from exc
 
         power_wave_valid_value = getattr(output, "power_wave_valid", None)
         if power_wave_valid_value is None:
@@ -293,13 +317,19 @@ def evaluate_port_power_spectrum(
                 or not np.all(result_valid[physical_modes, frequency_index])
             ):
                 continue
-            if excitation_position is not None and not power_wave_valid[frequency_index, excitation_position]:
+            if excitation_positions.size and not np.all(
+                power_wave_valid[frequency_index, excitation_positions]
+            ):
                 continue
 
             incident = incident_modal[physical_modes, frequency_index]
             outgoing = outgoing_modal[physical_modes, frequency_index]
-            physical_power_matrix = power_matrix[frequency_index][np.ix_(physical_modes, physical_modes)]
-            physical_cross_power_matrix = cross_power_matrix[frequency_index][np.ix_(physical_modes, physical_modes)]
+            physical_power_matrix = power_matrix[frequency_index][
+                np.ix_(physical_modes, physical_modes)
+            ]
+            physical_cross_power_matrix = cross_power_matrix[frequency_index][
+                np.ix_(physical_modes, physical_modes)
+            ]
             if not (
                 np.all(np.isfinite(incident))
                 and np.all(np.isfinite(outgoing))
@@ -317,16 +347,23 @@ def evaluate_port_power_spectrum(
                 )
             )
             incident_value = 0.0
-            if excitation_position is not None:
-                local_excitation_position = int(np.flatnonzero(physical_modes == excitation_position)[0])
-                excitation_amplitude = incident[local_excitation_position]
+            if excitation_positions.size:
+                local_excitation_positions = np.asarray(
+                    [
+                        int(np.flatnonzero(physical_modes == position)[0])
+                        for position in excitation_positions
+                    ],
+                    dtype=np.intp,
+                )
+                excitation_amplitudes = incident[local_excitation_positions]
+                excitation_power_matrix = physical_power_matrix[
+                    np.ix_(local_excitation_positions, local_excitation_positions)
+                ]
                 incident_value = np.real(
-                    np.conj(excitation_amplitude)
-                    * physical_power_matrix[
-                        local_excitation_position,
-                        local_excitation_position,
-                    ]
-                    * excitation_amplitude
+                    np.vdot(
+                        excitation_amplitudes,
+                        excitation_power_matrix @ excitation_amplitudes,
+                    )
                 )
             if not np.isfinite(accepted_value) or not np.isfinite(incident_value):
                 continue
@@ -583,8 +620,13 @@ def model_port_ids(model: "Model") -> tuple[str, ...]:
     references = []
     for grid in (model.G, *model.subgrids):
         local_ids = [monitor.output_id for monitor in getattr(grid, "port_monitors", ())]
-        local_ids.extend(f"tl{index}" for index, _ in enumerate(getattr(grid, "transmissionlines", ()), start=1))
-        local_ids.extend(f"frill{index}" for index, _ in enumerate(getattr(grid, "magneticfrillsources", ()), start=1))
+        local_ids.extend(
+            f"tl{index}" for index, _ in enumerate(getattr(grid, "transmissionlines", ()), start=1)
+        )
+        local_ids.extend(
+            f"frill{index}"
+            for index, _ in enumerate(getattr(grid, "magneticfrillsources", ()), start=1)
+        )
         local_ids.extend(monitor.output_id for monitor in getattr(grid, "eigenmodeports", ()))
         if len(set(local_ids)) != len(local_ids):
             location = "main grid" if grid is model.G else f"subgrid {grid.name!r}"
@@ -628,7 +670,8 @@ def validate_spectrum_limit(value) -> SpectrumLimit:
         raise ValueError("spectrum_limit must be a finite number or 'nyquist'")
     if value < MINIMUM_PHYSICAL_WAVELENGTH_CELLS:
         raise ValueError(
-            "numeric spectrum_limit must be at least " f"{MINIMUM_PHYSICAL_WAVELENGTH_CELLS:g} cells per wavelength"
+            "numeric spectrum_limit must be at least "
+            f"{MINIMUM_PHYSICAL_WAVELENGTH_CELLS:g} cells per wavelength"
         )
     return value
 
@@ -670,10 +713,14 @@ def _complex_relative_permittivity(material, frequencies):
     if not np.any(positive):
         return values
     if hasattr(material, "poles"):
-        values[positive] = np.asarray(material.calculate_er(frequencies[positive]), dtype=np.complex128)
+        values[positive] = np.asarray(
+            material.calculate_er(frequencies[positive]), dtype=np.complex128
+        )
     else:
         omega = 2 * np.pi * frequencies[positive]
-        values[positive] = material.er + material.se / (1j * omega * config.sim_config.em_consts["e0"])
+        values[positive] = material.er + material.se / (
+            1j * omega * config.sim_config.em_consts["e0"]
+        )
     return values
 
 
@@ -686,7 +733,9 @@ def _complex_relative_permeability(material, frequencies):
     positive = ~zero
     if np.any(positive):
         omega = 2 * np.pi * frequencies[positive]
-        values[positive] = material.mr + material.sm / (1j * omega * config.sim_config.em_consts["m0"])
+        values[positive] = material.mr + material.sm / (
+            1j * omega * config.sim_config.em_consts["m0"]
+        )
     return values
 
 
@@ -933,15 +982,23 @@ class RationalNetworkPortOutput:
         self.result: Optional[RationalNetworkPortResult] = None
         self.prepared = False
         self.minimum_wavelength_cells = (
-            DEFAULT_MINIMUM_WAVELENGTH_CELLS if self.spectrum_limit == "nyquist" else float(self.spectrum_limit)
+            DEFAULT_MINIMUM_WAVELENGTH_CELLS
+            if self.spectrum_limit == "nyquist"
+            else float(self.spectrum_limit)
         )
-        self.spectrum_limit_mode = "nyquist" if self.spectrum_limit == "nyquist" else "minimum_wavelength_cells"
+        self.spectrum_limit_mode = (
+            "nyquist" if self.spectrum_limit == "nyquist" else "minimum_wavelength_cells"
+        )
         self.incident_floor_db = DEFAULT_INCIDENT_FLOOR_DB
 
     def rebind_after_mpi_gather(self, grid: "FDTDGrid") -> None:
         """Reconnect the gathered output to its coordinator-side terminal."""
 
-        terminals = [terminal for terminal in getattr(grid, "networkterminals", ()) if terminal.ID == self.output_id]
+        terminals = [
+            terminal
+            for terminal in getattr(grid, "networkterminals", ())
+            if terminal.ID == self.output_id
+        ]
         if len(terminals) != 1:
             raise RuntimeError(
                 f"NetworkPort {self.output_id!r} could not uniquely rebind its MPI "
@@ -961,16 +1018,23 @@ class RationalNetworkPortOutput:
         if not self.terminal.prepared:
             self.terminal.prepare(grid)
         if not np.isfinite(self.reference_impedance) or self.reference_impedance <= 0:
-            raise ValueError(f"network port {self.output_id!r} requires a finite, positive reference impedance")
+            raise ValueError(
+                f"network port {self.output_id!r} requires a finite, positive reference impedance"
+            )
         if grid.iterations < 2:
             raise ValueError(f"network port {self.output_id!r} requires at least two iterations")
 
         self.dl = float(self.terminal.dl)
         self.area = float(self.terminal.area)
-        self.background_relative_permittivity = float(self.terminal.background_relative_permittivity)
+        self.background_relative_permittivity = float(
+            self.terminal.background_relative_permittivity
+        )
         self.background_conductivity = float(self.terminal.background_conductivity)
         self.gap_capacitance = (
-            config.sim_config.em_consts["e0"] * self.background_relative_permittivity * self.area / self.dl
+            config.sim_config.em_consts["e0"]
+            * self.background_relative_permittivity
+            * self.area
+            / self.dl
         )
         self.background_conductance = self.background_conductivity * self.area / self.dl
 
@@ -985,7 +1049,9 @@ class RationalNetworkPortOutput:
         else:
             last_mesh_index = full_frequency.size - 1
             limiting_index = last_mesh_index
-        self._frequency_slice = slice(None) if self.spectrum_limit_mode == "nyquist" else slice(0, last_mesh_index + 1)
+        self._frequency_slice = (
+            slice(None) if self.spectrum_limit_mode == "nyquist" else slice(0, last_mesh_index + 1)
+        )
         self._full_cells_per_wavelength = cells
         self._full_mesh_valid = mesh_valid_full
         self.nyquist_frequency = float(1 / (2 * grid.dt))
@@ -994,7 +1060,9 @@ class RationalNetworkPortOutput:
         self.independent_frequency_resolution = float(1 / (grid.iterations * grid.dt))
         self.dt = float(grid.dt)
         if hasattr(grid, "local_to_global"):
-            self.source_position = np.asarray(grid.local_to_global(self.terminal.coord), dtype=np.float64)
+            self.source_position = np.asarray(
+                grid.local_to_global(self.terminal.coord), dtype=np.float64
+            )
         else:
             self.source_position = np.asarray(
                 self.terminal.coord * np.asarray((grid.dx, grid.dy, grid.dz)),
@@ -1023,9 +1091,13 @@ class RationalNetworkPortOutput:
             dtype=real_dtype,
         )
 
-        frequency_full, total_voltage_full = engineering_rfft(total_voltage, grid.dt, time_offset=0.5 * grid.dt)
+        frequency_full, total_voltage_full = engineering_rfft(
+            total_voltage, grid.dt, time_offset=0.5 * grid.dt
+        )
         _, generator_full = engineering_rfft(generator_voltage, grid.dt, time_offset=0.5 * grid.dt)
-        _, network_current_full = engineering_rfft(network_current, grid.dt, time_offset=0.5 * grid.dt)
+        _, network_current_full = engineering_rfft(
+            network_current, grid.dt, time_offset=0.5 * grid.dt
+        )
         selection = self._frequency_slice
         frequency = frequency_full[selection]
         total_spectrum = total_voltage_full[selection]
@@ -1071,7 +1143,9 @@ class RationalNetworkPortOutput:
             else np.zeros(frequency.shape, dtype=bool)
         )
         mesh_valid = np.asarray(self._full_mesh_valid[selection], dtype=bool)
-        cells_per_wavelength = np.asarray(self._full_cells_per_wavelength[selection], dtype=real_dtype)
+        cells_per_wavelength = np.asarray(
+            self._full_cells_per_wavelength[selection], dtype=real_dtype
+        )
         nyquist = np.isclose(
             frequency,
             1 / (2 * grid.dt),
@@ -1161,7 +1235,9 @@ class RationalNetworkPortOutput:
         group.attrs["NyquistFrequency"] = self.nyquist_frequency
         group.attrs["LimitingMaterial"] = self.limiting_material
         group.attrs["IndependentFrequencyResolution"] = self.independent_frequency_resolution
-        group.attrs["FrequencyRange"] = np.asarray((result.frequency[0], result.frequency[-1]), dtype=real_dtype)
+        group.attrs["FrequencyRange"] = np.asarray(
+            (result.frequency[0], result.frequency[-1]), dtype=real_dtype
+        )
         valid_indices = np.flatnonzero(result.valid_s11)
         valid_range = (
             (result.frequency[valid_indices[0]], result.frequency[valid_indices[-1]])
@@ -1174,8 +1250,12 @@ class RationalNetworkPortOutput:
         group.attrs["forward_transform_sign"] = FORWARD_TRANSFORM_KERNEL
         group.attrs["real_dtype"] = real_dtype.name
         group.attrs["complex_dtype"] = complex_dtype.name
-        group.create_dataset("poles", data=np.asarray(self.terminal.model.poles, dtype=complex_dtype))
-        group.create_dataset("residues", data=np.asarray(self.terminal.model.residues, dtype=complex_dtype))
+        group.create_dataset(
+            "poles", data=np.asarray(self.terminal.model.poles, dtype=complex_dtype)
+        )
+        group.create_dataset(
+            "residues", data=np.asarray(self.terminal.model.residues, dtype=complex_dtype)
+        )
         datasets = {
             "time": result.time,
             "Vgenerator": result.generator_voltage,
@@ -1230,9 +1310,13 @@ class VoltageSourcePortMonitor:
         self.prepared = False
 
         self.minimum_wavelength_cells = (
-            DEFAULT_MINIMUM_WAVELENGTH_CELLS if spectrum_limit == "nyquist" else float(spectrum_limit)
+            DEFAULT_MINIMUM_WAVELENGTH_CELLS
+            if spectrum_limit == "nyquist"
+            else float(spectrum_limit)
         )
-        self.spectrum_limit_mode = "nyquist" if spectrum_limit == "nyquist" else "minimum_wavelength_cells"
+        self.spectrum_limit_mode = (
+            "nyquist" if spectrum_limit == "nyquist" else "minimum_wavelength_cells"
+        )
         self.incident_floor_db = DEFAULT_INCIDENT_FLOOR_DB
 
     @property
@@ -1261,12 +1345,14 @@ class VoltageSourcePortMonitor:
         receivers = [
             receiver
             for receiver in grid.rxs
-            if getattr(receiver, "internal", False) and getattr(receiver, "port_id", None) == self.output_id
+            if getattr(receiver, "internal", False)
+            and getattr(receiver, "port_id", None) == self.output_id
         ]
         sources = [
             source
             for source in grid.voltagesources
-            if source.polarisation == self.source.polarisation and np.array_equal(source.coord, self.source.coord)
+            if source.polarisation == self.source.polarisation
+            and np.array_equal(source.coord, self.source.coord)
         ]
         if len(receivers) != 1 or len(sources) != 1:
             raise RuntimeError(
@@ -1296,9 +1382,13 @@ class VoltageSourcePortMonitor:
         """Validate the built Yee edge and calculate fixed port parameters."""
 
         if grid.iterations < 2:
-            raise ValueError(f"Voltage-source port {self.output_id!r} requires at least two iterations")
+            raise ValueError(
+                f"Voltage-source port {self.output_id!r} requires at least two iterations"
+            )
         if not np.array_equal(self.receiver.coord, self.source.coord):
-            raise ValueError(f"Voltage-source port {self.output_id!r} receiver is no longer source-bound")
+            raise ValueError(
+                f"Voltage-source port {self.output_id!r} receiver is no longer source-bound"
+            )
         self.hard_source = self.source.resistance == 0
         if self.hard_source:
             component_id = f"E{self.source.polarisation}"
@@ -1321,10 +1411,16 @@ class VoltageSourcePortMonitor:
             self.source.background_is_dispersive = hasattr(material, "poles")
             self.source.source_material_numID = material_num_id
         elif getattr(self.source, "background_material_numID", None) is None:
-            raise ValueError(f"Voltage-source port {self.output_id!r} source material was not constructed")
-        self.background_is_dispersive = bool(getattr(self.source, "background_is_dispersive", False))
+            raise ValueError(
+                f"Voltage-source port {self.output_id!r} source material was not constructed"
+            )
+        self.background_is_dispersive = bool(
+            getattr(self.source, "background_is_dispersive", False)
+        )
         self.background_material = next(
-            item for item in grid.materials if item.numID == int(self.source.background_material_numID)
+            item
+            for item in grid.materials
+            if item.numID == int(self.source.background_material_numID)
         )
         if self.hard_source and self.background_is_dispersive:
             raise ValueError(
@@ -1336,14 +1432,20 @@ class VoltageSourcePortMonitor:
         self.reference_impedance = float(self.source.reference_impedance)
         if not np.isfinite(self.reference_impedance) or self.reference_impedance <= 0:
             raise ValueError(
-                f"Voltage-source port {self.output_id!r} requires a finite, positive " "reference impedance"
+                f"Voltage-source port {self.output_id!r} requires a finite, positive "
+                "reference impedance"
             )
         self.background_relative_permittivity = float(self.source.background_er)
         self.background_conductivity = float(self.source.background_se)
         if not np.isfinite(self.background_conductivity):
-            raise ValueError(f"Voltage-source port {self.output_id!r} cannot use a voltage source on a PEC edge")
+            raise ValueError(
+                f"Voltage-source port {self.output_id!r} cannot use a voltage source on a PEC edge"
+            )
         self.gap_capacitance = (
-            config.sim_config.em_consts["e0"] * self.background_relative_permittivity * self.area / self.dl
+            config.sim_config.em_consts["e0"]
+            * self.background_relative_permittivity
+            * self.area
+            / self.dl
         )
         self.background_conductance = self.background_conductivity * self.area / self.dl
 
@@ -1351,7 +1453,9 @@ class VoltageSourcePortMonitor:
         source_material = grid.materials[source_material_id]
         dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
         if not self.hard_source:
-            added_conductance = (float(source_material.se) - self.background_conductivity) * self.area / self.dl
+            added_conductance = (
+                (float(source_material.se) - self.background_conductivity) * self.area / self.dl
+            )
             tolerance = 64 * np.finfo(dtype).eps
             if not np.isclose(
                 added_conductance,
@@ -1366,9 +1470,13 @@ class VoltageSourcePortMonitor:
             if not np.isfinite(grid.updatecoeffsE[source_material_id, 4]) or np.isclose(
                 grid.updatecoeffsE[source_material_id, 4], 0
             ):
-                raise ValueError(f"Voltage-source port {self.output_id!r} source is on an inactive electric edge")
+                raise ValueError(
+                    f"Voltage-source port {self.output_id!r} source is on an inactive electric edge"
+                )
         elif f"I{self.source.polarisation}" not in self.receiver.outputs:
-            raise ValueError(f"Voltage-source port {self.output_id!r} hard source has no terminal-current samples")
+            raise ValueError(
+                f"Voltage-source port {self.output_id!r} hard source has no terminal-current samples"
+            )
 
         nsamples = grid.iterations - 1
         self.aligned_samples = nsamples
@@ -1423,23 +1531,33 @@ class VoltageSourcePortMonitor:
         if self.hard_source:
             return self._finalise_hard_source(grid)
         if not np.array_equal(self.receiver.coord, self.source.coord):
-            raise RuntimeError(f"Voltage-source port {self.output_id!r} receiver moved away from its source")
+            raise RuntimeError(
+                f"Voltage-source port {self.output_id!r} receiver moved away from its source"
+            )
 
         real_dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
         complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
         electric = np.asarray(self.receiver.outputs[self.component], dtype=real_dtype)
         if electric.size != grid.iterations:
-            raise RuntimeError(f"Voltage-source port {self.output_id!r} receiver history has the wrong length")
+            raise RuntimeError(
+                f"Voltage-source port {self.output_id!r} receiver history has the wrong length"
+            )
 
         integer_voltage = np.asarray(-self.dl * electric, dtype=real_dtype)
-        total_voltage = np.asarray(0.5 * (integer_voltage[:-1] + integer_voltage[1:]), dtype=real_dtype)
-        generator_voltage = np.asarray(self.source.waveformvalues_halfdt[: total_voltage.size], dtype=real_dtype)
+        total_voltage = np.asarray(
+            0.5 * (integer_voltage[:-1] + integer_voltage[1:]), dtype=real_dtype
+        )
+        generator_voltage = np.asarray(
+            self.source.waveformvalues_halfdt[: total_voltage.size], dtype=real_dtype
+        )
         time = np.asarray(
             (np.arange(total_voltage.size, dtype=real_dtype) + real_dtype.type(0.5)) * grid.dt,
             dtype=real_dtype,
         )
 
-        frequency_full, total_spectrum_full = engineering_rfft(total_voltage, grid.dt, time_offset=0.5 * grid.dt)
+        frequency_full, total_spectrum_full = engineering_rfft(
+            total_voltage, grid.dt, time_offset=0.5 * grid.dt
+        )
         generator_frequency, generator_spectrum_full = engineering_rfft(
             generator_voltage, grid.dt, time_offset=0.5 * grid.dt
         )
@@ -1452,7 +1570,9 @@ class VoltageSourcePortMonitor:
         generator_spectrum = generator_spectrum_full[selection]
         incident_spectrum = np.asarray(0.5 * generator_spectrum, dtype=complex_dtype)
         reflected_source = np.asarray(total_spectrum - incident_spectrum, dtype=complex_dtype)
-        s11_source, source_defined = _safe_complex_divide(reflected_source, incident_spectrum, complex_dtype)
+        s11_source, source_defined = _safe_complex_divide(
+            reflected_source, incident_spectrum, complex_dtype
+        )
 
         incident_magnitude = np.abs(incident_spectrum)
         incident_peak = float(np.max(incident_magnitude, initial=0.0))
@@ -1474,8 +1594,12 @@ class VoltageSourcePortMonitor:
             self.reference_impedance * gap_admittance,
             dtype=complex_dtype,
         )
-        s11, gap_correction_valid = correct_s11_for_parallel_gap(s11_source, gap_correction, complex_dtype)
-        exact_nyquist_included = self.aligned_samples % 2 == 0 and frequency.size == frequency_full.size
+        s11, gap_correction_valid = correct_s11_for_parallel_gap(
+            s11_source, gap_correction, complex_dtype
+        )
+        exact_nyquist_included = (
+            self.aligned_samples % 2 == 0 and frequency.size == frequency_full.size
+        )
         if self.gap_capacitance != 0 and exact_nyquist_included:
             gap_correction_valid[-1] = False
             s11[-1] = np.nan + 1j * np.nan
@@ -1485,7 +1609,9 @@ class VoltageSourcePortMonitor:
         yin, yin_defined = admittance_from_s11(s11, self.reference_impedance, complex_dtype)
 
         mesh_valid = np.asarray(self._full_mesh_valid[selection], dtype=bool)
-        cells_per_wavelength = np.asarray(self._full_cells_per_wavelength[selection], dtype=real_dtype)
+        cells_per_wavelength = np.asarray(
+            self._full_cells_per_wavelength[selection], dtype=real_dtype
+        )
         valid_s11 = mesh_valid & source_valid & gap_correction_valid
         valid_zin = valid_s11 & zin_defined
         valid_yin = valid_s11 & yin_defined
@@ -1548,14 +1674,18 @@ class VoltageSourcePortMonitor:
         """Derive a delta-gap port from prescribed voltage and loop current."""
 
         if not np.array_equal(self.receiver.coord, self.source.coord):
-            raise RuntimeError(f"Voltage-source port {self.output_id!r} receiver moved away from its source")
+            raise RuntimeError(
+                f"Voltage-source port {self.output_id!r} receiver moved away from its source"
+            )
 
         real_dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
         complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
         electric = np.asarray(self.receiver.outputs[self.component], dtype=real_dtype)
         loop_half = self._hard_loop_current_history(real_dtype)
         if electric.size != grid.iterations or loop_half.size != grid.iterations:
-            raise RuntimeError(f"Voltage-source port {self.output_id!r} receiver history has the wrong length")
+            raise RuntimeError(
+                f"Voltage-source port {self.output_id!r} receiver history has the wrong length"
+            )
 
         # At receiver-storage index m, E is at m*dt and H is at
         # (m-1/2)*dt. Drop the unexcited initial fields so each retained pair
@@ -1597,7 +1727,9 @@ class VoltageSourcePortMonitor:
             grid.dt,
             complex_dtype,
         )
-        terminal_current = np.asarray(loop_spectrum - gap_admittance * total_spectrum, dtype=complex_dtype)
+        terminal_current = np.asarray(
+            loop_spectrum - gap_admittance * total_spectrum, dtype=complex_dtype
+        )
 
         incident_source = np.asarray(
             0.5 * (total_spectrum + self.reference_impedance * loop_spectrum),
@@ -1615,9 +1747,15 @@ class VoltageSourcePortMonitor:
             0.5 * (total_spectrum - self.reference_impedance * terminal_current),
             dtype=complex_dtype,
         )
-        s11_source, source_plane_defined = _safe_complex_divide(reflected_source, incident_source, complex_dtype)
-        s11, terminal_wave_defined = _safe_complex_divide(reflected_terminal, incident_spectrum, complex_dtype)
-        zin_source, zin_source_defined = _safe_complex_divide(total_spectrum, loop_spectrum, complex_dtype)
+        s11_source, source_plane_defined = _safe_complex_divide(
+            reflected_source, incident_source, complex_dtype
+        )
+        s11, terminal_wave_defined = _safe_complex_divide(
+            reflected_terminal, incident_spectrum, complex_dtype
+        )
+        zin_source, zin_source_defined = _safe_complex_divide(
+            total_spectrum, loop_spectrum, complex_dtype
+        )
         zin, zin_defined = _safe_complex_divide(total_spectrum, terminal_current, complex_dtype)
         yin, yin_defined = _safe_complex_divide(terminal_current, total_spectrum, complex_dtype)
 
@@ -1636,7 +1774,9 @@ class VoltageSourcePortMonitor:
         gap_correction_valid = np.ones(frequency.shape, dtype=bool)
 
         mesh_valid = np.asarray(self._full_mesh_valid[selection], dtype=bool)
-        cells_per_wavelength = np.asarray(self._full_cells_per_wavelength[selection], dtype=real_dtype)
+        cells_per_wavelength = np.asarray(
+            self._full_cells_per_wavelength[selection], dtype=real_dtype
+        )
         source_plane_valid = source_plane_defined & zin_source_defined
         valid_s11 = mesh_valid & source_valid & gap_correction_valid
         valid_zin = valid_s11 & zin_defined
@@ -1710,7 +1850,9 @@ class VoltageSourcePortMonitor:
         group.attrs["GapCapacitance"] = self.gap_capacitance
         group.attrs["BackgroundConductance"] = self.background_conductance
         group.attrs["GapCorrection"] = "discrete_parallel_admittance"
-        group.attrs["TimeSampleOffset"] = self.hard_voltage_time_offset if self.hard_source else 0.5 * self.dt
+        group.attrs["TimeSampleOffset"] = (
+            self.hard_voltage_time_offset if self.hard_source else 0.5 * self.dt
+        )
         if self.hard_source:
             group.attrs["CurrentTimeSampleOffset"] = self.hard_current_time_offset
             group.attrs["CurrentTimeAlignment"] = "explicit_fft_half_step_phase"
@@ -1722,7 +1864,9 @@ class VoltageSourcePortMonitor:
         group.attrs["MeshFrequencyLimit"] = self.mesh_frequency_limit
         group.attrs["LimitingMaterial"] = self.limiting_material
         group.attrs["IndependentFrequencyResolution"] = self.independent_frequency_resolution
-        group.attrs["FrequencyRange"] = np.asarray((result.frequency[0], result.frequency[-1]), dtype=real_dtype)
+        group.attrs["FrequencyRange"] = np.asarray(
+            (result.frequency[0], result.frequency[-1]), dtype=real_dtype
+        )
         valid_indices = np.flatnonzero(result.valid_s11)
         valid_range = (
             (result.frequency[valid_indices[0]], result.frequency[valid_indices[-1]])
@@ -1777,7 +1921,9 @@ class VoltageSourcePortMonitor:
 
         self.grid_dl = np.asarray((grid.dx, grid.dy, grid.dz), dtype=np.float64)
         if hasattr(grid, "local_to_global"):
-            self.source_position = np.asarray(grid.local_to_global(self.source.coord), dtype=np.float64)
+            self.source_position = np.asarray(
+                grid.local_to_global(self.source.coord), dtype=np.float64
+            )
         else:
             self.source_position = np.asarray(self.source.coord * self.grid_dl, dtype=np.float64)
         self.dt = float(grid.dt)
@@ -1838,9 +1984,13 @@ class TransmissionLinePortOutput:
         self.result: Optional[TransmissionLinePortResult] = None
         self.prepared = False
         self.minimum_wavelength_cells = (
-            DEFAULT_MINIMUM_WAVELENGTH_CELLS if self.spectrum_limit == "nyquist" else float(self.spectrum_limit)
+            DEFAULT_MINIMUM_WAVELENGTH_CELLS
+            if self.spectrum_limit == "nyquist"
+            else float(self.spectrum_limit)
         )
-        self.spectrum_limit_mode = "nyquist" if self.spectrum_limit == "nyquist" else "minimum_wavelength_cells"
+        self.spectrum_limit_mode = (
+            "nyquist" if self.spectrum_limit == "nyquist" else "minimum_wavelength_cells"
+        )
         self.incident_floor_db = DEFAULT_INCIDENT_FLOOR_DB
 
     @property
@@ -1851,7 +2001,9 @@ class TransmissionLinePortOutput:
         """Calculate the native frequency axis and mesh-valid output band."""
 
         if grid.iterations < 2:
-            raise ValueError(f"Transmission line {self.output_id!r} requires at least two iterations")
+            raise ValueError(
+                f"Transmission line {self.output_id!r} requires at least two iterations"
+            )
         if not np.isfinite(self.source.resistance) or self.source.resistance <= 0:
             raise ValueError(f"Transmission line {self.output_id!r} has an invalid resistance")
         if not np.isfinite(self.source.dl) or self.source.dl <= 0:
@@ -1929,18 +2081,26 @@ class TransmissionLinePortOutput:
         for name in ("Vinc", "Iinc", "Vtotal", "Itotal"):
             values = np.asarray(getattr(self.source, name), dtype=real_dtype)
             if values.ndim != 1 or values.size < self.nsamples:
-                raise RuntimeError(f"Transmission line {self.output_id!r} {name} history has " "the wrong length")
+                raise RuntimeError(
+                    f"Transmission line {self.output_id!r} {name} history has " "the wrong length"
+                )
             values = values[: self.nsamples]
             if not np.all(np.isfinite(values)):
-                raise RuntimeError(f"Transmission line {self.output_id!r} {name} history is not finite")
+                raise RuntimeError(
+                    f"Transmission line {self.output_id!r} {name} history is not finite"
+                )
             histories[name] = values
 
         frequency_full, incident_voltage_full = engineering_rfft(histories["Vinc"], grid.dt)
         _, total_voltage_full = engineering_rfft(histories["Vtotal"], grid.dt)
         # Index n stores I at (n - 1/2) dt. Applying the physical sample-time
         # offset here preserves all N samples and the voltage FFT grid.
-        _, incident_current_full = engineering_rfft(histories["Iinc"], grid.dt, time_offset=-0.5 * grid.dt)
-        _, total_current_full = engineering_rfft(histories["Itotal"], grid.dt, time_offset=-0.5 * grid.dt)
+        _, incident_current_full = engineering_rfft(
+            histories["Iinc"], grid.dt, time_offset=-0.5 * grid.dt
+        )
+        _, total_current_full = engineering_rfft(
+            histories["Itotal"], grid.dt, time_offset=-0.5 * grid.dt
+        )
 
         selection = self._frequency_slice
         frequency = frequency_full[selection]
@@ -1949,7 +2109,9 @@ class TransmissionLinePortOutput:
         incident_current = incident_current_full[selection]
         total_current = total_current_full[selection]
         reflected_voltage = np.asarray(total_voltage - incident_voltage, dtype=complex_dtype)
-        s11, source_defined = _safe_complex_divide(reflected_voltage, incident_voltage, complex_dtype)
+        s11, source_defined = _safe_complex_divide(
+            reflected_voltage, incident_voltage, complex_dtype
+        )
 
         incident_magnitude = np.abs(incident_voltage)
         incident_peak = float(np.max(incident_magnitude, initial=0.0))
@@ -1975,21 +2137,28 @@ class TransmissionLinePortOutput:
         reflected_from_current = np.full(frequency.shape, np.nan + 1j * np.nan, dtype=complex_dtype)
         inverse_half_cell_phase = np.conj(half_cell_phase)
         reflected_from_current[line_propagation_valid] = (
-            incident_voltage[line_propagation_valid] * inverse_half_cell_phase[line_propagation_valid]
+            incident_voltage[line_propagation_valid]
+            * inverse_half_cell_phase[line_propagation_valid]
             - self.reference_impedance * total_current[line_propagation_valid]
         ) * inverse_half_cell_phase[line_propagation_valid]
-        s11_current, s11_current_defined = _safe_complex_divide(reflected_from_current, incident_voltage, complex_dtype)
+        s11_current, s11_current_defined = _safe_complex_divide(
+            reflected_from_current, incident_voltage, complex_dtype
+        )
         terminal_current = np.asarray(
             (incident_voltage - reflected_from_current) / self.reference_impedance,
             dtype=complex_dtype,
         )
-        terminal_voltage_current = np.asarray(incident_voltage + reflected_from_current, dtype=complex_dtype)
+        terminal_voltage_current = np.asarray(
+            incident_voltage + reflected_from_current, dtype=complex_dtype
+        )
         zin_current, zin_current_defined = _safe_complex_divide(
             terminal_voltage_current, terminal_current, complex_dtype
         )
 
         mesh_valid = np.asarray(self._full_mesh_valid[selection], dtype=bool)
-        cells_per_wavelength = np.asarray(self._full_cells_per_wavelength[selection], dtype=real_dtype)
+        cells_per_wavelength = np.asarray(
+            self._full_cells_per_wavelength[selection], dtype=real_dtype
+        )
         valid_s11 = mesh_valid & source_valid
         valid_zin = valid_s11 & zin_defined
         valid_yin = valid_s11 & yin_defined
@@ -2074,7 +2243,9 @@ class TransmissionLinePortOutput:
         group.attrs["MeshFrequencyLimit"] = self.mesh_frequency_limit
         group.attrs["LimitingMaterial"] = self.limiting_material
         group.attrs["IndependentFrequencyResolution"] = self.independent_frequency_resolution
-        group.attrs["FrequencyRange"] = np.asarray((result.frequency[0], result.frequency[-1]), dtype=real_dtype)
+        group.attrs["FrequencyRange"] = np.asarray(
+            (result.frequency[0], result.frequency[-1]), dtype=real_dtype
+        )
         valid_indices = np.flatnonzero(result.valid_s11)
         valid_range = (
             (result.frequency[valid_indices[0]], result.frequency[valid_indices[-1]])
@@ -2191,9 +2362,13 @@ class MagneticFrillPortOutput:
         self.result: Optional[MagneticFrillPortResult] = None
         self.prepared = False
         self.minimum_wavelength_cells = (
-            DEFAULT_MINIMUM_WAVELENGTH_CELLS if self.spectrum_limit == "nyquist" else float(self.spectrum_limit)
+            DEFAULT_MINIMUM_WAVELENGTH_CELLS
+            if self.spectrum_limit == "nyquist"
+            else float(self.spectrum_limit)
         )
-        self.spectrum_limit_mode = "nyquist" if self.spectrum_limit == "nyquist" else "minimum_wavelength_cells"
+        self.spectrum_limit_mode = (
+            "nyquist" if self.spectrum_limit == "nyquist" else "minimum_wavelength_cells"
+        )
         self.incident_floor_db = DEFAULT_INCIDENT_FLOOR_DB
 
     @property
@@ -2204,7 +2379,9 @@ class MagneticFrillPortOutput:
         """Calculate the native frequency axis and mesh-valid output band."""
 
         if grid.iterations < 2:
-            raise ValueError(f"Magnetic frill source {self.output_id!r} requires at least two iterations")
+            raise ValueError(
+                f"Magnetic frill source {self.output_id!r} requires at least two iterations"
+            )
         if not np.isfinite(self.source.Z0) or self.source.Z0 <= 0:
             raise ValueError(f"Magnetic frill source {self.output_id!r} has an invalid Z0")
 
@@ -2264,18 +2441,29 @@ class MagneticFrillPortOutput:
         for name in ("Vinc", "Vtotal", "Itot"):
             values = np.asarray(getattr(self.source, name), dtype=real_dtype)
             if values.ndim != 1 or values.size < self.nsamples:
-                raise RuntimeError(f"Magnetic frill source {self.output_id!r} {name} history " "has the wrong length")
+                raise RuntimeError(
+                    f"Magnetic frill source {self.output_id!r} {name} history "
+                    "has the wrong length"
+                )
             values = values[: self.nsamples]
             if not np.all(np.isfinite(values)):
-                raise RuntimeError(f"Magnetic frill source {self.output_id!r} {name} history is not finite")
+                raise RuntimeError(
+                    f"Magnetic frill source {self.output_id!r} {name} history is not finite"
+                )
             histories[name] = values
 
         # Hyun equations (9)-(11): voltage is at integer time and Itot is
         # averaged from the adjacent magnetic half steps to the same time.
         time_offset = 0.0
-        frequency_full, incident_voltage_full = engineering_rfft(histories["Vinc"], grid.dt, time_offset=time_offset)
-        _, total_voltage_full = engineering_rfft(histories["Vtotal"], grid.dt, time_offset=time_offset)
-        _, total_current_full = engineering_rfft(histories["Itot"], grid.dt, time_offset=time_offset)
+        frequency_full, incident_voltage_full = engineering_rfft(
+            histories["Vinc"], grid.dt, time_offset=time_offset
+        )
+        _, total_voltage_full = engineering_rfft(
+            histories["Vtotal"], grid.dt, time_offset=time_offset
+        )
+        _, total_current_full = engineering_rfft(
+            histories["Itot"], grid.dt, time_offset=time_offset
+        )
 
         selection = self._frequency_slice
         frequency = frequency_full[selection]
@@ -2283,7 +2471,9 @@ class MagneticFrillPortOutput:
         total_voltage = total_voltage_full[selection]
         total_current = total_current_full[selection]
         reflected_voltage = np.asarray(total_voltage - incident_voltage, dtype=complex_dtype)
-        s11, source_defined = _safe_complex_divide(reflected_voltage, incident_voltage, complex_dtype)
+        s11, source_defined = _safe_complex_divide(
+            reflected_voltage, incident_voltage, complex_dtype
+        )
 
         incident_magnitude = np.abs(incident_voltage)
         incident_peak = float(np.max(incident_magnitude, initial=0.0))
@@ -2300,7 +2490,9 @@ class MagneticFrillPortOutput:
         yin, yin_defined = admittance_from_s11(s11, self.reference_impedance, complex_dtype)
 
         mesh_valid = np.asarray(self._full_mesh_valid[selection], dtype=bool)
-        cells_per_wavelength = np.asarray(self._full_cells_per_wavelength[selection], dtype=real_dtype)
+        cells_per_wavelength = np.asarray(
+            self._full_cells_per_wavelength[selection], dtype=real_dtype
+        )
         valid_s11 = mesh_valid & source_valid
         valid_zin = valid_s11 & zin_defined
         valid_yin = valid_s11 & yin_defined
@@ -2366,7 +2558,9 @@ class MagneticFrillPortOutput:
         group.attrs["MeshFrequencyLimit"] = self.mesh_frequency_limit
         group.attrs["LimitingMaterial"] = self.limiting_material
         group.attrs["IndependentFrequencyResolution"] = self.independent_frequency_resolution
-        group.attrs["FrequencyRange"] = np.asarray((result.frequency[0], result.frequency[-1]), dtype=real_dtype)
+        group.attrs["FrequencyRange"] = np.asarray(
+            (result.frequency[0], result.frequency[-1]), dtype=real_dtype
+        )
         valid_indices = np.flatnonzero(result.valid_s11)
         valid_range = (
             (result.frequency[valid_indices[0]], result.frequency[valid_indices[-1]])

--- a/gprMax/sar.py
+++ b/gprMax/sar.py
@@ -632,12 +632,16 @@ class SARMonitor:
                 for source in group
                 if source.waveformID == self.waveform_id
             )
-            bindings.extend(
-                (guide.aux_source, source_grid)
-                for guide in getattr(source_grid, "virtual_waveguides", ())
-                if getattr(guide, "aux_source", None) is not None
-                and guide.aux_source.waveformID == self.waveform_id
-            )
+            for guide in getattr(source_grid, "virtual_waveguides", ()):
+                guide_sources = getattr(guide, "aux_sources", None)
+                if guide_sources is None:
+                    source = getattr(guide, "aux_source", None)
+                    guide_sources = () if source is None else (source,)
+                bindings.extend(
+                    (source, source_grid)
+                    for source in guide_sources
+                    if source.waveformID == self.waveform_id
+                )
         if not bindings:
             raise ValueError(
                 f"SAR waveform {self.waveform_id!r} is not associated with an active source"

--- a/gprMax/sources.py
+++ b/gprMax/sources.py
@@ -1639,6 +1639,7 @@ class EigenmodeSource(Source):
                     "discarded. Use a band-limited waveform; for a finite frequency band, "
                     "EigenmodeExcitation(..., waveform='auto') can synthesize one automatically."
                 )
+        input_spectrum = np.array(spectrum, copy=True)
         spectrum = np.array(spectrum, copy=True)
         spectrum[0] = 0
         if padded_count % 2 == 0:
@@ -1738,6 +1739,7 @@ class EigenmodeSource(Source):
         magnetic_phase = self._magnetic_stagger_factor(omega, beta, G.dt, normal_spacing)
 
         drive_factor = self._drive_spectral_factor(bin_frequencies)
+        driven_input_spectrum = input_spectrum * drive_factor
         driven_spectrum = spectrum * drive_factor
         electric_weights = weights * (driven_spectrum * normalization)[np.newaxis, :]
         magnetic_weights = (
@@ -1756,7 +1758,7 @@ class EigenmodeSource(Source):
         if padded_count % 2 == 0:
             scalar_spectrum[-1] = 0
         reconstructed_waveform = np.fft.irfft(scalar_spectrum, n=padded_count)[:sample_count]
-        driven_waveform = np.fft.irfft(driven_spectrum, n=padded_count)[:sample_count]
+        driven_waveform = np.fft.irfft(driven_input_spectrum, n=padded_count)[:sample_count]
         waveform_peak = float(np.max(np.abs(driven_waveform)))
         reconstruction_error = (
             float(np.max(np.abs(reconstructed_waveform - driven_waveform)) / waveform_peak)

--- a/gprMax/sources.py
+++ b/gprMax/sources.py
@@ -19,7 +19,7 @@
 
 import logging
 import math
-from copy import deepcopy
+from copy import copy, deepcopy
 
 import numpy as np
 import numpy.typing as npt
@@ -238,6 +238,25 @@ def initialise_eigenmode_ports(grid):
                     port.resolved_anchor_policy = "auto_broadband"
             break
 
+    # Additional drives on an already-solved physical port reuse its modal
+    # anchor bank. They are independent timestep sources but deliberately do
+    # not own another monitor or repeat the FDFD solve.
+    additional_sources = []
+    for owner in tuple(grid.eigenmodesources):
+        for drive in tuple(getattr(owner, "drive_specs", ()))[1:]:
+            source = copy(owner)
+            source.port_monitor = None
+            source.drive_specs = (drive,)
+            source.set_drive_parameters(drive)
+            source.configure_cached_excitation(grid, drive.mode_index, drive.waveform)
+            source.port_monitor = owner.port_monitor
+            source._plot_eigenmode_excitation(grid)
+            source.port_monitor = None
+            additional_sources.append(source)
+        if owner.port_monitor is not None:
+            owner.port_monitor.set_drive_metadata(getattr(owner, "drive_specs", ()))
+    grid.eigenmodesources.extend(additional_sources)
+
 
 class EigenmodeSource(Source):
     """Holds data for an eigenmode source and prepares material slices.
@@ -339,6 +358,31 @@ class EigenmodeSource(Source):
         self.dft_stop = None
         self.dft_points = None
         self.port_monitor = None
+        self.drive_specs = ()
+        self.drive_amplitude = 1.0
+        self.drive_power = 1.0
+        self.drive_phase_deg = 0.0
+        self.drive_delay_s = 0.0
+
+    def set_drive_parameters(self, drive):
+        """Attach the scalar and spectral controls for one modal drive."""
+
+        self.drive_amplitude = float(drive.amplitude)
+        self.drive_power = float(drive.power)
+        self.drive_phase_deg = float(drive.phase_deg)
+        self.drive_delay_s = float(drive.delay_s)
+        self.plot_waveform = drive.plot_waveform
+
+    def _drive_spectral_factor(self, frequencies):
+        phase = np.deg2rad(self.drive_phase_deg)
+        frequencies = np.asarray(frequencies, dtype=np.float64)
+        return self.drive_amplitude * np.exp(
+            1j * phase - 1j * 2 * np.pi * frequencies * self.drive_delay_s
+        )
+
+    def _drive_requires_quadrature(self):
+        phase = math.remainder(self.drive_phase_deg, 360.0)
+        return abs(phase) > 1e-12 or self.drive_delay_s != 0.0
 
     def grid_init(self, G):
         """Prepare source data that depends on the final built Yee grid."""
@@ -618,7 +662,7 @@ class EigenmodeSource(Source):
         """Choose real-only or in-phase/quadrature single-mode injection."""
         residual = self._align_tangential_mode_for_real_injection()
         self._store_real_modal_fields()
-        if residual <= self.COMPLEX_PROFILE_TOLERANCE:
+        if residual <= self.COMPLEX_PROFILE_TOLERANCE and not self._drive_requires_quadrature():
             if self.mpi_coordinator:
                 logger.info(
                     "Single-frequency eigenmode tangential complex-profile residual "
@@ -1693,8 +1737,12 @@ class EigenmodeSource(Source):
         normal_spacing = G.dl[self.normal_axis]
         magnetic_phase = self._magnetic_stagger_factor(omega, beta, G.dt, normal_spacing)
 
-        electric_weights = weights * (spectrum * normalization)[np.newaxis, :]
-        magnetic_weights = weights * (spectrum * normalization * magnetic_phase)[np.newaxis, :]
+        drive_factor = self._drive_spectral_factor(bin_frequencies)
+        driven_spectrum = spectrum * drive_factor
+        electric_weights = weights * (driven_spectrum * normalization)[np.newaxis, :]
+        magnetic_weights = (
+            weights * (driven_spectrum * normalization * magnetic_phase)[np.newaxis, :]
+        )
         # DC and Nyquist are self-conjugate FFT bins and cannot carry a
         # general complex modal coefficient.
         electric_weights[:, 0] = 0
@@ -1703,18 +1751,19 @@ class EigenmodeSource(Source):
             electric_weights[:, -1] = 0
             magnetic_weights[:, -1] = 0
 
-        scalar_spectrum = spectrum * partition
+        scalar_spectrum = driven_spectrum * partition
         scalar_spectrum[0] = 0
         if padded_count % 2 == 0:
             scalar_spectrum[-1] = 0
         reconstructed_waveform = np.fft.irfft(scalar_spectrum, n=padded_count)[:sample_count]
-        waveform_peak = float(np.max(np.abs(waveform)))
+        driven_waveform = np.fft.irfft(driven_spectrum, n=padded_count)[:sample_count]
+        waveform_peak = float(np.max(np.abs(driven_waveform)))
         reconstruction_error = (
-            float(np.max(np.abs(reconstructed_waveform - waveform)) / waveform_peak)
+            float(np.max(np.abs(reconstructed_waveform - driven_waveform)) / waveform_peak)
             if waveform_peak > 0
-            else float(np.max(np.abs(reconstructed_waveform - waveform)))
+            else float(np.max(np.abs(reconstructed_waveform - driven_waveform)))
         )
-        self.broadband_input_waveform = waveform
+        self.broadband_input_waveform = driven_waveform
         self.broadband_reconstructed_waveform = reconstructed_waveform
         self.broadband_waveform_error = reconstruction_error
 
@@ -1820,11 +1869,14 @@ class EigenmodeSource(Source):
         if samples is None:
             times = np.arange(sample_count, dtype=np.float64) * G.dt
             samples = np.asarray(
-                [self.waveform.calculate_value(time - self.start, G.dt) for time in times],
+                [self._waveform_value(time, G) for time in times],
                 dtype=np.float64,
             )
         input_path = config.sim_config.input_file_path
-        output_path = input_path.parent / f"{input_path.stem}_EigenmodeExcitation.png"
+        suffix = ""
+        if len(getattr(G, "eigenmodeexcitations", ())) > 1:
+            suffix = f"_Port{self.port_index}_Mode{self.mode_index}"
+        output_path = input_path.parent / (f"{input_path.stem}_EigenmodeExcitation{suffix}.png")
         plot_eigenmode_excitation(
             samples=samples,
             dt=G.dt,
@@ -2246,13 +2298,13 @@ class EigenmodeSource(Source):
         return 0.5 * G.dt + neff * G.dl[self.normal_axis] / (2 * config.c)
 
     def _waveform_value(self, time, G):
-        return self.waveform.calculate_value(time - self.start, G.dt)
+        return self.drive_amplitude * self.waveform.calculate_value(time - self.start, G.dt)
 
     def _modal_value(self, field, u, v, time, G):
         if field is None:
             return 0.0
         local_time = time - self.start
-        envelope = self.waveform.calculate_value(local_time, G.dt)
+        envelope = self.drive_amplitude * self.waveform.calculate_value(local_time, G.dt)
         value = field[u - self.transverse_start[0], v - self.transverse_start[1]]
         return float(envelope * np.real(value))
 

--- a/gprMax/studies.py
+++ b/gprMax/studies.py
@@ -1880,6 +1880,8 @@ class EigenmodeStudy(Study):
             monitor.reset_run_state(grid)
             monitor.is_source = False
             monitor.excitation_mode_index = None
+            monitor.excitation_mode_indices = ()
+            monitor.drive_metadata = ()
             monitor.magnetic_side = 1 if int(monitor.port_index) in self._runtime_guides else -1
         for guide in self._runtime_guides.values():
             guide.clear_active_source()
@@ -1891,10 +1893,15 @@ class EigenmodeStudy(Study):
 
         source = self._runtime_ports[port_number]
         source.spectral_threshold = grid.eigenmodeband.spectral_threshold
-        source.configure_cached_excitation(grid, mode_index, self._waveform)
         monitor = self._runtime_monitors[port_number]
-        monitor.is_source = True
-        monitor.excitation_mode_index = mode_index
+        drive = self._excitation
+        # The scheduled channel changes, while the reusable excitation keeps
+        # its waveform, amplitude, phase, and delay controls.
+        drive.port_index = port_number
+        drive.mode_index = mode_index
+        source.set_drive_parameters(drive)
+        source.configure_cached_excitation(grid, mode_index, self._waveform)
+        monitor.set_drive_metadata((drive,))
         monitor.magnetic_side = 1
         guide = self._runtime_guides.get(port_number)
         if guide is None:

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -2446,7 +2446,26 @@ class VirtualWaveguide(GridUserObject):
 
 
 class EigenmodeExcitation(GridUserObject):
-    """Attach the single active modal excitation to a defined port."""
+    """Attach one active modal drive to a defined port.
+
+    Several excitations may share the same base waveform and drive different
+    port/mode channels. Each physical port is solved and monitored only once;
+    its additional drives reuse the cached modal anchor bank.
+
+    Args:
+        port: One-based ``EigenmodePort`` number.
+        mode: One of the modes monitored by that port.
+        waveform: Shared waveform ID, or ``'auto'`` for the bandpass pulse.
+        amplitude: Non-zero modal amplitude scale. Mutually exclusive with
+            ``power``.
+        power: Optional relative incident-power scale; applies amplitude
+            ``sqrt(power)``.
+        phase_deg: Constant spectral phase in degrees.
+        delay_s: True time delay in seconds, applied as
+            ``exp(-1j * 2*pi*f*delay_s)``.
+        plot_waveform: Write or suppress this drive's waveform/DFT plot. The
+            default writes it only for geometry-only runs.
+    """
 
     @property
     def order(self):
@@ -2484,8 +2503,6 @@ class EigenmodeExcitation(GridUserObject):
         return kwargs
 
     def build(self, grid: FDTDGrid):
-        if grid.eigenmodeexcitation is not None:
-            raise ValueError("Only one EigenmodeExcitation may be defined per grid.")
         if grid.eigenmodeband is None:
             raise ValueError(f"{self.params_str()} requires one EigenmodeBand.")
         try:
@@ -2508,7 +2525,29 @@ class EigenmodeExcitation(GridUserObject):
             )
         band = grid.eigenmodeband
         waveform_arg = self.kwargs.get("waveform", "auto")
-        amplitude = float(self.kwargs.get("amplitude", 1.0))
+        amplitude_given = "amplitude" in self.kwargs
+        power_given = "power" in self.kwargs
+        if amplitude_given and power_given:
+            raise ValueError(f"{self.params_str()} accepts amplitude or power, not both.")
+        if power_given:
+            power = float(self.kwargs["power"])
+            if not np.isfinite(power) or power <= 0:
+                raise ValueError(f"{self.params_str()} power must be finite and positive.")
+            amplitude = float(np.sqrt(power))
+        else:
+            amplitude = float(self.kwargs.get("amplitude", 1.0))
+            if not np.isfinite(amplitude) or amplitude == 0:
+                raise ValueError(
+                    f"{self.params_str()} amplitude must be finite and non-zero. "
+                    "Omit the excitation to leave a channel passive."
+                )
+            power = amplitude**2
+        phase_deg = float(self.kwargs.get("phase_deg", 0.0))
+        delay_s = float(self.kwargs.get("delay_s", 0.0))
+        if not np.isfinite(phase_deg):
+            raise ValueError(f"{self.params_str()} phase_deg must be finite.")
+        if not np.isfinite(delay_s):
+            raise ValueError(f"{self.params_str()} delay_s must be finite.")
         plot_waveform = self.kwargs.get("plot_waveform")
         if plot_waveform is not None and not isinstance(plot_waveform, (bool, np.bool_)):
             raise ValueError(f"{self.params_str()} plot_waveform must be True, False, or None.")
@@ -2516,24 +2555,29 @@ class EigenmodeExcitation(GridUserObject):
             plot_waveform = bool(plot_waveform)
         generated_waveform = isinstance(waveform_arg, str) and waveform_arg.lower() == "auto"
         if generated_waveform:
-            waveform = EigenmodeBandpassWaveform(
-                band_id=band.id,
-                fmin=band.fmin,
-                fmax=band.fmax,
-                amplitude=amplitude,
-                dt=grid.dt,
-                sample_count=int(grid.iterations),
-                spectral_threshold=band.spectral_threshold,
-                transition=band.transition,
-            )
-            if any(existing.ID == waveform.ID for existing in grid.waveforms):
-                raise ValueError(
-                    f"Generated eigenmode waveform ID {waveform.ID!r} is already in use."
+            waveform_id = f"{band.id}_auto_bandpass"
+            matches = [waveform for waveform in grid.waveforms if waveform.ID == waveform_id]
+            if matches:
+                waveform = matches[0]
+                if not isinstance(waveform, EigenmodeBandpassWaveform):
+                    raise ValueError(
+                        f"Generated eigenmode waveform ID {waveform_id!r} is already in use."
+                    )
+            else:
+                # Drive scaling is deliberately separate from the common base
+                # waveform, allowing all array channels to share one spectrum.
+                waveform = EigenmodeBandpassWaveform(
+                    band_id=band.id,
+                    fmin=band.fmin,
+                    fmax=band.fmax,
+                    amplitude=1.0,
+                    dt=grid.dt,
+                    sample_count=int(grid.iterations),
+                    spectral_threshold=band.spectral_threshold,
+                    transition=band.transition,
                 )
-            grid.waveforms.append(waveform)
+                grid.waveforms.append(waveform)
         else:
-            if amplitude != 1.0:
-                raise ValueError("EigenmodeExcitation amplitude is only used with waveform='auto'.")
             waveform_id = str(waveform_arg)
             matches = [waveform for waveform in grid.waveforms if waveform.ID == waveform_id]
             if not matches:
@@ -2541,42 +2585,86 @@ class EigenmodeExcitation(GridUserObject):
                     f"{self.params_str()} references unknown waveform {waveform_id!r}."
                 )
             waveform = matches[0]
-        band.resolve_spectrum(grid, waveform, generated_waveform=generated_waveform)
-
-        reusable_study = bool(getattr(self, "_reusable_study", False))
-        for port_number in sorted(grid.eigenmodeportdefs):
-            port = grid.eigenmodeportdefs[port_number]
-            is_source = port_number == source_port_number
-            port.resolve_anchors(band, is_source=(is_source or reusable_study))
-            common = self._runtime_plane_kwargs(port, band)
-            if is_source:
-                common.update(
-                    {
-                        "mode_index": excitation_mode,
-                        "mode_count": max(port.modes),
-                        "waveform_id": waveform.ID,
-                        "spectral_threshold": band.spectral_threshold,
-                    }
+        if grid.eigenmodeexcitations:
+            base_waveform = grid.eigenmodeexcitations[0].waveform
+            if waveform.ID != base_waveform.ID:
+                raise ValueError(
+                    "Simultaneous EigenmodeExcitation objects must share one base "
+                    f"waveform; got {base_waveform.ID!r} and {waveform.ID!r}."
                 )
-                _EigenmodeSourceBuilder(**common).build(grid)
-                runtime = grid.eigenmodesources[-1]
-                runtime.mode_indices = port.modes
-                runtime.plot_waveform = plot_waveform
-            else:
-                common.update({"mode_count": max(port.modes), "id": f"port{port.port}"})
-                _EigenmodeReceiverBuilder(**common).build(grid)
-                runtime = grid.eigenmodereceivers[-1]
-                runtime.mode_indices = port.modes
-                runtime.spectral_threshold = band.spectral_threshold
-            runtime.anchor_policy = port.anchor_policy
-            runtime.requested_anchor_policy = port.anchor_policy
-            runtime.resolved_anchor_policy = port.anchor_policy
-            runtime.fallback_frequency = 0.5 * (band.fmin + band.fmax)
-        grid.eigenmodeexcitation = self
+        else:
+            band.resolve_spectrum(grid, waveform, generated_waveform=generated_waveform)
+
+        channel = (source_port_number, excitation_mode)
+        existing_channels = {
+            (excitation.port_index, excitation.mode_index)
+            for excitation in grid.eigenmodeexcitations
+        }
+        if channel in existing_channels:
+            raise ValueError(
+                f"Eigenmode port {source_port_number}, mode {excitation_mode} is already driven."
+            )
+        self.port_index = source_port_number
+        self.mode_index = excitation_mode
+        self.waveform = waveform
+        self.amplitude = amplitude
+        self.power = power
+        self.phase_deg = phase_deg
+        self.delay_s = delay_s
+        self.plot_waveform = plot_waveform
+        grid.eigenmodeexcitations.append(self)
+        if grid.eigenmodeexcitation is None:
+            grid.eigenmodeexcitation = self
         logger.info(
             f"{self.grid_name(grid)}Eigenmode excitation created on port "
-            f"{source_port_number}, mode {excitation_mode}, using waveform {waveform.ID!r}."
+            f"{source_port_number}, mode {excitation_mode}, using waveform {waveform.ID!r}, "
+            f"amplitude {amplitude:g}, phase {phase_deg:g} degrees, and delay {delay_s:g} s."
         )
+
+
+def build_eigenmode_runtime_ports(grid):
+    """Build one modal runtime owner per physical port after all drives exist."""
+
+    band = grid.eigenmodeband
+    drives_by_port = {}
+    for excitation in grid.eigenmodeexcitations:
+        drives_by_port.setdefault(excitation.port_index, []).append(excitation)
+    reusable_study = bool(
+        len(grid.eigenmodeexcitations) == 1
+        and getattr(grid.eigenmodeexcitations[0], "_reusable_study", False)
+    )
+    for port_number in sorted(grid.eigenmodeportdefs):
+        port = grid.eigenmodeportdefs[port_number]
+        drives = drives_by_port.get(port_number, [])
+        port.resolve_anchors(band, is_source=(bool(drives) or reusable_study))
+        common = EigenmodeExcitation._runtime_plane_kwargs(port, band)
+        if drives:
+            first = drives[0]
+            common.update(
+                {
+                    "mode_index": first.mode_index,
+                    "mode_count": max(port.modes),
+                    "waveform_id": first.waveform.ID,
+                    "spectral_threshold": band.spectral_threshold,
+                }
+            )
+            _EigenmodeSourceBuilder(**common).build(grid)
+            runtime = grid.eigenmodesources[-1]
+            runtime.mode_indices = port.modes
+            runtime.plot_waveform = first.plot_waveform
+            runtime.drive_specs = tuple(drives)
+            runtime.set_drive_parameters(first)
+        else:
+            common.update({"mode_count": max(port.modes), "id": f"port{port.port}"})
+            _EigenmodeReceiverBuilder(**common).build(grid)
+            runtime = grid.eigenmodereceivers[-1]
+            runtime.mode_indices = port.modes
+            runtime.spectral_threshold = band.spectral_threshold
+            runtime.drive_specs = ()
+        runtime.anchor_policy = port.anchor_policy
+        runtime.requested_anchor_policy = port.anchor_policy
+        runtime.resolved_anchor_policy = port.anchor_policy
+        runtime.fallback_frequency = 0.5 * (band.fmin + band.fmax)
 
 
 def _validate_eigenmode_dft(label, start, stop, points):

--- a/gprMax/virtual_waveguide.py
+++ b/gprMax/virtual_waveguide.py
@@ -63,6 +63,7 @@ class VirtualWaveguide:
         self._validate()
         self.aux_grid = self._build_auxiliary_grid()
         self.aux_source = self._build_auxiliary_source()
+        self.aux_sources = [] if self.aux_source is None else [self.aux_source]
         if self.aux_source is not None:
             self.aux_grid.eigenmodesources.append(self.aux_source)
         self.aux_updates = (
@@ -402,26 +403,39 @@ class VirtualWaveguide:
     def set_active_source(self, source):
         """Install a configured cached modal source in the auxiliary guide."""
 
-        self.port = source
-        self.aux_source = copy.copy(source)
-        self.aux_source.transverse_start = np.asarray((0, 0), dtype=np.int32)
-        self.aux_source.transverse_stop = np.asarray((self.nu, self.nv), dtype=np.int32)
+        self.set_active_sources((source,))
+
+    def set_active_sources(self, sources):
+        """Install all configured modal drives belonging to this aperture."""
+
+        sources = tuple(sources)
+        if not sources:
+            self.clear_active_source()
+            return
+        self.port = sources[0]
         distance = self.spec.length_cells - self.spec.pml_cells - self.spec.source_clearance_cells
-        self.aux_source.plane_index = (
-            distance if self.direction_sign < 0 else self.spec.length_cells - distance
-        )
-        self.aux_source.global_plane_index = self.aux_source.plane_index
-        self.aux_source.global_transverse_start = np.asarray((0, 0), dtype=np.int32)
-        self.aux_source.global_transverse_stop = np.asarray((self.nu, self.nv), dtype=np.int32)
-        self.aux_source.tfsf_owned_lower = np.zeros(3, dtype=np.int32)
-        self.aux_source.tfsf_owned_upper = np.asarray(self.aux_grid.size + 1, dtype=np.int32)
-        self.aux_source.port_monitor = None
-        self.aux_grid.eigenmodesources[:] = [self.aux_source]
+        plane_index = distance if self.direction_sign < 0 else self.spec.length_cells - distance
+        self.aux_sources = []
+        for source in sources:
+            aux_source = copy.copy(source)
+            aux_source.transverse_start = np.asarray((0, 0), dtype=np.int32)
+            aux_source.transverse_stop = np.asarray((self.nu, self.nv), dtype=np.int32)
+            aux_source.plane_index = plane_index
+            aux_source.global_plane_index = plane_index
+            aux_source.global_transverse_start = np.asarray((0, 0), dtype=np.int32)
+            aux_source.global_transverse_stop = np.asarray((self.nu, self.nv), dtype=np.int32)
+            aux_source.tfsf_owned_lower = np.zeros(3, dtype=np.int32)
+            aux_source.tfsf_owned_upper = np.asarray(self.aux_grid.size + 1, dtype=np.int32)
+            aux_source.port_monitor = None
+            self.aux_sources.append(aux_source)
+        self.aux_source = self.aux_sources[0]
+        self.aux_grid.eigenmodesources[:] = self.aux_sources
 
     def clear_active_source(self):
         """Leave this guide as a passive matched modal load."""
 
         self.aux_source = None
+        self.aux_sources = []
         self.aux_grid.eigenmodesources.clear()
 
     def reset_run_state(self):
@@ -793,9 +807,8 @@ def initialise_virtual_waveguides(grid):
 
     if not grid.virtual_waveguide_specs:
         return
-    runtime_ports = {
-        int(port.port_index): port for port in (*grid.eigenmodesources, *grid.eigenmodereceivers)
-    }
+    all_runtime_sources = tuple(grid.eigenmodesources)
+    runtime_ports = {int(monitor.port_index): monitor.owner for monitor in grid.eigenmodeports}
     for port_number, spec in sorted(grid.virtual_waveguide_specs.items()):
         try:
             port = runtime_ports[port_number]
@@ -804,11 +817,18 @@ def initialise_virtual_waveguides(grid):
                 f"Virtual waveguide references unknown eigenmode port {port_number}."
             ) from exc
         guide = VirtualWaveguide(grid, port, spec)
+        active_sources = [
+            source for source in all_runtime_sources if int(source.port_index) == port_number
+        ]
+        if active_sources:
+            guide.set_active_sources(active_sources)
         grid.virtual_waveguides.append(guide)
-        if port in grid.eigenmodesources:
-            grid.eigenmodesources.remove(port)
+        grid.eigenmodesources[:] = [
+            source for source in grid.eigenmodesources if int(source.port_index) != port_number
+        ]
         source_description = (
-            f", source plane {guide.aux_source.plane_index}"
+            f", {len(guide.aux_sources)} source drive(s) at plane "
+            f"{guide.aux_source.plane_index}"
             if guide.aux_source is not None
             else ", passive"
         )

--- a/tests/cmds_multiuse/test_eigenmode_commands.py
+++ b/tests/cmds_multiuse/test_eigenmode_commands.py
@@ -11,43 +11,42 @@ from gprMax.user_objects.cmds_multiuse import (
     EigenmodeBand,
     EigenmodeExcitation,
     EigenmodePort,
+    build_eigenmode_runtime_ports,
 )
 
 
 def _configure_grid(monkeypatch):
     monkeypatch.setattr(
         config,
-        'sim_config',
-        SimpleNamespace(general={'solver': 'cpu'}, mpi=False),
+        "sim_config",
+        SimpleNamespace(general={"solver": "cpu"}, mpi=False),
     )
-    monkeypatch.setattr(config, 'get_model_config', lambda: SimpleNamespace(mode='2D TMz'))
+    monkeypatch.setattr(config, "get_model_config", lambda: SimpleNamespace(mode="2D TMz"))
     grid = FDTDGrid()
     grid.size = np.asarray((100, 40, 1), dtype=np.int64)
     grid.dl = np.asarray((1e-3, 1e-3, 1e-3))
     grid.dt = 1e-12
     grid.iterations = 4096
     grid.timewindow = grid.dt * grid.iterations
-    grid.pmls['thickness'].update(
-        {'x0': 10, 'xmax': 10, 'y0': 5, 'ymax': 5, 'z0': 0, 'zmax': 0}
-    )
+    grid.pmls["thickness"].update({"x0": 10, "xmax": 10, "y0": 5, "ymax": 5, "z0": 0, "zmax": 0})
     return grid
 
 
-def _build_definitions(grid, *, source_anchors='auto', receiver_anchors='auto'):
-    EigenmodeBand(id='wg', fmin=4e9, fmax=6e9, points=21).build(grid)
+def _build_definitions(grid, *, source_anchors="auto", receiver_anchors="auto"):
+    EigenmodeBand(id="wg", fmin=4e9, fmax=6e9, points=21).build(grid)
     EigenmodePort(
         port=1,
         p1=(0.01, 0.005, 0),
-        p2=(0.01, 0.035, float('inf')),
-        direction='+',
+        p2=(0.01, 0.035, float("inf")),
+        direction="+",
         modes=(1, 2),
         anchors=source_anchors,
     ).build(grid)
     EigenmodePort(
         port=2,
         p1=(0.09, 0.005, 0),
-        p2=(0.09, 0.035, float('inf')),
-        direction='-',
+        p2=(0.09, 0.035, float("inf")),
+        direction="-",
         modes=(1,),
         anchors=receiver_anchors,
     ).build(grid)
@@ -60,13 +59,14 @@ def test_one_band_is_shared_while_each_port_owns_anchors(monkeypatch):
     EigenmodeExcitation(
         port=1,
         mode=1,
-        waveform='auto',
+        waveform="auto",
         plot_waveform=False,
     ).build(grid)
+    build_eigenmode_runtime_ports(grid)
 
-    assert grid.eigenmodeband.id == 'wg'
-    assert grid.eigenmodeportdefs[1].anchor_policy == 'auto'
-    assert grid.eigenmodeportdefs[2].anchor_policy == 'explicit'
+    assert grid.eigenmodeband.id == "wg"
+    assert grid.eigenmodeportdefs[1].anchor_policy == "auto"
+    assert grid.eigenmodeportdefs[2].anchor_policy == "explicit"
     assert grid.eigenmodeportdefs[2].resolved_anchors == (2e9, 4e9, 6e9, 8e9)
     assert grid.eigenmodesources[0].mode_indices == (1, 2)
     assert grid.eigenmodereceivers[0].mode_indices == (1,)
@@ -80,7 +80,8 @@ def test_single_explicit_anchor_is_intentional_constant_basis(monkeypatch):
     grid = _configure_grid(monkeypatch)
     _build_definitions(grid, source_anchors=(5e9,), receiver_anchors=(5e9,))
 
-    EigenmodeExcitation(port=1, mode=1, waveform='auto').build(grid)
+    EigenmodeExcitation(port=1, mode=1, waveform="auto").build(grid)
+    build_eigenmode_runtime_ports(grid)
 
     assert grid.eigenmodesources[0].frequencies == (5e9,)
     assert grid.eigenmodereceivers[0].frequencies == (5e9,)
@@ -88,57 +89,149 @@ def test_single_explicit_anchor_is_intentional_constant_basis(monkeypatch):
 
 def test_duplicate_global_band_is_rejected(monkeypatch):
     grid = _configure_grid(monkeypatch)
-    EigenmodeBand(id='first', fmin=4e9, fmax=6e9, points=21).build(grid)
+    EigenmodeBand(id="first", fmin=4e9, fmax=6e9, points=21).build(grid)
 
-    with pytest.raises(ValueError, match='Exactly one EigenmodeBand'):
-        EigenmodeBand(id='second', fmin=4e9, fmax=6e9, points=21).build(grid)
+    with pytest.raises(ValueError, match="Exactly one EigenmodeBand"):
+        EigenmodeBand(id="second", fmin=4e9, fmax=6e9, points=21).build(grid)
 
 
 def test_hash_commands_parse_global_band_per_port_anchors_and_excitation(monkeypatch):
-    monkeypatch.setattr(config, 'get_model_config', lambda: SimpleNamespace(mode='2D TMz'))
+    monkeypatch.setattr(config, "get_model_config", lambda: SimpleNamespace(mode="2D TMz"))
     commands = defaultdict(lambda: None)
-    commands['#eigenmode_band'] = ['wg 4e9 6e9 21']
-    commands['#eigenmode_port'] = [
-        '1 0.01 0.005 0 0.01 0.035 inf + 1,2 auto y',
-        '2 0.09 0.005 0 0.09 0.035 inf - 1 4e9 5e9 6e9 n',
+    commands["#eigenmode_band"] = ["wg 4e9 6e9 21"]
+    commands["#eigenmode_port"] = [
+        "1 0.01 0.005 0 0.01 0.035 inf + 1,2 auto y",
+        "2 0.09 0.005 0 0.09 0.035 inf - 1 4e9 5e9 6e9 n",
     ]
-    commands['#eigenmode_excitation'] = ['1 1 auto n']
+    commands["#eigenmode_excitation"] = ["1 1 auto n"]
 
     objects = process_multicmds(commands)
 
     band = next(obj for obj in objects if isinstance(obj, EigenmodeBand))
     ports = [obj for obj in objects if isinstance(obj, EigenmodePort)]
     excitation = next(obj for obj in objects if isinstance(obj, EigenmodeExcitation))
-    assert band.kwargs == {'id': 'wg', 'fmin': 4e9, 'fmax': 6e9, 'points': 21}
-    assert ports[0].kwargs['anchors'] == 'auto'
-    assert ports[0].kwargs['plot_fields'] is True
-    assert ports[1].kwargs['anchors'] == (4e9, 5e9, 6e9)
-    assert ports[1].kwargs['plot_fields'] is False
+    assert band.kwargs == {"id": "wg", "fmin": 4e9, "fmax": 6e9, "points": 21}
+    assert ports[0].kwargs["anchors"] == "auto"
+    assert ports[0].kwargs["plot_fields"] is True
+    assert ports[1].kwargs["anchors"] == (4e9, 5e9, 6e9)
+    assert ports[1].kwargs["plot_fields"] is False
     assert excitation.kwargs == {
-        'port': 1,
-        'mode': 1,
-        'waveform': 'auto',
-        'plot_waveform': False,
+        "port": 1,
+        "mode": 1,
+        "waveform": "auto",
+        "plot_waveform": False,
     }
 
 
 def test_hash_excitation_plot_control_does_not_require_waveform_argument():
     commands = defaultdict(lambda: None)
-    commands['#eigenmode_band'] = ['wg 4e9 6e9 21']
-    commands['#eigenmode_port'] = ['1 0.01 0.005 0 0.01 0.035 inf + 1 auto']
-    commands['#eigenmode_excitation'] = ['1 1 y']
+    commands["#eigenmode_band"] = ["wg 4e9 6e9 21"]
+    commands["#eigenmode_port"] = ["1 0.01 0.005 0 0.01 0.035 inf + 1 auto"]
+    commands["#eigenmode_excitation"] = ["1 1 y"]
 
     objects = process_multicmds(commands)
 
     excitation = next(obj for obj in objects if isinstance(obj, EigenmodeExcitation))
-    assert excitation.kwargs == {'port': 1, 'mode': 1, 'plot_waveform': True}
+    assert excitation.kwargs == {"port": 1, "mode": 1, "plot_waveform": True}
+
+
+def test_multiple_excitations_share_waveform_and_build_one_owner_per_port(monkeypatch):
+    grid = _configure_grid(monkeypatch)
+    _build_definitions(grid)
+
+    first = EigenmodeExcitation(
+        port=1,
+        mode=1,
+        waveform="auto",
+        power=4,
+        phase_deg=30,
+        delay_s=2e-12,
+    )
+    second = EigenmodeExcitation(port=2, mode=1, waveform="auto", amplitude=0.5)
+    first.build(grid)
+    second.build(grid)
+    build_eigenmode_runtime_ports(grid)
+
+    assert len(grid.waveforms) == 1
+    assert len(grid.eigenmodeexcitations) == 2
+    assert len(grid.eigenmodesources) == 2
+    assert not grid.eigenmodereceivers
+    assert grid.eigenmodesources[0].drive_amplitude == pytest.approx(2)
+    assert grid.eigenmodesources[0].drive_phase_deg == pytest.approx(30)
+    assert grid.eigenmodesources[0].drive_delay_s == pytest.approx(2e-12)
+
+
+def test_multiple_modes_on_one_port_build_one_physical_owner(monkeypatch):
+    grid = _configure_grid(monkeypatch)
+    _build_definitions(grid)
+
+    EigenmodeExcitation(port=1, mode=1, waveform="auto").build(grid)
+    EigenmodeExcitation(port=1, mode=2, waveform="auto", phase_deg=90).build(grid)
+    build_eigenmode_runtime_ports(grid)
+
+    assert len(grid.eigenmodesources) == 1
+    assert len(grid.eigenmodesources[0].drive_specs) == 2
+    assert len(grid.eigenmodereceivers) == 1
+
+
+def test_duplicate_modal_drive_and_mixed_waveforms_are_rejected(monkeypatch):
+    grid = _configure_grid(monkeypatch)
+    _build_definitions(grid)
+    grid.waveforms.append(SimpleNamespace(ID="other"))
+    EigenmodeExcitation(port=1, mode=1, waveform="auto").build(grid)
+
+    with pytest.raises(ValueError, match="already driven"):
+        EigenmodeExcitation(port=1, mode=1, waveform="auto").build(grid)
+    with pytest.raises(ValueError, match="share one base waveform"):
+        EigenmodeExcitation(port=1, mode=2, waveform="other").build(grid)
+
+
+def test_drive_amplitude_and_power_are_mutually_exclusive(monkeypatch):
+    grid = _configure_grid(monkeypatch)
+    _build_definitions(grid)
+
+    with pytest.raises(ValueError, match="amplitude or power"):
+        EigenmodeExcitation(
+            port=1,
+            mode=1,
+            waveform="auto",
+            amplitude=1,
+            power=1,
+        ).build(grid)
+
+
+def test_hash_multiple_excitations_parse_drive_controls():
+    commands = defaultdict(lambda: None)
+    commands["#eigenmode_band"] = ["wg 4e9 6e9 21"]
+    commands["#eigenmode_port"] = [
+        "1 0.01 0.005 0 0.01 0.035 inf + 1 auto",
+        "2 0.09 0.005 0 0.09 0.035 inf - 1 auto",
+    ]
+    commands["#eigenmode_excitation"] = [
+        "1 1 auto 1 0 0 n",
+        "2 1 auto 0.5 90 2e-12 y",
+    ]
+
+    objects = process_multicmds(commands)
+    excitations = [obj for obj in objects if isinstance(obj, EigenmodeExcitation)]
+
+    assert len(excitations) == 2
+    assert excitations[1].kwargs == {
+        "port": 2,
+        "mode": 1,
+        "waveform": "auto",
+        "amplitude": 0.5,
+        "phase_deg": 90.0,
+        "delay_s": 2e-12,
+        "plot_waveform": True,
+    }
 
 
 def test_hash_ports_require_one_band_and_excitation():
     commands = defaultdict(lambda: None)
-    commands['#eigenmode_port'] = ['1 0 0 0 0 1 1 + 1 auto']
+    commands["#eigenmode_port"] = ["1 0 0 0 0 1 1 + 1 auto"]
 
-    with pytest.raises(ValueError, match='exactly one #eigenmode_band'):
+    with pytest.raises(ValueError, match="exactly one #eigenmode_band"):
         process_multicmds(commands)
 
 
@@ -147,5 +240,5 @@ def test_grid_rejects_port_definitions_without_excitation():
     grid.eigenmodeband = object()
     grid.eigenmodeportdefs[1] = object()
 
-    with pytest.raises(ValueError, match='exactly one EigenmodeExcitation'):
+    with pytest.raises(ValueError, match="at least one EigenmodeExcitation"):
         grid._eigenmode_port_grid_init()

--- a/tests/cmds_multiuse/test_eigenmode_source_2d.py
+++ b/tests/cmds_multiuse/test_eigenmode_source_2d.py
@@ -17,6 +17,19 @@ INF = float("inf")
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 
 
+def test_modal_drive_spectral_factor_combines_phase_and_true_time_delay():
+    source = RuntimeEigenmodeSource(None)
+    source.drive_amplitude = 2
+    source.drive_phase_deg = 30
+    source.drive_delay_s = 25e-12
+    frequencies = np.asarray((2e9, 5e9))
+
+    factor = source._drive_spectral_factor(frequencies)
+
+    expected = 2 * np.exp(1j * np.deg2rad(30) - 1j * 2 * np.pi * frequencies * 25e-12)
+    np.testing.assert_allclose(factor, expected, rtol=1e-14, atol=1e-14)
+
+
 def _scene(mode):
     scene = gprMax.Scene()
     scene.add(gprMax.DomainMode(mode=mode))

--- a/tests/ntff/test_port_power.py
+++ b/tests/ntff/test_port_power.py
@@ -83,6 +83,7 @@ def _eigenmode_port(*, is_source):
     monitor.mode_indices = (1, 2)
     monitor.is_source = is_source
     monitor.excitation_mode_index = 1 if is_source else None
+    monitor.excitation_mode_indices = (1,) if is_source else ()
     monitor.mode_power_valid = np.ones((1, 2), dtype=bool)
     monitor.power_matrix_valid = np.ones(1, dtype=bool)
     monitor.power_matrix = np.asarray(
@@ -139,6 +140,24 @@ def test_eigenmode_port_power_uses_full_modal_matrix(monkeypatch, is_source):
     else:
         assert_allclose(spectrum.incident_power, 0)
     assert spectrum.terminal_valid.all()
+
+
+def test_eigenmode_port_incident_power_uses_all_driven_modes_and_cross_terms(monkeypatch):
+    monitor = _eigenmode_port(is_source=True)
+    monitor.excitation_mode_index = None
+    monitor.excitation_mode_indices = (1, 2)
+    monkeypatch.setattr(
+        ports,
+        "_port_mesh_valid",
+        lambda output, grid, frequency: np.ones(frequency.shape, dtype=bool),
+    )
+
+    spectrum = evaluate_port_power_spectrum(monitor, SimpleNamespace(), [5.0])
+
+    assert_allclose(
+        spectrum.incident_power,
+        modal_power_spectrum(monitor.result.incident, monitor.power_matrix),
+    )
 
 
 def test_lossy_eigenmode_accepted_power_keeps_interference_term(monkeypatch):

--- a/tests/test_eigenmode_ports.py
+++ b/tests/test_eigenmode_ports.py
@@ -968,6 +968,35 @@ def test_sparameter_csv_contains_s11_and_each_s21_mode(tmp_path, monkeypatch):
     assert {int(row["source_mode"]) for row in rows} == {2}
 
 
+def test_multiple_drives_are_not_labelled_as_an_sparameter_column():
+    frequency = np.asarray([5e9])
+
+    def monitor(port_index, modes):
+        return SimpleNamespace(
+            is_source=True,
+            port_index=port_index,
+            excitation_mode_index=None,
+            excitation_mode_indices=tuple(modes),
+            mode_indices=tuple(modes),
+            result=EigenmodePortResult(
+                frequency=frequency,
+                incident=np.ones((len(modes), 1), dtype=np.complex128),
+                outgoing=np.zeros((len(modes), 1), dtype=np.complex128),
+                valid=np.ones((len(modes), 1), dtype=bool),
+                condition_number=np.ones(1),
+            ),
+            finalise=lambda grid: None,
+        )
+
+    grid = SimpleNamespace(
+        name="main_grid",
+        eigenmodeports=[monitor(1, (1,)), monitor(2, (1,))],
+    )
+
+    assert finalise_eigenmode_ports(grid) is None
+    assert all(not hasattr(port, "s_parameters") for port in grid.eigenmodeports)
+
+
 def test_invalid_source_bin_does_not_invalidate_other_sparameter_bins(tmp_path, monkeypatch):
     frequency = np.asarray([5e9, 6e9])
     source = SimpleNamespace(

--- a/tests/test_eigenmode_study.py
+++ b/tests/test_eigenmode_study.py
@@ -91,6 +91,177 @@ def _study_for_channels(excitation, channels):
     )
 
 
+def _add_centre_receiver(scene):
+    scene.add(gprMax.Rx(p1=(0.03, 0.025, INF)))
+    return scene
+
+
+def _simultaneous_two_port_scene():
+    scene, _ = _two_port_waveguide_scene(active_port=1)
+    scene.add(
+        gprMax.EigenmodeExcitation(
+            port=2,
+            mode=1,
+            waveform="wave",
+            amplitude=0.5,
+            phase_deg=90,
+            plot_waveform=False,
+        )
+    )
+    return _add_centre_receiver(scene)
+
+
+@pytest.mark.integration
+def test_simultaneous_modal_drives_obey_linear_superposition(tmp_path):
+    first_scene, _ = _two_port_waveguide_scene(active_port=1)
+    _add_centre_receiver(first_scene)
+    second_scene, second_excitation = _two_port_waveguide_scene(active_port=2)
+    second_excitation.kwargs["amplitude"] = 0.5
+    second_excitation.kwargs["phase_deg"] = 90
+    _add_centre_receiver(second_scene)
+    combined_scene = _simultaneous_two_port_scene()
+
+    paths = {}
+    for name, scene in (
+        ("first", first_scene),
+        ("second", second_scene),
+        ("combined", combined_scene),
+    ):
+        path = tmp_path / name
+        gprMax.run(
+            scenes=[scene],
+            outputfile=path,
+            hide_progress_bars=True,
+            log_level=30,
+        )
+        paths[name] = path.with_suffix(".h5")
+
+    with h5py.File(paths["first"]) as first, h5py.File(paths["second"]) as second, h5py.File(
+        paths["combined"]
+    ) as combined:
+        expected = first["rxs/rx1/Ez"][...] + second["rxs/rx1/Ez"][...]
+        np.testing.assert_allclose(
+            combined["rxs/rx1/Ez"][...],
+            expected,
+            rtol=1e-5,
+            atol=1e-6 * np.max(np.abs(expected)),
+        )
+        for port_index in (1, 2):
+            port = combined[f"eigenmode_ports/port{port_index}"]
+            assert port.attrs["ResponseType"] == "driven"
+            assert "S" not in port
+        assert tuple(combined["eigenmode_ports/port1"].attrs["ExcitationModes"]) == (1,)
+        assert tuple(combined["eigenmode_ports/port2"].attrs["ExcitationModes"]) == (1,)
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+def test_cuda_simultaneous_modal_drives_match_cpu(tmp_path, gpu_device):
+    cpu_output = tmp_path / "simultaneous_cpu"
+    cuda_output = tmp_path / "simultaneous_cuda"
+    gprMax.run(
+        scenes=[_simultaneous_two_port_scene()],
+        outputfile=cpu_output,
+        hide_progress_bars=True,
+        log_level=30,
+    )
+    gprMax.run(
+        scenes=[_simultaneous_two_port_scene()],
+        outputfile=cuda_output,
+        gpu=[gpu_device],
+        hide_progress_bars=True,
+        log_level=30,
+    )
+
+    with h5py.File(cpu_output.with_suffix(".h5")) as cpu, h5py.File(
+        cuda_output.with_suffix(".h5")
+    ) as cuda:
+        np.testing.assert_allclose(
+            cuda["rxs/rx1/Ez"][...],
+            cpu["rxs/rx1/Ez"][...],
+            rtol=2e-5,
+            atol=2e-6 * np.max(np.abs(cpu["rxs/rx1/Ez"][...])),
+        )
+        for port_index in (1, 2):
+            for dataset in ("incident", "outgoing"):
+                np.testing.assert_allclose(
+                    cuda[f"eigenmode_ports/port{port_index}/{dataset}"][...],
+                    cpu[f"eigenmode_ports/port{port_index}/{dataset}"][...],
+                    rtol=3e-5,
+                    atol=1e-7,
+                )
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+def test_opencl_simultaneous_modal_drives_match_cpu(tmp_path, opencl_device):
+    cpu_output = tmp_path / "simultaneous_cpu"
+    opencl_output = tmp_path / "simultaneous_opencl"
+    gprMax.run(
+        scenes=[_simultaneous_two_port_scene()],
+        outputfile=cpu_output,
+        hide_progress_bars=True,
+        log_level=30,
+    )
+    gprMax.run(
+        scenes=[_simultaneous_two_port_scene()],
+        outputfile=opencl_output,
+        opencl=[opencl_device],
+        hide_progress_bars=True,
+        log_level=30,
+    )
+
+    with h5py.File(cpu_output.with_suffix(".h5")) as cpu, h5py.File(
+        opencl_output.with_suffix(".h5")
+    ) as opencl:
+        np.testing.assert_allclose(
+            opencl["rxs/rx1/Ez"][...],
+            cpu["rxs/rx1/Ez"][...],
+            rtol=2e-5,
+            atol=2e-6 * np.max(np.abs(cpu["rxs/rx1/Ez"][...])),
+        )
+        for port_index in (1, 2):
+            for dataset in ("incident", "outgoing"):
+                np.testing.assert_allclose(
+                    opencl[f"eigenmode_ports/port{port_index}/{dataset}"][...],
+                    cpu[f"eigenmode_ports/port{port_index}/{dataset}"][...],
+                    rtol=3e-5,
+                    atol=1e-7,
+                )
+
+
+@pytest.mark.integration
+def test_two_modes_on_one_port_reuse_one_monitor(tmp_path):
+    scene, _ = _two_port_waveguide_scene(active_port=1, modes=(1, 2))
+    scene.add(
+        gprMax.EigenmodeExcitation(
+            port=1,
+            mode=2,
+            waveform="wave",
+            amplitude=0.25,
+            phase_deg=-45,
+            plot_waveform=False,
+        )
+    )
+    output = tmp_path / "two_modes_one_port"
+
+    gprMax.run(
+        scenes=[scene],
+        outputfile=output,
+        hide_progress_bars=True,
+        log_level=30,
+    )
+
+    with h5py.File(output.with_suffix(".h5")) as handle:
+        assert set(handle["eigenmode_ports"]) == {"port1", "port2"}
+        source = handle["eigenmode_ports/port1"]
+        assert tuple(source.attrs["ExcitationModes"]) == (1, 2)
+        np.testing.assert_allclose(source.attrs["DriveAmplitudes"], (1, 0.25))
+        np.testing.assert_allclose(source.attrs["DrivePhasesDegrees"], (0, -45))
+        assert source.attrs["ResponseType"] == "driven"
+        assert "S" not in source
+
+
 @pytest.mark.integration
 def test_eigenmode_study_matches_fresh_builds_without_resolving_modes(tmp_path, monkeypatch):
     solves = 0
@@ -370,6 +541,145 @@ def _two_virtual_port_scene(active_port=1):
     )
     scene.add(excitation)
     return scene, excitation
+
+
+def _two_virtual_port_broadband_scene(active_port=1, *, simultaneous=False):
+    """Matched, lossless TE10 guide used for analytical multi-drive validation."""
+
+    scene, excitation = _two_virtual_port_scene(active_port)
+    time_window = next(
+        item for item in scene.single_use_objects if isinstance(item, gprMax.TimeWindow)
+    )
+    time_window.time = 1.2e-9
+    band = next(item for item in scene.grid_objects if isinstance(item, gprMax.EigenmodeBand))
+    band.kwargs.update(fmin=20e9, fmax=24e9, points=17)
+    for port in (item for item in scene.grid_objects if isinstance(item, gprMax.EigenmodePort)):
+        port.kwargs["anchors"] = (16.9e9, 22e9, 27e9)
+    excitation.kwargs["waveform"] = "auto"
+    if simultaneous:
+        scene.add(
+            gprMax.EigenmodeExcitation(
+                port=2,
+                mode=1,
+                waveform="auto",
+                amplitude=0.5,
+                phase_deg=90,
+                delay_s=7.5e-12,
+                plot_waveform=False,
+            )
+        )
+    return scene, excitation
+
+
+@pytest.mark.integration
+def test_simultaneous_drives_match_lossless_rectangular_waveguide_solution(tmp_path):
+    """Validate driven modal waves against b=S*a and analytical TE10 propagation.
+
+    Two independent excitations measure the complete incident and outgoing
+    wave matrices.  Their right quotient gives the scattering matrix without
+    treating the small residual reflection from either auxiliary termination
+    as a new network excitation.  A third solve drives both ports with a
+    complex broadband weight and must obey the resulting b=S*a relation.
+
+    The physical guide is uniform, reciprocal, and lossless.  Its dominant
+    TE10 propagation constant is beta=sqrt(k0**2-(pi/a)**2), so transmission
+    over the distance L between reference planes is exp(-j*beta*L).
+    """
+
+    single_paths = []
+    for active_port in (1, 2):
+        scene, _ = _two_virtual_port_broadband_scene(active_port)
+        output = tmp_path / f"rectangular_guide_port{active_port}"
+        gprMax.run(
+            scenes=[scene],
+            outputfile=output,
+            cpu_precision="double",
+            hide_progress_bars=True,
+            log_level=30,
+        )
+        single_paths.append(output.with_suffix(".h5"))
+
+    simultaneous_scene, _ = _two_virtual_port_broadband_scene(1, simultaneous=True)
+    simultaneous_path = tmp_path / "rectangular_guide_simultaneous"
+    gprMax.run(
+        scenes=[simultaneous_scene],
+        outputfile=simultaneous_path,
+        cpu_precision="double",
+        hide_progress_bars=True,
+        log_level=30,
+    )
+
+    incident_columns = []
+    outgoing_columns = []
+    frequency = None
+    for path in single_paths:
+        with h5py.File(path) as output:
+            if frequency is None:
+                frequency = output["eigenmode_ports/port1/frequency"][...]
+            incident_columns.append(
+                np.stack(
+                    [output[f"eigenmode_ports/port{port}/incident"][0] for port in (1, 2)],
+                    axis=-1,
+                )
+            )
+            outgoing_columns.append(
+                np.stack(
+                    [output[f"eigenmode_ports/port{port}/outgoing"][0] for port in (1, 2)],
+                    axis=-1,
+                )
+            )
+
+    # A and B have shape (frequency, output channel, excitation case).
+    incident_matrix = np.stack(incident_columns, axis=-1)
+    outgoing_matrix = np.stack(outgoing_columns, axis=-1)
+    scattering = np.asarray(
+        [
+            np.linalg.solve(incident_matrix[index].T, outgoing_matrix[index].T).T
+            for index in range(frequency.size)
+        ]
+    )
+
+    with h5py.File(simultaneous_path.with_suffix(".h5")) as output:
+        simultaneous_incident = np.stack(
+            [output[f"eigenmode_ports/port{port}/incident"][0] for port in (1, 2)],
+            axis=-1,
+        )
+        simultaneous_outgoing = np.stack(
+            [output[f"eigenmode_ports/port{port}/outgoing"][0] for port in (1, 2)],
+            axis=-1,
+        )
+
+    predicted_outgoing = np.einsum("fij,fj->fi", scattering, simultaneous_incident)
+    driven_residual = np.linalg.norm(predicted_outgoing - simultaneous_outgoing, axis=1)
+    driven_residual /= np.linalg.norm(simultaneous_outgoing, axis=1)
+    assert np.max(driven_residual) < 3e-5
+
+    # Reciprocity and losslessness are independent of the analytical phase.
+    np.testing.assert_allclose(
+        scattering[:, 0, 1],
+        scattering[:, 1, 0],
+        rtol=1e-5,
+        atol=1e-8,
+    )
+    identity = np.eye(2)
+    unitarity_error = max(
+        np.linalg.norm(matrix.conj().T @ matrix - identity, ord=2) for matrix in scattering
+    )
+    assert unitarity_error < 3e-4
+
+    wave_speed = 299_792_458.0
+    broad_wall = 0.010
+    reference_plane_spacing = 0.020
+    cutoff = wave_speed / (2 * broad_wall)
+    assert np.all(frequency > cutoff)
+    propagation_constant = np.sqrt(
+        (2 * np.pi * frequency / wave_speed) ** 2 - (np.pi / broad_wall) ** 2
+    )
+    analytical_transmission = np.exp(-1j * propagation_constant * reference_plane_spacing)
+    measured_transmission = scattering[:, 1, 0]
+    assert np.max(np.abs(np.abs(measured_transmission) - 1)) < 2.5e-3
+    phase_error = np.angle(measured_transmission / analytical_transmission)
+    assert np.max(np.abs(phase_error)) < np.deg2rad(1.5)
 
 
 def _two_port_broadband_scene(active_port=1):

--- a/tests/test_virtual_waveguide_integration.py
+++ b/tests/test_virtual_waveguide_integration.py
@@ -65,6 +65,23 @@ def _uniform_waveguide_scene(normal_axis, direction):
     return scene
 
 
+def _multimode_virtual_waveguide_scene():
+    scene = _uniform_waveguide_scene(normal_axis=0, direction="+")
+    port = next(obj for obj in scene.grid_objects if isinstance(obj, gprMax.EigenmodePort))
+    port.kwargs["modes"] = (1, 2)
+    scene.add(
+        gprMax.EigenmodeExcitation(
+            port=1,
+            mode=2,
+            waveform="wave",
+            amplitude=0.3,
+            phase_deg=90,
+            plot_waveform=False,
+        )
+    )
+    return scene
+
+
 @pytest.mark.integration
 def test_virtual_waveguide_full_solve_is_rotation_and_direction_invariant(tmp_path):
     reflection = {}
@@ -87,6 +104,74 @@ def test_virtual_waveguide_full_solve_is_rotation_and_direction_invariant(tmp_pa
                 reflection[normal_axis, direction] = value
 
     for normal_axis in range(3):
-        assert reflection[normal_axis, "-"] == pytest.approx(
-            reflection[normal_axis, "+"], abs=1e-4
+        assert reflection[normal_axis, "-"] == pytest.approx(reflection[normal_axis, "+"], abs=1e-4)
+
+
+@pytest.mark.integration
+def test_virtual_waveguide_supports_two_simultaneous_modes_on_one_aperture(tmp_path):
+    outputfile = tmp_path / "virtual_multimode"
+
+    gprMax.run(
+        scenes=[_multimode_virtual_waveguide_scene()],
+        outputfile=outputfile,
+        hide_progress_bars=True,
+        log_level=30,
+    )
+
+    with h5py.File(outputfile.with_suffix(".h5"), "r") as output:
+        port_output = output["eigenmode_ports/port1"]
+        assert tuple(port_output.attrs["ExcitationModes"]) == (1, 2)
+        assert port_output.attrs["ResponseType"] == "driven"
+        assert np.all(np.isfinite(port_output["incident"][...]))
+        assert np.all(np.isfinite(port_output["outgoing"][...]))
+        assert "S" not in port_output
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+def test_cuda_multimode_virtual_waveguide_matches_cpu(tmp_path, gpu_device):
+    paths = {}
+    for name, gpu in (("cpu", None), ("cuda", [gpu_device])):
+        outputfile = tmp_path / f"virtual_multimode_{name}"
+        gprMax.run(
+            scenes=[_multimode_virtual_waveguide_scene()],
+            outputfile=outputfile,
+            gpu=gpu,
+            hide_progress_bars=True,
+            log_level=30,
         )
+        paths[name] = outputfile.with_suffix(".h5")
+
+    with h5py.File(paths["cpu"], "r") as cpu, h5py.File(paths["cuda"], "r") as cuda:
+        for dataset in ("incident", "outgoing"):
+            np.testing.assert_allclose(
+                cuda[f"eigenmode_ports/port1/{dataset}"][...],
+                cpu[f"eigenmode_ports/port1/{dataset}"][...],
+                rtol=3e-5,
+                atol=1e-7,
+            )
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+def test_opencl_multimode_virtual_waveguide_matches_cpu(tmp_path, opencl_device):
+    paths = {}
+    for name, opencl in (("cpu", None), ("opencl", [opencl_device])):
+        outputfile = tmp_path / f"virtual_multimode_{name}"
+        gprMax.run(
+            scenes=[_multimode_virtual_waveguide_scene()],
+            outputfile=outputfile,
+            opencl=opencl,
+            hide_progress_bars=True,
+            log_level=30,
+        )
+        paths[name] = outputfile.with_suffix(".h5")
+
+    with h5py.File(paths["cpu"], "r") as cpu, h5py.File(paths["opencl"], "r") as opencl:
+        for dataset in ("incident", "outgoing"):
+            np.testing.assert_allclose(
+                opencl[f"eigenmode_ports/port1/{dataset}"][...],
+                cpu[f"eigenmode_ports/port1/{dataset}"][...],
+                rtol=3e-5,
+                atol=1e-7,
+            )


### PR DESCRIPTION
## Summary

- allow multiple `EigenmodeExcitation` objects to drive different ports or modes simultaneously
- support per-drive amplitude or incident power, constant phase, and true time delay
- reuse one solved anchor bank, monitor, and virtual waveguide for multiple modes on the same physical port
- preserve the existing one-active-channel `EigenmodeStudy` workflow for complete S-matrix generation
- write raw incident/outgoing modal waves and drive metadata for simultaneous driven states, without labelling those results as an S-parameter column
- use the full modal quadratic power form, including cross terms, for driven-state antenna gain normalisation
- make multi-drive virtual-waveguide sources available to SAR source-waveform normalisation
- document the Python API, hash-command syntax, phase convention, driven-output schema, and recommended array workflows

## Drive convention

Each modal drive applies

`d_q(f) = A_q exp(+j phi_q) exp(-j 2 pi f tau_q)`

where `A_q` is supplied directly with `amplitude` or derived as `sqrt(power)`. All simultaneous drives share one base waveform. A zero-amplitude drive is rejected; an omitted channel is passive.

The hash-command form is:

`#eigenmode_excitation: port mode [auto|waveform_id] [amplitude] [phase_deg] [delay_s] [y|n]`

## Output behaviour

- one active modal channel retains the existing S-parameter-column output
- two or more active channels produce `ResponseType=driven`, incident/outgoing modal waves, and drive metadata
- driven outputs deliberately do not contain an `S` dataset because simultaneous excitation is not one S-matrix column

## Validation

A broadband, lossless rectangular TE10 waveguide test over 20-24 GHz now verifies the implementation independently through network theory and the analytical propagation constant

`beta = sqrt(k0^2 - (pi/a)^2)`.

Measured results in double precision:

- maximum relative residual in `b = S a`: `6.06e-6`
- maximum reciprocity error `|S12 - S21|`: `9.49e-16`
- maximum lossless unitarity error: `1.44e-4`
- maximum transmission-magnitude error from unity: `0.183%`
- maximum TE10 analytical phase error: `1.24 degrees` (RMS `0.89 degrees`)

Test runs:

- eigenmode-study CPU regressions: 11 passed
- focused CUDA simultaneous/multimode parity: 2 passed
- focused OpenCL simultaneous/multimode parity: 2 passed
- broader relevant CPU suite during development: 146 passed, 6 deselected
- Black 23.12.1, isort 5.13.2, and `git diff --check`: passed
