### PR TITLE
Add processing module: gain, background removal, subtraction and FFT (Component 3) : GSoC 2026

### DIFF
--- a/examples/cylinder_Ascan_2D_freespace.in
+++ b/examples/cylinder_Ascan_2D_freespace.in
@@ -1,0 +1,13 @@
+#title: Free-space reference for cylinder_Ascan_2D, target removed
+#domain: 0.240 0.210 0.002
+#dx_dy_dz: 0.002 0.002 0.002
+#time_window: 3e-9
+
+#material: 6 0 1 0 half_space
+
+#waveform: ricker 1 1.5e9 my_ricker
+#hertzian_dipole: z 0.100 0.170 0 my_ricker
+#rx: 0.140 0.170 0
+
+#box: 0 0 0 0.240 0.170 0.002 half_space
+

--- a/tests/test_h5_reader.py
+++ b/tests/test_h5_reader.py
@@ -1,0 +1,342 @@
+"""
+tests/test_h5_reader.py: unit tests for toolboxes/Marimo/h5_reader.py
+
+Run from repo root:
+    pytest tests/test_h5_reader.py -v
+
+Uses a synthetic HDF5 fixture built in memory — no real gprMax output
+file required. Tests cover metadata extraction, component reading,
+utility functions, and error handling.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from toolboxes.Marimo.h5_reader import (
+    build_label,
+    format_metadata_text,
+    get_time_axis,
+    get_trace,
+    get_unit_label,
+    list_components,
+    list_receivers,
+    load_file,
+    load_files,
+)
+
+# Fixtures
+
+
+DT = 4.717308673499368e-12  # seconds (from real cylinder_Ascan_2D.h5)
+ITERATIONS = 637
+NRX = 1
+NSRC = 1
+
+COMPONENTS = {
+    "Ex": np.zeros(ITERATIONS, dtype=np.float64),
+    "Ey": np.zeros(ITERATIONS, dtype=np.float64),
+    "Ez": np.linspace(-1000, 1000, ITERATIONS, dtype=np.float64),
+    "Hx": np.ones(ITERATIONS, dtype=np.float64) * 0.5,
+    "Hy": np.ones(ITERATIONS, dtype=np.float64) * -0.5,
+    "Hz": np.zeros(ITERATIONS, dtype=np.float64),
+}
+
+
+def _write_synthetic_h5(path: Path, title: str = "Test A-scan") -> None:
+    """Write a minimal valid gprMax v4 HDF5 file for testing."""
+    with h5py.File(path, "w") as f:
+        # Root attributes
+        f.attrs["Title"] = title
+        f.attrs["dt"] = DT
+        f.attrs["dx_dy_dz"] = np.array([0.002, 0.002, 0.002])
+        f.attrs["Iterations"] = ITERATIONS
+        f.attrs["nrx"] = NRX
+        f.attrs["nsrc"] = NSRC
+        f.attrs["nx_ny_nz"] = np.array([120, 105, 1])
+        f.attrs["gprMax"] = "4.0.0b0"
+
+        # Receiver
+        rx1 = f.require_group("rxs/rx1")
+        rx1.attrs["Name"] = "Rx(70,85,0)"
+        rx1.attrs["Position"] = np.array([0.14, 0.17, 0.0])
+        for comp, data in COMPONENTS.items():
+            rx1.create_dataset(comp, data=data)
+
+        # Source
+        src1 = f.require_group("srcs/src1")
+        src1.attrs["Type"] = "HertzianDipole"
+        src1.attrs["Position"] = np.array([0.10, 0.17, 0.0])
+
+
+@pytest.fixture
+def h5_file(tmp_path: Path) -> Path:
+    """Single synthetic HDF5 file."""
+    p = tmp_path / "test_ascan.h5"
+    _write_synthetic_h5(p)
+    return p
+
+
+@pytest.fixture
+def h5_file_b(tmp_path: Path) -> Path:
+    """Second synthetic HDF5 file with a different title."""
+    p = tmp_path / "test_ascan_freespace.h5"
+    _write_synthetic_h5(p, title="Free space A-scan")
+    return p
+
+
+@pytest.fixture
+def loaded(h5_file: Path):
+    """Pre-loaded FileData dict."""
+    return load_file(h5_file)
+
+
+# load_file — metadata
+
+
+class TestLoadFileMeta:
+    def test_title(self, loaded):
+        assert loaded["meta"]["title"] == "Test A-scan"
+
+    def test_dt(self, loaded):
+        assert loaded["meta"]["dt"] == pytest.approx(DT)
+
+    def test_iterations(self, loaded):
+        assert loaded["meta"]["iterations"] == ITERATIONS
+
+    def test_nrx(self, loaded):
+        assert loaded["meta"]["nrx"] == NRX
+
+    def test_nsrc(self, loaded):
+        assert loaded["meta"]["nsrc"] == NSRC
+
+    def test_dx_dy_dz(self, loaded):
+        assert loaded["meta"]["dx_dy_dz"] == pytest.approx([0.002, 0.002, 0.002])
+
+    def test_nx_ny_nz(self, loaded):
+        assert loaded["meta"]["nx_ny_nz"] == [120, 105, 1]
+
+    def test_gprmax_version(self, loaded):
+        assert loaded["meta"]["gprmax_version"] == "4.0.0b0"
+
+
+# load_file — receiver structure
+
+
+class TestLoadFileReceivers:
+    def test_receiver_keys(self, loaded):
+        assert "rx1" in loaded["receivers"]
+
+    def test_receiver_name(self, loaded):
+        assert loaded["receivers"]["rx1"]["name"] == "Rx(70,85,0)"
+
+    def test_receiver_position(self, loaded):
+        assert loaded["receivers"]["rx1"]["position"] == pytest.approx([0.14, 0.17, 0.0])
+
+    def test_all_components_present(self, loaded):
+        components = loaded["receivers"]["rx1"]["components"]
+        for comp in COMPONENTS:
+            assert comp in components
+
+    def test_component_shape(self, loaded):
+        ez = loaded["receivers"]["rx1"]["components"]["Ez"]
+        assert ez.shape == (ITERATIONS,)
+
+    def test_component_values(self, loaded):
+        ez = loaded["receivers"]["rx1"]["components"]["Ez"]
+        assert ez[0] == pytest.approx(COMPONENTS["Ez"][0])
+        assert ez[-1] == pytest.approx(COMPONENTS["Ez"][-1])
+
+
+# load_file — source structure
+
+
+class TestLoadFileSources:
+    def test_source_keys(self, loaded):
+        assert "src1" in loaded["sources"]
+
+    def test_source_type(self, loaded):
+        assert loaded["sources"]["src1"]["type"] == "HertzianDipole"
+
+    def test_source_position(self, loaded):
+        assert loaded["sources"]["src1"]["position"] == pytest.approx([0.10, 0.17, 0.0])
+
+
+# load_file — time axis
+
+
+class TestLoadFileTimeAxis:
+    def test_time_ns_length(self, loaded):
+        assert len(loaded["time_ns"]) == ITERATIONS
+
+    def test_time_ns_starts_at_zero(self, loaded):
+        assert loaded["time_ns"][0] == pytest.approx(0.0)
+
+    def test_time_ns_end_value(self, loaded):
+        expected_end = (ITERATIONS - 1) * DT * 1e9
+        assert loaded["time_ns"][-1] == pytest.approx(expected_end)
+
+
+# load_file — error handling
+
+
+class TestLoadFileErrors:
+    def test_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            load_file("/nonexistent/path/file.h5")
+
+    def test_invalid_hdf5(self, tmp_path):
+        bad = tmp_path / "bad.h5"
+        bad.write_text("not an hdf5 file")
+        with pytest.raises(OSError):
+            load_file(bad)
+
+
+# load_files — multi-file
+
+
+class TestLoadFiles:
+    def test_returns_both_files(self, h5_file, h5_file_b):
+        result = load_files([h5_file, h5_file_b])
+        assert len(result) == 2
+
+    def test_keyed_by_filename(self, h5_file):
+        result = load_files([h5_file])
+        assert "test_ascan.h5" in result
+
+    def test_collision_uses_full_path(self, tmp_path):
+        # Two files with identical names in different directories
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+        p_a = dir_a / "ascan.h5"
+        p_b = dir_b / "ascan.h5"
+        _write_synthetic_h5(p_a)
+        _write_synthetic_h5(p_b)
+        result = load_files([p_a, p_b])
+        # One entry will be the short name, one will be the full path
+        assert len(result) == 2
+
+
+# get_time_axis
+
+
+class TestGetTimeAxis:
+    def test_ns_unit(self, loaded):
+        t = get_time_axis(loaded, unit="ns")
+        assert t[-1] == pytest.approx((ITERATIONS - 1) * DT * 1e9)
+
+    def test_s_unit(self, loaded):
+        t = get_time_axis(loaded, unit="s")
+        assert t[-1] == pytest.approx((ITERATIONS - 1) * DT)
+
+    def test_iter_unit(self, loaded):
+        t = get_time_axis(loaded, unit="iter")
+        assert t[-1] == pytest.approx(ITERATIONS - 1)
+
+    def test_invalid_unit(self, loaded):
+        with pytest.raises(ValueError, match="Unknown unit"):
+            get_time_axis(loaded, unit="ms")
+
+
+# list_components
+
+
+class TestListComponents:
+    def test_returns_all_components(self, loaded):
+        comps = list_components(loaded)
+        assert set(comps) == set(COMPONENTS.keys())
+
+    def test_sorted(self, loaded):
+        comps = list_components(loaded)
+        assert comps == sorted(comps)
+
+    def test_missing_receiver_returns_empty(self, loaded):
+        comps = list_components(loaded, receiver="rx99")
+        assert comps == []
+
+
+# list_receivers
+
+
+class TestListReceivers:
+    def test_returns_rx1(self, loaded):
+        assert list_receivers(loaded) == ["rx1"]
+
+
+# get_trace
+
+
+class TestGetTrace:
+    def test_ez_values(self, loaded):
+        trace = get_trace(loaded, "Ez")
+        np.testing.assert_array_almost_equal(trace, COMPONENTS["Ez"])
+
+    def test_positive_polarity(self, loaded):
+        trace = get_trace(loaded, "Hx", polarity=1)
+        assert trace[0] == pytest.approx(COMPONENTS["Hx"][0])
+
+    def test_negative_polarity_arg(self, loaded):
+        trace = get_trace(loaded, "Hx", polarity=-1)
+        assert trace[0] == pytest.approx(-COMPONENTS["Hx"][0])
+
+    def test_negative_polarity_suffix(self, loaded):
+        trace = get_trace(loaded, "Hx-")
+        assert trace[0] == pytest.approx(-COMPONENTS["Hx"][0])
+
+    def test_missing_component_raises(self, loaded):
+        with pytest.raises(KeyError, match="Iz"):
+            get_trace(loaded, "Iz")
+
+
+# get_unit_label
+
+
+class TestGetUnitLabel:
+    def test_electric_field(self):
+        assert get_unit_label("Ez") == "V/m"
+
+    def test_magnetic_field(self):
+        assert get_unit_label("Hx") == "A/m"
+
+    def test_current(self):
+        assert get_unit_label("Ix") == "A"
+
+    def test_polarity_suffix_stripped(self):
+        assert get_unit_label("Ez-") == "V/m"
+
+
+# build_label
+
+
+class TestBuildLabel:
+    def test_label_format(self):
+        label = build_label("cylinder_Ascan_2D.h5", "rx1", "Ez")
+        assert label == "cylinder_Ascan_2D · rx1 · Ez"
+
+    def test_stem_only(self):
+        label = build_label("examples/cylinder_Ascan_2D.h5", "rx1", "Ez")
+        assert label == "cylinder_Ascan_2D · rx1 · Ez"
+
+
+# format_metadata_text
+
+
+class TestFormatMetadataText:
+    def test_contains_title(self, loaded):
+        text = format_metadata_text(loaded)
+        assert "Test A-scan" in text
+
+    def test_contains_iterations(self, loaded):
+        text = format_metadata_text(loaded)
+        assert str(ITERATIONS) in text
+
+    def test_contains_receiver_info(self, loaded):
+        text = format_metadata_text(loaded)
+        assert "rx1" in text
+        assert "Rx(70,85,0)" in text

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -11,6 +11,7 @@ from toolboxes.Marimo.processing import (
     gain_curve,
     gain_label,
     remove_mean_trace,
+    subtract_traces,
 )
 
 DT = 4.717308673499368e-12
@@ -405,3 +406,53 @@ class TestSpectrumViewLimit:
 
     def test_empty_input_returns_zero(self):
         assert spectrum_view_limit(np.array([]), np.array([])) == 0.0
+
+
+class TestSubtractTraces:
+    def test_identical_runs_cancel(self):
+        t = _trace()
+        assert subtract_traces(t, t, DT, DT) == pytest.approx(np.zeros_like(t))
+
+    def test_isolates_the_difference(self):
+        # A target run is the free-space run plus the target's response.
+        free = _trace()
+        target_response = np.zeros(ITERATIONS)
+        target_response[60] = 5.0
+        result = subtract_traces(free + target_response, free, DT, DT)
+        assert result == pytest.approx(target_response)
+
+    def test_works_on_matrices(self):
+        a, b = _matrix(), _matrix()
+        result = subtract_traces(a, b, DT, DT)
+        assert result.shape == (ITERATIONS, N_TRACES)
+        assert result == pytest.approx(np.zeros_like(a))
+
+    def test_shape_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="shape mismatch"):
+            subtract_traces(_trace(100), _trace(50), DT, DT)
+
+    def test_equal_length_but_different_dt_rejected(self):
+        # The failure this guard exists for: two runs with the same iteration
+        # count but different time steps line up index by index while
+        # representing different instants.
+        with pytest.raises(ValueError, match="time steps differ"):
+            subtract_traces(_trace(), _trace(), DT, DT * 1.5)
+
+    def test_negligible_dt_difference_accepted(self):
+        # Float round-trips through HDF5 should not trip the guard.
+        subtract_traces(_trace(), _trace(), DT, DT * (1 + 1e-12))
+
+    def test_missing_dt_skips_the_time_check(self):
+        # Callers without dt still get the shape check.
+        subtract_traces(_trace(), _trace())
+
+    def test_inputs_not_mutated(self):
+        a, b = _trace(), _trace(amplitude=2.0)
+        a0, b0 = a.copy(), b.copy()
+        subtract_traces(a, b, DT, DT)
+        assert a == pytest.approx(a0)
+        assert b == pytest.approx(b0)
+
+    def test_integer_input_does_not_truncate(self):
+        result = subtract_traces(np.array([3, 3]), np.array([1, 2]))
+        assert result == pytest.approx([2.0, 1.0])

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -4,6 +4,8 @@ import numpy as np
 import pytest
 
 from toolboxes.Marimo.processing import (
+    fft_spectrum,
+    spectrum_view_limit,
     GAIN_KINDS,
     apply_gain,
     gain_curve,
@@ -303,3 +305,103 @@ class TestMovingWindowBackgroundRemoval:
         _, background = remove_mean_trace(matrix, window=3)
         assert background[0, 0] == pytest.approx(1.0)
         assert background[0, -1] == pytest.approx(3.0)
+
+
+class TestFFTSpectrum:
+    """Exercises the wrapper around gprMax's own fft_power.
+
+    Skipped rather than failed when gprMax isn't importable, so the rest of
+    this suite still runs on a checkout without a built extension.
+    """
+
+    # 637 samples at this dt is the real cylinder_Ascan_2D window, 3.005 ns.
+    # ITERATIONS (100) is too short to hold one period of a 1.5 GHz Ricker,
+    # which would make any frequency assertion meaningless.
+    N_FFT = 637
+
+    @staticmethod
+    def _ricker(n=637, dt=DT, f0=1.5e9):
+        t = np.arange(n) * dt
+        tau = np.pi * f0 * (t - 1.0 / f0)
+        return (1.0 - 2.0 * tau**2) * np.exp(-(tau**2))
+
+    def test_positive_frequencies_only(self):
+        pytest.importorskip("gprMax.utilities.utilities")
+        freqs, power, _ = fft_spectrum(self._ricker(), DT)
+        assert np.all(freqs >= 0)
+        assert freqs.size == self.N_FFT // 2
+        assert power.size == freqs.size
+
+    def test_full_axis_includes_negative_frequencies(self):
+        # Pins why positive_only exists: the raw fft_power axis is mirrored.
+        pytest.importorskip("gprMax.utilities.utilities")
+        freqs, _, _ = fft_spectrum(self._ricker(), DT, positive_only=False)
+        assert freqs.size == self.N_FFT
+        assert np.any(freqs < 0)
+
+    def test_peak_frequency_matches_source(self):
+        pytest.importorskip("gprMax.utilities.utilities")
+        freqs, power, _ = fft_spectrum(self._ricker(f0=1.5e9), DT)
+        # A 3 ns window gives 0.333 GHz bins, so the best possible answer is
+        # the nearest bin to 1.5 GHz, not 1.5 GHz itself.
+        bin_hz = float(freqs[1] - freqs[0])
+        assert abs(freqs[int(np.argmax(power))] - 1.5e9) <= bin_hz
+
+    def test_power_is_relative_to_own_peak(self):
+        pytest.importorskip("gprMax.utilities.utilities")
+        _, power, _ = fft_spectrum(self._ricker(), DT)
+        assert power.max() == pytest.approx(0.0, abs=1e-9)
+
+    def test_peak_db_recovers_amplitude_difference(self):
+        # The whole reason peak_db is returned: fft_power alone makes a
+        # 1000x-larger trace look identical to the original.
+        pytest.importorskip("gprMax.utilities.utilities")
+        quiet = self._ricker()
+        loud = quiet * 1000.0
+        _, p_quiet, peak_quiet = fft_spectrum(quiet, DT)
+        _, p_loud, peak_loud = fft_spectrum(loud, DT)
+        assert p_quiet == pytest.approx(p_loud)
+        assert peak_loud - peak_quiet == pytest.approx(60.0, abs=0.01)
+
+    def test_flat_trace_reports_none_instead_of_a_fake_spectrum(self):
+        # Ex in a 2D TMz model. fft_power turns this into a flat 0 dB line
+        # that looks like real data.
+        pytest.importorskip("gprMax.utilities.utilities")
+        freqs, power, peak_db = fft_spectrum(np.zeros(self.N_FFT), DT)
+        assert peak_db is None
+        assert freqs.size == self.N_FFT // 2
+        assert np.all(power == 0.0)
+
+    def test_two_dimensional_input_rejected(self):
+        with pytest.raises(ValueError, match="must be 1D"):
+            fft_spectrum(np.zeros((10, 2)), DT)
+
+    def test_empty_input_rejected(self):
+        with pytest.raises(ValueError, match="empty"):
+            fft_spectrum(np.array([]), DT)
+
+
+class TestSpectrumViewLimit:
+    def test_limit_is_a_multiple_of_the_peak(self):
+        freqs = np.linspace(0.0, 100e9, 500)
+        power = np.full(500, -60.0)
+        power[10] = 0.0  # peak at freqs[10]
+        limit = spectrum_view_limit(freqs, power, multiple=4.0)
+        assert limit == pytest.approx(4.0 * freqs[10])
+
+    def test_clamped_to_available_maximum(self):
+        # plot_Ascan.py's index-based freqmaxpower*4 overshoots here.
+        freqs = np.linspace(0.0, 100e9, 500)
+        power = np.full(500, -60.0)
+        power[400] = 0.0
+        limit = spectrum_view_limit(freqs, power, multiple=4.0)
+        assert limit == pytest.approx(freqs.max())
+
+    def test_dc_peak_falls_back_to_full_range(self):
+        freqs = np.linspace(0.0, 100e9, 500)
+        power = np.full(500, -60.0)
+        power[0] = 0.0
+        assert spectrum_view_limit(freqs, power) == pytest.approx(freqs.max())
+
+    def test_empty_input_returns_zero(self):
+        assert spectrum_view_limit(np.array([]), np.array([])) == 0.0

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -157,7 +157,7 @@ class TestGainLabel:
         assert gain_label("constant", 2.5) == "constant gain x2.5"
 
     def test_carries_units_and_start(self):
-        assert gain_label("db", 6.0, start_ns=1.2) == "db gain 6 dB per ns from 1.2 ns"
+        assert gain_label("db", 6.0, start_ns=1.2) == "dB gain 6 dB per ns from 1.2 ns"
 
     def test_carries_clamp(self):
         label = gain_label("exponential", 2.0, max_gain=50.0)
@@ -199,3 +199,107 @@ class TestRemoveMeanTrace:
         original = matrix.copy()
         remove_mean_trace(matrix)
         assert matrix == pytest.approx(original)
+
+
+class TestPowerAndSecGain:
+    def test_power_floored_at_one(self):
+        # Bare t**b is 0 at t=0 and <1 below 1 ns, which would blank the start
+        # of a 3 ns gprMax window instead of amplifying anything.
+        t = np.linspace(0.0, 3.0, 61)
+        curve = gain_curve(t, "power", power=1.0)
+        assert curve[0] == pytest.approx(1.0)
+        assert np.all(curve >= 1.0)
+
+    def test_power_exact_where_it_amplifies(self):
+        t = np.linspace(0.0, 4.0, 81)
+        curve = gain_curve(t, "power", power=2.0)
+        above = t > 1.0
+        assert curve[above] == pytest.approx(t[above] ** 2.0)
+
+    def test_power_monotonic(self):
+        curve = gain_curve(np.linspace(0.0, 5.0, 101), "power", power=1.5)
+        assert np.all(np.diff(curve) >= 0)
+
+    def test_sec_is_product_of_its_two_terms(self):
+        # SEC is exp(a*t) * t**b. Pin the composition so the two halves can't
+        # drift apart from the standalone kinds.
+        t = np.linspace(0.0, 3.0, 61)
+        expo = gain_curve(t, "exponential", factor=0.4)
+        powr = gain_curve(t, "power", power=1.5)
+        sec = gain_curve(t, "sec", factor=0.4, power=1.5)
+        assert sec == pytest.approx(expo * powr)
+
+    def test_sec_with_zero_exponent_matches_exponential(self):
+        t = np.linspace(0.0, 3.0, 61)
+        sec = gain_curve(t, "sec", factor=0.4, power=0.0)
+        expo = gain_curve(t, "exponential", factor=0.4)
+        assert sec == pytest.approx(expo)
+
+    def test_sec_honours_start_and_clamp(self):
+        t = np.linspace(0.0, 5.0, 101)
+        curve = gain_curve(t, "sec", factor=1.0, power=2.0, start_ns=1.0, max_gain=20.0)
+        assert np.all(curve[t < 1.0] == 1.0)
+        assert curve.max() == pytest.approx(20.0)
+
+    def test_power_applies_across_matrix(self):
+        matrix = _matrix()
+        t = _time_ns()
+        gained, curve = apply_gain(matrix, t, "sec", factor=0.5, power=1.0)
+        for j in range(N_TRACES):
+            assert gained[:, j] == pytest.approx(matrix[:, j] * curve)
+
+    def test_every_kind_has_ui_metadata(self):
+        for kind, meta in GAIN_KINDS.items():
+            assert set(meta) == {"label", "factor_unit", "uses_power"}
+            gain_curve(_time_ns(), kind, factor=1.0, power=1.0)
+
+
+class TestGainLabelExtra:
+    def test_power(self):
+        assert gain_label("power", power=1.5) == "power gain t^1.5"
+
+    def test_sec(self):
+        assert gain_label("sec", 0.5, 1.5) == "SEC gain a=0.5 per ns, b=1.5"
+
+
+class TestMovingWindowBackgroundRemoval:
+    def test_window_removes_local_background(self):
+        matrix = np.column_stack([_trace()] * 9)
+        result, background = remove_mean_trace(matrix, window=3)
+        assert result == pytest.approx(np.zeros_like(matrix))
+        assert background.shape == matrix.shape
+
+    def test_window_preserves_a_dipping_event_global_mean_would_smear(self):
+        # A drifting background is exactly the case the moving window exists
+        # for: the global mean leaves residual, the window does not.
+        n_traces = 21
+        drift = np.linspace(0.0, 4.0, n_traces)
+        matrix = np.zeros((ITERATIONS, n_traces))
+        matrix[30, :] = drift
+        global_result, _ = remove_mean_trace(matrix)
+        window_result, _ = remove_mean_trace(matrix, window=3)
+        assert np.abs(window_result[30]).max() < np.abs(global_result[30]).max()
+
+    def test_window_wider_than_profile_matches_global_mean(self):
+        matrix = _matrix()
+        wide, _ = remove_mean_trace(matrix, window=N_TRACES * 10)
+        glob, _ = remove_mean_trace(matrix)
+        assert wide == pytest.approx(glob)
+
+    def test_window_of_one_is_a_no_op_removing_everything(self):
+        matrix = _matrix()
+        result, background = remove_mean_trace(matrix, window=1)
+        assert result == pytest.approx(np.zeros_like(matrix))
+        assert background == pytest.approx(matrix)
+
+    def test_window_below_one_rejected(self):
+        with pytest.raises(ValueError, match="at least 1 trace"):
+            remove_mean_trace(_matrix(), window=0)
+
+    def test_edge_columns_use_full_width_window(self):
+        # Clamped, not zero-padded: an edge trace must not be biased toward
+        # zero by averaging over a half-empty window.
+        matrix = np.tile(np.arange(5, dtype=float), (ITERATIONS, 1))
+        _, background = remove_mean_trace(matrix, window=3)
+        assert background[0, 0] == pytest.approx(1.0)
+        assert background[0, -1] == pytest.approx(3.0)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,0 +1,201 @@
+"""Tests for processing.py gain functions and background removal."""
+
+import numpy as np
+import pytest
+
+from toolboxes.Marimo.processing import (
+    GAIN_KINDS,
+    apply_gain,
+    gain_curve,
+    gain_label,
+    remove_mean_trace,
+)
+
+DT = 4.717308673499368e-12
+ITERATIONS = 100
+N_TRACES = 7  # deliberately not equal to ITERATIONS: a transposed matrix
+# would raise instead of silently producing a plausible-looking result
+
+
+def _time_ns(iterations=ITERATIONS):
+    return np.arange(iterations) * DT * 1e9
+
+
+def _trace(iterations=ITERATIONS, amplitude=1.0):
+    return np.sin(np.linspace(0, 6.28, iterations)) * amplitude
+
+
+def _matrix(iterations=ITERATIONS, n_traces=N_TRACES):
+    return np.column_stack([_trace(iterations, amplitude=j + 1) for j in range(n_traces)])
+
+
+class TestGainCurve:
+    def test_none_is_identity(self):
+        curve = gain_curve(_time_ns(), "none")
+        assert np.all(curve == 1.0)
+
+    def test_curve_length_matches_time_axis(self):
+        for kind in GAIN_KINDS:
+            curve = gain_curve(_time_ns(), kind, factor=2.0)
+            assert curve.shape == (ITERATIONS,)
+
+    def test_constant_is_flat(self):
+        curve = gain_curve(_time_ns(), "constant", factor=3.0)
+        assert np.all(curve == 3.0)
+
+    def test_linear_starts_at_one_and_rises(self):
+        t = _time_ns()
+        curve = gain_curve(t, "linear", factor=2.0)
+        assert curve[0] == pytest.approx(1.0)
+        assert curve[-1] == pytest.approx(1.0 + 2.0 * t[-1])
+        assert np.all(np.diff(curve) >= 0)
+
+    def test_exponential_matches_closed_form(self):
+        t = _time_ns()
+        curve = gain_curve(t, "exponential", factor=1.5)
+        assert curve == pytest.approx(np.exp(1.5 * t))
+
+    def test_db_twenty_per_ns_is_ten_times_after_one_ns(self):
+        t = np.array([0.0, 1.0, 2.0])
+        curve = gain_curve(t, "db", factor=20.0)
+        assert curve == pytest.approx([1.0, 10.0, 100.0])
+
+    def test_start_ns_leaves_earlier_samples_untouched(self):
+        t = np.linspace(0.0, 3.0, 61)
+        curve = gain_curve(t, "exponential", factor=2.0, start_ns=1.0)
+        assert np.all(curve[t < 1.0] == 1.0)
+        assert curve[t == 1.0] == pytest.approx(1.0)
+        assert np.all(curve[t > 1.0] > 1.0)
+
+    def test_max_gain_clamps(self):
+        curve = gain_curve(np.linspace(0.0, 3.0, 61), "exponential", factor=5.0, max_gain=50.0)
+        assert curve.max() == pytest.approx(50.0)
+
+    def test_curve_never_goes_negative(self):
+        # A negative linear factor decays past zero without the clip, which
+        # would flip trace polarity partway down and fake a reflection.
+        curve = gain_curve(np.linspace(0.0, 3.0, 61), "linear", factor=-10.0)
+        assert np.all(curve >= 0.0)
+
+    def test_unknown_kind_rejected(self):
+        with pytest.raises(ValueError, match="Unknown gain kind"):
+            gain_curve(_time_ns(), "agc")
+
+    def test_two_dimensional_time_axis_rejected(self):
+        with pytest.raises(ValueError, match="must be 1D"):
+            gain_curve(np.zeros((10, 2)), "linear")
+
+
+class TestApplyGain:
+    def test_trace_scaled_by_curve(self):
+        t = _time_ns()
+        trace = _trace()
+        gained, curve = apply_gain(trace, t, "exponential", factor=2.0)
+        assert gained == pytest.approx(trace * curve)
+
+    def test_matrix_keeps_shape(self):
+        matrix = _matrix()
+        gained, curve = apply_gain(matrix, _time_ns(), "linear", factor=1.0)
+        assert gained.shape == (ITERATIONS, N_TRACES)
+        assert curve.shape == (ITERATIONS,)
+
+    def test_matrix_column_matches_single_trace(self):
+        # Antonis's composability ask: gain applied to one A-scan and the
+        # same gain broadcast across a B-scan must be the same operation.
+        t = _time_ns()
+        matrix = _matrix()
+        gained_matrix, _ = apply_gain(matrix, t, "db", factor=6.0, start_ns=0.5)
+        for j in range(N_TRACES):
+            gained_trace, _ = apply_gain(matrix[:, j], t, "db", factor=6.0, start_ns=0.5)
+            assert gained_matrix[:, j] == pytest.approx(gained_trace)
+
+    def test_gain_applied_down_time_not_across_traces(self):
+        # Pins the broadcast axis. stack_traces() returns (n_samples,
+        # n_traces); multiplying by a bare (n_samples,) curve would broadcast
+        # against the trace axis instead and silently scale the wrong way.
+        t = np.arange(4, dtype=float)
+        matrix = np.ones((4, 3))
+        gained, _ = apply_gain(matrix, t, "linear", factor=1.0)
+        assert gained[:, 0] == pytest.approx([1.0, 2.0, 3.0, 4.0])
+        assert np.all(gained[0, :] == 1.0)
+
+    def test_length_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="time axis has"):
+            apply_gain(_trace(iterations=50), _time_ns(100), "linear")
+
+    def test_transposed_matrix_rejected(self):
+        with pytest.raises(ValueError, match="n_samples, n_traces"):
+            apply_gain(_matrix().T, _time_ns(), "linear")
+
+    def test_three_dimensional_data_rejected(self):
+        with pytest.raises(ValueError, match="must be 1D or 2D"):
+            apply_gain(np.zeros((ITERATIONS, 2, 2)), _time_ns(), "linear")
+
+    def test_none_returns_data_unchanged(self):
+        matrix = _matrix()
+        gained, curve = apply_gain(matrix, _time_ns(), "none")
+        assert gained == pytest.approx(matrix)
+        assert np.all(curve == 1.0)
+
+    def test_input_not_mutated(self):
+        matrix = _matrix()
+        original = matrix.copy()
+        apply_gain(matrix, _time_ns(), "exponential", factor=3.0)
+        assert matrix == pytest.approx(original)
+
+    def test_integer_input_does_not_truncate(self):
+        data = np.ones(4, dtype=int)
+        gained, _ = apply_gain(data, np.arange(4, dtype=float), "linear", factor=0.5)
+        assert gained == pytest.approx([1.0, 1.5, 2.0, 2.5])
+
+
+class TestGainLabel:
+    def test_none(self):
+        assert gain_label("none") == "no gain"
+
+    def test_constant(self):
+        assert gain_label("constant", 2.5) == "constant gain x2.5"
+
+    def test_carries_units_and_start(self):
+        assert gain_label("db", 6.0, start_ns=1.2) == "db gain 6 dB per ns from 1.2 ns"
+
+    def test_carries_clamp(self):
+        label = gain_label("exponential", 2.0, max_gain=50.0)
+        assert label == "exponential gain 2 per ns, clamped at x50"
+
+    def test_unknown_kind_rejected(self):
+        with pytest.raises(ValueError, match="Unknown gain kind"):
+            gain_label("agc")
+
+
+class TestRemoveMeanTrace:
+    def test_identical_traces_cancel_to_zero(self):
+        matrix = np.column_stack([_trace()] * N_TRACES)
+        result, mean_trace = remove_mean_trace(matrix)
+        assert result == pytest.approx(np.zeros_like(matrix))
+        assert mean_trace == pytest.approx(_trace())
+
+    def test_stationary_component_removed_target_kept(self):
+        direct = _trace()
+        matrix = np.column_stack([direct.copy() for _ in range(N_TRACES)])
+        target = np.zeros(ITERATIONS)
+        target[60] = 5.0
+        matrix[:, 3] += target
+        result, _ = remove_mean_trace(matrix)
+        assert result[60, 3] == pytest.approx(5.0 * (1 - 1 / N_TRACES))
+        assert np.argmax(np.abs(result[:, 3])) == 60
+
+    def test_shape_preserved(self):
+        result, mean_trace = remove_mean_trace(_matrix())
+        assert result.shape == (ITERATIONS, N_TRACES)
+        assert mean_trace.shape == (ITERATIONS,)
+
+    def test_one_dimensional_input_rejected(self):
+        with pytest.raises(ValueError, match="must be 2D"):
+            remove_mean_trace(_trace())
+
+    def test_input_not_mutated(self):
+        matrix = _matrix()
+        original = matrix.copy()
+        remove_mean_trace(matrix)
+        assert matrix == pytest.approx(original)

--- a/tests/test_trace_matrix.py
+++ b/tests/test_trace_matrix.py
@@ -1,0 +1,198 @@
+"""Tests for trace_matrix.py against synthetic single-trace HDF5 files."""
+
+import h5py
+import numpy as np
+import pytest
+
+from toolboxes.Marimo.h5_reader import load_file
+from toolboxes.Marimo.trace_matrix import process_trace, stack_traces
+
+DT = 4.717308673499368e-12
+ITERATIONS = 100
+
+
+def _write_trace(path, x_pos, amplitude=1.0, iterations=ITERATIONS, components=("Ez",)):
+    with h5py.File(path, "w") as f:
+        f.attrs["Title"] = "synthetic"
+        f.attrs["dt"] = DT
+        f.attrs["dx_dy_dz"] = [0.002, 0.002, 0.002]
+        f.attrs["Iterations"] = iterations
+        f.attrs["nrx"] = 1
+        f.attrs["nsrc"] = 1
+        f.attrs["nx_ny_nz"] = [120, 105, 1]
+        f.attrs["gprMax"] = "4.0.0"
+
+        rx = f.create_group("rxs/rx1")
+        rx.attrs["Name"] = "Rx(70,85,0)"
+        rx.attrs["Position"] = [0.14, 0.17, 0.0]
+        for comp in components:
+            rx.create_dataset(comp, data=np.sin(np.linspace(0, 6.28, iterations)) * amplitude)
+
+        src = f.create_group("srcs/src1")
+        src.attrs["Type"] = "HertzianDipole"
+        src.attrs["Position"] = [x_pos, 0.17, 0.0]
+    return path
+
+
+def _write_trace_no_source(path, iterations=ITERATIONS):
+    with h5py.File(path, "w") as f:
+        f.attrs["Title"] = "no-source"
+        f.attrs["dt"] = DT
+        f.attrs["dx_dy_dz"] = [0.002, 0.002, 0.002]
+        f.attrs["Iterations"] = iterations
+        f.attrs["nrx"] = 1
+        f.attrs["nsrc"] = 0
+        f.attrs["nx_ny_nz"] = [120, 105, 1]
+        f.attrs["gprMax"] = "4.0.0"
+        rx = f.create_group("rxs/rx1")
+        rx.attrs["Name"] = "Rx(70,85,0)"
+        rx.attrs["Position"] = [0.14, 0.17, 0.0]
+        rx.create_dataset("Ez", data=np.zeros(iterations))
+    return path
+
+
+def _write_trace_two_receivers(path, x_pos, iterations=ITERATIONS):
+    with h5py.File(path, "w") as f:
+        f.attrs["Title"] = "two-rx"
+        f.attrs["dt"] = DT
+        f.attrs["dx_dy_dz"] = [0.002, 0.002, 0.002]
+        f.attrs["Iterations"] = iterations
+        f.attrs["nrx"] = 2
+        f.attrs["nsrc"] = 1
+        f.attrs["nx_ny_nz"] = [120, 105, 1]
+        f.attrs["gprMax"] = "4.0.0"
+
+        rx1 = f.create_group("rxs/rx1")
+        rx1.attrs["Name"] = "Rx(70,85,0)"
+        rx1.attrs["Position"] = [0.14, 0.17, 0.0]
+        rx1.create_dataset("Ez", data=np.ones(iterations) * 1.0)
+
+        rx2 = f.create_group("rxs/rx2")
+        rx2.attrs["Name"] = "Rx(90,85,0)"
+        rx2.attrs["Position"] = [0.18, 0.17, 0.0]
+        rx2.create_dataset("Ez", data=np.ones(iterations) * 2.0)
+
+        src = f.create_group("srcs/src1")
+        src.attrs["Type"] = "HertzianDipole"
+        src.attrs["Position"] = [x_pos, 0.17, 0.0]
+    return path
+
+
+class TestProcessTrace:
+    def test_success_extracts_component_and_position(self, tmp_path):
+        fdata = load_file(_write_trace(tmp_path / "t1.h5", x_pos=0.05, amplitude=3.0))
+        result = process_trace(fdata, "Ez", expected_len=None)
+        assert result["ok"] is True
+        assert result["component"] == "Ez"
+        assert result["receiver"] == "rx1"
+        assert result["x"] == pytest.approx(0.05)
+        assert len(result["array"]) == ITERATIONS
+
+    def test_falls_back_to_ez_when_preferred_missing(self, tmp_path):
+        fdata = load_file(_write_trace(tmp_path / "t1.h5", x_pos=0.05))
+        result = process_trace(fdata, "Hx", expected_len=None)
+        assert result["ok"] is True
+        assert result["component"] == "Ez"
+
+    def test_falls_back_to_first_available_when_no_ez(self, tmp_path):
+        fdata = load_file(
+            _write_trace(tmp_path / "t1.h5", x_pos=0.05, components=("Hx", "Hy"))
+        )
+        result = process_trace(fdata, "Ez", expected_len=None)
+        assert result["ok"] is True
+        assert result["component"] in ("Hx", "Hy")
+
+    def test_mismatched_length_rejected(self, tmp_path):
+        fdata = load_file(_write_trace(tmp_path / "t1.h5", x_pos=0.05, iterations=50))
+        result = process_trace(fdata, "Ez", expected_len=100)
+        assert result["ok"] is False
+        assert "50 samples" in result["reason"]
+
+    def test_missing_source_gives_none_position(self, tmp_path):
+        fdata = load_file(_write_trace_no_source(tmp_path / "t1.h5"))
+        result = process_trace(fdata, "Ez", expected_len=None)
+        assert result["ok"] is True
+        assert result["x"] is None
+
+    def test_defaults_to_first_receiver_when_no_preference(self, tmp_path):
+        fdata = load_file(_write_trace_two_receivers(tmp_path / "t1.h5", x_pos=0.05))
+        result = process_trace(fdata, "Ez", expected_len=None)
+        assert result["receiver"] == "rx1"
+        assert result["array"][0] == pytest.approx(1.0)
+
+    def test_honours_preferred_receiver(self, tmp_path):
+        fdata = load_file(_write_trace_two_receivers(tmp_path / "t1.h5", x_pos=0.05))
+        result = process_trace(fdata, "Ez", expected_len=None, preferred_receiver="rx2")
+        assert result["receiver"] == "rx2"
+        assert result["array"][0] == pytest.approx(2.0)
+
+    def test_falls_back_to_first_receiver_if_preferred_not_present(self, tmp_path):
+        fdata = load_file(_write_trace_two_receivers(tmp_path / "t1.h5", x_pos=0.05))
+        result = process_trace(fdata, "Ez", expected_len=None, preferred_receiver="rx99")
+        assert result["receiver"] == "rx1"
+
+
+class TestStackTraces:
+    def test_stacks_in_given_order(self, tmp_path):
+        files = [
+            load_file(_write_trace(tmp_path / f"t{i}.h5", x_pos=0.04 + i * 0.002, amplitude=i + 1))
+            for i in range(5)
+        ]
+        result = stack_traces(files, preferred_component="Ez")
+        assert result["matrix"].shape == (ITERATIONS, 5)
+        assert result["positions_x"] == [pytest.approx(0.04 + i * 0.002) for i in range(5)]
+        assert result["warnings"] == []
+        assert result["all_positions_physical"] is True
+
+    def test_amplitude_scaling_preserved_per_column(self, tmp_path):
+        files = [
+            load_file(_write_trace(tmp_path / f"t{i}.h5", x_pos=float(i), amplitude=i + 1))
+            for i in range(4)
+        ]
+        result = stack_traces(files)
+        peaks = [round(float(np.max(np.abs(result["matrix"][:, j])))) for j in range(4)]
+        assert peaks == [1, 2, 3, 4]
+
+    def test_empty_input_returns_none_matrix(self):
+        result = stack_traces([])
+        assert result["matrix"] is None
+        assert result["positions_x"] == []
+        assert result["warnings"] == []
+
+    def test_mismatched_file_skipped_with_warning_rest_still_stacked(self, tmp_path):
+        good = [
+            load_file(_write_trace(tmp_path / "a.h5", x_pos=0.0)),
+            load_file(_write_trace(tmp_path / "b.h5", x_pos=0.01)),
+        ]
+        bad = load_file(_write_trace(tmp_path / "c.h5", x_pos=0.02, iterations=50))
+        result = stack_traces([good[0], bad, good[1]])
+        assert result["matrix"].shape == (ITERATIONS, 2)
+        assert len(result["warnings"]) == 1
+        assert "trace 1" in result["warnings"][0]
+
+    def test_missing_source_falls_back_to_index_and_flags_non_physical(self, tmp_path):
+        files = [
+            load_file(_write_trace(tmp_path / "a.h5", x_pos=0.0)),
+            load_file(_write_trace_no_source(tmp_path / "b.h5")),
+        ]
+        result = stack_traces(files)
+        assert result["all_positions_physical"] is False
+        assert result["positions_x"][1] == 1.0  # fell back to index
+
+    def test_component_choice_is_consistent_across_stack(self, tmp_path):
+        files = [
+            load_file(_write_trace(tmp_path / f"t{i}.h5", x_pos=float(i), components=("Ez", "Hx")))
+            for i in range(3)
+        ]
+        result = stack_traces(files, preferred_component="Hx")
+        assert result["component"] == "Hx"
+        assert result["matrix"].shape == (ITERATIONS, 3)
+
+    def test_preferred_receiver_threads_through_stack(self, tmp_path):
+        files = [
+            load_file(_write_trace_two_receivers(tmp_path / f"t{i}.h5", x_pos=float(i)))
+            for i in range(3)
+        ]
+        result = stack_traces(files, preferred_component="Ez", preferred_receiver="rx2")
+        assert result["receiver"] == "rx2"
+        assert np.all(result["matrix"] == 2.0)

--- a/toolboxes/Marimo/ascan_dashboard.py
+++ b/toolboxes/Marimo/ascan_dashboard.py
@@ -1,0 +1,732 @@
+import marimo
+
+__generated_with = "0.23.8"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import csv
+    import io
+    from pathlib import Path
+
+    import marimo as mo
+    import numpy as np
+    import plotly.graph_objects as go
+
+    from toolboxes.Marimo.h5_reader import (
+        build_label,
+        format_metadata_text,
+        get_time_axis,
+        get_trace,
+        get_unit_label,
+        list_components,
+        list_receivers,
+        load_files,
+    )
+
+    # Research-quality colour palette (Matplotlib tab10, colorblind-friendly)
+    PALETTE = [
+        "#1f77b4",
+        "#d62728",
+        "#2ca02c",
+        "#ff7f0e",
+        "#9467bd",
+        "#8c564b",
+        "#e377c2",
+        "#17becf",
+        "#bcbd22",
+        "#7f7f7f",
+    ]
+
+    COLOUR_NAMES = {
+        "Blue": "#1f77b4",
+        "Red": "#d62728",
+        "Green": "#2ca02c",
+        "Orange": "#ff7f0e",
+        "Purple": "#9467bd",
+        "Brown": "#8c564b",
+        "Pink": "#e377c2",
+        "Teal": "#17becf",
+        "Olive": "#bcbd22",
+        "Grey": "#7f7f7f",
+        "Cyan": "#4FC3F7",
+        "Black": "#111111",
+    }
+
+    return (
+        COLOUR_NAMES,
+        PALETTE,
+        Path,
+        build_label,
+        csv,
+        format_metadata_text,
+        get_time_axis,
+        get_trace,
+        get_unit_label,
+        go,
+        io,
+        list_components,
+        list_receivers,
+        load_files,
+        mo,
+        np,
+    )
+
+
+# ── SECTION 1: File loading ────────────────────────────────────────────────
+@app.cell
+def _(mo):
+    file_browser = mo.ui.file_browser(
+        filetypes=[".h5"],
+        label="",
+        multiple=True,
+    )
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("# gprMax A-Scan Post-Processing Dashboard"),
+                mo.md(
+                    "Load one or more `.h5` output files, select field components, "
+                    "and build publication-quality overlay plots with SVG, PDF, "
+                    "and CSV export."
+                ),
+                mo.md("---"),
+                mo.md("### Step 1 — Load output files"),
+                mo.md(
+                    "_Select one or more gprMax `.h5` output files. "
+                    "All field components (Ex, Ey, Ez, Hx, Hy, Hz) "
+                    "are detected automatically from each file._"
+                ),
+                file_browser,
+            ],
+            gap="0.4rem",
+        )
+    )
+    return (file_browser,)
+
+
+# ── SECTION 2: Data loading + metadata banner ──────────────────────────────
+@app.cell
+def _(file_browser, format_metadata_text, load_files, mo):
+    if not file_browser.value:
+        mo.stop(True, mo.md(""))
+
+    _paths = [f.path for f in file_browser.value]
+    _loaded = load_files(_paths)
+    get_data, set_data = mo.state({"files": _loaded})
+
+    _cards = [
+        mo.callout(
+            mo.md(f"**{_fname}**\n\n{format_metadata_text(_fdata)}"),
+            kind="info",
+        )
+        for _fname, _fdata in _loaded.items()
+    ]
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md(f"### {len(_loaded)} file(s) loaded"),
+                *_cards,
+                mo.md("---"),
+            ],
+            gap="0.4rem",
+        )
+    )
+    return get_data, set_data
+
+
+# ── STATE: isolated — no UI dependencies ──────────────────────────────────
+@app.cell
+def _(mo):
+    get_traces, set_traces = mo.state([])
+    return get_traces, set_traces
+
+
+# ── SECTION 3: Trace picker ────────────────────────────────────────────────
+@app.cell
+def _(
+    COLOUR_NAMES,
+    PALETTE,
+    get_data,
+    get_traces,
+    list_components,
+    list_receivers,
+    mo,
+):
+    _state = get_data()
+    _files = _state["files"]
+
+    if not _files:
+        mo.stop(True, mo.md("No files loaded."))
+
+    _file_options = list(_files.keys())
+    _first_file = _file_options[0]
+    _first_rx = list_receivers(_files[_first_file])[0]
+    _first_comps = list_components(_files[_first_file], _first_rx)
+
+    _next_hex = PALETTE[len(get_traces()) % len(PALETTE)]
+    _auto_name = next((name for name, h in COLOUR_NAMES.items() if h == _next_hex), "Blue")
+
+    file_selector = mo.ui.dropdown(
+        options=_file_options,
+        value=_first_file,
+        label="File",
+    )
+    receiver_selector = mo.ui.dropdown(
+        options=list_receivers(_files[_first_file]),
+        value=_first_rx,
+        label="Receiver",
+    )
+    component_selector = mo.ui.dropdown(
+        options=_first_comps,
+        value="Ez" if "Ez" in _first_comps else _first_comps[0],
+        label="Component",
+    )
+    colour_selector = mo.ui.dropdown(
+        options=COLOUR_NAMES,
+        value=_auto_name,
+        label="Trace colour",
+    )
+    add_button = mo.ui.run_button(label="＋  Add trace")
+    clear_button = mo.ui.run_button(label="✕  Clear all")
+
+    _traces_now = get_traces()
+    if _traces_now:
+        _remove_opts = {t["label"]: i for i, t in enumerate(_traces_now)}
+        remove_selector = mo.ui.dropdown(
+            options=_remove_opts,
+            value=list(_remove_opts.keys())[0],
+            label="Remove a trace",
+        )
+        remove_button = mo.ui.run_button(label="－  Remove selected")
+        _remove_section = mo.vstack(
+            [
+                mo.md("**Remove a trace**"),
+                mo.hstack([remove_selector, remove_button], gap="1rem"),
+            ],
+            gap="0.3rem",
+        )
+    else:
+        remove_selector = None
+        remove_button = None
+        _remove_section = mo.md("")
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 2 — Build your plot"),
+                mo.md(
+                    "_Select a file, receiver, and field component. "
+                    "Colour auto-advances through the research palette — "
+                    "override before clicking Add._"
+                ),
+                mo.md("**Select source**"),
+                mo.hstack([file_selector, receiver_selector], gap="2rem"),
+                mo.md("**Select component and colour**"),
+                mo.hstack([component_selector, colour_selector], gap="2rem"),
+                mo.hstack([add_button, clear_button], gap="1rem"),
+                mo.md("---"),
+                _remove_section,
+            ],
+            gap="0.5rem",
+        )
+    )
+    return (
+        add_button,
+        clear_button,
+        colour_selector,
+        component_selector,
+        file_selector,
+        receiver_selector,
+        remove_button,
+        remove_selector,
+    )
+
+
+# ── BUTTON HANDLER ─────────────────────────────────────────────────────────
+@app.cell
+def _(
+    add_button,
+    build_label,
+    clear_button,
+    colour_selector,
+    component_selector,
+    file_selector,
+    get_data,
+    get_traces,
+    list_components,
+    mo,
+    receiver_selector,
+    remove_button,
+    remove_selector,
+    set_traces,
+):
+    if add_button.value:
+        _fname = file_selector.value
+        _rx = receiver_selector.value
+        _comp = component_selector.value
+        _available = list_components(get_data()["files"][_fname], _rx)
+        if _comp not in _available:
+            mo.output.replace(
+                mo.callout(
+                    mo.md(
+                        f"**Component not found.** "
+                        f"`{_comp}` is not in `{_fname}` / `{_rx}`. "
+                        f"Available: {', '.join(_available)}"
+                    ),
+                    kind="danger",
+                )
+            )
+        else:
+            _new = {
+                "filename": _fname,
+                "receiver": _rx,
+                "component": _comp,
+                "colour": colour_selector.value,
+                "label": build_label(_fname, _rx, _comp),
+            }
+            _cur = get_traces()
+            _dup = any(
+                t["filename"] == _new["filename"]
+                and t["receiver"] == _new["receiver"]
+                and t["component"] == _new["component"]
+                for t in _cur
+            )
+            if not _dup:
+                set_traces(_cur + [_new])
+
+    if remove_button is not None and remove_button.value and remove_selector is not None:
+        _idx = remove_selector.value
+        set_traces([t for i, t in enumerate(get_traces()) if i != _idx])
+
+    if clear_button.value:
+        set_traces([])
+
+    _traces = get_traces()
+    if _traces:
+        _header = "| # | Colour | Component | File | Receiver |"
+        _sep = "|---|--------|-----------|------|----------|"
+        _rows = "\n".join(
+            f"| {i + 1} "
+            f"| <span style='background:{t['colour']};display:inline-block;"
+            f"width:32px;height:14px;border-radius:3px;'></span> "
+            f"| `{t['component']}` "
+            f"| `{t['filename']}` "
+            f"| `{t['receiver']}` |"
+            for i, t in enumerate(_traces)
+        )
+        mo.output.replace(
+            mo.vstack(
+                [
+                    mo.md(f"**{len(_traces)} active trace(s)**"),
+                    mo.md(f"{_header}\n{_sep}\n{_rows}"),
+                    mo.md("---"),
+                ],
+                gap="0.3rem",
+            )
+        )
+    else:
+        mo.output.replace(
+            mo.vstack(
+                [
+                    mo.callout(
+                        mo.md(
+                            "No traces added yet. "
+                            "Use the picker above and click **＋ Add trace**."
+                        ),
+                        kind="neutral",
+                    ),
+                    mo.md("---"),
+                ],
+                gap="0.25rem",
+            )
+        )
+
+
+# ── SECTION 4: Plot appearance controls ───────────────────────────────────
+@app.cell
+def _(mo):
+    bg_colour = mo.ui.dropdown(
+        options={
+            "Light": "#ffffff",
+            "Paper white": "#f8f9fa",
+            "Dark": "#0e1117",
+        },
+        value="Light",
+        label="Background",
+    )
+    line_width = mo.ui.slider(
+        start=0.5,
+        stop=4.0,
+        step=0.5,
+        value=1.5,
+        label="Line width",
+    )
+    font_size = mo.ui.slider(
+        start=10,
+        stop=22,
+        step=1,
+        value=13,
+        label="Font size",
+    )
+    show_grid = mo.ui.checkbox(label="Show grid", value=True)
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 3 — Adjust appearance"),
+                mo.hstack(
+                    [bg_colour, line_width, font_size, show_grid],
+                    gap="1.5rem",
+                    justify="start",
+                ),
+            ],
+            gap="0.5rem",
+        )
+    )
+    return bg_colour, font_size, line_width, show_grid
+
+
+# ── SECTION 5: Time zoom slider ────────────────────────────────────────────
+@app.cell
+def _(get_data, get_traces, mo):
+    if not get_traces():
+        mo.stop(True, mo.md(""))
+
+    _files = get_data()["files"]
+    _max_ns = max(
+        round(f["meta"]["iterations"] * f["meta"]["dt"] * 1e9, 4) for f in _files.values()
+    )
+    _step = round(_max_ns / 600, 4)
+
+    time_slider = mo.ui.range_slider(
+        start=0.0,
+        stop=_max_ns,
+        step=_step,
+        value=[0.0, _max_ns],
+        label="Time window (ns)",
+        full_width=True,
+    )
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 4 — Zoom time window"),
+                mo.md(
+                    "_Drag handles to focus on a specific time range. "
+                    "CSV export always contains the full unzoomed data._"
+                ),
+                time_slider,
+                mo.md("---"),
+            ],
+            gap="0.4rem",
+        )
+    )
+    return (time_slider,)
+
+
+# ── SECTION 6: Figure renderer + export ───────────────────────────────────
+@app.cell
+def _(
+    bg_colour,
+    csv,
+    font_size,
+    get_data,
+    get_time_axis,
+    get_trace,
+    get_traces,
+    get_unit_label,
+    go,
+    io,
+    line_width,
+    mo,
+    show_grid,
+    time_slider,
+):
+    _traces = get_traces()
+    if not _traces:
+        mo.stop(
+            True,
+            mo.callout(
+                mo.md("Add at least one trace using the picker above " "to render the plot."),
+                kind="warn",
+            ),
+        )
+
+    _files = get_data()["files"]
+    _bg = bg_colour.value
+    _is_dark = _bg == "#0e1117"
+    _fc = "#e8e8e8" if _is_dark else "#1a1a1a"
+    _gc = "rgba(255,255,255,0.1)" if _is_dark else "rgba(0,0,0,0.07)"
+    _lc = "rgba(255,255,255,0.25)" if _is_dark else "rgba(0,0,0,0.18)"
+
+    # ── Build figure ────────────────────────────────────────────────────────
+    _fig = go.Figure()
+    _has_e = False
+    _has_h = False
+    _comps_seen = []
+    _files_seen = []
+
+    # Store full arrays for CSV export (unaffected by zoom)
+    _csv_time: dict = {}
+    _csv_data: dict = {}
+
+    for _t in _traces:
+        _fdata = _files[_t["filename"]]
+        _arr = get_trace(_fdata, _t["component"], _t["receiver"])
+        _time = get_time_axis(_fdata, unit="ns")
+        _unit = get_unit_label(_t["component"])
+        _on_y2 = _unit == "A/m"
+
+        if _on_y2:
+            _has_h = True
+        else:
+            _has_e = True
+
+        # Track unique time axes by (n_steps, dt) tuple
+        _fmeta = _fdata["meta"]
+        _tax_key = (_fmeta["iterations"], round(_fmeta["dt"], 15))
+        if _tax_key not in _csv_time:
+            _csv_time[_tax_key] = _time
+        _csv_data[_t["label"]] = (_tax_key, _arr)
+
+        _fig.add_trace(
+            go.Scatter(
+                x=_time,
+                y=_arr,
+                mode="lines",
+                name=_t["label"],
+                line=dict(
+                    color=_t["colour"],
+                    width=line_width.value,
+                    dash="dash" if _on_y2 else "solid",
+                ),
+                yaxis="y2" if _on_y2 else "y",
+                hovertemplate=(
+                    "%{x:.4f} ns<br>%{y:.5g} " + _unit + "<extra>" + _t["label"] + "</extra>"
+                ),
+            )
+        )
+
+        if _t["component"] not in _comps_seen:
+            _comps_seen.append(_t["component"])
+        if _t["filename"] not in _files_seen:
+            _files_seen.append(_t["filename"])
+
+    _title = ", ".join(_comps_seen) + "  ·  " + "  +  ".join(_files_seen)
+    _dual = _has_e and _has_h
+
+    _axis_base = dict(
+        showgrid=show_grid.value,
+        gridcolor=_gc,
+        gridwidth=0.5,
+        showline=True,
+        linecolor=_lc,
+        linewidth=1,
+        tickfont=dict(size=font_size.value - 1, color=_fc),
+        title_font=dict(size=font_size.value, color=_fc),
+        zeroline=True,
+        zerolinecolor=_lc,
+        zerolinewidth=1,
+    )
+
+    if _dual:
+        _y1_label = "E-field [V/m]"
+    elif _has_e:
+        _y1_label = "Field strength [V/m]"
+    else:
+        _y1_label = "Field strength [A/m]"
+
+    _t_start, _t_end = time_slider.value
+
+    _layout = dict(
+        title=dict(
+            text=_title,
+            font=dict(size=font_size.value + 1, color=_fc),
+            x=0.0,
+            xanchor="left",
+        ),
+        xaxis=dict(
+            title="Time (ns)",
+            range=[_t_start, _t_end],
+            **_axis_base,
+        ),
+        yaxis=dict(title=_y1_label, **_axis_base),
+        paper_bgcolor=_bg,
+        plot_bgcolor=_bg,
+        legend=dict(
+            font=dict(size=font_size.value - 1, color=_fc),
+            bgcolor="rgba(0,0,0,0.0)",
+            bordercolor=_lc,
+            borderwidth=1,
+        ),
+        height=500,
+        margin=dict(l=72, r=80 if _dual else 32, t=55, b=60),
+        hovermode="x unified",
+    )
+
+    if _dual:
+        _layout["yaxis2"] = dict(
+            title="H-field [A/m]",
+            overlaying="y",
+            side="right",
+            showgrid=False,
+            showline=True,
+            linecolor=_lc,
+            linewidth=1,
+            tickfont=dict(size=font_size.value - 1, color=_fc),
+            title_font=dict(size=font_size.value, color=_fc),
+            zeroline=False,
+        )
+
+    _fig.update_layout(**_layout)
+
+    # ── CSV export ──────────────────────────────────────────────────────────
+    # Always exports FULL data (not the zoomed window).
+    # If all traces share the same time axis: one time column.
+    # If traces come from files with different dt/iterations: paired columns.
+    try:
+        _buf = io.StringIO()
+        _writer = csv.writer(_buf)
+
+        _single_axis = len(_csv_time) == 1
+
+        if _single_axis:
+            _shared_time = list(_csv_time.values())[0]
+            _header_row = ["time_ns"] + [t["label"] for t in _traces]
+            _writer.writerow(_header_row)
+            for _i in range(len(_shared_time)):
+                _row = [f"{_shared_time[_i]:.8g}"] + [
+                    f"{_csv_data[t['label']][1][_i]:.10g}" for t in _traces
+                ]
+                _writer.writerow(_row)
+        else:
+            # Paired time + value columns per trace
+            _header_row = []
+            for _t in _traces:
+                _header_row.extend([f"time_ns ({_t['label']})", _t["label"]])
+            _writer.writerow(_header_row)
+            _max_len = max(len(_csv_data[t["label"]][1]) for t in _traces)
+            for _i in range(_max_len):
+                _row = []
+                for _t in _traces:
+                    _tax_key, _arr = _csv_data[_t["label"]]
+                    _time = _csv_time[_tax_key]
+                    if _i < len(_arr):
+                        _row.extend([f"{_time[_i]:.8g}", f"{_arr[_i]:.10g}"])
+                    else:
+                        _row.extend(["", ""])
+                _writer.writerow(_row)
+
+        _csv_bytes = _buf.getvalue().encode("utf-8")
+        _csv_btn = mo.download(
+            data=_csv_bytes,
+            filename="gprmax_ascan.csv",
+            label="Download CSV (full data)",
+            mimetype="text/csv",
+        )
+    except Exception as _e:
+        _csv_btn = mo.md(f"_CSV export error: `{_e}`_")
+
+    # ── SVG export ──────────────────────────────────────────────────────────
+    try:
+        import plotly.io as _pio
+
+        _svg_bytes = _pio.to_image(_fig, format="svg", width=1200, height=600, scale=2)
+        _svg_btn = mo.download(
+            data=_svg_bytes,
+            filename="gprmax_ascan.svg",
+            label="Download SVG",
+            mimetype="image/svg+xml",
+        )
+    except Exception as _e:
+        _svg_btn = mo.md(
+            f"_SVG: `{type(_e).__name__}` — "
+            f"run `plotly_get_chrome` to install kaleido's Chrome, "
+            f"or use the camera icon in the plot toolbar._"
+        )
+
+    # ── PDF export ──────────────────────────────────────────────────────────
+    try:
+        import plotly.io as _pio
+
+        _pdf_bytes = _pio.to_image(_fig, format="pdf", width=1200, height=600, scale=2)
+        _pdf_btn = mo.download(
+            data=_pdf_bytes,
+            filename="gprmax_ascan.pdf",
+            label="Download PDF",
+            mimetype="application/pdf",
+        )
+    except Exception as _e:
+        _pdf_btn = mo.md(f"_PDF: `{type(_e).__name__}` — run `plotly_get_chrome` first._")
+
+    # ── Interactive HTML — no kaleido needed ────────────────────────────────
+    try:
+        _html_bytes = _fig.to_html(full_html=True, include_plotlyjs=True).encode("utf-8")
+        _html_btn = mo.download(
+            data=_html_bytes,
+            filename="gprmax_ascan.html",
+            label="Download HTML (interactive)",
+            mimetype="text/html",
+        )
+    except Exception:
+        _html_btn = mo.md("")
+
+    # ── Notes ────────────────────────────────────────────────────────────────
+    _notes = []
+    if _dual:
+        _notes.append(
+            "_Solid lines → E-field (left axis, V/m)  ·  "
+            "Dashed lines → H-field (right axis, A/m)_"
+        )
+    _notes.append(
+        "_Hover for exact values. "
+        "Camera icon in toolbar → SVG (no kaleido needed via toolbar). "
+        "Run `plotly_get_chrome` once to enable SVG/PDF download buttons._"
+    )
+
+    mo.vstack(
+        [
+            mo.md("### Plot"),
+            mo.ui.plotly(
+                _fig,
+                config={
+                    "toImageButtonOptions": {
+                        "format": "svg",
+                        "filename": "gprmax_ascan",
+                        "height": 600,
+                        "width": 1200,
+                        "scale": 2,
+                    },
+                    "displaylogo": False,
+                    "modeBarButtonsToRemove": ["lasso2d", "select2d"],
+                },
+            ),
+            mo.md("  \n".join(_notes)),
+            mo.md("**Export**"),
+            mo.hstack(
+                [_csv_btn, _html_btn, _svg_btn, _pdf_btn],
+                gap="1rem",
+                justify="start",
+            ),
+            mo.md("---"),
+            mo.callout(
+                mo.md(
+                    "**Upcoming features**\n\n"
+                    "- Background subtraction "
+                    "(target trace minus free-space trace)\n"
+                    "- FFT frequency spectrum toggle\n"
+                    "- Assemble multiple A-scan files → B-scan radargram\n"
+                    "- 3D surface viewer from multi-position A-scan data"
+                ),
+                kind="neutral",
+            ),
+        ],
+        gap="0.5rem",
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/toolboxes/Marimo/ascan_dashboard.py
+++ b/toolboxes/Marimo/ascan_dashboard.py
@@ -30,6 +30,7 @@ def _():
         fft_spectrum,
         gain_label,
         spectrum_view_limit,
+        subtract_traces,
     )
 
     # Research-quality colour palette (Matplotlib tab10, colorblind-friendly)
@@ -83,6 +84,7 @@ def _():
         mo,
         np,
         spectrum_view_limit,
+        subtract_traces,
     )
 
 
@@ -147,6 +149,49 @@ def _(file_browser, format_metadata_text, load_files, mo):
         )
     )
     return get_data, set_data
+
+
+# ── SECTION 2b: Background subtraction reference ──────────────────────────
+# Depends on the loaded files and nothing else. Tying it to the trace list
+# would rebuild the dropdown, and reset the choice, on every added trace.
+@app.cell
+def _(get_data, mo):
+    _file_names = list(get_data()["files"].keys())
+
+    if len(_file_names) < 2:
+        subtract_ref = None
+        mo.output.replace(
+            mo.md(
+                "_Load a second file, a free-space run of the same model with the "
+                "target removed, to enable background subtraction._"
+            )
+            if _file_names
+            else mo.md("")
+        )
+    else:
+        subtract_ref = mo.ui.dropdown(
+            options={"None": "", **{n: n for n in _file_names}},
+            value="None",
+            label="Subtract reference file",
+        )
+        mo.output.replace(
+            mo.vstack(
+                [
+                    mo.md("### Step 1b — Background subtraction"),
+                    mo.md(
+                        "_Pick a free-space run of the same model. For every plotted "
+                        "trace, the matching receiver and component from that file is "
+                        "subtracted, which cancels the source pulse and the direct "
+                        "coupling and leaves the target response. Display only: CSV "
+                        "export stays raw._"
+                    ),
+                    subtract_ref,
+                    mo.md("---"),
+                ],
+                gap="0.4rem",
+            )
+        )
+    return (subtract_ref,)
 
 
 # ── STATE: isolated — no UI dependencies ──────────────────────────────────
@@ -617,6 +662,8 @@ def _(
     show_gain_curve,
     show_grid,
     spectrum_view_limit,
+    subtract_ref,
+    subtract_traces,
     time_slider,
 ):
     _traces = get_traces()
@@ -636,6 +683,29 @@ def _(
     _gc = "rgba(255,255,255,0.1)" if _is_dark else "rgba(0,0,0,0.07)"
     _lc = "rgba(255,255,255,0.25)" if _is_dark else "rgba(0,0,0,0.18)"
     _freq_mode = domain.value == "freq"
+
+    # Background subtraction. A data operation rather than a display one, so
+    # unlike gain it also applies to the spectrum: the point of subtracting is
+    # that the difference is what you want to analyse. CSV still exports the
+    # untouched file contents, with the operation recorded on the first line.
+    _ref_name = subtract_ref.value if subtract_ref is not None else ""
+    _subtracted = []
+    _sub_warnings = []
+
+    def _apply_subtraction(arr, trace, fdata):
+        if not _ref_name or trace["filename"] == _ref_name:
+            return arr
+        _ref_fdata = _files[_ref_name]
+        try:
+            _ref_arr = get_trace(_ref_fdata, trace["component"], trace["receiver"])
+            _out = subtract_traces(
+                arr, _ref_arr, fdata["meta"]["dt"], _ref_fdata["meta"]["dt"]
+            )
+        except (KeyError, ValueError) as _err:
+            _sub_warnings.append(f"{trace['label']}: {_err}")
+            return arr
+        _subtracted.append(trace["label"])
+        return _out
 
     # ── Gain settings ───────────────────────────────────────────────────────
     # Every parameter widget is None when gain is off, and gain_factor is also
@@ -690,7 +760,9 @@ def _(
             _fdata = _files[_t["filename"]]
             _raw = get_trace(_fdata, _t["component"], _t["receiver"])
             _dt = _fdata["meta"]["dt"]
-            _freqs, _pdb, _peak_db = fft_spectrum(_raw, _dt)
+            _freqs, _pdb, _peak_db = fft_spectrum(
+                _apply_subtraction(_raw, _t, _fdata), _dt
+            )
             if _peak_db is None:
                 _flat_traces.append(_t["label"])
                 continue
@@ -778,6 +850,8 @@ def _(
             + "  +  ".join(_plot_files)
             + f"  ·  power spectrum ({_ref_text})"
         )
+        if _subtracted:
+            _title += f"  ·  minus {_ref_name}"
         _layout = dict(
             title=dict(
                 text=_title,
@@ -806,6 +880,8 @@ def _(
             f"# domain: frequency ({_ref_text}). "
             f"Power in dB, full positive spectrum, view range not applied."
         )
+        if _subtracted:
+            _csv_comment += f" Displayed spectra had {_ref_name} subtracted."
         _gain_text = "no gain"
         _dual = False
 
@@ -832,9 +908,11 @@ def _(
                 _csv_x[_tax_key] = _time
             _csv_data[_t["label"]] = (_tax_key, _raw)
 
+            _base = _apply_subtraction(_raw, _t, _fdata)
+
             if _gain_on:
                 _arr, _curve = apply_gain(
-                    _raw,
+                    _base,
                     _time,
                     _kind,
                     factor=_factor,
@@ -845,7 +923,7 @@ def _(
                 if _tax_key not in _gain_curves:
                     _gain_curves[_tax_key] = (_time, _curve)
             else:
-                _arr = _raw
+                _arr = _base
 
             _fig.add_trace(
                 go.Scatter(
@@ -873,6 +951,8 @@ def _(
         _gain_text = gain_label(_kind, _factor, _power, _start, _max_gain if _clamp_bound else None)
 
         _title = _source_title
+        if _subtracted:
+            _title += f"  ·  minus {_ref_name}"
         if _gain_on:
             _title += "  ·  " + _gain_text
         _dual = _has_e and _has_h
@@ -928,6 +1008,8 @@ def _(
         _csv_first_col = "time_ns"
         _csv_filename = "gprmax_ascan.csv"
         _csv_comment = f"# gain: {_gain_text.replace(',', ';')}. Values below are raw."
+        if _subtracted:
+            _csv_comment += f" Plot had {_ref_name} subtracted; values below have not."
 
         # ── Gain curve panel ────────────────────────────────────────────────
         # Its own figure rather than a third overlaying y-axis on the main
@@ -1066,6 +1148,21 @@ def _(
     # ── Notes ────────────────────────────────────────────────────────────────
     _notes = []
     _warn = []
+    if _sub_warnings:
+        _warn.append(
+            mo.callout(
+                mo.md(
+                    "**Could not subtract the reference from every trace:**\n\n"
+                    + "\n".join(f"- {w}" for w in _sub_warnings)
+                ),
+                kind="warn",
+            )
+        )
+    if _subtracted:
+        _notes.append(
+            f"_`{_ref_name}` subtracted from {len(_subtracted)} trace(s). "
+            "Any trace from that file itself is left alone._"
+        )
     if _freq_mode:
         _notes.append(
             "_Spectra are computed from the raw traces. Gain is a time-domain "
@@ -1130,12 +1227,16 @@ def _(
             mo.md("---"),
             mo.callout(
                 mo.md(
-                    "**Upcoming features**\n\n"
-                    "- Background subtraction "
-                    "(target trace minus free-space trace)\n\n"
-                    "B-scan assembly from multiple A-scan files, the 3D surface "
-                    "viewer, gain and mean-trace background removal across a "
-                    "radargram are in `bscan_dashboard.py`."
+                    "**Elsewhere in the toolbox**\n\n"
+                    "- `bscan_dashboard.py` assembles a radargram from multiple "
+                    "A-scan files or watches one being written, with a 3D surface "
+                    "view, gain, and mean-trace background removal for the case "
+                    "where no free-space run exists.\n"
+                    "- `recipes/ascan_workflow.py` goes from model parameters "
+                    "through a solver run to this dashboard's input in one "
+                    "notebook.\n"
+                    "- `recipes/velocity_permittivity.py` recovers a soil "
+                    "permittivity from the shape of a reflection hyperbola."
                 ),
                 kind="neutral",
             ),

--- a/toolboxes/Marimo/ascan_dashboard.py
+++ b/toolboxes/Marimo/ascan_dashboard.py
@@ -24,6 +24,13 @@ def _():
         list_receivers,
         load_files,
     )
+    from toolboxes.Marimo.processing import (
+        GAIN_KINDS,
+        apply_gain,
+        fft_spectrum,
+        gain_label,
+        spectrum_view_limit,
+    )
 
     # Research-quality colour palette (Matplotlib tab10, colorblind-friendly)
     PALETTE = [
@@ -56,11 +63,15 @@ def _():
 
     return (
         COLOUR_NAMES,
+        GAIN_KINDS,
         PALETTE,
         Path,
+        apply_gain,
         build_label,
         csv,
+        fft_spectrum,
         format_metadata_text,
+        gain_label,
         get_time_axis,
         get_trace,
         get_unit_label,
@@ -71,6 +82,7 @@ def _():
         load_files,
         mo,
         np,
+        spectrum_view_limit,
     )
 
 
@@ -429,12 +441,169 @@ def _(get_data, get_traces, mo):
     return (time_slider,)
 
 
+# ── SECTION 5b: Gain kind ─────────────────────────────────────────────────
+# Widget creation only. Its .value is read in the next cell, which builds the
+# parameter sliders for whichever kind is selected — reading .value in the
+# cell that creates the widget raises at runtime and marimo check misses it.
+@app.cell
+def _(GAIN_KINDS, get_traces, mo):
+    if not get_traces():
+        mo.stop(True, mo.md(""))
+
+    gain_kind = mo.ui.dropdown(
+        options={_meta["label"]: _k for _k, _meta in GAIN_KINDS.items()},
+        value="None",
+        label="Gain function",
+    )
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 5 — Gain"),
+                mo.md(
+                    "_Time-varying amplification to compensate spherical spreading "
+                    "and attenuation. Power is `t^b`, exponential is `exp(a·t)`, "
+                    "and SEC is their product, the gain most published GPR "
+                    "processing flows use. Display only: CSV export stays raw._"
+                ),
+                gain_kind,
+            ],
+            gap="0.4rem",
+        )
+    )
+    return (gain_kind,)
+
+
+# ── SECTION 5c: Gain parameters ───────────────────────────────────────────
+# Rebuilt per kind: `factor` means a multiplier, a slope, a rate, or dB per ns
+# depending on the kind, so one fixed slider range would be wrong for most of
+# them. All widgets are None when no gain is selected, same pattern the trace
+# picker uses for its remove controls.
+#
+# Depends on gain_kind alone, deliberately. Deriving the gain-start range from
+# the loaded time window would make this cell depend on get_traces through the
+# zoom slider, so adding a trace would rebuild these widgets and silently reset
+# every gain setting. Start is a percentage of the window instead; the renderer
+# resolves it against the real time axis and the resolved ns lands in the title.
+@app.cell
+def _(GAIN_KINDS, gain_kind, mo):
+    _FACTOR_SLIDERS = {
+        "constant": dict(start=0.1, stop=20.0, step=0.1, value=2.0, label="Factor (x)"),
+        "linear": dict(start=0.0, stop=10.0, step=0.1, value=1.0, label="Slope (per ns)"),
+        "exponential": dict(start=0.0, stop=5.0, step=0.05, value=1.0, label="Rate a (per ns)"),
+        "db": dict(start=0.0, stop=60.0, step=0.5, value=6.0, label="Gain (dB per ns)"),
+        "sec": dict(start=0.0, stop=5.0, step=0.05, value=0.5, label="Rate a (per ns)"),
+    }
+
+    _kind = gain_kind.value
+
+    if _kind == "none":
+        gain_factor = None
+        gain_power = None
+        gain_start = None
+        gain_clamp = None
+        gain_max = None
+        show_gain_curve = None
+        mo.output.replace(mo.md(""))
+    else:
+        _cfg = _FACTOR_SLIDERS.get(_kind)
+        gain_factor = mo.ui.slider(**_cfg, debounce=True) if _cfg else None
+        gain_power = (
+            mo.ui.slider(start=0.0, stop=4.0, step=0.1, value=1.0, label="Exponent b", debounce=True)
+            if GAIN_KINDS[_kind]["uses_power"]
+            else None
+        )
+        gain_start = mo.ui.slider(
+            start=0.0,
+            stop=100.0,
+            step=0.5,
+            value=0.0,
+            label="Gain start (% of window)",
+            debounce=True,
+        )
+        gain_clamp = mo.ui.checkbox(label="Limit maximum gain", value=True)
+        gain_max = mo.ui.slider(
+            start=1, stop=1000, step=1, value=100, label="Maximum gain (x)", debounce=True
+        )
+        show_gain_curve = mo.ui.checkbox(label="Show gain curve", value=True)
+
+        _params = [w for w in (gain_factor, gain_power, gain_start) if w is not None]
+        mo.output.replace(
+            mo.vstack(
+                [
+                    mo.hstack(_params, gap="1.5rem", justify="start"),
+                    mo.hstack([gain_clamp, gain_max, show_gain_curve], gap="1.5rem", justify="start"),
+                    mo.md(
+                        "_Time before the gain start keeps a gain of exactly 1, so the "
+                        "direct wave can be left alone rather than saturating the plot._"
+                    ),
+                    mo.md("---"),
+                ],
+                gap="0.5rem",
+            )
+        )
+    return gain_clamp, gain_factor, gain_max, gain_power, gain_start, show_gain_curve
+
+
+# ── SECTION 5d: Domain ────────────────────────────────────────────────────
+# No data dependency, so switching domain or reference never disturbs the
+# gain settings and vice versa.
+@app.cell
+def _(get_traces, mo):
+    if not get_traces():
+        mo.stop(True, mo.md(""))
+
+    domain = mo.ui.dropdown(
+        options={"Time": "time", "Frequency (FFT)": "freq"},
+        value="Time",
+        label="Domain",
+    )
+    fft_reference = mo.ui.dropdown(
+        options={"Shared (compare amplitudes)": "shared", "Per trace (each peaks at 0 dB)": "own"},
+        value="Shared (compare amplitudes)",
+        label="dB reference",
+    )
+    fft_full_range = mo.ui.checkbox(label="Show full spectrum to Nyquist", value=False)
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 6 — Domain"),
+                mo.md(
+                    "_The spectrum comes from gprMax's own `fft_power`, so it matches "
+                    "`plot_Ascan.py`. That function normalises every trace against its "
+                    "own peak, which makes a loud trace and a quiet one look identical; "
+                    "the shared reference undoes that so overlaid spectra are "
+                    "comparable. Traces in different units (V/m against A/m) are "
+                    "referenced within their own unit, since a decibel difference "
+                    "across units means nothing._"
+                ),
+                mo.hstack([domain, fft_reference, fft_full_range], gap="1.5rem", justify="start"),
+                mo.md("---"),
+            ],
+            gap="0.4rem",
+        )
+    )
+    return domain, fft_full_range, fft_reference
+
+
 # ── SECTION 6: Figure renderer + export ───────────────────────────────────
 @app.cell
 def _(
+    apply_gain,
     bg_colour,
     csv,
+    domain,
+    fft_full_range,
+    fft_reference,
+    fft_spectrum,
     font_size,
+    gain_clamp,
+    gain_factor,
+    gain_kind,
+    gain_label,
+    gain_max,
+    gain_power,
+    gain_start,
     get_data,
     get_time_axis,
     get_trace,
@@ -444,7 +613,10 @@ def _(
     io,
     line_width,
     mo,
+    np,
+    show_gain_curve,
     show_grid,
+    spectrum_view_limit,
     time_slider,
 ):
     _traces = get_traces()
@@ -463,62 +635,20 @@ def _(
     _fc = "#e8e8e8" if _is_dark else "#1a1a1a"
     _gc = "rgba(255,255,255,0.1)" if _is_dark else "rgba(0,0,0,0.07)"
     _lc = "rgba(255,255,255,0.25)" if _is_dark else "rgba(0,0,0,0.18)"
+    _freq_mode = domain.value == "freq"
 
-    # ── Build figure ────────────────────────────────────────────────────────
-    _fig = go.Figure()
-    _has_e = False
-    _has_h = False
-    _comps_seen = []
-    _files_seen = []
-
-    # Store full arrays for CSV export (unaffected by zoom)
-    _csv_time: dict = {}
-    _csv_data: dict = {}
-
-    for _t in _traces:
-        _fdata = _files[_t["filename"]]
-        _arr = get_trace(_fdata, _t["component"], _t["receiver"])
-        _time = get_time_axis(_fdata, unit="ns")
-        _unit = get_unit_label(_t["component"])
-        _on_y2 = _unit == "A/m"
-
-        if _on_y2:
-            _has_h = True
-        else:
-            _has_e = True
-
-        # Track unique time axes by (n_steps, dt) tuple
-        _fmeta = _fdata["meta"]
-        _tax_key = (_fmeta["iterations"], round(_fmeta["dt"], 15))
-        if _tax_key not in _csv_time:
-            _csv_time[_tax_key] = _time
-        _csv_data[_t["label"]] = (_tax_key, _arr)
-
-        _fig.add_trace(
-            go.Scatter(
-                x=_time,
-                y=_arr,
-                mode="lines",
-                name=_t["label"],
-                line=dict(
-                    color=_t["colour"],
-                    width=line_width.value,
-                    dash="dash" if _on_y2 else "solid",
-                ),
-                yaxis="y2" if _on_y2 else "y",
-                hovertemplate=(
-                    "%{x:.4f} ns<br>%{y:.5g} " + _unit + "<extra>" + _t["label"] + "</extra>"
-                ),
-            )
-        )
-
-        if _t["component"] not in _comps_seen:
-            _comps_seen.append(_t["component"])
-        if _t["filename"] not in _files_seen:
-            _files_seen.append(_t["filename"])
-
-    _title = ", ".join(_comps_seen) + "  ·  " + "  +  ".join(_files_seen)
-    _dual = _has_e and _has_h
+    # ── Gain settings ───────────────────────────────────────────────────────
+    # Every parameter widget is None when gain is off, and gain_factor is also
+    # None for the power kind, which has no factor of its own.
+    _kind = gain_kind.value
+    _gain_on = _kind != "none" and not _freq_mode
+    _factor = gain_factor.value if gain_factor is not None else 1.0
+    _power = gain_power.value if gain_power is not None else 1.0
+    _max_gain = gain_max.value if (gain_clamp is not None and gain_clamp.value) else None
+    _window_ns = max(
+        f["meta"]["iterations"] * f["meta"]["dt"] * 1e9 for f in _files.values()
+    )
+    _start = (gain_start.value / 100.0) * _window_ns if gain_start is not None else 0.0
 
     _axis_base = dict(
         showgrid=show_grid.value,
@@ -533,99 +663,365 @@ def _(
         zerolinecolor=_lc,
         zerolinewidth=1,
     )
+    _files_seen = []
+    _comps_seen = []
+    for _t in _traces:
+        if _t["component"] not in _comps_seen:
+            _comps_seen.append(_t["component"])
+        if _t["filename"] not in _files_seen:
+            _files_seen.append(_t["filename"])
+    _source_title = ", ".join(_comps_seen) + "  ·  " + "  +  ".join(_files_seen)
 
-    if _dual:
-        _y1_label = "E-field [V/m]"
-    elif _has_e:
-        _y1_label = "Field strength [V/m]"
+    _fig = go.Figure()
+    _gain_panel = []
+    _flat_traces = []
+    _csv_x: dict = {}
+    _csv_data: dict = {}
+    _gain_curves: dict = {}
+
+    if _freq_mode:
+        # ── Frequency domain ────────────────────────────────────────────────
+        # Always transforms the raw trace, never the gained one. Gain
+        # multiplies in time, which convolves in frequency, so the centre
+        # frequency read off a gained spectrum would be wrong — and checking
+        # that the antenna behaved as specified is the reason for this view.
+        _spectra = []
+        for _t in _traces:
+            _fdata = _files[_t["filename"]]
+            _raw = get_trace(_fdata, _t["component"], _t["receiver"])
+            _dt = _fdata["meta"]["dt"]
+            _freqs, _pdb, _peak_db = fft_spectrum(_raw, _dt)
+            if _peak_db is None:
+                _flat_traces.append(_t["label"])
+                continue
+            _spectra.append(
+                dict(
+                    trace=_t,
+                    freqs=_freqs,
+                    power=_pdb,
+                    peak_db=_peak_db,
+                    unit=get_unit_label(_t["component"]),
+                )
+            )
+
+        if not _spectra:
+            mo.stop(
+                True,
+                mo.callout(
+                    mo.md(
+                        "**Nothing to transform.** Every selected trace is all "
+                        "zeros, so it has no spectrum: "
+                        + ", ".join(f"`{n}`" for n in _flat_traces)
+                        + ". A component that isn't excited by the model (Ex in a "
+                        "2D TMz run, for example) is stored as zeros."
+                    ),
+                    kind="warn",
+                ),
+            )
+
+        # Shared reference per unit family. Referencing a V/m trace against an
+        # A/m one would report a decibel difference between different
+        # quantities, which is not a physical statement.
+        _refs = {}
+        if fft_reference.value == "shared":
+            for _s in _spectra:
+                _refs[_s["unit"]] = max(_refs.get(_s["unit"], -np.inf), _s["peak_db"])
+
+        _limit_hz = 0.0
+        for _s in _spectra:
+            _offset = (
+                _s["peak_db"] - _refs[_s["unit"]] if fft_reference.value == "shared" else 0.0
+            )
+            _shown = _s["power"] + _offset
+            _t = _s["trace"]
+            _key = (len(_s["freqs"]), round(float(_s["freqs"][1] - _s["freqs"][0]), 6))
+            if _key not in _csv_x:
+                _csv_x[_key] = _s["freqs"]
+            _csv_data[_t["label"]] = (_key, _shown)
+            _limit_hz = max(_limit_hz, spectrum_view_limit(_s["freqs"], _s["power"]))
+            _fig.add_trace(
+                go.Scatter(
+                    x=_s["freqs"] / 1e9,
+                    y=_shown,
+                    mode="lines",
+                    name=_t["label"],
+                    line=dict(color=_t["colour"], width=line_width.value),
+                    hovertemplate=(
+                        "%{x:.4g} GHz<br>%{y:.4g} dB<extra>" + _t["label"] + "</extra>"
+                    ),
+                )
+            )
+
+        _x_range = (
+            None
+            if fft_full_range.value
+            else [0.0, max(_limit_hz / 1e9, 1e-6)]
+        )
+        _ref_text = (
+            "shared reference per unit"
+            if fft_reference.value == "shared"
+            else "each trace at its own 0 dB"
+        )
+        # Title names only what is actually drawn. _source_title covers every
+        # selected trace, including any dropped for having no spectrum, and an
+        # exported figure must not claim a component that isn't in it.
+        _plot_comps = []
+        _plot_files = []
+        for _s in _spectra:
+            if _s["trace"]["component"] not in _plot_comps:
+                _plot_comps.append(_s["trace"]["component"])
+            if _s["trace"]["filename"] not in _plot_files:
+                _plot_files.append(_s["trace"]["filename"])
+        _title = (
+            ", ".join(_plot_comps)
+            + "  ·  "
+            + "  +  ".join(_plot_files)
+            + f"  ·  power spectrum ({_ref_text})"
+        )
+        _layout = dict(
+            title=dict(
+                text=_title,
+                font=dict(size=font_size.value + 1, color=_fc),
+                x=0.0,
+                xanchor="left",
+            ),
+            xaxis=dict(title="Frequency (GHz)", range=_x_range, **_axis_base),
+            yaxis=dict(title="Power (dB)", **_axis_base),
+            paper_bgcolor=_bg,
+            plot_bgcolor=_bg,
+            legend=dict(
+                font=dict(size=font_size.value - 1, color=_fc),
+                bgcolor="rgba(0,0,0,0.0)",
+                bordercolor=_lc,
+                borderwidth=1,
+            ),
+            height=500,
+            margin=dict(l=72, r=32, t=55, b=60),
+            hovermode="x unified",
+        )
+        _fig.update_layout(**_layout)
+        _csv_first_col = "freq_hz"
+        _csv_filename = "gprmax_ascan_spectrum.csv"
+        _csv_comment = (
+            f"# domain: frequency ({_ref_text}). "
+            f"Power in dB, full positive spectrum, view range not applied."
+        )
+        _gain_text = "no gain"
+        _dual = False
+
     else:
-        _y1_label = "Field strength [A/m]"
+        # ── Time domain ─────────────────────────────────────────────────────
+        _has_e = False
+        _has_h = False
 
-    _t_start, _t_end = time_slider.value
+        for _t in _traces:
+            _fdata = _files[_t["filename"]]
+            _raw = get_trace(_fdata, _t["component"], _t["receiver"])
+            _time = get_time_axis(_fdata, unit="ns")
+            _unit = get_unit_label(_t["component"])
+            _on_y2 = _unit == "A/m"
 
-    _layout = dict(
-        title=dict(
-            text=_title,
-            font=dict(size=font_size.value + 1, color=_fc),
-            x=0.0,
-            xanchor="left",
-        ),
-        xaxis=dict(
-            title="Time (ns)",
-            range=[_t_start, _t_end],
-            **_axis_base,
-        ),
-        yaxis=dict(title=_y1_label, **_axis_base),
-        paper_bgcolor=_bg,
-        plot_bgcolor=_bg,
-        legend=dict(
-            font=dict(size=font_size.value - 1, color=_fc),
-            bgcolor="rgba(0,0,0,0.0)",
-            bordercolor=_lc,
-            borderwidth=1,
-        ),
-        height=500,
-        margin=dict(l=72, r=80 if _dual else 32, t=55, b=60),
-        hovermode="x unified",
-    )
+            if _on_y2:
+                _has_h = True
+            else:
+                _has_e = True
 
-    if _dual:
-        _layout["yaxis2"] = dict(
-            title="H-field [A/m]",
-            overlaying="y",
-            side="right",
-            showgrid=False,
-            showline=True,
-            linecolor=_lc,
-            linewidth=1,
-            tickfont=dict(size=font_size.value - 1, color=_fc),
-            title_font=dict(size=font_size.value, color=_fc),
-            zeroline=False,
+            _fmeta = _fdata["meta"]
+            _tax_key = (_fmeta["iterations"], round(_fmeta["dt"], 15))
+            if _tax_key not in _csv_x:
+                _csv_x[_tax_key] = _time
+            _csv_data[_t["label"]] = (_tax_key, _raw)
+
+            if _gain_on:
+                _arr, _curve = apply_gain(
+                    _raw,
+                    _time,
+                    _kind,
+                    factor=_factor,
+                    power=_power,
+                    start_ns=_start,
+                    max_gain=_max_gain,
+                )
+                if _tax_key not in _gain_curves:
+                    _gain_curves[_tax_key] = (_time, _curve)
+            else:
+                _arr = _raw
+
+            _fig.add_trace(
+                go.Scatter(
+                    x=_time,
+                    y=_arr,
+                    mode="lines",
+                    name=_t["label"],
+                    line=dict(
+                        color=_t["colour"],
+                        width=line_width.value,
+                        dash="dash" if _on_y2 else "solid",
+                    ),
+                    yaxis="y2" if _on_y2 else "y",
+                    hovertemplate=(
+                        "%{x:.4f} ns<br>%{y:.5g} " + _unit + "<extra>" + _t["label"] + "</extra>"
+                    ),
+                )
+            )
+
+        # Only report the clamp when it actually bound. Naming a limit the gain
+        # never reached puts a misleading number in an exported figure title.
+        _clamp_bound = _max_gain is not None and any(
+            float(np.max(_c)) >= _max_gain for _, _c in _gain_curves.values()
+        )
+        _gain_text = gain_label(_kind, _factor, _power, _start, _max_gain if _clamp_bound else None)
+
+        _title = _source_title
+        if _gain_on:
+            _title += "  ·  " + _gain_text
+        _dual = _has_e and _has_h
+
+        if _dual:
+            _y1_label = "E-field [V/m]"
+        elif _has_e:
+            _y1_label = "Field strength [V/m]"
+        else:
+            _y1_label = "Field strength [A/m]"
+        if _gain_on:
+            _y1_label += " (gained)"
+
+        _t_start, _t_end = time_slider.value
+
+        _layout = dict(
+            title=dict(
+                text=_title,
+                font=dict(size=font_size.value + 1, color=_fc),
+                x=0.0,
+                xanchor="left",
+            ),
+            xaxis=dict(title="Time (ns)", range=[_t_start, _t_end], **_axis_base),
+            yaxis=dict(title=_y1_label, **_axis_base),
+            paper_bgcolor=_bg,
+            plot_bgcolor=_bg,
+            legend=dict(
+                font=dict(size=font_size.value - 1, color=_fc),
+                bgcolor="rgba(0,0,0,0.0)",
+                bordercolor=_lc,
+                borderwidth=1,
+            ),
+            height=500,
+            margin=dict(l=72, r=80 if _dual else 32, t=55, b=60),
+            hovermode="x unified",
         )
 
-    _fig.update_layout(**_layout)
+        if _dual:
+            _layout["yaxis2"] = dict(
+                title="H-field [A/m]" + (" (gained)" if _gain_on else ""),
+                overlaying="y",
+                side="right",
+                showgrid=False,
+                showline=True,
+                linecolor=_lc,
+                linewidth=1,
+                tickfont=dict(size=font_size.value - 1, color=_fc),
+                title_font=dict(size=font_size.value, color=_fc),
+                zeroline=False,
+            )
+
+        _fig.update_layout(**_layout)
+        _csv_first_col = "time_ns"
+        _csv_filename = "gprmax_ascan.csv"
+        _csv_comment = f"# gain: {_gain_text.replace(',', ';')}. Values below are raw."
+
+        # ── Gain curve panel ────────────────────────────────────────────────
+        # Its own figure rather than a third overlaying y-axis on the main
+        # plot. The right axis is already taken whenever an H-field trace is
+        # active, so sharing it would make the curve appear or vanish
+        # depending on which traces happen to be added. A separate panel is
+        # also how RADAN and ReflexW present gain curves.
+        if _gain_on and show_gain_curve is not None and show_gain_curve.value and _gain_curves:
+            _gfig = go.Figure()
+            for _gt, _gcurve in _gain_curves.values():
+                _gfig.add_trace(
+                    go.Scatter(
+                        x=_gt,
+                        y=_gcurve,
+                        mode="lines",
+                        name="gain",
+                        showlegend=False,
+                        line=dict(color="#7f7f7f", width=line_width.value),
+                        hovertemplate="%{x:.4f} ns<br>x%{y:.4g}<extra>gain</extra>",
+                    )
+                )
+            _all_gain = np.concatenate([c for _, c in _gain_curves.values()])
+            _gfig.update_layout(
+                xaxis=dict(
+                    range=[_t_start, _t_end],
+                    showgrid=show_grid.value,
+                    gridcolor=_gc,
+                    showline=True,
+                    linecolor=_lc,
+                    tickfont=dict(size=font_size.value - 2, color=_fc),
+                ),
+                yaxis=dict(
+                    title="Gain (x)",
+                    type="log" if float(np.min(_all_gain)) > 0 else "linear",
+                    showgrid=show_grid.value,
+                    gridcolor=_gc,
+                    showline=True,
+                    linecolor=_lc,
+                    tickfont=dict(size=font_size.value - 2, color=_fc),
+                    title_font=dict(size=font_size.value - 1, color=_fc),
+                ),
+                paper_bgcolor=_bg,
+                plot_bgcolor=_bg,
+                height=170,
+                margin=dict(l=72, r=80 if _dual else 32, t=10, b=34),
+            )
+            _gain_panel = [
+                mo.md(f"**Applied gain curve** — {_gain_text}"),
+                mo.ui.plotly(_gfig, config={"displaylogo": False, "displayModeBar": False}),
+            ]
 
     # ── CSV export ──────────────────────────────────────────────────────────
-    # Always exports FULL data (not the zoomed window).
-    # If all traces share the same time axis: one time column.
-    # If traces come from files with different dt/iterations: paired columns.
+    # Always the full unzoomed data for whichever domain is on screen: raw
+    # amplitudes in time, full positive spectrum in frequency. The first line
+    # is written in both cases so the format never changes silently, and
+    # commas inside it become semicolons to keep it one unquoted field.
+    # One shared x column when every trace has the same axis, paired columns
+    # when they don't.
     try:
         _buf = io.StringIO()
+        _buf.write(_csv_comment.replace(",", ";") + "\n")
         _writer = csv.writer(_buf)
-
-        _single_axis = len(_csv_time) == 1
+        _single_axis = len(_csv_x) == 1
 
         if _single_axis:
-            _shared_time = list(_csv_time.values())[0]
-            _header_row = ["time_ns"] + [t["label"] for t in _traces]
-            _writer.writerow(_header_row)
-            for _i in range(len(_shared_time)):
-                _row = [f"{_shared_time[_i]:.8g}"] + [
-                    f"{_csv_data[t['label']][1][_i]:.10g}" for t in _traces
-                ]
-                _writer.writerow(_row)
+            _shared_x = list(_csv_x.values())[0]
+            _writer.writerow([_csv_first_col] + [t["label"] for t in _traces if t["label"] in _csv_data])
+            _cols = [t for t in _traces if t["label"] in _csv_data]
+            for _i in range(len(_shared_x)):
+                _writer.writerow(
+                    [f"{_shared_x[_i]:.8g}"]
+                    + [f"{_csv_data[t['label']][1][_i]:.10g}" for t in _cols]
+                )
         else:
-            # Paired time + value columns per trace
+            _cols = [t for t in _traces if t["label"] in _csv_data]
             _header_row = []
-            for _t in _traces:
-                _header_row.extend([f"time_ns ({_t['label']})", _t["label"]])
+            for _t in _cols:
+                _header_row.extend([f"{_csv_first_col} ({_t['label']})", _t["label"]])
             _writer.writerow(_header_row)
-            _max_len = max(len(_csv_data[t["label"]][1]) for t in _traces)
+            _max_len = max(len(_csv_data[t["label"]][1]) for t in _cols)
             for _i in range(_max_len):
                 _row = []
-                for _t in _traces:
-                    _tax_key, _arr = _csv_data[_t["label"]]
-                    _time = _csv_time[_tax_key]
-                    if _i < len(_arr):
-                        _row.extend([f"{_time[_i]:.8g}", f"{_arr[_i]:.10g}"])
+                for _t in _cols:
+                    _k, _vals = _csv_data[_t["label"]]
+                    _xs = _csv_x[_k]
+                    if _i < len(_vals):
+                        _row.extend([f"{_xs[_i]:.8g}", f"{_vals[_i]:.10g}"])
                     else:
                         _row.extend(["", ""])
                 _writer.writerow(_row)
 
-        _csv_bytes = _buf.getvalue().encode("utf-8")
         _csv_btn = mo.download(
-            data=_csv_bytes,
-            filename="gprmax_ascan.csv",
+            data=_buf.getvalue().encode("utf-8"),
+            filename=_csv_filename,
             label="Download CSV (full data)",
             mimetype="text/csv",
         )
@@ -634,50 +1030,71 @@ def _(
 
     # ── SVG/PDF export ─────────────────────────────────────────────────────
     # Lazy on purpose: mo.download accepts a zero-arg callable and only
-    # calls it when the button is clicked. kaleido spins up headless
-    # Chrome per export, which is slow — computing it eagerly here meant
-    # this cell paid that cost twice (SVG + PDF) on every re-render, which
-    # includes every appearance-control change and every drag tick of an
-    # undebounced slider. Same bug and same fix as bscan_dashboard.py.
+    # calls it when the button is clicked. kaleido spins up headless Chrome
+    # per export, which is slow — computing it eagerly here meant this cell
+    # paid that cost twice on every re-render, which includes every
+    # appearance-control change and every drag tick of an undebounced
+    # slider. Same bug and same fix as bscan_dashboard.py.
+    _stem = _csv_filename.rsplit(".", 1)[0]
+
     def _make_svg():
         import plotly.io as _pio
+
         return _pio.to_image(_fig, format="svg", width=1200, height=600, scale=2)
 
     def _make_pdf():
         import plotly.io as _pio
+
         return _pio.to_image(_fig, format="pdf", width=1200, height=600, scale=2)
 
-    _svg_btn = mo.download(
-        data=_make_svg, filename="gprmax_ascan.svg", label="Download SVG", mimetype="image/svg+xml"
-    )
-    _pdf_btn = mo.download(
-        data=_make_pdf, filename="gprmax_ascan.pdf", label="Download PDF", mimetype="application/pdf"
-    )
-
-    # ── Interactive HTML — no kaleido needed, but still lazy ───────────────
-    # to_html(include_plotlyjs=True) embeds the entire Plotly.js library
-    # (several MB) as base64 into the button's data on every render,
-    # regardless of how much actual trace data there is. Not slow like
-    # kaleido since there's no external process, but still pure waste to
-    # recompute on every appearance/zoom change for a download that may
-    # never be clicked.
     def _make_html():
         return _fig.to_html(full_html=True, include_plotlyjs=True).encode("utf-8")
 
+    _svg_btn = mo.download(
+        data=_make_svg, filename=f"{_stem}.svg", label="Download SVG", mimetype="image/svg+xml"
+    )
+    _pdf_btn = mo.download(
+        data=_make_pdf, filename=f"{_stem}.pdf", label="Download PDF", mimetype="application/pdf"
+    )
     _html_btn = mo.download(
         data=_make_html,
-        filename="gprmax_ascan.html",
+        filename=f"{_stem}.html",
         label="Download HTML (interactive)",
         mimetype="text/html",
     )
 
     # ── Notes ────────────────────────────────────────────────────────────────
     _notes = []
-    if _dual:
+    _warn = []
+    if _freq_mode:
         _notes.append(
-            "_Solid lines → E-field (left axis, V/m)  ·  "
-            "Dashed lines → H-field (right axis, A/m)_"
+            "_Spectra are computed from the raw traces. Gain is a time-domain "
+            "correction and reshapes a spectrum, so it is not applied here._"
         )
+        if _flat_traces:
+            _warn.append(
+                mo.callout(
+                    mo.md(
+                        "**Skipped, no spectrum:** "
+                        + ", ".join(f"`{n}`" for n in _flat_traces)
+                        + ". These traces are all zeros, which `fft_power` would "
+                        "otherwise render as a flat 0 dB line indistinguishable "
+                        "from real data."
+                    ),
+                    kind="warn",
+                )
+            )
+    else:
+        if _dual:
+            _notes.append(
+                "_Solid lines → E-field (left axis, V/m)  ·  "
+                "Dashed lines → H-field (right axis, A/m)_"
+            )
+        if _gain_on:
+            _notes.append(
+                "_Plot and image exports show gained amplitudes. "
+                "CSV stays raw, with the gain recorded on its first line._"
+            )
     _notes.append(
         "_Hover for exact values. "
         "Camera icon in toolbar → SVG (no kaleido needed via toolbar). "
@@ -687,12 +1104,13 @@ def _(
     mo.vstack(
         [
             mo.md("### Plot"),
+            *_warn,
             mo.ui.plotly(
                 _fig,
                 config={
                     "toImageButtonOptions": {
                         "format": "svg",
-                        "filename": "gprmax_ascan",
+                        "filename": _stem,
                         "height": 600,
                         "width": 1200,
                         "scale": 2,
@@ -701,6 +1119,7 @@ def _(
                     "modeBarButtonsToRemove": ["lasso2d", "select2d"],
                 },
             ),
+            *_gain_panel,
             mo.md("  \n".join(_notes)),
             mo.md("**Export**"),
             mo.hstack(
@@ -713,10 +1132,10 @@ def _(
                 mo.md(
                     "**Upcoming features**\n\n"
                     "- Background subtraction "
-                    "(target trace minus free-space trace)\n"
-                    "- FFT frequency spectrum toggle\n"
-                    "- Assemble multiple A-scan files → B-scan radargram\n"
-                    "- 3D surface viewer from multi-position A-scan data"
+                    "(target trace minus free-space trace)\n\n"
+                    "B-scan assembly from multiple A-scan files, the 3D surface "
+                    "viewer, gain and mean-trace background removal across a "
+                    "radargram are in `bscan_dashboard.py`."
                 ),
                 kind="neutral",
             ),

--- a/toolboxes/Marimo/ascan_dashboard.py
+++ b/toolboxes/Marimo/ascan_dashboard.py
@@ -204,7 +204,7 @@ def _(
         _remove_section = mo.vstack(
             [
                 mo.md("**Remove a trace**"),
-                mo.hstack([remove_selector, remove_button], gap="1rem"),
+                mo.hstack([remove_selector, remove_button], gap="1rem", justify="start"),
             ],
             gap="0.3rem",
         )
@@ -223,10 +223,10 @@ def _(
                     "override before clicking Add._"
                 ),
                 mo.md("**Select source**"),
-                mo.hstack([file_selector, receiver_selector], gap="2rem"),
+                mo.hstack([file_selector, receiver_selector], gap="2rem", justify="start"),
                 mo.md("**Select component and colour**"),
-                mo.hstack([component_selector, colour_selector], gap="2rem"),
-                mo.hstack([add_button, clear_button], gap="1rem"),
+                mo.hstack([component_selector, colour_selector], gap="2rem", justify="start"),
+                mo.hstack([add_button, clear_button], gap="1rem", justify="start"),
                 mo.md("---"),
                 _remove_section,
             ],
@@ -363,6 +363,7 @@ def _(mo):
         step=0.5,
         value=1.5,
         label="Line width",
+        debounce=True,
     )
     font_size = mo.ui.slider(
         start=10,
@@ -370,6 +371,7 @@ def _(mo):
         step=1,
         value=13,
         label="Font size",
+        debounce=True,
     )
     show_grid = mo.ui.checkbox(label="Show grid", value=True)
 
@@ -408,6 +410,7 @@ def _(get_data, get_traces, mo):
         value=[0.0, _max_ns],
         label="Time window (ns)",
         full_width=True,
+        debounce=True,
     )
     mo.output.replace(
         mo.vstack(
@@ -629,49 +632,44 @@ def _(
     except Exception as _e:
         _csv_btn = mo.md(f"_CSV export error: `{_e}`_")
 
-    # ── SVG export ──────────────────────────────────────────────────────────
-    try:
+    # ── SVG/PDF export ─────────────────────────────────────────────────────
+    # Lazy on purpose: mo.download accepts a zero-arg callable and only
+    # calls it when the button is clicked. kaleido spins up headless
+    # Chrome per export, which is slow — computing it eagerly here meant
+    # this cell paid that cost twice (SVG + PDF) on every re-render, which
+    # includes every appearance-control change and every drag tick of an
+    # undebounced slider. Same bug and same fix as bscan_dashboard.py.
+    def _make_svg():
         import plotly.io as _pio
+        return _pio.to_image(_fig, format="svg", width=1200, height=600, scale=2)
 
-        _svg_bytes = _pio.to_image(_fig, format="svg", width=1200, height=600, scale=2)
-        _svg_btn = mo.download(
-            data=_svg_bytes,
-            filename="gprmax_ascan.svg",
-            label="Download SVG",
-            mimetype="image/svg+xml",
-        )
-    except Exception as _e:
-        _svg_btn = mo.md(
-            f"_SVG: `{type(_e).__name__}` — "
-            f"run `plotly_get_chrome` to install kaleido's Chrome, "
-            f"or use the camera icon in the plot toolbar._"
-        )
-
-    # ── PDF export ──────────────────────────────────────────────────────────
-    try:
+    def _make_pdf():
         import plotly.io as _pio
+        return _pio.to_image(_fig, format="pdf", width=1200, height=600, scale=2)
 
-        _pdf_bytes = _pio.to_image(_fig, format="pdf", width=1200, height=600, scale=2)
-        _pdf_btn = mo.download(
-            data=_pdf_bytes,
-            filename="gprmax_ascan.pdf",
-            label="Download PDF",
-            mimetype="application/pdf",
-        )
-    except Exception as _e:
-        _pdf_btn = mo.md(f"_PDF: `{type(_e).__name__}` — run `plotly_get_chrome` first._")
+    _svg_btn = mo.download(
+        data=_make_svg, filename="gprmax_ascan.svg", label="Download SVG", mimetype="image/svg+xml"
+    )
+    _pdf_btn = mo.download(
+        data=_make_pdf, filename="gprmax_ascan.pdf", label="Download PDF", mimetype="application/pdf"
+    )
 
-    # ── Interactive HTML — no kaleido needed ────────────────────────────────
-    try:
-        _html_bytes = _fig.to_html(full_html=True, include_plotlyjs=True).encode("utf-8")
-        _html_btn = mo.download(
-            data=_html_bytes,
-            filename="gprmax_ascan.html",
-            label="Download HTML (interactive)",
-            mimetype="text/html",
-        )
-    except Exception:
-        _html_btn = mo.md("")
+    # ── Interactive HTML — no kaleido needed, but still lazy ───────────────
+    # to_html(include_plotlyjs=True) embeds the entire Plotly.js library
+    # (several MB) as base64 into the button's data on every render,
+    # regardless of how much actual trace data there is. Not slow like
+    # kaleido since there's no external process, but still pure waste to
+    # recompute on every appearance/zoom change for a download that may
+    # never be clicked.
+    def _make_html():
+        return _fig.to_html(full_html=True, include_plotlyjs=True).encode("utf-8")
+
+    _html_btn = mo.download(
+        data=_make_html,
+        filename="gprmax_ascan.html",
+        label="Download HTML (interactive)",
+        mimetype="text/html",
+    )
 
     # ── Notes ────────────────────────────────────────────────────────────────
     _notes = []

--- a/toolboxes/Marimo/bscan_dashboard.py
+++ b/toolboxes/Marimo/bscan_dashboard.py
@@ -1,0 +1,866 @@
+import marimo
+
+__generated_with = "0.23.8"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import csv
+    import io
+    import re
+    import time
+    from pathlib import Path
+
+    import marimo as mo
+    import numpy as np
+    import plotly.graph_objects as go
+
+    from toolboxes.Marimo.h5_reader import (
+        format_metadata_text,
+        get_unit_label,
+        list_components,
+        list_receivers,
+        load_file,
+    )
+    from toolboxes.Marimo.trace_matrix import process_trace, stack_traces
+
+    # gprMax per-trace B-scan naming: <base><N>.h5, e.g. cylinder_Bscan_2D1.h5
+    # .. cylinder_Bscan_2D60.h5 for a -n 60 run. \d+ is greedy, so multi-digit
+    # trace numbers parse correctly.
+    TRACE_FILE_RE = re.compile(r"^(.*?)(\d+)\.h5$")
+
+    def discover_bases(directory: str) -> dict[str, int]:
+        """Group .h5 trace files in `directory` by inferred base name."""
+        d = Path(directory)
+        if not directory or not d.is_dir():
+            return {}
+        bases: dict[str, int] = {}
+        for p in sorted(d.glob("*.h5")):
+            if "merged" in p.name.lower():
+                continue
+            m = TRACE_FILE_RE.match(p.name)
+            if m:
+                bases[m.group(1)] = bases.get(m.group(1), 0) + 1
+        return bases
+
+    def find_trace_files(directory: str, base: str) -> list[tuple[int, Path]]:
+        """Trace files for `base` in `directory`, sorted by trace number."""
+        d = Path(directory)
+        if not directory or not base or not d.is_dir():
+            return []
+        found = []
+        for p in d.glob(f"{base}*.h5"):
+            if "merged" in p.name.lower():
+                continue
+            m = TRACE_FILE_RE.match(p.name)
+            if m and m.group(1) == base:
+                found.append((int(m.group(2)), p))
+        found.sort(key=lambda t: t[0])
+        return found
+
+    def build_bscan_figure(matrix, x, y, x_title, unit, colourscale, bg, font_size, view_mode, title_text, time_range=None, normalize=False):
+        """Heatmap or 3D Surface from an assembled (time x position) matrix."""
+        if normalize:
+            peak = np.max(np.abs(matrix), axis=0)
+            peak[peak == 0] = 1.0
+            matrix = matrix / peak
+            unit = "normalized"
+
+        is_dark = bg == "#0e1117"
+        fc = "#e8e8e8" if is_dark else "#1a1a1a"
+        lc = "rgba(255,255,255,0.25)" if is_dark else "rgba(0,0,0,0.18)"
+        amp = float(np.max(np.abs(matrix))) or 1.0
+
+        # Time axis always drawn with early time at top (GPR convention).
+        # Plotly's "reversed" autorange doesn't combine cleanly with an
+        # explicit zoom range, so this always sets an explicit descending
+        # range instead of relying on autorange.
+        lo, hi = time_range if time_range is not None else (float(np.min(y)), float(np.max(y)))
+        time_axis_range = [hi, lo]
+
+        if view_mode == "3D Surface":
+            fig = go.Figure(
+                data=go.Surface(
+                    z=matrix,
+                    x=x,
+                    y=y,
+                    colorscale=colourscale,
+                    cmin=-amp,
+                    cmax=amp,
+                    colorbar=dict(title=dict(text=unit, font=dict(color=fc)), tickfont=dict(color=fc)),
+                )
+            )
+            fig.update_layout(
+                scene=dict(
+                    xaxis=dict(title=x_title, color=fc),
+                    yaxis=dict(title="Time (ns)", range=time_axis_range, color=fc),
+                    zaxis=dict(title=unit, color=fc),
+                ),
+                height=600,
+            )
+        else:
+            fig = go.Figure(
+                data=go.Heatmap(
+                    z=matrix,
+                    x=x,
+                    y=y,
+                    colorscale=colourscale,
+                    zmid=0,
+                    zmin=-amp,
+                    zmax=amp,
+                    colorbar=dict(title=dict(text=unit, font=dict(color=fc)), tickfont=dict(color=fc)),
+                )
+            )
+            fig.update_layout(
+                xaxis=dict(
+                    title=x_title,
+                    tickfont=dict(size=font_size - 1, color=fc),
+                    title_font=dict(size=font_size, color=fc),
+                    showline=True,
+                    linecolor=lc,
+                ),
+                yaxis=dict(
+                    title="Time (ns)",
+                    range=time_axis_range,
+                    tickfont=dict(size=font_size - 1, color=fc),
+                    title_font=dict(size=font_size, color=fc),
+                    showline=True,
+                    linecolor=lc,
+                ),
+                height=550,
+                margin=dict(l=72, r=32, t=55, b=55),
+            )
+
+        fig.update_layout(
+            title=dict(text=title_text, font=dict(size=font_size + 1, color=fc), x=0.0, xanchor="left"),
+            paper_bgcolor=bg,
+            plot_bgcolor=bg,
+        )
+        return fig
+
+    def render_bscan_section(matrix, positions_x, time_ns, component, all_positions_physical, index_label, colourscale, bg, font_size, view_mode, normalize, title_text, csv_filename, time_range=None, sample_file=None):
+        """Metadata banner + plot + CSV/SVG/PDF export. Shared by both the
+        live and load-files renderer cells so the two don't drift apart.
+        """
+        if matrix is None:
+            return mo.callout(mo.md("No traces to show yet."), kind="neutral")
+
+        x_title = (
+            "Source x-position (m)"
+            if all_positions_physical
+            else f"{index_label} (source position unavailable in one or more files)"
+        )
+        fig = build_bscan_figure(
+            matrix, positions_x, time_ns, x_title, get_unit_label(component or "Ez"),
+            colourscale, bg, font_size, view_mode, title_text,
+            time_range=time_range, normalize=normalize,
+        )
+
+        # CSV always exports the full, unzoomed, un-normalized matrix —
+        # same convention ascan_dashboard.py uses for its time-zoom slider.
+        try:
+            buf = io.StringIO()
+            writer = csv.writer(buf)
+            writer.writerow(["time_ns"] + [f"x={p:.4f}" for p in positions_x])
+            for i in range(len(time_ns)):
+                writer.writerow([f"{time_ns[i]:.8g}"] + [f"{matrix[i, j]:.10g}" for j in range(matrix.shape[1])])
+            csv_btn = mo.download(
+                data=buf.getvalue().encode("utf-8"), filename=csv_filename,
+                label="Download CSV (full matrix)", mimetype="text/csv",
+            )
+        except Exception as e:
+            csv_btn = mo.md(f"_CSV export error: `{e}`_")
+
+        stem = csv_filename.rsplit(".", 1)[0]
+
+        # Lazy on purpose: mo.download accepts a zero-arg callable and only
+        # calls it when the button is clicked. kaleido spins up headless
+        # Chrome per export, which is slow — computing it eagerly here
+        # meant every poll tick (every 1-2s with live polling on) paid that
+        # cost twice for a download nobody asked for yet. That was the
+        # actual cause of the "reloads every couple seconds" slowness.
+        def _make_svg():
+            import plotly.io as pio
+            return pio.to_image(fig, format="svg", width=1200, height=600, scale=2)
+
+        def _make_pdf():
+            import plotly.io as pio
+            return pio.to_image(fig, format="pdf", width=1200, height=600, scale=2)
+
+        svg_btn = mo.download(data=_make_svg, filename=f"{stem}.svg", label="Download SVG", mimetype="image/svg+xml")
+        pdf_btn = mo.download(data=_make_pdf, filename=f"{stem}.pdf", label="Download PDF", mimetype="application/pdf")
+
+        elements = []
+        if sample_file is not None:
+            elements.append(mo.callout(mo.md(format_metadata_text(sample_file)), kind="info"))
+        elements += [
+            mo.md("### Radargram"),
+            mo.ui.plotly(
+                fig,
+                config={
+                    "toImageButtonOptions": {"format": "svg", "filename": stem, "height": 600, "width": 1200, "scale": 2},
+                    "displaylogo": False,
+                },
+            ),
+            mo.md("**Export**"),
+            mo.hstack([csv_btn, svg_btn, pdf_btn], gap="1rem", justify="start"),
+            mo.md(
+                "_SVG/PDF need `plotly_get_chrome` run once. If either "
+                "fails, the camera icon in the plot toolbar above always "
+                "works and needs no setup._"
+            ),
+        ]
+        return mo.vstack(elements, gap="0.5rem")
+
+    return (
+        Path,
+        discover_bases,
+        find_trace_files,
+        list_components,
+        list_receivers,
+        load_file,
+        mo,
+        np,
+        process_trace,
+        render_bscan_section,
+        stack_traces,
+        time,
+    )
+
+
+# ══ PART 1 — LIVE MONITORING ═══════════════════════════════════════════════
+# Watches a directory while a B-scan is actively running.
+
+
+# ── Step 1: Output directory ────────────────────────────────────────────
+# Widget creation and reading its .value must be in separate cells in this
+# marimo version, so the base-name scan happens in the next cell.
+@app.cell
+def _(mo):
+    directory_input = mo.ui.text(
+        label="",
+        placeholder="/absolute/path/to/gprMax/output/directory",
+        full_width=True,
+    )
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("# gprMax B-Scan Dashboard"),
+                mo.md(
+                    "Two ways to build a radargram: watch a B-scan while "
+                    "it's still running (Part 1), or assemble one from "
+                    "A-scan files you already have (Part 2)."
+                ),
+                mo.md("---"),
+                mo.md("## Part 1 — Live monitoring"),
+                mo.md(
+                    "Watches a directory while gprMax writes one closed "
+                    "`.h5` file per trace, building the radargram as each "
+                    "one completes. Safe to point at a directory before "
+                    "the simulation starts."
+                ),
+                mo.md("### Step 1 — Output directory"),
+                directory_input,
+            ],
+            gap="0.4rem",
+        )
+    )
+    return (directory_input,)
+
+
+# ── Step 2: Base filename ───────────────────────────────────────────────
+@app.cell
+def _(Path, directory_input, discover_bases, mo):
+    _dir = directory_input.value
+    _bases = discover_bases(_dir)
+
+    if _dir and not Path(_dir).is_dir():
+        _status = mo.callout(mo.md(f"`{_dir}` is not a directory."), kind="danger")
+        base_selector = mo.ui.dropdown(options=["—"], value="—", label="Base filename")
+    elif not _bases:
+        _status = mo.md(
+            "_Waiting for `.h5` trace files matching gprMax's per-trace "
+            "naming (`<basename><N>.h5`) to appear in this directory._"
+            if _dir
+            else ""
+        )
+        base_selector = mo.ui.dropdown(options=["—"], value="—", label="Base filename")
+    else:
+        _options = {
+            f"{b}   ({n} file{'s' if n != 1 else ''} so far)": b
+            for b, n in sorted(_bases.items())
+        }
+        base_selector = mo.ui.dropdown(
+            options=_options, value=list(_options.keys())[0], label="Base filename"
+        )
+        _status = mo.md(f"_Detected {len(_bases)} distinct base name(s)._")
+
+    mo.output.replace(
+        mo.vstack([mo.md("### Step 2 — Base filename"), _status, base_selector], gap="0.4rem")
+    )
+    return (base_selector,)
+
+
+# ── State: isolated, no UI params — must only ever run once. Sharing this
+# cell with a widget caused a state-reset bug in ascan_dashboard.py
+# (Component 3) — don't repeat that here.
+@app.cell
+def _(mo):
+    get_bscan_state, set_bscan_state = mo.state(
+        {
+            "seen": set(),
+            "matrix_cols": [],
+            "positions_x": [],
+            "trace_nums": [],
+            "time_ns": None,
+            "component": None,
+            "receiver": None,
+            "base_name": None,
+            "known_components": ["Ez"],
+            "all_positions_physical": True,
+            "warnings": [],
+            "last_poll": None,
+            "sample_file": None,
+        }
+    )
+    return get_bscan_state, set_bscan_state
+
+
+# ── Step 3: Polling ──────────────────────────────────────────────────────
+@app.cell
+def _(mo):
+    live_toggle = mo.ui.switch(label="Live polling", value=True)
+    refresh = mo.ui.refresh(options=["1s", "2s", "5s", "10s", "30s"], default_interval="2s")
+    poll_now_button = mo.ui.run_button(label="⟳  Poll now")
+    reset_button = mo.ui.run_button(label="↺  Reset accumulated data")
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 3 — Polling"),
+                mo.hstack([live_toggle, refresh, poll_now_button, reset_button], gap="1.5rem", justify="start"),
+                mo.md(
+                    "_Each tick only reads unseen files and appends them — "
+                    "never rebuilds from scratch. Changing base filename, "
+                    "field component, or receiver resets accumulated data "
+                    "automatically._"
+                ),
+            ],
+            gap="0.4rem",
+        )
+    )
+    return live_toggle, poll_now_button, refresh, reset_button
+
+
+# ── Step 4: Field component & receiver ──────────────────────────────────
+# Independent of get_bscan_state() on purpose. The poll cell below writes
+# that state and depends on these widgets — reading state here to build
+# the options caused an infinite loop (poll writes -> this reruns -> new
+# widgets -> poll reruns -> ...). Peeking at the file directly instead
+# means this only reruns when directory/base actually change.
+@app.cell
+def _(base_selector, directory_input, find_trace_files, list_components, list_receivers, load_file, mo):
+    _known_comps = ["Ez"]
+    _known_rx = ["rx1"]
+    _files = find_trace_files(directory_input.value, base_selector.value)
+
+    if _files:
+        try:
+            _fdata = load_file(_files[0][1])
+            _known_rx = list_receivers(_fdata) or _known_rx
+            _known_comps = list_components(_fdata, _known_rx[0]) or _known_comps
+        except (FileNotFoundError, OSError, KeyError):
+            pass  # file may still be mid-write — the poll cell retries it
+
+    _default_comp = "Ez" if "Ez" in _known_comps else _known_comps[0]
+    component_selector = mo.ui.dropdown(options=_known_comps, value=_default_comp, label="Field component")
+    receiver_selector = mo.ui.dropdown(options=_known_rx, value=_known_rx[0], label="Receiver")
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 4 — Field component & receiver"),
+                mo.md("_Read from the first trace file found, not assumed._"),
+                mo.hstack([component_selector, receiver_selector], gap="2rem", justify="start"),
+            ],
+            gap="0.4rem",
+        )
+    )
+    return component_selector, receiver_selector
+
+
+# ── Poll / load ──────────────────────────────────────────────────────────
+@app.cell
+def _(
+    Path,
+    base_selector,
+    component_selector,
+    directory_input,
+    find_trace_files,
+    get_bscan_state,
+    live_toggle,
+    load_file,
+    mo,
+    poll_now_button,
+    process_trace,
+    receiver_selector,
+    refresh,
+    reset_button,
+    set_bscan_state,
+    time,
+):
+    _ = refresh.value  # reactive dependency on the polling timer
+
+    _prev = get_bscan_state()
+    _base = base_selector.value
+    _current_component = component_selector.value
+    _current_receiver = receiver_selector.value
+
+    if not directory_input.value or _base in (None, "—"):
+        mo.stop(
+            True,
+            mo.callout(
+                mo.md("Enter a directory and select a base filename above to start watching."),
+                kind="neutral",
+            ),
+        )
+
+    _needs_reset = (
+        reset_button.value
+        or _prev["base_name"] != _base
+        or _prev["component"] != _current_component
+        or _prev["receiver"] != _current_receiver
+    )
+
+    # Fresh dict for set_bscan_state() rather than mutating _prev in place —
+    # matches the append-a-new-list pattern in ascan_dashboard.py's handler.
+    if _needs_reset:
+        _seen, _cols, _xpos, _nums = set(), [], [], []
+        _time_ns, _all_physical, _warnings, _sample_file = None, True, [], None
+    else:
+        _seen = set(_prev["seen"])
+        _cols = list(_prev["matrix_cols"])
+        _xpos = list(_prev["positions_x"])
+        _nums = list(_prev["trace_nums"])
+        _time_ns = _prev["time_ns"]
+        _all_physical = _prev["all_positions_physical"]
+        _warnings = list(_prev["warnings"])
+        _sample_file = _prev["sample_file"]
+
+    _known_components = _prev["known_components"]
+    _new_warnings = []
+    _new_trace_count = 0
+    _should_scan = live_toggle.value or poll_now_button.value or _needs_reset
+
+    if _should_scan and Path(directory_input.value).is_dir():
+        for _num, _path in find_trace_files(directory_input.value, _base):
+            _key = str(_path.resolve())
+            if _key in _seen:
+                continue
+
+            try:
+                _fdata = load_file(_path)
+            except (FileNotFoundError, OSError, KeyError):
+                continue  # still being written — retry next tick, don't mark seen
+
+            _result = process_trace(_fdata, _current_component, len(_cols[0]) if _cols else None, _current_receiver)
+            if _result["known_components"]:
+                _known_components = _result["known_components"]
+
+            if not _result["ok"]:
+                _new_warnings.append(f"{_path.name}: {_result['reason']} — skipped")
+                _seen.add(_key)
+                continue
+
+            if _time_ns is None:
+                _time_ns = _result["time_ns"]
+            if _sample_file is None:
+                _sample_file = _fdata
+            if _result["x"] is None:
+                _all_physical = False
+
+            _cols.append(_result["array"])
+            _xpos.append(_result["x"] if _result["x"] is not None else float(_num))
+            _nums.append(_num)
+            _seen.add(_key)
+            _new_trace_count += 1
+
+    _scan_time = time.strftime("%H:%M:%S") if _should_scan else _prev["last_poll"]
+    _all_warnings = (_warnings + _new_warnings)[-10:]
+
+    # Only touch shared state when something real happened — a reset, a
+    # newly loaded trace, or a new warning. An empty poll (the common case
+    # once caught up) leaves state untouched, so the time-window slider and
+    # renderer downstream don't rebuild every tick for no reason. The
+    # status line below still updates the displayed poll time every tick
+    # regardless, since that's local to this cell's own output and doesn't
+    # trigger anything downstream.
+    _changed = _needs_reset or _new_trace_count > 0 or bool(_new_warnings)
+    if _changed:
+        set_bscan_state(
+            {
+                "seen": _seen,
+                "matrix_cols": _cols,
+                "positions_x": _xpos,
+                "trace_nums": _nums,
+                "time_ns": _time_ns,
+                "component": _current_component,
+                "receiver": _current_receiver,
+                "base_name": _base,
+                "known_components": _known_components,
+                "all_positions_physical": _all_physical,
+                "warnings": _all_warnings,
+                "last_poll": _scan_time,
+                "sample_file": _sample_file,
+            }
+        )
+
+    _parts = [f"**{len(_cols)} trace(s) loaded**"]
+    if _current_component:
+        _parts.append(f"component `{_current_component}`")
+    if _current_receiver:
+        _parts.append(f"receiver `{_current_receiver}`")
+    _parts.append(f"last poll {_scan_time or '—'}")
+    _summary = [mo.md("  ·  ".join(_parts))]
+    if _all_warnings:
+        _summary.append(
+            mo.callout(
+                mo.md("**Skipped files:**\n\n" + "\n".join(f"- {w}" for w in _all_warnings)),
+                kind="warn",
+            )
+        )
+    mo.output.replace(mo.vstack(_summary, gap="0.3rem"))
+    return
+
+
+
+# ── Step 5: Time window ─────────────────────────────────────────────────
+@app.cell
+def _(get_bscan_state, mo):
+    _state = get_bscan_state()
+    if not _state["matrix_cols"]:
+        mo.stop(True, mo.md(""))
+
+    _max_ns = float(_state["time_ns"][-1])
+    live_time_range = mo.ui.range_slider(
+        start=0.0, stop=_max_ns, step=round(_max_ns / 600, 4),
+        value=[0.0, _max_ns], label="Time window (ns)", full_width=True, debounce=True,
+    )
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 5 — Time window"),
+                mo.md("_Zooms the plot only — CSV export always contains the full unzoomed data._"),
+                live_time_range,
+            ],
+            gap="0.4rem",
+        )
+    )
+    return (live_time_range,)
+
+
+# ── Step 6: Appearance ───────────────────────────────────────────────────
+@app.cell
+def _(mo):
+    live_view_mode = mo.ui.dropdown(options=["Heatmap", "3D Surface"], value="Heatmap", label="View")
+    live_colourscale = mo.ui.dropdown(
+        options=["RdBu", "Viridis", "Greys", "Turbo"], value="RdBu", label="Colourscale"
+    )
+    live_bg = mo.ui.dropdown(
+        options={"Light": "#ffffff", "Paper white": "#f8f9fa", "Dark": "#0e1117"},
+        value="Light",
+        label="Background",
+    )
+    live_font_size = mo.ui.slider(start=10, stop=22, step=1, value=13, label="Font size", debounce=True)
+    live_normalize = mo.ui.checkbox(label="Normalize each trace (view only — CSV stays raw)", value=False)
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 6 — Appearance"),
+                mo.hstack([live_view_mode, live_colourscale, live_bg, live_font_size], gap="1.5rem", justify="start"),
+                live_normalize,
+            ],
+            gap="0.5rem",
+        )
+    )
+    return live_bg, live_colourscale, live_font_size, live_normalize, live_view_mode
+
+
+# ── Live renderer + export ──────────────────────────────────────────────
+@app.cell
+def _(
+    get_bscan_state,
+    live_bg,
+    live_colourscale,
+    live_font_size,
+    live_normalize,
+    live_time_range,
+    live_view_mode,
+    mo,
+    np,
+    render_bscan_section,
+):
+    _state = get_bscan_state()
+    _cols = _state["matrix_cols"]
+
+    if not _cols:
+        mo.stop(
+            True,
+            mo.callout(
+                mo.md("No traces loaded yet. Point Step 1 at a directory containing gprMax B-scan output."),
+                kind="neutral",
+            ),
+        )
+
+    mo.output.replace(
+        render_bscan_section(
+            matrix=np.column_stack(_cols),
+            positions_x=_state["positions_x"],
+            time_ns=_state["time_ns"],
+            component=_state["component"],
+            all_positions_physical=_state["all_positions_physical"],
+            index_label="Trace index",
+            colourscale=live_colourscale.value,
+            bg=live_bg.value,
+            font_size=live_font_size.value,
+            view_mode=live_view_mode.value,
+            normalize=live_normalize.value,
+            title_text=f"B-scan radargram — {_state['component']} ({len(_cols)} traces)",
+            csv_filename="gprmax_bscan_live.csv",
+            time_range=tuple(live_time_range.value),
+            sample_file=_state["sample_file"],
+        )
+    )
+    return
+
+
+# ══ PART 2 — LOAD FILES ═════════════════════════════════════════════════════
+# Assembles a radargram from A-scan files you already have — not
+# necessarily from a live-running B-scan, and not necessarily numbered
+# sequentially. Ordered by source x-position when available, falling back
+# to selection order. Independent of Part 1's state entirely.
+
+
+# ── Step 7: Pick files ───────────────────────────────────────────────────
+@app.cell
+def _(mo):
+    file_picker = mo.ui.file_browser(filetypes=[".h5"], multiple=True, label="")
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("## Part 2 — Load files"),
+                mo.md(
+                    "Pick any set of single-trace `.h5` files — a finished "
+                    "B-scan, or hand-picked A-scans from different runs — "
+                    "and assemble them into a radargram or 3D surface."
+                ),
+                mo.md("### Step 7 — Select files"),
+                file_picker,
+            ],
+            gap="0.4rem",
+        )
+    )
+    return (file_picker,)
+
+
+# ── Step 8: Field component & receiver ──────────────────────────────────
+# Same independent-peek pattern as Part 1's Step 4, for the same reason:
+# this must not depend on the assemble cell's output, since the assemble
+# cell depends on these widgets.
+@app.cell
+def _(file_picker, list_components, list_receivers, load_file, mo):
+    _known_comps = ["Ez"]
+    _known_rx = ["rx1"]
+
+    if file_picker.value:
+        try:
+            _fdata = load_file(file_picker.value[0].path)
+            _known_rx = list_receivers(_fdata) or _known_rx
+            _known_comps = list_components(_fdata, _known_rx[0]) or _known_comps
+        except (FileNotFoundError, OSError, KeyError):
+            pass
+
+    _default_comp = "Ez" if "Ez" in _known_comps else _known_comps[0]
+    load_component_selector = mo.ui.dropdown(options=_known_comps, value=_default_comp, label="Field component")
+    load_receiver_selector = mo.ui.dropdown(options=_known_rx, value=_known_rx[0], label="Receiver")
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 8 — Field component & receiver"),
+                mo.md("_Read from the first selected file, not assumed._"),
+                mo.hstack([load_component_selector, load_receiver_selector], gap="2rem", justify="start"),
+            ],
+            gap="0.4rem",
+        )
+    )
+    return load_component_selector, load_receiver_selector
+
+
+# ── Assemble ─────────────────────────────────────────────────────────────
+@app.cell
+def _(file_picker, load_component_selector, load_file, load_receiver_selector, mo, stack_traces):
+    if not file_picker.value:
+        mo.stop(True, mo.md(""))
+
+    _loaded = []
+    _load_warnings = []
+    for _f in file_picker.value:
+        try:
+            _loaded.append((len(_loaded), load_file(_f.path)))
+        except (FileNotFoundError, OSError, KeyError) as _e:
+            _load_warnings.append(f"{_f.path}: {type(_e).__name__} — skipped")
+
+    def _sort_key(item):
+        _idx, _fdata = item
+        _sources = _fdata.get("sources", {})
+        if "src1" in _sources:
+            return (0, _sources["src1"]["position"][0])
+        return (1, _idx)  # no position: keep original selection order, after positioned ones
+
+    _ordered = [fdata for _, fdata in sorted(_loaded, key=_sort_key)]
+    load_result = stack_traces(_ordered, load_component_selector.value, load_receiver_selector.value)
+    load_result["warnings"] = _load_warnings + load_result["warnings"]
+    load_result["sample_file"] = _ordered[0] if _ordered else None
+
+    _msg = f"**{len(_ordered)} file(s) loaded**"
+    if load_result["component"]:
+        _msg += f"  ·  component `{load_result['component']}`"
+    if load_result["receiver"]:
+        _msg += f"  ·  receiver `{load_result['receiver']}`"
+    _out = [mo.md(_msg)]
+    if load_result["warnings"]:
+        _out.append(
+            mo.callout(
+                mo.md("**Skipped:**\n\n" + "\n".join(f"- {w}" for w in load_result["warnings"])),
+                kind="warn",
+            )
+        )
+    mo.output.replace(mo.vstack(_out, gap="0.3rem"))
+    return (load_result,)
+
+
+# ── Step 9: Time window ─────────────────────────────────────────────────
+@app.cell
+def _(load_result, mo):
+    if load_result["matrix"] is None:
+        mo.stop(True, mo.md(""))
+
+    _max_ns = float(load_result["time_ns"][-1])
+    load_time_range = mo.ui.range_slider(
+        start=0.0, stop=_max_ns, step=round(_max_ns / 600, 4),
+        value=[0.0, _max_ns], label="Time window (ns)", full_width=True, debounce=True,
+    )
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 9 — Time window"),
+                mo.md("_Zooms the plot only — CSV export always contains the full unzoomed data._"),
+                load_time_range,
+            ],
+            gap="0.4rem",
+        )
+    )
+    return (load_time_range,)
+
+
+# ── Step 10: Appearance ──────────────────────────────────────────────────
+@app.cell
+def _(mo):
+    load_view_mode = mo.ui.dropdown(options=["Heatmap", "3D Surface"], value="Heatmap", label="View")
+    load_colourscale = mo.ui.dropdown(
+        options=["RdBu", "Viridis", "Greys", "Turbo"], value="RdBu", label="Colourscale"
+    )
+    load_bg = mo.ui.dropdown(
+        options={"Light": "#ffffff", "Paper white": "#f8f9fa", "Dark": "#0e1117"},
+        value="Light",
+        label="Background",
+    )
+    load_font_size = mo.ui.slider(start=10, stop=22, step=1, value=13, label="Font size", debounce=True)
+    load_normalize = mo.ui.checkbox(label="Normalize each trace (view only — CSV stays raw)", value=False)
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 10 — Appearance"),
+                mo.hstack([load_view_mode, load_colourscale, load_bg, load_font_size], gap="1.5rem", justify="start"),
+                load_normalize,
+            ],
+            gap="0.5rem",
+        )
+    )
+    return load_bg, load_colourscale, load_font_size, load_normalize, load_view_mode
+
+
+# ── Load-files renderer + export ────────────────────────────────────────
+@app.cell
+def _(
+    load_bg,
+    load_colourscale,
+    load_font_size,
+    load_normalize,
+    load_result,
+    load_time_range,
+    load_view_mode,
+    mo,
+    render_bscan_section,
+):
+    if load_result["matrix"] is None:
+        mo.stop(
+            True,
+            mo.callout(mo.md("No usable traces in the current selection."), kind="neutral"),
+        )
+
+    mo.output.replace(
+        render_bscan_section(
+            matrix=load_result["matrix"],
+            positions_x=load_result["positions_x"],
+            time_ns=load_result["time_ns"],
+            component=load_result["component"],
+            all_positions_physical=load_result["all_positions_physical"],
+            index_label="File index",
+            colourscale=load_colourscale.value,
+            bg=load_bg.value,
+            font_size=load_font_size.value,
+            view_mode=load_view_mode.value,
+            normalize=load_normalize.value,
+            title_text=f"Assembled radargram — {load_result['component']} ({load_result['matrix'].shape[1]} traces)",
+            csv_filename="gprmax_bscan_assembled.csv",
+            time_range=tuple(load_time_range.value),
+            sample_file=load_result["sample_file"],
+        )
+    )
+    return
+
+
+# ── Known gaps ────────────────────────────────────────────────────────────
+@app.cell
+def _(mo):
+    mo.callout(
+        mo.md(
+            "**Known gaps — deliberate, not oversights**\n\n"
+            "- No fallback yet to a merged output file if gprMax stops "
+            "writing fully-closed per-trace files. Deferred: current "
+            "behaviour (one closed file per trace) has been confirmed "
+            "against real runs, so this defends against a scenario with "
+            "no indication it's coming.\n"
+            "- Part 2 orders by source x-position when available; files "
+            "without that metadata fall back to selection order, which "
+            "may not reflect physical position.\n"
+            "- No invert-polarity or time-shift controls. Antonis's "
+            "\"manipulate\" scope wasn't fully pinned down — zoom and "
+            "normalize are built, the rest is worth clarifying before "
+            "guessing further.\n"
+            "- Background subtraction and FFT are intentionally not here "
+            "— deferred for ascan_dashboard.py too, staying consistent "
+            "with that call."
+        ),
+        kind="neutral",
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/toolboxes/Marimo/bscan_dashboard.py
+++ b/toolboxes/Marimo/bscan_dashboard.py
@@ -23,6 +23,12 @@ def _():
         list_receivers,
         load_file,
     )
+    from toolboxes.Marimo.processing import (
+        GAIN_KINDS,
+        apply_gain,
+        gain_label,
+        remove_mean_trace,
+    )
     from toolboxes.Marimo.trace_matrix import process_trace, stack_traces
 
     # gprMax per-trace B-scan naming: <base><N>.h5, e.g. cylinder_Bscan_2D1.h5
@@ -58,6 +64,120 @@ def _():
                 found.append((int(m.group(2)), p))
         found.sort(key=lambda t: t[0])
         return found
+
+    def apply_processing(matrix, time_ns, processing):
+        """Background removal then gain, in that order. Returns
+        (display_matrix, gain_curve, summary, background).
+
+        Order is not arbitrary: the GPR literature is consistent that
+        background removal comes before gain, because gaining first
+        amplifies the stationary direct wave along with everything else and
+        leaves a much larger residual for the subtraction to cancel.
+        Display normalisation happens last, inside build_bscan_figure.
+
+        `summary` is the one-line description that goes into the plot title
+        and the CSV header, so an exported figure records what was done.
+        """
+        proc = processing or {}
+        kind = proc.get("kind", "none")
+        window = proc.get("background_window")
+        parts = []
+
+        display = matrix
+        background = None
+
+        if proc.get("remove_background"):
+            display, background = remove_mean_trace(display, window)
+            parts.append(
+                "background removed (all traces)"
+                if window is None
+                else f"background removed ({window}-trace window)"
+            )
+
+        curve = None
+        if kind != "none":
+            # Start is carried as a percentage so the control cell has no
+            # dependency on the data. A live B-scan rebuilds its time-window
+            # slider on every arriving trace, and an ns-valued start slider
+            # would be rebuilt with it, resetting gain mid-run.
+            window_ns = float(time_ns[-1]) if len(time_ns) else 0.0
+            start_ns = (proc.get("start_pct", 0.0) / 100.0) * window_ns
+            max_gain = proc.get("max_gain")
+            display, curve = apply_gain(
+                display,
+                time_ns,
+                kind,
+                factor=proc.get("factor", 1.0),
+                power=proc.get("power", 1.0),
+                start_ns=start_ns,
+                max_gain=max_gain,
+            )
+            # Only name the clamp when it actually bound. Reporting a limit
+            # the gain never reached puts a misleading number in a title.
+            bound = max_gain is not None and float(np.max(curve)) >= max_gain
+            parts.append(
+                gain_label(
+                    kind,
+                    proc.get("factor", 1.0),
+                    proc.get("power", 1.0),
+                    start_ns,
+                    max_gain if bound else None,
+                )
+            )
+
+        return display, curve, "  ·  ".join(parts), background
+
+    def build_gain_curve_figure(time_ns, curve, bg, font_size, time_range, line_colour="#7f7f7f"):
+        """Small standalone panel for the applied gain curve.
+
+        Its own figure rather than an extra axis on the radargram: a heatmap
+        has no spare y-axis, and a 3D surface has none at all. Time runs
+        horizontally here even though the radargram draws it vertically,
+        which keeps this panel identical to the one in ascan_dashboard.py.
+        """
+        is_dark = bg == "#0e1117"
+        fc = "#e8e8e8" if is_dark else "#1a1a1a"
+        lc = "rgba(255,255,255,0.25)" if is_dark else "rgba(0,0,0,0.18)"
+        gc = "rgba(255,255,255,0.1)" if is_dark else "rgba(0,0,0,0.07)"
+
+        fig = go.Figure(
+            data=go.Scatter(
+                x=time_ns,
+                y=curve,
+                mode="lines",
+                showlegend=False,
+                line=dict(color=line_colour, width=1.5),
+                hovertemplate="%{x:.4f} ns<br>x%{y:.4g}<extra>gain</extra>",
+            )
+        )
+        lo, hi = time_range if time_range is not None else (float(time_ns[0]), float(time_ns[-1]))
+        fig.update_layout(
+            xaxis=dict(
+                title="Time (ns)",
+                range=[lo, hi],
+                showgrid=True,
+                gridcolor=gc,
+                showline=True,
+                linecolor=lc,
+                tickfont=dict(size=font_size - 2, color=fc),
+                title_font=dict(size=font_size - 1, color=fc),
+            ),
+            yaxis=dict(
+                title="Gain (x)",
+                type="log" if float(np.min(curve)) > 0 else "linear",
+                showgrid=True,
+                gridcolor=gc,
+                showline=True,
+                linecolor=lc,
+                tickfont=dict(size=font_size - 2, color=fc),
+                title_font=dict(size=font_size - 1, color=fc),
+            ),
+            paper_bgcolor=bg,
+            plot_bgcolor=bg,
+            height=180,
+            margin=dict(l=72, r=32, t=10, b=44),
+        )
+        return fig
 
     def build_bscan_figure(matrix, x, y, x_title, unit, colourscale, bg, font_size, view_mode, title_text, time_range=None, normalize=False):
         """Heatmap or 3D Surface from an assembled (time x position) matrix."""
@@ -139,12 +259,26 @@ def _():
         )
         return fig
 
-    def render_bscan_section(matrix, positions_x, time_ns, component, all_positions_physical, index_label, colourscale, bg, font_size, view_mode, normalize, title_text, csv_filename, time_range=None, sample_file=None):
+    def render_bscan_section(matrix, positions_x, time_ns, component, all_positions_physical, index_label, colourscale, bg, font_size, view_mode, normalize, title_text, csv_filename, time_range=None, sample_file=None, processing=None):
         """Metadata banner + plot + CSV/SVG/PDF export. Shared by both the
         live and load-files renderer cells so the two don't drift apart.
+
+        Processing lives here rather than in the two renderer cells for the
+        same reason: one implementation, so background removal and gain
+        cannot behave differently between live monitoring and load-files.
         """
         if matrix is None:
             return mo.callout(mo.md("No traces to show yet."), kind="neutral")
+
+        display, gain_curve, proc_summary, _background = apply_processing(
+            matrix, time_ns, processing
+        )
+        proc = processing or {}
+        unit = get_unit_label(component or "Ez")
+        if proc.get("kind", "none") != "none":
+            unit += " (gained)"
+        if proc_summary:
+            title_text = f"{title_text}  ·  {proc_summary}"
 
         x_title = (
             "Source x-position (m)"
@@ -152,22 +286,29 @@ def _():
             else f"{index_label} (source position unavailable in one or more files)"
         )
         fig = build_bscan_figure(
-            matrix, positions_x, time_ns, x_title, get_unit_label(component or "Ez"),
+            display, positions_x, time_ns, x_title, unit,
             colourscale, bg, font_size, view_mode, title_text,
             time_range=time_range, normalize=normalize,
         )
 
-        # CSV always exports the full, unzoomed, un-normalized matrix —
-        # same convention ascan_dashboard.py uses for its time-zoom slider.
+        # CSV always exports the full, unzoomed, un-normalized, unprocessed
+        # matrix — same convention ascan_dashboard.py uses. The processing
+        # line is written whether or not any processing is active, so the
+        # file format never changes depending on a UI setting. Commas inside
+        # the summary become semicolons to keep it one unquoted field.
         try:
             buf = io.StringIO()
+            buf.write(
+                f"# processing: {(proc_summary or 'none').replace(',', ';')}. "
+                f"Values below are raw.\n"
+            )
             writer = csv.writer(buf)
             writer.writerow(["time_ns"] + [f"x={p:.4f}" for p in positions_x])
             for i in range(len(time_ns)):
                 writer.writerow([f"{time_ns[i]:.8g}"] + [f"{matrix[i, j]:.10g}" for j in range(matrix.shape[1])])
             csv_btn = mo.download(
                 data=buf.getvalue().encode("utf-8"), filename=csv_filename,
-                label="Download CSV (full matrix)", mimetype="text/csv",
+                label="Download CSV (full raw matrix)", mimetype="text/csv",
             )
         except Exception as e:
             csv_btn = mo.md(f"_CSV export error: `{e}`_")
@@ -203,17 +344,38 @@ def _():
                     "displaylogo": False,
                 },
             ),
+        ]
+
+        if gain_curve is not None and proc.get("show_curve"):
+            elements += [
+                mo.md(f"**Applied gain curve** — {proc_summary}"),
+                mo.ui.plotly(
+                    build_gain_curve_figure(time_ns, gain_curve, bg, font_size, time_range),
+                    config={"displaylogo": False, "displayModeBar": False},
+                ),
+            ]
+
+        notes = []
+        if proc_summary:
+            notes.append(
+                "_Radargram and image exports show processed amplitudes. "
+                "CSV stays raw, with the processing recorded on its first line._"
+            )
+        notes.append(
+            "_SVG/PDF need `plotly_get_chrome` run once. If either "
+            "fails, the camera icon in the plot toolbar above always "
+            "works and needs no setup._"
+        )
+
+        elements += [
             mo.md("**Export**"),
             mo.hstack([csv_btn, svg_btn, pdf_btn], gap="1rem", justify="start"),
-            mo.md(
-                "_SVG/PDF need `plotly_get_chrome` run once. If either "
-                "fails, the camera icon in the plot toolbar above always "
-                "works and needs no setup._"
-            ),
+            mo.md("  \n".join(notes)),
         ]
         return mo.vstack(elements, gap="0.5rem")
 
     return (
+        GAIN_KINDS,
         Path,
         discover_bases,
         find_trace_files,
@@ -534,7 +696,6 @@ def _(
     return
 
 
-
 # ── Step 5: Time window ─────────────────────────────────────────────────
 @app.cell
 def _(get_bscan_state, mo):
@@ -588,14 +749,111 @@ def _(mo):
     return live_bg, live_colourscale, live_font_size, live_normalize, live_view_mode
 
 
+# ── Step 6b: Processing controls ─────────────────────────────────────────
+# Widget creation only. live_gain_kind's .value drives the parameter cell
+# below, and reading it here would raise at runtime.
+@app.cell
+def _(GAIN_KINDS, mo):
+    live_gain_kind = mo.ui.dropdown(
+        options={_meta["label"]: _k for _k, _meta in GAIN_KINDS.items()},
+        value="None",
+        label="Gain function",
+    )
+    live_remove_bg = mo.ui.checkbox(label="Remove background (mean trace)", value=False)
+    live_bg_window = mo.ui.slider(
+        start=0, stop=51, step=1, value=0,
+        label="Background window (traces, 0 = all)", debounce=True,
+    )
+    live_show_curve = mo.ui.checkbox(label="Show gain curve", value=True)
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 6b — Processing"),
+                mo.md(
+                    "_Background removal runs first, then gain, then display "
+                    "normalisation, matching standard GPR processing order. "
+                    "CSV export stays raw throughout._"
+                ),
+                mo.hstack([live_remove_bg, live_bg_window], gap="1.5rem", justify="start"),
+                mo.hstack([live_gain_kind, live_show_curve], gap="1.5rem", justify="start"),
+            ],
+            gap="0.4rem",
+        )
+    )
+    return live_bg_window, live_gain_kind, live_remove_bg, live_show_curve
+
+
+# ── Step 6c: Gain parameters ─────────────────────────────────────────────
+# Depends on live_gain_kind alone. Anything derived from the accumulated
+# state would rebuild these widgets on every arriving trace and reset the
+# gain settings in the middle of a live run, which is why the gain start is
+# a percentage of the window rather than an absolute time.
+@app.cell
+def _(GAIN_KINDS, live_gain_kind, mo):
+    _FACTOR_SLIDERS = {
+        "constant": dict(start=0.1, stop=20.0, step=0.1, value=2.0, label="Factor (x)"),
+        "linear": dict(start=0.0, stop=10.0, step=0.1, value=1.0, label="Slope (per ns)"),
+        "exponential": dict(start=0.0, stop=5.0, step=0.05, value=1.0, label="Rate a (per ns)"),
+        "db": dict(start=0.0, stop=60.0, step=0.5, value=6.0, label="Gain (dB per ns)"),
+        "sec": dict(start=0.0, stop=5.0, step=0.05, value=0.5, label="Rate a (per ns)"),
+    }
+
+    _kind = live_gain_kind.value
+
+    if _kind == "none":
+        live_gain_factor = None
+        live_gain_power = None
+        live_gain_start = None
+        live_gain_clamp = None
+        live_gain_max = None
+        mo.output.replace(mo.md(""))
+    else:
+        _cfg = _FACTOR_SLIDERS.get(_kind)
+        live_gain_factor = mo.ui.slider(**_cfg, debounce=True) if _cfg else None
+        live_gain_power = (
+            mo.ui.slider(start=0.0, stop=4.0, step=0.1, value=1.0, label="Exponent b", debounce=True)
+            if GAIN_KINDS[_kind]["uses_power"]
+            else None
+        )
+        live_gain_start = mo.ui.slider(
+            start=0.0, stop=100.0, step=0.5, value=0.0,
+            label="Gain start (% of window)", debounce=True,
+        )
+        live_gain_clamp = mo.ui.checkbox(label="Limit maximum gain", value=True)
+        live_gain_max = mo.ui.slider(
+            start=1, stop=1000, step=1, value=100, label="Maximum gain (x)", debounce=True
+        )
+        _params = [w for w in (live_gain_factor, live_gain_power, live_gain_start) if w is not None]
+        mo.output.replace(
+            mo.vstack(
+                [
+                    mo.hstack(_params, gap="1.5rem", justify="start"),
+                    mo.hstack([live_gain_clamp, live_gain_max], gap="1.5rem", justify="start"),
+                ],
+                gap="0.4rem",
+            )
+        )
+    return live_gain_clamp, live_gain_factor, live_gain_max, live_gain_power, live_gain_start
+
+
 # ── Live renderer + export ──────────────────────────────────────────────
 @app.cell
 def _(
     get_bscan_state,
     live_bg,
+    live_bg_window,
     live_colourscale,
     live_font_size,
+    live_gain_clamp,
+    live_gain_factor,
+    live_gain_kind,
+    live_gain_max,
+    live_gain_power,
+    live_gain_start,
     live_normalize,
+    live_remove_bg,
+    live_show_curve,
     live_time_range,
     live_view_mode,
     mo,
@@ -631,6 +889,20 @@ def _(
             csv_filename="gprmax_bscan_live.csv",
             time_range=tuple(live_time_range.value),
             sample_file=_state["sample_file"],
+            processing=dict(
+                kind=live_gain_kind.value,
+                factor=live_gain_factor.value if live_gain_factor is not None else 1.0,
+                power=live_gain_power.value if live_gain_power is not None else 1.0,
+                start_pct=live_gain_start.value if live_gain_start is not None else 0.0,
+                max_gain=(
+                    live_gain_max.value
+                    if (live_gain_clamp is not None and live_gain_clamp.value)
+                    else None
+                ),
+                remove_background=live_remove_bg.value,
+                background_window=(None if live_bg_window.value == 0 else live_bg_window.value),
+                show_curve=live_show_curve.value,
+            ),
         )
     )
     return
@@ -794,14 +1066,111 @@ def _(mo):
     return load_bg, load_colourscale, load_font_size, load_normalize, load_view_mode
 
 
+# ── Step 10b: Processing controls ─────────────────────────────────────────
+# Widget creation only. load_gain_kind's .value drives the parameter cell
+# below, and reading it here would raise at runtime.
+@app.cell
+def _(GAIN_KINDS, mo):
+    load_gain_kind = mo.ui.dropdown(
+        options={_meta["label"]: _k for _k, _meta in GAIN_KINDS.items()},
+        value="None",
+        label="Gain function",
+    )
+    load_remove_bg = mo.ui.checkbox(label="Remove background (mean trace)", value=False)
+    load_bg_window = mo.ui.slider(
+        start=0, stop=51, step=1, value=0,
+        label="Background window (traces, 0 = all)", debounce=True,
+    )
+    load_show_curve = mo.ui.checkbox(label="Show gain curve", value=True)
+
+    mo.output.replace(
+        mo.vstack(
+            [
+                mo.md("### Step 10b — Processing"),
+                mo.md(
+                    "_Background removal runs first, then gain, then display "
+                    "normalisation, matching standard GPR processing order. "
+                    "CSV export stays raw throughout._"
+                ),
+                mo.hstack([load_remove_bg, load_bg_window], gap="1.5rem", justify="start"),
+                mo.hstack([load_gain_kind, load_show_curve], gap="1.5rem", justify="start"),
+            ],
+            gap="0.4rem",
+        )
+    )
+    return load_bg_window, load_gain_kind, load_remove_bg, load_show_curve
+
+
+# ── Step 10c: Gain parameters ─────────────────────────────────────────────
+# Depends on load_gain_kind alone. Anything derived from the accumulated
+# state would rebuild these widgets on every arriving trace and reset the
+# gain settings in the middle of a live run, which is why the gain start is
+# a percentage of the window rather than an absolute time.
+@app.cell
+def _(GAIN_KINDS, load_gain_kind, mo):
+    _FACTOR_SLIDERS = {
+        "constant": dict(start=0.1, stop=20.0, step=0.1, value=2.0, label="Factor (x)"),
+        "linear": dict(start=0.0, stop=10.0, step=0.1, value=1.0, label="Slope (per ns)"),
+        "exponential": dict(start=0.0, stop=5.0, step=0.05, value=1.0, label="Rate a (per ns)"),
+        "db": dict(start=0.0, stop=60.0, step=0.5, value=6.0, label="Gain (dB per ns)"),
+        "sec": dict(start=0.0, stop=5.0, step=0.05, value=0.5, label="Rate a (per ns)"),
+    }
+
+    _kind = load_gain_kind.value
+
+    if _kind == "none":
+        load_gain_factor = None
+        load_gain_power = None
+        load_gain_start = None
+        load_gain_clamp = None
+        load_gain_max = None
+        mo.output.replace(mo.md(""))
+    else:
+        _cfg = _FACTOR_SLIDERS.get(_kind)
+        load_gain_factor = mo.ui.slider(**_cfg, debounce=True) if _cfg else None
+        load_gain_power = (
+            mo.ui.slider(start=0.0, stop=4.0, step=0.1, value=1.0, label="Exponent b", debounce=True)
+            if GAIN_KINDS[_kind]["uses_power"]
+            else None
+        )
+        load_gain_start = mo.ui.slider(
+            start=0.0, stop=100.0, step=0.5, value=0.0,
+            label="Gain start (% of window)", debounce=True,
+        )
+        load_gain_clamp = mo.ui.checkbox(label="Limit maximum gain", value=True)
+        load_gain_max = mo.ui.slider(
+            start=1, stop=1000, step=1, value=100, label="Maximum gain (x)", debounce=True
+        )
+        _params = [w for w in (load_gain_factor, load_gain_power, load_gain_start) if w is not None]
+        mo.output.replace(
+            mo.vstack(
+                [
+                    mo.hstack(_params, gap="1.5rem", justify="start"),
+                    mo.hstack([load_gain_clamp, load_gain_max], gap="1.5rem", justify="start"),
+                ],
+                gap="0.4rem",
+            )
+        )
+    return load_gain_clamp, load_gain_factor, load_gain_max, load_gain_power, load_gain_start
+
+
 # ── Load-files renderer + export ────────────────────────────────────────
 @app.cell
 def _(
     load_bg,
+    load_bg_window,
     load_colourscale,
     load_font_size,
+    load_gain_clamp,
+    load_gain_factor,
+    load_gain_kind,
+    load_gain_max,
+    load_gain_power,
+    load_gain_start,
     load_normalize,
+    load_remove_bg,
     load_result,
+    load_show_curve,
     load_time_range,
     load_view_mode,
     mo,
@@ -830,6 +1199,20 @@ def _(
             csv_filename="gprmax_bscan_assembled.csv",
             time_range=tuple(load_time_range.value),
             sample_file=load_result["sample_file"],
+            processing=dict(
+                kind=load_gain_kind.value,
+                factor=load_gain_factor.value if load_gain_factor is not None else 1.0,
+                power=load_gain_power.value if load_gain_power is not None else 1.0,
+                start_pct=load_gain_start.value if load_gain_start is not None else 0.0,
+                max_gain=(
+                    load_gain_max.value
+                    if (load_gain_clamp is not None and load_gain_clamp.value)
+                    else None
+                ),
+                remove_background=load_remove_bg.value,
+                background_window=(None if load_bg_window.value == 0 else load_bg_window.value),
+                show_curve=load_show_curve.value,
+            ),
         )
     )
     return
@@ -850,12 +1233,16 @@ def _(mo):
             "without that metadata fall back to selection order, which "
             "may not reflect physical position.\n"
             "- No invert-polarity or time-shift controls. Antonis's "
-            "\"manipulate\" scope wasn't fully pinned down — zoom and "
-            "normalize are built, the rest is worth clarifying before "
-            "guessing further.\n"
-            "- Background subtraction and FFT are intentionally not here "
-            "— deferred for ascan_dashboard.py too, staying consistent "
-            "with that call."
+            "\"manipulate\" scope wasn't fully pinned down — zoom, "
+            "normalize, gain and background removal are built, the rest "
+            "is worth clarifying before guessing further.\n"
+            "- No AGC. It equalises amplitudes over a local window and "
+            "destroys relative reflectivity, which is precisely what an "
+            "FDTD simulation gets right and a field instrument does not.\n"
+            "- Bandpass and lowpass filters, and B-scan minus B-scan "
+            "subtraction, are not built. Same processing family as gain "
+            "and background removal, and they plug into the same "
+            "`processing.py` module when they are."
         ),
         kind="neutral",
     )

--- a/toolboxes/Marimo/h5_reader.py
+++ b/toolboxes/Marimo/h5_reader.py
@@ -1,0 +1,371 @@
+"""
+h5_reader.py: gprMax HDF5 output file reader for the Marimo dashboard.
+
+Reads one or more gprMax v4 .h5 output files into a structured dict.
+No marimo dependency — pure h5py + numpy. Designed to be the foundation
+layer that all dashboard cells import from.
+
+Usage:
+    from toolboxes.Marimo.h5_reader import load_files, load_file
+
+    data = load_files([
+        "examples/cylinder_Ascan_2D.h5",
+        "examples/cylinder_Ascan_2D_freespace.h5",
+    ])
+
+    # Access a specific trace
+    ez = data["cylinder_Ascan_2D.h5"]["receivers"]["rx1"]["components"]["Ez"]
+    dt = data["cylinder_Ascan_2D.h5"]["meta"]["dt"]
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import h5py
+import numpy as np
+
+# ComponentMap: {"Ez": np.ndarray, "Hx": np.ndarray, ...}
+ComponentMap = dict[str, np.ndarray]
+
+# ReceiverInfo: full data for one receiver point
+ReceiverInfo = dict[str, Any]
+# {
+#   "name":       str              e.g. "Rx(70,85,0)"
+#   "position":   list[float]      e.g. [0.14, 0.17, 0.0]
+#   "components": ComponentMap
+# }
+
+# FileMeta: root-level attributes from the HDF5 file
+FileMeta = dict[str, Any]
+# {
+#   "title":       str
+#   "dt":          float           time step in seconds
+#   "dx_dy_dz":    list[float]     spatial discretisation [m, m, m]
+#   "iterations":  int
+#   "nrx":         int             number of receivers
+#   "nsrc":        int             number of sources
+#   "nx_ny_nz":    list[int]       grid dimensions in cells
+#   "gprmax_version": str
+# }
+
+# SourceInfo: metadata for one source point
+SourceInfo = dict[str, Any]
+# {
+#   "type":     str   e.g. "HertzianDipole"
+#   "position": list[float]
+# }
+
+# FileData: everything read from one .h5 file
+FileData = dict[str, Any]
+# {
+#   "path":      str               absolute path to the file
+#   "meta":      FileMeta
+#   "receivers": dict[str, ReceiverInfo]   keyed by "rx1", "rx2", ...
+#   "sources":   dict[str, SourceInfo]     keyed by "src1", "src2", ...
+#   "time_ns":   np.ndarray                time axis in nanoseconds
+# }
+
+
+# Core reader
+
+
+def load_file(path: str | Path) -> FileData:
+    """Read a single gprMax v4 HDF5 output file.
+
+    Args:
+        path: Path to the .h5 file.
+
+    Returns:
+        FileData dict containing metadata, all receiver traces, and
+        a precomputed nanosecond time axis.
+
+    Raises:
+        FileNotFoundError: if the path does not exist.
+        KeyError: if the file is missing expected gprMax structure.
+        OSError: if the file cannot be opened (not a valid HDF5 file).
+    """
+    path = Path(path).resolve()
+    if not path.exists():
+        raise FileNotFoundError(f"HDF5 file not found: {path}")
+
+    with h5py.File(path, "r") as f:
+        meta = _read_meta(f)
+        receivers = _read_receivers(f, path)
+        sources = _read_sources(f)
+
+    # Build nanosecond time axis from root dt
+    iterations = meta["iterations"]
+    dt = meta["dt"]
+    time_ns = np.arange(iterations) * dt * 1e9  # seconds → nanoseconds
+
+    return {
+        "path": str(path),
+        "meta": meta,
+        "receivers": receivers,
+        "sources": sources,
+        "time_ns": time_ns,
+    }
+
+
+def load_files(paths: list[str | Path]) -> dict[str, FileData]:
+    """Read multiple gprMax HDF5 output files.
+
+    Args:
+        paths: List of paths to .h5 files.
+
+    Returns:
+        Dict keyed by filename (not full path) mapping to FileData.
+        If two files share the same filename, the second is keyed by
+        its full path to avoid collision.
+
+    Raises:
+        FileNotFoundError: if any path does not exist.
+    """
+    result: dict[str, FileData] = {}
+    seen_names: set[str] = set()
+
+    for p in paths:
+        data = load_file(p)
+        name = Path(p).name
+
+        # Avoid key collision when two files share the same filename
+        if name in seen_names:
+            name = str(Path(p).resolve())
+        seen_names.add(name)
+
+        result[name] = data
+
+    return result
+
+
+# Time axis utility
+
+
+def get_time_axis(file_data: FileData, unit: str = "ns") -> np.ndarray:
+    """Return the time axis for a loaded file.
+
+    Args:
+        file_data: FileData dict from load_file().
+        unit: "ns" (nanoseconds, default), "s" (seconds), or "iter" (iterations).
+
+    Returns:
+        1D numpy array.
+    """
+    iterations = file_data["meta"]["iterations"]
+    dt = file_data["meta"]["dt"]
+
+    if unit == "ns":
+        return np.arange(iterations) * dt * 1e9
+    elif unit == "s":
+        return np.arange(iterations) * dt
+    elif unit == "iter":
+        return np.arange(iterations, dtype=float)
+    else:
+        raise ValueError(f"Unknown unit '{unit}'. Use 'ns', 's', or 'iter'.")
+
+
+# Component and receiver utilities
+
+
+def list_components(file_data: FileData, receiver: str = "rx1") -> list[str]:
+    """Return available field component names for a given receiver.
+
+    Args:
+        file_data: FileData dict from load_file().
+        receiver: Receiver key, e.g. "rx1".
+
+    Returns:
+        Sorted list of component names, e.g. ["Ex", "Ey", "Ez", "Hx", "Hy", "Hz"].
+    """
+    try:
+        return sorted(file_data["receivers"][receiver]["components"].keys())
+    except KeyError:
+        return []
+
+
+def list_receivers(file_data: FileData) -> list[str]:
+    """Return receiver keys available in the file.
+
+    Returns:
+        List of receiver keys, e.g. ["rx1", "rx2"].
+    """
+    return list(file_data["receivers"].keys())
+
+
+def get_trace(
+    file_data: FileData,
+    component: str,
+    receiver: str = "rx1",
+    polarity: int = 1,
+) -> np.ndarray:
+    """Return a single field component array.
+
+    Args:
+        file_data: FileData dict from load_file().
+        component: Field component name, e.g. "Ez". Append "-" for negative
+                   polarity, e.g. "Ez-".
+        receiver: Receiver key, e.g. "rx1".
+        polarity: +1 or -1. If component ends with "-", polarity is forced to -1.
+
+    Returns:
+        1D numpy array of field values.
+    """
+    # Handle polarity suffix convention from plot_Ascan.py
+    if component.endswith("-"):
+        component = component[:-1]
+        polarity = -1
+
+    try:
+        arr = file_data["receivers"][receiver]["components"][component]
+    except KeyError:
+        available = list_components(file_data, receiver)
+        raise KeyError(
+            f"Component '{component}' not found in {receiver}. "
+            f"Available: {available}"
+        )
+
+    return arr * polarity
+
+
+def get_unit_label(component: str) -> str:
+    """Return the SI unit label for a field component.
+
+    Args:
+        component: Component name, e.g. "Ez", "Hx", "Ix".
+
+    Returns:
+        Unit string for axis labelling.
+    """
+    component = component.rstrip("-")
+    if component.startswith("E"):
+        return "V/m"
+    elif component.startswith("H"):
+        return "A/m"
+    elif component.startswith("I"):
+        return "A"
+    return ""
+
+
+def build_label(filename: str, receiver: str, component: str) -> str:
+    """Build a descriptive trace label for plot legends.
+
+    Args:
+        filename: Key from load_files() dict (usually the filename).
+        receiver: Receiver key, e.g. "rx1".
+        component: Component name, e.g. "Ez".
+
+    Returns:
+        Human-readable label, e.g. "cylinder_Ascan_2D · rx1 · Ez".
+    """
+    stem = Path(filename).stem
+    return f"{stem} · {receiver} · {component}"
+
+
+# Metadata formatting
+
+
+def format_metadata_text(file_data: FileData) -> str:
+    """Format file metadata as a human-readable markdown string.
+
+    Intended for use in mo.md() metadata banners.
+
+    Args:
+        file_data: FileData dict from load_file().
+
+    Returns:
+        Markdown-formatted metadata string.
+    """
+    m = file_data["meta"]
+    dx, dy, dz = m["dx_dy_dz"]
+    nx, ny, nz = m["nx_ny_nz"]
+    dt_ps = m["dt"] * 1e12  # seconds → picoseconds
+    total_ns = m["iterations"] * m["dt"] * 1e9
+
+    lines = [
+        f"**{m['title']}**",
+        f"gprMax {m['gprmax_version']} · "
+        f"{m['iterations']} iterations · "
+        f"{total_ns:.3f} ns total window",
+        f"dt = {dt_ps:.4f} ps · "
+        f"dx/dy/dz = {dx*1000:.1f}/{dy*1000:.1f}/{dz*1000:.1f} mm · "
+        f"grid = {nx}×{ny}×{nz} cells",
+        f"{m['nrx']} receiver(s) · {m['nsrc']} source(s)",
+    ]
+
+    # Add receiver positions
+    for rx_key, rx_info in file_data["receivers"].items():
+        pos = rx_info["position"]
+        name = rx_info["name"]
+        lines.append(
+            f"  {rx_key}: {name} at "
+            f"({pos[0]:.3f}, {pos[1]:.3f}, {pos[2]:.3f}) m"
+        )
+
+    return "\n\n".join(lines[:3]) + "\n\n" + "\n".join(lines[3:])
+
+
+# Private helpers
+
+
+def _read_meta(f: h5py.File) -> FileMeta:
+    """Extract root-level metadata attributes."""
+    attrs = dict(f.attrs)
+    return {
+        "title": str(attrs.get("Title", "Untitled")),
+        "dt": float(attrs["dt"]),
+        "dx_dy_dz": list(map(float, attrs["dx_dy_dz"])),
+        "iterations": int(attrs["Iterations"]),
+        "nrx": int(attrs.get("nrx", 0)),
+        "nsrc": int(attrs.get("nsrc", 0)),
+        "nx_ny_nz": list(map(int, attrs.get("nx_ny_nz", [0, 0, 0]))),
+        "gprmax_version": str(attrs.get("gprMax", "unknown")),
+    }
+
+
+def _read_receivers(f: h5py.File, path: Path) -> dict[str, ReceiverInfo]:
+    """Read all receiver data from the HDF5 file."""
+    receivers: dict[str, ReceiverInfo] = {}
+
+    if "rxs" not in f:
+        return receivers
+
+    for rx_key in f["rxs"].keys():
+        rx_group = f["rxs"][rx_key]
+        rx_attrs = dict(rx_group.attrs)
+
+        components: ComponentMap = {}
+        for comp_name in rx_group.keys():
+            dataset = rx_group[comp_name]
+            if isinstance(dataset, h5py.Dataset):
+                components[comp_name] = dataset[:]
+
+        position = list(map(float, rx_attrs.get("Position", [0.0, 0.0, 0.0])))
+
+        receivers[rx_key] = {
+            "name": str(rx_attrs.get("Name", rx_key)),
+            "position": position,
+            "components": components,
+        }
+
+    return receivers
+
+
+def _read_sources(f: h5py.File) -> dict[str, SourceInfo]:
+    """Read all source metadata from the HDF5 file."""
+    sources: dict[str, SourceInfo] = {}
+
+    if "srcs" not in f:
+        return sources
+
+    for src_key in f["srcs"].keys():
+        src_attrs = dict(f["srcs"][src_key].attrs)
+        sources[src_key] = {
+            "type": str(src_attrs.get("Type", "unknown")),
+            "position": list(
+                map(float, src_attrs.get("Position", [0.0, 0.0, 0.0]))
+            ),
+        }
+
+    return sources

--- a/toolboxes/Marimo/processing.py
+++ b/toolboxes/Marimo/processing.py
@@ -1,0 +1,174 @@
+"""
+processing.py: amplitude processing for gprMax traces and B-scan matrices.
+
+No marimo dependency, same principle as h5_reader.py and trace_matrix.py:
+pure numpy, testable with plain pytest, importable from any dashboard cell.
+
+Every function here works on a single A-scan trace, shape (n_samples,), and
+on an assembled B-scan matrix, shape (n_samples, n_traces) — the orientation
+trace_matrix.stack_traces() produces. One implementation, not two, so a gain
+applied to a trace in ascan_dashboard.py and the same gain applied across a
+radargram in bscan_dashboard.py cannot drift apart.
+
+Gain functions return the applied curve alongside the gained data. A gained
+radargram without its curve is uninterpretable — the researcher has to be
+able to see what was done to the amplitudes, not just the result.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# Gain kind -> unit of its `factor` argument, for labels and slider captions.
+# Keys are the accepted `kind` values; build a dashboard dropdown from these
+# rather than hardcoding a second list somewhere.
+GAIN_KINDS: dict[str, str] = {
+    "none": "",
+    "constant": "x",
+    "linear": "per ns",
+    "exponential": "per ns",
+    "db": "dB per ns",
+}
+
+
+def gain_curve(
+    time_ns: np.ndarray,
+    kind: str,
+    factor: float = 1.0,
+    start_ns: float = 0.0,
+    max_gain: float | None = None,
+) -> np.ndarray:
+    """Build the time-varying amplification curve, shape (n_samples,).
+
+    `factor` means something different per kind, hence GAIN_KINDS:
+        none         ignored, curve is all ones
+        constant     flat multiplier applied from start_ns onward
+        linear       1 + factor * t, t in ns since start_ns
+        exponential  exp(factor * t)
+        db           10 ** (factor * t / 20), factor in dB per ns
+
+    Time before `start_ns` gets a gain of exactly 1.0 so the direct wave can
+    be left alone — amplifying it along with everything else just saturates
+    the colour scale on a B-scan and hides the reflections underneath.
+
+    `max_gain` clamps the curve. Exponential gain over a few ns reaches
+    absurd numbers quickly (exp(5 * 3) is 3.3e6), so this is a real guard,
+    not defensive padding.
+    """
+    t = np.asarray(time_ns, dtype=float)
+    if t.ndim != 1:
+        raise ValueError(f"time_ns must be 1D, got shape {t.shape}")
+
+    kind = kind.lower()
+    if kind not in GAIN_KINDS:
+        raise ValueError(f"Unknown gain kind '{kind}'. Options: {list(GAIN_KINDS)}")
+
+    factor = float(factor)
+    elapsed = np.clip(t - float(start_ns), 0.0, None)
+
+    if kind == "none":
+        curve = np.ones_like(t)
+    elif kind == "constant":
+        curve = np.where(t >= float(start_ns), factor, 1.0)
+    elif kind == "linear":
+        curve = 1.0 + factor * elapsed
+    elif kind == "exponential":
+        curve = np.exp(factor * elapsed)
+    else:  # db
+        curve = 10.0 ** (factor * elapsed / 20.0)
+
+    # Gain is never negative. A negative factor on linear or constant would
+    # otherwise cross zero and flip trace polarity partway down, which reads
+    # as a physical reflection that isn't there. Polarity inversion is a
+    # separate control if it's ever wanted, not a side effect of gain.
+    curve = np.clip(curve, 0.0, None)
+
+    if max_gain is not None:
+        curve = np.minimum(curve, float(max_gain))
+
+    return curve
+
+
+def apply_gain(
+    data: np.ndarray,
+    time_ns: np.ndarray,
+    kind: str,
+    factor: float = 1.0,
+    start_ns: float = 0.0,
+    max_gain: float | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Apply a gain curve down the time axis. Returns (gained, curve).
+
+    `data` is either one trace, shape (n_samples,), or a stacked B-scan
+    matrix, shape (n_samples, n_traces). Axis 0 is time in both cases, so
+    every trace in a matrix gets the identical curve.
+
+    The returned curve is always 1D and always the full sample length, ready
+    to plot on a second y-axis next to the gained trace.
+    """
+    arr = np.asarray(data, dtype=float)
+    t = np.asarray(time_ns, dtype=float)
+
+    if arr.ndim not in (1, 2):
+        raise ValueError(f"data must be 1D or 2D, got shape {arr.shape}")
+    if arr.shape[0] != t.shape[0]:
+        raise ValueError(
+            f"time axis has {t.shape[0]} samples, data has {arr.shape[0]} "
+            f"along axis 0 (data shape {arr.shape}) — a B-scan matrix must be "
+            f"(n_samples, n_traces)"
+        )
+
+    curve = gain_curve(t, kind, factor, start_ns, max_gain)
+    gained = arr * curve if arr.ndim == 1 else arr * curve[:, None]
+
+    return gained, curve
+
+
+def gain_label(
+    kind: str,
+    factor: float = 1.0,
+    start_ns: float = 0.0,
+    max_gain: float | None = None,
+) -> str:
+    """One-line description of a gain setting, for plot titles and CSV headers.
+
+    CSV export stays raw, so the header comment carrying this string is the
+    only record of what the plot the user was looking at actually showed.
+    """
+    kind = kind.lower()
+    if kind not in GAIN_KINDS:
+        raise ValueError(f"Unknown gain kind '{kind}'. Options: {list(GAIN_KINDS)}")
+
+    if kind == "none":
+        return "no gain"
+
+    if kind == "constant":
+        text = f"constant gain x{factor:g}"
+    else:
+        text = f"{kind} gain {factor:g} {GAIN_KINDS[kind]}"
+
+    if start_ns:
+        text += f" from {start_ns:g} ns"
+    if max_gain is not None:
+        text += f", clamped at x{max_gain:g}"
+
+    return text
+
+
+def remove_mean_trace(matrix: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Subtract the mean trace from every column. Returns (result, mean_trace).
+
+    The real-world background removal: with the antenna stepping across a
+    surface, the direct wave and any flat-layer reflection are identical in
+    every trace, so the across-trace mean is almost entirely that stationary
+    signal. Subtracting it leaves the target response.
+
+    This is the equivalent of target-minus-free-space subtraction for the
+    common case where no separate free-space simulation exists.
+    """
+    arr = np.asarray(matrix, dtype=float)
+    if arr.ndim != 2:
+        raise ValueError(f"matrix must be 2D (n_samples, n_traces), got shape {arr.shape}")
+
+    mean_trace = arr.mean(axis=1)
+    return arr - mean_trace[:, None], mean_trace

--- a/toolboxes/Marimo/processing.py
+++ b/toolboxes/Marimo/processing.py
@@ -268,3 +268,85 @@ def _moving_mean(arr: np.ndarray, window: int) -> np.ndarray:
         out[:, j] = (cumsum[:, hi] - cumsum[:, lo]) / (hi - lo)
 
     return out
+
+
+# Frequency domain
+
+
+def fft_spectrum(
+    waveform: np.ndarray,
+    dt: float,
+    positive_only: bool = True,
+) -> tuple[np.ndarray, np.ndarray, float | None]:
+    """Power spectrum of one trace. Returns (freqs_hz, power_db, peak_db).
+
+    The transform itself is gprMax's own `fft_power`, imported rather than
+    reimplemented so this stays consistent with `plot_Ascan.py`. Three things
+    about that function need handling at the call site:
+
+    1. It normalises each trace against its own maximum, so every spectrum
+       peaks at 0 dB no matter its absolute amplitude. Overlay a 1000 V/m
+       trace with a 3 A/m one and they look identical. `peak_db` is that
+       trace's absolute peak power in dB; adding it to `power_db` recovers
+       absolute values, which is what makes overlaid spectra comparable.
+    2. It returns the whole `fftfreq`, negative frequencies included, which
+       plots as a mirrored spectrum. `positive_only` slices to the first
+       half.
+    3. An all-zero trace produces -inf, which its own guard rewrites to 0,
+       which the shift then turns into a flat 0 dB line indistinguishable
+       from a real spectrum. Ex in a 2D TMz model is exactly this case.
+       `peak_db` is None for such a trace so the caller can say so instead
+       of drawing a meaningless flat line.
+
+    The import is deferred so that importing this module, and testing every
+    other function in it, does not require a built gprMax.
+    """
+    arr = np.asarray(waveform, dtype=float)
+    if arr.ndim != 1:
+        raise ValueError(f"waveform must be 1D, got shape {arr.shape}")
+    if arr.size == 0:
+        raise ValueError("waveform is empty")
+
+    from gprMax.utilities.utilities import fft_power
+
+    if not np.any(arr):
+        freqs = np.fft.fftfreq(arr.size, d=dt)
+        power = np.zeros(arr.size, dtype=float)
+        peak_db = None
+    else:
+        freqs, power = fft_power(arr, dt)
+        peak_db = float(10.0 * np.log10(np.max(np.abs(np.fft.fft(arr)) ** 2)))
+
+    if positive_only:
+        half = arr.size // 2
+        freqs, power = freqs[:half], power[:half]
+
+    return freqs, power, peak_db
+
+
+def spectrum_view_limit(
+    freqs: np.ndarray,
+    power_db: np.ndarray,
+    multiple: float = 4.0,
+) -> float:
+    """Upper frequency for a sensible default spectrum view, in Hz.
+
+    With dt around 4.7 ps the Nyquist frequency is above 100 GHz, while a
+    1.5 GHz antenna puts all of its energy in the first couple of percent of
+    that axis. Plotting to Nyquist shows a spike against a flat floor.
+
+    `plot_Ascan.py` solves this with `freqmaxpower * 4` as an array index,
+    which runs past the end of the array whenever the peak sits beyond a
+    quarter of the spectrum. Working in frequency and clamping to the
+    available maximum cannot overshoot.
+    """
+    if freqs.size == 0 or power_db.size == 0:
+        return 0.0
+
+    peak_hz = float(freqs[int(np.argmax(power_db))])
+    limit = multiple * peak_hz
+    available = float(np.max(freqs))
+
+    if limit <= 0.0 or limit > available:
+        return available
+    return limit

--- a/toolboxes/Marimo/processing.py
+++ b/toolboxes/Marimo/processing.py
@@ -4,30 +4,43 @@ processing.py: amplitude processing for gprMax traces and B-scan matrices.
 No marimo dependency, same principle as h5_reader.py and trace_matrix.py:
 pure numpy, testable with plain pytest, importable from any dashboard cell.
 
-Every function here works on a single A-scan trace, shape (n_samples,), and
-on an assembled B-scan matrix, shape (n_samples, n_traces) — the orientation
+Every function works on a single A-scan trace, shape (n_samples,), and on an
+assembled B-scan matrix, shape (n_samples, n_traces) — the orientation
 trace_matrix.stack_traces() produces. One implementation, not two, so a gain
 applied to a trace in ascan_dashboard.py and the same gain applied across a
 radargram in bscan_dashboard.py cannot drift apart.
 
 Gain functions return the applied curve alongside the gained data. A gained
-radargram without its curve is uninterpretable — the researcher has to be
-able to see what was done to the amplitudes, not just the result.
+radargram without its curve is uninterpretable — the researcher has to see
+what was done to the amplitudes, not just the result.
+
+Naming follows the GPR processing literature rather than inventing new terms:
+power gain t**b, exponential gain exp(a*t), and their product SEC (Spreading
+and Exponential Compensation), which is the gain most published GPR flows
+actually use. AGC is deliberately absent — it equalises amplitudes by local
+window and destroys relative reflectivity, which is the one thing an FDTD
+simulation gets exactly right and a field instrument does not.
+
+Standard processing order, which the dashboards follow:
+    background removal -> gain -> filtering -> display normalisation
 """
 
 from __future__ import annotations
 
 import numpy as np
 
-# Gain kind -> unit of its `factor` argument, for labels and slider captions.
-# Keys are the accepted `kind` values; build a dashboard dropdown from these
-# rather than hardcoding a second list somewhere.
-GAIN_KINDS: dict[str, str] = {
-    "none": "",
-    "constant": "x",
-    "linear": "per ns",
-    "exponential": "per ns",
-    "db": "dB per ns",
+# Gain kind -> UI metadata. Build the dashboard dropdown and decide which
+# sliders to show from this, rather than hardcoding a second list elsewhere.
+#   factor_unit  unit of the `factor` argument, None if unused
+#   uses_power   whether the `power` argument applies
+GAIN_KINDS: dict[str, dict] = {
+    "none": {"label": "None", "factor_unit": None, "uses_power": False},
+    "constant": {"label": "Constant", "factor_unit": "x", "uses_power": False},
+    "linear": {"label": "Linear", "factor_unit": "per ns", "uses_power": False},
+    "power": {"label": "Power (t^b)", "factor_unit": None, "uses_power": True},
+    "exponential": {"label": "Exponential", "factor_unit": "per ns", "uses_power": False},
+    "db": {"label": "dB", "factor_unit": "dB per ns", "uses_power": False},
+    "sec": {"label": "SEC (spreading + exponential)", "factor_unit": "per ns", "uses_power": True},
 }
 
 
@@ -35,25 +48,38 @@ def gain_curve(
     time_ns: np.ndarray,
     kind: str,
     factor: float = 1.0,
+    power: float = 1.0,
     start_ns: float = 0.0,
     max_gain: float | None = None,
 ) -> np.ndarray:
     """Build the time-varying amplification curve, shape (n_samples,).
 
-    `factor` means something different per kind, hence GAIN_KINDS:
-        none         ignored, curve is all ones
-        constant     flat multiplier applied from start_ns onward
-        linear       1 + factor * t, t in ns since start_ns
-        exponential  exp(factor * t)
-        db           10 ** (factor * t / 20), factor in dB per ns
+    With t the elapsed time in ns since `start_ns`:
+
+        none         1
+        constant     factor
+        linear       1 + factor * t
+        power        t ** power              spherical spreading compensation
+        exponential  exp(factor * t)         ohmic attenuation compensation
+        db           10 ** (factor * t / 20) same family, amplitude decibels
+        sec          exp(factor * t) * t ** power
+
+    SEC is the composition of the two physical corrections and is the gain
+    most published GPR processing flows use. Setting power=1 reduces its
+    spreading term to the textbook linear gain.
 
     Time before `start_ns` gets a gain of exactly 1.0 so the direct wave can
-    be left alone — amplifying it along with everything else just saturates
-    the colour scale on a B-scan and hides the reflections underneath.
+    be left alone. Amplifying it along with everything else saturates the
+    colour scale on a B-scan and buries the reflections underneath.
 
-    `max_gain` clamps the curve. Exponential gain over a few ns reaches
-    absurd numbers quickly (exp(5 * 3) is 3.3e6), so this is a real guard,
-    not defensive padding.
+    `max_gain` bounds the curve, which is standard practice — exponential
+    gain over a few ns reaches absurd numbers quickly (exp(5 * 3) is 3.3e6).
+
+    The power term is floored at 1.0 rather than evaluated as a bare t**b.
+    Bare t**b is zero at t=0 and below 1 for all t<1 ns, so on a 3 ns gprMax
+    window it would blank the first sample and attenuate the first third of
+    the trace — the opposite of what a gain is for. Flooring keeps t**b exact
+    everywhere it amplifies and holds at unity everywhere it would not.
     """
     t = np.asarray(time_ns, dtype=float)
     if t.ndim != 1:
@@ -64,6 +90,7 @@ def gain_curve(
         raise ValueError(f"Unknown gain kind '{kind}'. Options: {list(GAIN_KINDS)}")
 
     factor = float(factor)
+    power = float(power)
     elapsed = np.clip(t - float(start_ns), 0.0, None)
 
     if kind == "none":
@@ -72,10 +99,14 @@ def gain_curve(
         curve = np.where(t >= float(start_ns), factor, 1.0)
     elif kind == "linear":
         curve = 1.0 + factor * elapsed
+    elif kind == "power":
+        curve = _power_term(elapsed, power)
     elif kind == "exponential":
         curve = np.exp(factor * elapsed)
-    else:  # db
+    elif kind == "db":
         curve = 10.0 ** (factor * elapsed / 20.0)
+    else:  # sec
+        curve = np.exp(factor * elapsed) * _power_term(elapsed, power)
 
     # Gain is never negative. A negative factor on linear or constant would
     # otherwise cross zero and flip trace polarity partway down, which reads
@@ -94,6 +125,7 @@ def apply_gain(
     time_ns: np.ndarray,
     kind: str,
     factor: float = 1.0,
+    power: float = 1.0,
     start_ns: float = 0.0,
     max_gain: float | None = None,
 ) -> tuple[np.ndarray, np.ndarray]:
@@ -104,7 +136,7 @@ def apply_gain(
     every trace in a matrix gets the identical curve.
 
     The returned curve is always 1D and always the full sample length, ready
-    to plot on a second y-axis next to the gained trace.
+    to plot against the same time axis as the trace it was applied to.
     """
     arr = np.asarray(data, dtype=float)
     t = np.asarray(time_ns, dtype=float)
@@ -118,7 +150,7 @@ def apply_gain(
             f"(n_samples, n_traces)"
         )
 
-    curve = gain_curve(t, kind, factor, start_ns, max_gain)
+    curve = gain_curve(t, kind, factor, power, start_ns, max_gain)
     gained = arr * curve if arr.ndim == 1 else arr * curve[:, None]
 
     return gained, curve
@@ -127,6 +159,7 @@ def apply_gain(
 def gain_label(
     kind: str,
     factor: float = 1.0,
+    power: float = 1.0,
     start_ns: float = 0.0,
     max_gain: float | None = None,
 ) -> str:
@@ -142,10 +175,18 @@ def gain_label(
     if kind == "none":
         return "no gain"
 
+    unit = GAIN_KINDS[kind]["factor_unit"]
+
     if kind == "constant":
         text = f"constant gain x{factor:g}"
+    elif kind == "power":
+        text = f"power gain t^{power:g}"
+    elif kind == "sec":
+        text = f"SEC gain a={factor:g} {unit}, b={power:g}"
+    elif kind == "db":
+        text = f"dB gain {factor:g} {unit}"
     else:
-        text = f"{kind} gain {factor:g} {GAIN_KINDS[kind]}"
+        text = f"{kind} gain {factor:g} {unit}"
 
     if start_ns:
         text += f" from {start_ns:g} ns"
@@ -155,20 +196,75 @@ def gain_label(
     return text
 
 
-def remove_mean_trace(matrix: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    """Subtract the mean trace from every column. Returns (result, mean_trace).
+def remove_mean_trace(
+    matrix: np.ndarray,
+    window: int | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Subtract the average trace from every column. Returns (result, background).
 
-    The real-world background removal: with the antenna stepping across a
-    surface, the direct wave and any flat-layer reflection are identical in
-    every trace, so the across-trace mean is almost entirely that stationary
-    signal. Subtracting it leaves the target response.
+    With the antenna stepping across a surface, the direct wave and any
+    flat-layer reflection are identical in every trace, so the across-trace
+    mean is almost entirely that stationary signal. Subtracting it leaves the
+    target response. This is the equivalent of target-minus-free-space
+    subtraction for the case where no separate free-space run exists.
 
-    This is the equivalent of target-minus-free-space subtraction for the
-    common case where no separate free-space simulation exists.
+    `window` selects between the two conventions in the literature:
+        None      mean over all traces. Correct for a gprMax B-scan, where
+                  every trace comes from the identical model and the
+                  background is genuinely stationary.
+        int       mean over a moving window of that many traces, the
+                  convention for real survey lines where the background
+                  drifts along the profile.
+
+    The returned background is the full (n_samples, n_traces) array that was
+    subtracted when a window is used, and the single (n_samples,) mean trace
+    when it is not — in both cases exactly what was removed, so it can be
+    displayed rather than taken on trust.
     """
     arr = np.asarray(matrix, dtype=float)
     if arr.ndim != 2:
         raise ValueError(f"matrix must be 2D (n_samples, n_traces), got shape {arr.shape}")
 
-    mean_trace = arr.mean(axis=1)
-    return arr - mean_trace[:, None], mean_trace
+    if window is None:
+        background = arr.mean(axis=1)
+        return arr - background[:, None], background
+
+    window = int(window)
+    if window < 1:
+        raise ValueError(f"window must be at least 1 trace, got {window}")
+
+    background = _moving_mean(arr, window)
+    return arr - background, background
+
+
+# Private helpers
+
+
+def _power_term(elapsed: np.ndarray, power: float) -> np.ndarray:
+    """t**power, floored at 1.0. See gain_curve for why the floor is there."""
+    with np.errstate(divide="ignore", invalid="ignore"):
+        term = np.power(elapsed, power)
+    term = np.nan_to_num(term, nan=1.0, posinf=np.inf, neginf=1.0)
+    return np.maximum(term, 1.0)
+
+
+def _moving_mean(arr: np.ndarray, window: int) -> np.ndarray:
+    """Per-column mean over a moving window of columns, same shape as `arr`.
+
+    Windows are clamped at the profile ends rather than zero-padded, so edge
+    traces average over a full-width window of their nearest neighbours
+    instead of being biased toward zero.
+    """
+    n_traces = arr.shape[1]
+    width = min(window, n_traces)
+    half = width // 2
+
+    cumsum = np.concatenate([np.zeros((arr.shape[0], 1)), np.cumsum(arr, axis=1)], axis=1)
+
+    out = np.empty_like(arr)
+    for j in range(n_traces):
+        hi = min(n_traces, max(j - half, 0) + width)
+        lo = max(0, hi - width)
+        out[:, j] = (cumsum[:, hi] - cumsum[:, lo]) / (hi - lo)
+
+    return out

--- a/toolboxes/Marimo/processing.py
+++ b/toolboxes/Marimo/processing.py
@@ -350,3 +350,48 @@ def spectrum_view_limit(
     if limit <= 0.0 or limit > available:
         return available
     return limit
+
+
+def subtract_traces(
+    target: np.ndarray,
+    reference: np.ndarray,
+    dt_target: float | None = None,
+    dt_reference: float | None = None,
+    rtol: float = 1e-6,
+) -> np.ndarray:
+    """Elementwise `target - reference`, for isolating a buried target's response.
+
+    Run the model twice, once with the target and once without, and subtract.
+    What cancels is everything the two runs share: the source pulse, the direct
+    coupling between antennas, and any reflection from a flat interface. What
+    survives is the target.
+
+    Works on a single trace, shape (n_samples,), and on two B-scan matrices of
+    the same shape.
+
+    Both time steps should be passed whenever they are known. Checking the
+    sample count alone is not enough: two runs can produce the same number of
+    samples from different `#time_window` and `#dx_dy_dz` settings, in which
+    case the arrays line up index by index while representing different
+    instants, and the subtraction silently returns nonsense. Comparing dt
+    catches that.
+    """
+    a = np.asarray(target, dtype=float)
+    b = np.asarray(reference, dtype=float)
+
+    if a.shape != b.shape:
+        raise ValueError(
+            f"shape mismatch: target {a.shape}, reference {b.shape}. "
+            "Both runs must have the same iteration count."
+        )
+
+    if dt_target is not None and dt_reference is not None:
+        if not np.isclose(float(dt_target), float(dt_reference), rtol=rtol, atol=0.0):
+            raise ValueError(
+                f"time steps differ: target dt={float(dt_target):.6e} s, "
+                f"reference dt={float(dt_reference):.6e} s. The arrays are the same "
+                "length but their samples are at different instants, so subtracting "
+                "them index by index is meaningless."
+            )
+
+    return a - b

--- a/toolboxes/Marimo/requirements.txt
+++ b/toolboxes/Marimo/requirements.txt
@@ -1,0 +1,5 @@
+marimo>=0.9.0
+h5py>=3.0
+plotly>=5.0
+numpy>=1.21
+kaleido>=1.0

--- a/toolboxes/Marimo/trace_matrix.py
+++ b/toolboxes/Marimo/trace_matrix.py
@@ -1,0 +1,133 @@
+"""
+trace_matrix.py: stacks single-trace gprMax HDF5 files into a
+position x time matrix — the shared core behind both the B-scan heatmap
+and 3D surface views.
+
+No marimo dependency, same design principle as h5_reader.py: pure logic,
+testable with plain pytest, importable from any dashboard cell that needs
+it. Used by bscan_dashboard.py's live-polling path (one new trace per
+tick) and its load-files path (all traces at once).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from toolboxes.Marimo.h5_reader import (
+    FileData,
+    get_time_axis,
+    get_trace,
+    list_components,
+    list_receivers,
+)
+
+ProcessedTrace = dict[str, Any]
+# success: {"ok": True, "component", "receiver", "array", "time_ns", "x",
+#           "known_components"}
+# failure: {"ok": False, "reason", "known_components"}
+
+StackResult = dict[str, Any]
+# {"matrix": np.ndarray | None, "positions_x": list[float],
+#  "time_ns": np.ndarray | None, "component": str | None,
+#  "receiver": str | None, "all_positions_physical": bool,
+#  "warnings": list[str]}
+
+
+def process_trace(
+    file_data: FileData,
+    preferred_component: str | None,
+    expected_len: int | None,
+    preferred_receiver: str | None = None,
+) -> ProcessedTrace:
+    """Validate and extract one column from a loaded single-trace file.
+
+    `expected_len`, if given, must match the trace's sample count — this
+    is what catches a run where dt or iteration count drifted mid-sequence.
+    `preferred_receiver` picks a specific receiver key when the file has
+    more than one; falls back to the first receiver found otherwise.
+    """
+    rxs = list_receivers(file_data)
+    rx = preferred_receiver if preferred_receiver in rxs else (rxs[0] if rxs else "rx1")
+    comps = list_components(file_data, rx)
+
+    if not comps:
+        return {"ok": False, "reason": "no field components found", "known_components": comps}
+
+    comp = preferred_component if preferred_component in comps else (
+        "Ez" if "Ez" in comps else comps[0]
+    )
+    arr = get_trace(file_data, comp, rx)
+
+    if expected_len is not None and len(arr) != expected_len:
+        return {
+            "ok": False,
+            "reason": f"{len(arr)} samples vs expected {expected_len}",
+            "known_components": comps,
+        }
+
+    sources = file_data.get("sources", {})
+    x = sources["src1"]["position"][0] if "src1" in sources else None
+
+    return {
+        "ok": True,
+        "component": comp,
+        "receiver": rx,
+        "array": arr,
+        "time_ns": get_time_axis(file_data, unit="ns"),
+        "x": x,
+        "known_components": comps,
+    }
+
+
+def stack_traces(
+    file_datas: list[FileData],
+    preferred_component: str | None = None,
+    preferred_receiver: str | None = None,
+) -> StackResult:
+    """Stack already-loaded single-trace files into a matrix, in the order
+    given. Ordering is the caller's decision — by trace number for a live
+    sequential run, by physical position for a hand-picked file set.
+
+    Skips traces with no usable component or a sample-count mismatch
+    against the first accepted trace, recording why in `warnings` rather
+    than raising, since one bad file shouldn't kill the whole assembly.
+    """
+    cols: list[np.ndarray] = []
+    xpos: list[float] = []
+    warnings: list[str] = []
+    time_ns = None
+    component = preferred_component
+    receiver = None
+    all_physical = True
+
+    for i, fdata in enumerate(file_datas):
+        expected_len = len(cols[0]) if cols else None
+        result = process_trace(fdata, component, expected_len, preferred_receiver)
+
+        if not result["ok"]:
+            warnings.append(f"trace {i}: {result['reason']} — skipped")
+            continue
+
+        component = result["component"]
+        receiver = result["receiver"]
+        if time_ns is None:
+            time_ns = result["time_ns"]
+
+        x = result["x"]
+        if x is None:
+            all_physical = False
+
+        cols.append(result["array"])
+        xpos.append(x if x is not None else float(i))
+
+    return {
+        "matrix": np.column_stack(cols) if cols else None,
+        "positions_x": xpos,
+        "time_ns": time_ns,
+        "component": component,
+        "receiver": receiver,
+        "all_positions_physical": all_physical,
+        "warnings": warnings,
+    }


### PR DESCRIPTION
Builds on #696 (A-scan dashboard + `h5_reader.py`) and #720 (B-scan dashboard). Both are unmerged, so their commits and files appear in this diff. New files here are `toolboxes/Marimo/processing.py`, `tests/test_processing.py` and `examples/cylinder_Ascan_2D_freespace.in`.

## Summary

`processing.py` is a marimo-free numpy module holding the amplitude processing for both dashboards. One implementation is used for a single A-scan trace and for a full B-scan matrix, so the two cannot drift apart.

**Gain.** Constant, linear, power (`t^b`), exponential (`exp(a·t)`), dB per ns, and SEC (`exp(a·t) · t^b`). SEC is the gain most published GPR flows use; `b=1` reduces its spreading term to the textbook linear gain. Gain onset is adjustable so the direct wave can be left alone instead of saturating the plot, and the curve can be bounded. The applied curve is plotted in its own panel below the figure in both dashboards.

**Free-space subtraction.** Run the model twice, once with the target and once without, and subtract. What cancels is everything the two runs share: the source pulse, the direct coupling between antennas, and any flat-interface reflection. What survives is the target. `examples/cylinder_Ascan_2D_freespace.in` is included so this is testable without constructing the reference run by hand. On the standard example the cylinder response is about 12% of the direct wave and effectively invisible; after subtraction it is the largest feature in the trace.

**Background removal.** Mean-trace subtraction across a B-scan, globally or over a moving window of traces. This is the equivalent of the above for real survey data, where no free-space run exists. Global is the default: every trace in a gprMax B-scan comes from the identical model, so the background is genuinely stationary. The window matches the convention for survey lines where it drifts along the profile.

**FFT.** Frequency-domain toggle on the A-scan dashboard, using `fft_power` from `gprMax/utilities/utilities.py` rather than reimplementing the transform.

Processing order is subtraction and background removal, then gain, then display normalisation. Gaining first amplifies the stationary direct wave and leaves a larger residual for the subtraction to cancel.

## Design notes

Subtraction is treated as a data operation and gain as a display one, which is why subtraction also applies to the spectrum and gain does not. Gain multiplies in time, which convolves in frequency, so a centre frequency read off a gained spectrum would be wrong. Subtraction isolates the signal you actually want to analyse, so its spectrum is the meaningful one.

CSV export always contains the untouched file contents. Every CSV writes a first line recording what was applied, including when nothing was, so the format never changes depending on a UI setting. In frequency domain the CSV holds the spectrum at full resolution regardless of the view range, and the first line says so.

`subtract_traces` checks the time step as well as the sample count. Two runs can produce the same iteration count from different `#time_window` or `#dx_dy_dz` settings, in which case the arrays line up index by index while representing different instants and the subtraction silently returns nonsense. Length alone would pass. A trace whose own file is the reference is left alone rather than zeroed, and a component missing from the reference leaves that trace unsubtracted with a note rather than failing the render.

AGC is deliberately absent. It equalises amplitudes over a local window and destroys relative reflectivity, which is the one thing an FDTD simulation gets right and a field instrument does not.

The power term is floored at 1.0 rather than evaluated as a bare `t^b`, which is zero at `t=0` and below 1 for all `t<1 ns`. On a 3 ns window that would blank the first sample and attenuate the first third of the trace. Flooring keeps `t^b` exact everywhere it amplifies.

Gain onset is stored as a percentage of the time window, not an absolute time. An ns-valued control would depend on the loaded data, so it would be rebuilt and reset whenever a trace was added or, on the live B-scan, whenever a new trace arrived mid-run.

## Notes on existing code

`fft_power` normalises each trace against its own maximum before returning, so every spectrum peaks at 0 dB regardless of absolute amplitude and two traces 20x apart plot identically when overlaid. The dashboard offers a shared reference that recovers the true ratio, computed within each unit family since a decibel difference between V/m and A/m is not a physical statement.

An all-zero trace produces `-inf` on the same path, which the function's own guard rewrites to 0 and the shift turns into a flat 0 dB line indistinguishable from real data. `Ex` in a 2D TMz model is exactly this case. The dashboard names such traces instead of drawing them.

The `freqmaxpower * 4` view fallback in `toolboxes/Plotting/plot_Ascan.py` is applied as an array index and can run past the end of the array when the peak sits beyond a quarter of the spectrum. `spectrum_view_limit()` does the same thing in frequency and clamps.

## Tests

68 tests in `tests/test_processing.py`. Guards are mutation-tested: removing the gain broadcast axis, the negative-gain clip, the gain-onset floor, the power floor, the moving-window edge clamp, the subtraction shape check or the subtraction time-step check each fails at least one named test.

`processing.py` has no marimo dependency and the `fft_power` import is deferred, so the module and most of its tests run on a checkout without a built gprMax. The FFT tests skip rather than fail.

## How to test

`plotly_get_chrome` is needed once for the SVG and PDF buttons. The camera icon in the plot toolbar works without it.

```
pytest tests/test_processing.py -v
```

**Gain and the curve panel**

```
python -m gprMax examples/cylinder_Ascan_2D.in
marimo run toolboxes/Marimo/ascan_dashboard.py
```

Load `cylinder_Ascan_2D.h5` and add `Ez`. Under Step 5 pick any gain. The curve appears below the plot on a log axis, the y-axis label gains a `(gained)` marker, and the title records the settings. At 6 dB per ns the curve reads 1.41 at 0.5 ns and 7.94 at 3 ns, which is `10^(6t/20)`. Raise the gain start and the curve stays flat at 1 before it. Download the CSV and confirm the first line records the gain while the values below are unchanged from the ungained export.

**Free-space subtraction**

```
python -m gprMax examples/cylinder_Ascan_2D_freespace.in
```

Load both `.h5` files, add `Ez` from `cylinder_Ascan_2D.h5`, then pick the free-space file in Step 1b. The direct wave near 1.1 ns cancels and the cylinder reflection near 2.2 ns becomes the largest feature. The title records the subtraction and the CSV first line says the exported values do not have it applied.

**FFT**

Add `Hx` and `Ex`, then switch Step 6 to Frequency. `Ex` is listed in a warning callout rather than drawn. The view auto-ranges to about 6.7 GHz out of a 105 GHz Nyquist and both spectra peak near 1.5 GHz, matching the source. Tick "Show full spectrum to Nyquist" to see why the auto-range exists.

**Background removal and gain on a radargram**

```
python -m gprMax examples/cylinder_Bscan_2D.in -n 60
marimo run toolboxes/Marimo/bscan_dashboard.py
```

Use Part 2 and select the 60 trace files. Under Step 10b tick background removal: the direct wave disappears and the hyperbola is left. Then set gain to SEC. The title records both operations in the order applied, and the CSV first line repeats it while the matrix below stays raw. Part 1 takes the same controls against a live run.

## Screenshots
<img width="1476" height="972" alt="Screenshot 2026-08-20 at 3 49 02 AM" src="https://github.com/user-attachments/assets/bdc16088-3ed5-46d2-baa9-b9541ceb3aa0" />
<img width="1129" height="659" alt="Screenshot 2026-08-20 at 1 44 54 PM" src="https://github.com/user-attachments/assets/a2648c13-6290-4eda-8dd6-1d8a052d0a3f" />
<img width="1547" height="1008" alt="Screenshot 2026-08-20 at 1 55 19 PM" src="https://github.com/user-attachments/assets/d277a533-5570-40cc-82ec-4c23274ebe81" />
<img width="1476" height="972" alt="Screenshot 2026-08-21 at 2 19 14 AM" src="https://github.com/user-attachments/assets/2982cf8a-3c86-4f64-87bf-c2aaed9af2fe" />


