### PR TITLE
feat(eigenmode): expand multiport antenna workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ gprMax/cython/fields_updates_dispersive.pyx
 # build, dist and egg-info directories
 build/
 dist/
+target/
 *.egg-info/
 docs/.buildinfo
 
@@ -57,5 +58,8 @@ cov.xml
 # IDEs
 .idea/
 .vscode/
+
+# Agents
+AGENTS.md
 .codex_tmp
-target/
+

--- a/docs/source/eigenmode_port.rst
+++ b/docs/source/eigenmode_port.rst
@@ -11,13 +11,13 @@ one field component. One shared ``#eigenmode_band`` defines the DFT bins and
 ``#eigenmode_port`` defines every active or passive reference plane. One
 ``#eigenmode_excitation`` produces one S-matrix column. Several excitation
 commands may instead drive a deliberate array state with independent modal
-amplitudes, phases, or delays; that run writes incident and outgoing modal
-waves, but does not label them as S-parameters. Excitation may be omitted only
+amplitudes, phases, or delays; that run writes incident/outgoing waves and
+the active reflection coefficient at every driven channel. Excitation may be omitted only
 when every port has a passive ``#virtual_waveguide``; that passive-only form
 also writes raw modal spectra but no S matrix.
 
-Start with the three examples
-=============================
+Start with the six examples
+============================
 
 If your main goal is to calculate S-parameters, start in
 ``examples/features/eigenmode_ports``. The examples are numbered in the order
@@ -38,7 +38,16 @@ they should be used:
      - Reflection and conversion between monitored modes
    * - ``example_3_antenna_and_farfield``
      - Rectangular-waveguide-fed pyramidal horn
-     - S11, a 3D far field, and E-/H-plane antenna patterns
+     - Matched virtual feed, closed NTFF, S11, and antenna patterns
+   * - ``example_4_complete_s_matrix``
+     - Two-port gapped microstrip carrying its dominant quasi-TEM mode
+     - The complete 2 by 2 S matrix and a reciprocity check from one reusable build
+   * - ``example_5_phased_array``
+     - Four-element waveguide antenna array
+     - Active S-parameters and a dense xy-plane beam-squint cut
+   * - ``example_6_near_cutoff``
+     - Rectangular guide across TE10 cutoff
+     - Dense cutoff anchors and explicit coefficient/power validity
 
 Run the commands below from the repository root. Output is written beside each
 input so that the no-argument plotting scripts can find it.
@@ -81,6 +90,25 @@ The three eigenmode commands provide the S-parameter setup:
 ``#eigenmode_band`` defines one frequency grid shared by every port: 21 points
 from 4 to 6 GHz. Sharing the bins is important because an S-parameter compares
 incident and outgoing waves at the same frequency.
+
+Optional frequencies may follow the uniform point count:
+
+.. code-block:: none
+
+   #eigenmode_band: eigenmode_band 4e9 6e9 21 4.25e9 4.75e9 5.25e9
+
+gprMax sorts and deduplicates the union of the uniform grid and these trailing
+values. They are additional direct-DFT/output bins at every eigenmode port,
+not modal field-solve anchors. Anchor selection remains the final ``auto`` or
+explicit frequency list on each ``#eigenmode_port``. The equivalent Python API
+is ``EigenmodeBand(..., frequencies=(4.25e9, 4.75e9, 5.25e9))``.
+
+When ``#ntff_antenna_ports`` uses modal incident and accepted power, every
+``#ntff_frequency`` value must be present in this final eigenmode DFT union.
+The NTFF grid may be a strict subset: a dense modal grid can therefore produce
+smooth S-parameter traces while NTFF fields and patterns are evaluated only at
+selected frequencies. If a desired NTFF value does not fall on the uniform
+grid, append it to ``#eigenmode_band`` as shown above.
 
 Each ``#eigenmode_port`` supplies a unique port number, two corners of its
 cross-section, a direction pointing *into* the device, the modes to monitor,
@@ -191,116 +219,6 @@ Try changing one thing at a time:
   conversion terms are no longer available; the unmeasured field has not
   physically disappeared.
 
-Build the complete modal S matrix without rebuilding
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-A normal run excites the single port and mode selected by
-``#eigenmode_excitation`` and therefore produces one column of a modal S
-matrix. To characterize every declared port/mode channel, add an eigenmode
-study whose CSV selects each channel exactly once:
-
-.. code-block:: text
-
-   case_id,object_id,port,mode
-   p1m1,eigenmode_excitation_1,1,1
-   p1m2,eigenmode_excitation_1,1,2
-   p2m1,eigenmode_excitation_1,2,1
-   p2m2,eigenmode_excitation_1,2,2
-
-Reference it from the input file with:
-
-.. code-block:: none
-
-   #study: eigenmode modal_cases.csv
-
-gprMax solves the FDFD modal anchors for every port during the first geometry
-build. Each later case resets the FDTD fields, modal DFT phases and
-accumulators, and any virtual-waveguide fields and PML histories, then
-synthesizes the selected source from the cached phase-aligned modal basis. It
-does not repeat the FDFD solves. This works when the complete eigenmode setup
-belongs either to the main grid or to one HSG subgrid; ports from different
-grids cannot be combined in one modal study.
-
-Every monitor records its incident and outgoing waves in every case, including
-small residual incident waves at nominally passive terminations. With the case
-vectors arranged as columns,
-
-.. math::
-
-   A(f) = [a^{(1)}(f)\;\cdots\;a^{(N)}(f)], \qquad
-   B(f) = [b^{(1)}(f)\;\cdots\;b^{(N)}(f)],
-
-the aggregate response is defined by :math:`B=SA`. gprMax solves the
-transposed linear system for :math:`S` at each frequency rather than assuming
-that :math:`A` is diagonal. The same operation converts the raw NTFF run
-fields into embedded modal fields. Frequencies with an incomplete or
-ill-conditioned incident basis are marked invalid; the raw matrices and
-condition number remain in the aggregate output for diagnosis.
-
-Drive several ports or modes together
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Use repeated excitation commands for a prescribed array or multimode state:
-
-.. code-block:: none
-
-   #eigenmode_excitation: 1 1 auto 1 0 0
-   #eigenmode_excitation: 2 1 auto 0.70710678 90 0
-
-Every drive must use the same base waveform. A physical port is solved and
-monitored once even when more than one of its modes is driven. The complex
-spectral multiplier for drive :math:`q` is
-
-.. math::
-
-   d_q(f) = A_q \exp\!\left(j\phi_q\right)
-            \exp\!\left(-j2\pi f\tau_q\right),
-
-where :math:`A_q` is the amplitude, :math:`\phi_q` is the constant phase, and
-:math:`\tau_q` is a true time delay. A constant phase is normally used for a
-phase-steered array at its design frequency; a non-zero delay gives the
-frequency-linear phase required for true-time-delay steering. In the Python
-API, ``power=P`` may replace ``amplitude=A`` and uses :math:`A=\sqrt{P}``.
-Because every modal profile is power-normalized, :math:`P` is the relative
-per-frequency incident-power scale applied to the common waveform spectrum;
-it is not the time-integrated energy of the finite pulse.
-
-The superposed response is a driven state, not a column of the independently
-excited S matrix. Its HDF5 port groups retain ``incident`` and ``outgoing``
-waves and record ``ResponseType=driven``, ``ExcitationModes``, drive
-amplitudes, powers, phases, delays, and waveform IDs. They deliberately omit
-``S`` and no ``*_sparameters.csv`` is written. Use ``EigenmodeStudy`` when the
-complete S matrix is required, then apply arbitrary weights to that matrix or
-to separately stored embedded far-field responses in post-processing.
-
-An NTFF transform may also be evaluated directly for the simultaneous state.
-Its fields, pattern, and directivity are those of the coherent superposition.
-When every physical port is associated with the transform, incident power is
-summed over the driven modal subspaces using the full modal power matrices,
-including off-diagonal cross terms; net accepted power is summed over all
-active and passive ports. Gain and realized gain therefore describe that
-particular driven state, not an embedded element or an S-matrix column.
-
-The per-case files identify their input port and mode. The aggregate
-``<output>_study.h5`` stores the complete matrix using
-``S[frequency, output_channel, input_channel]``; ``channel_ports`` and
-``channel_modes`` map both channel axes. This aggregate matrix is the
-full-incident-matrix de-embedded result; a per-case ``S_column`` is only the
-single-source-normalized run diagnostic. The physical and generalized
-validity masks remain separate. Use ``-i N`` to restart at case ``N`` while
-retaining compatible raw cases already stored in the aggregate file. The
-Python API additionally provides modal power/phase/delay weights for array
-synthesis. A versioned JSON codebook can evaluate and store many named states
-without rerunning FDTD, and can opt into retaining complex embedded NTFF
-fields plus the full-sphere basis required for coherent gain/directivity
-normalisation. Hash-command models use ``#array_codebook: file.json``; see
-:ref:`input-api`.
-
-The independent study cases and their NTFF transforms run on the selected CPU,
-CUDA, OpenCL, or Metal solver. Codebook weighting is deliberately a host-side
-post-processing operation on the retained complex responses, so it introduces
-no codebook-specific field arrays or kernels on an accelerator.
-
 Example 2: a curved waveguide
 -----------------------------
 
@@ -354,16 +272,33 @@ waveguide. Further ``#box`` commands form nine expanding hollow sections, and
 ``#plate`` commands close the annular faces between them. Together they are a
 closed, staircased approximation of a pyramidal horn. The eigenmode port lies
 in the uniform feed and launches its fundamental TE10-like mode over
-8--12 GHz. One explicit 10 GHz anchor deliberately uses a fixed modal basis;
-the automatic waveform's small spectral tails extend below the guide cutoff,
-where the mode cannot supply a propagating one-watt source anchor.
+8--12 GHz. Its 101-point uniform DFT sweep has 40 MHz spacing, so the requested
+8.5, 9.5, 10.5, and 11.5 GHz NTFF values would otherwise fall between modal
+bins. The trailing values on ``#eigenmode_band`` add those four bins; the other
+listed NTFF values already coincide with uniform bins and are removed by
+deduplication. The resulting eigenmode grid therefore has 105 frequencies,
+while the NTFF transform uses only its nine-frequency subset.
+
+The ``auto`` on ``#eigenmode_port`` is a separate setting: it selects and
+tracks enough modal field-solve anchors to represent the broadband TE10-like
+profile and the automatic waveform's significant spectrum. It does not define
+the 105 DFT/output frequencies. Because the generated waveform has a small
+spectral guard below TE10 cutoff, this example may report a low-overlap or
+non-propagating guard-anchor warning. The tracked evanescent profile remains
+available as a generalized monitor reference, but gprMax excludes it from
+one-watt source synthesis; the requested 8--12 GHz source band remains
+propagating.
 
 The remaining commands request antenna results:
 
-* ``#ntff_surface ... x0`` encloses the horn with a five-face equivalent-current
-  surface. Its feed-side ``x0`` face is deliberately omitted.
-* ``#ntff_frequency`` uses exactly the same frequency bins as
-  ``#eigenmode_band``. This equality is required for gain normalization.
+* ``#virtual_waveguide`` continues the guide behind its internal port plane
+  and absorbs reflected guided waves outside the main FDTD domain.
+* ``#ntff_surface`` encloses the complete physical antenna with all six
+  equivalent-current faces in homogeneous air.
+* Every ``#ntff_frequency`` bin must be present in the final
+  ``#eigenmode_band`` DFT union. The NTFF bins may be a strict subset; gain
+  normalization selects only their matching modal incident- and
+  accepted-power samples.
 * ``#ntff_antenna_ports`` identifies the modal feed whose incident and accepted
   powers normalize gain and realized gain.
 * ``#ntff_far_field_array`` requests a full-sphere angular grid and the field,
@@ -372,23 +307,23 @@ The remaining commands request antenna results:
 * ``#geometry_view`` writes the staircased horn geometry for inspection in
   ParaView.
 
-Why the feed crosses the PML and NTFF face
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Why the virtual feed permits a closed NTFF surface
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The uniform waveguide continues directly through the model's negative-x PML;
-it is not terminated by a metal wall inside the model. A reflected guide wave
-can therefore leave and be absorbed instead of reflecting from an artificial
-short circuit. The eigenmode source is outside the Huygens volume, and the
-feed crosses its omitted ``x0`` face. If that face were included, its sampled
-surface would intersect the guide and the equivalent-current radiation
-integral would not represent a closed surface in homogeneous free space.
+Traditionally, the uniform guide must extend through a domain PML so reflected
+guide waves see a matched termination. A Huygens surface then omits the face
+crossed by the guide. That open surface discards the field contribution through
+the opening and cannot be used by the Ramahi/KSIR formulation, which requires
+all six physical faces.
 
-An omitted face also omits any real radiated or evanescent field crossing that
-opening. Keep the horn transition well away from it. For higher accuracy,
-lengthen the uniform feed between the omitted face and the horn throat, move
-the omitted face farther back along that uniform section, and confirm that the
-far field changes negligibly. The feed should still pass continuously into
-the PML.
+Here the physical guide begins at the internal port plane. The auxiliary
+virtual waveguide continues behind it, contains the source, and absorbs the
+returning guided wave. The main-domain region behind the port is therefore
+homogeneous air, so the NTFF ``x0`` face closes without intersecting metal or
+the port aperture. This gives both a matched port and a closed NTFF surface.
+The same closed surface can be used for equivalent-current or Ramahi/KSIR
+outputs. KSIR compatibility is determined only by surface closure; an
+eigenmode source adds no separate incompatibility rule.
 
 Inspect, run, and plot the horn
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -439,10 +374,241 @@ directivity and gain indicates loss or incomplete radiation accounting.
    3D FDTD run because there are eight times more cells and about twice as many
    time steps.
 
-Useful convergence experiments are to lengthen the uniform feed, move or
-enlarge the sampled NTFF faces while keeping them outside the PML, refine the
-mesh, and lengthen the time window. Change only one quantity per run so that a
-shift in S11 or the far field has a clear cause.
+Useful convergence experiments are to change the physical throat length and
+virtual-guide length/PML thickness, move or enlarge the sampled NTFF faces
+while keeping them outside the PML, refine the mesh, and lengthen the time
+window. Change only one quantity per run so that a shift in S11 or the far
+field has a clear cause.
+
+Example 4: build the complete dominant-mode S matrix without rebuilding
+-------------------------------------------------------------------------
+
+Example 4 turns the reusable-study workflow into a complete runnable
+two-port microstrip model. A centred 2 mm series gap provides a simple
+capacitive discontinuity, so the result contains non-trivial reflection and
+transmission. The strip carries only its dominant quasi-TEM mode, so there is
+one modal channel at each physical port. The shared band requests 101 DFT
+frequencies from 4 to 8 GHz:
+
+.. literalinclude:: ../../examples/features/eigenmode_ports/example_4_complete_s_matrix/complete_s_matrix.in
+   :language: none
+   :caption: ``example_4_complete_s_matrix/complete_s_matrix.in``
+   :linenos:
+
+Its two cases select each declared channel exactly once:
+
+.. literalinclude:: ../../examples/features/eigenmode_ports/example_4_complete_s_matrix/modal_cases.csv
+   :language: text
+   :caption: ``example_4_complete_s_matrix/modal_cases.csv``
+
+Run the input once, then plot the aggregate result:
+
+.. code-block:: console
+
+   python -m gprMax examples/features/eigenmode_ports/example_4_complete_s_matrix/complete_s_matrix.in -outputfile examples/features/eigenmode_ports/example_4_complete_s_matrix/complete_s_matrix
+   python examples/features/eigenmode_ports/example_4_complete_s_matrix/plot_results.py
+
+Each microstrip feed remains uniform from its reference plane through the
+x-directed domain PML, which gives each inward-pointing port a matched
+continuation while keeping the gap between the reference planes. The first
+case builds the geometry and solves, tracks, and phase-aligns every modal
+anchor. The second case resets the FDTD fields, DFT accumulators, and PML
+histories, but reuses that built geometry and modal basis. The result is
+``complete_s_matrix_study.h5``, with
+``S[frequency, output_channel, input_channel]``. ``channel_ports`` and
+``channel_modes`` identify the two matrix axes. Driving port 1 supplies
+:math:`S_{11}` and :math:`S_{21}`; driving port 2 supplies :math:`S_{12}` and
+:math:`S_{22}`.
+
+The solver retains the full measured incident matrix :math:`A`, including
+small incident waves at nominally passive ports, and solves :math:`B=SA`.
+This is more accurate than dividing every response by only the nominal source
+coefficient. If the incident basis is incomplete or ill-conditioned, the
+corresponding matrix bins are marked invalid while :math:`A`, :math:`B`, and
+the condition number remain available for diagnosis. Use ``-i N`` to restart
+an interrupted study at case ``N``; a compatible existing aggregate retains
+the already completed cases.
+
+This example also demonstrates Lorentz reciprocity. For a linear,
+time-invariant structure made from reciprocal materials, and with consistent
+modal normalization, reference planes, and phase conventions, the modal
+scattering matrix is symmetric:
+
+.. math::
+
+   S_{ij}=S_{ji}, \qquad \text{and therefore}\qquad S_{21}=S_{12}.
+
+The plotting script gives :math:`S_{11}`, :math:`S_{21}`, :math:`S_{12}`, and
+:math:`S_{22}` separate panels, each with magnitude and unwrapped phase. Compare
+both the magnitude and phase panels for :math:`S_{21}` and :math:`S_{12}` to
+observe reciprocity directly; magnitude alone is a weaker check because it can
+hide a phase-reference error. Reciprocity does not, by itself, require
+:math:`S_{11}=S_{22}`. This centred gap additionally has port-exchange
+symmetry, so the two reflection responses should also agree. Magnetically
+biased non-reciprocal media, time variation, and nonlinear operation fall
+outside this reciprocal result.
+
+Example 5: drive an array and plot active S-parameters and beam squint
+------------------------------------------------------------------------
+
+Example 5 uses four virtual-waveguide-fed open-ended guides as a linear array:
+
+.. literalinclude:: ../../examples/features/eigenmode_ports/example_5_phased_array/phased_array.in
+   :language: none
+   :caption: ``example_5_phased_array/phased_array.in``
+   :linenos:
+
+Its eigenmode band first creates ten uniform S-parameter bins and then appends
+9, 10, and 11 GHz explicitly. After sorting and deduplication, that denser
+modal grid contains every 8, 9, 10, 11, and 12 GHz NTFF bin. NTFF gain and
+efficiency use only those matching modal-power samples; the additional modal
+bins remain available in the active-S CSV.
+
+Only the plotted :math:`\theta=90` degree xy-plane cut is stored, with a dense
+one-degree :math:`\phi` spacing. Directivity, gain, and efficiency still need
+total radiated power: gprMax evaluates a coarser full sphere internally for
+that normalization and discards the temporary sphere instead of writing it to
+the HDF5 file.
+
+Repeated ``#eigenmode_excitation`` commands may target several ports or several
+modes on one port. Every drive uses the same base waveform. Its complex
+spectral multiplier is
+
+.. math::
+
+   d_q(f)=A_q\exp(j\phi_q)\exp(-j2\pi f\tau_q),
+
+where :math:`A_q`, :math:`\phi_q`, and :math:`\tau_q` are its amplitude,
+constant phase, and true time delay. The Python API may specify ``power=P``
+instead of ``amplitude=A`` and uses :math:`A=\sqrt{P}`. A physical port is
+solved and monitored once even when several of its modes are driven.
+
+Run and plot it with:
+
+.. code-block:: console
+
+   python -m gprMax examples/features/eigenmode_ports/example_5_phased_array/phased_array.in --geometry-only
+   python -m gprMax examples/features/eigenmode_ports/example_5_phased_array/phased_array.in -outputfile examples/features/eigenmode_ports/example_5_phased_array/phased_array
+   python examples/features/eigenmode_ports/example_5_phased_array/plot_results.py
+
+The four equal-amplitude drives use a constant progressive phase
+:math:`\Delta\phi=-108` degrees and an element spacing :math:`d=18` mm. For
+the phase convention used in the input, the ideal uniform-array-factor maximum
+in the xy plane obeys
+
+.. math::
+
+   \sin\phi_{\mathrm{AF}}(f)
+   =-\frac{\Delta\phi}{k_0(f)d},
+   \qquad k_0(f)=\frac{2\pi f}{c},
+
+where :math:`\Delta\phi` is expressed in radians and positive :math:`\phi`
+points from +x toward +y. This predicts 38.7, 33.7, 30.0, 27.0, and 24.6
+degrees at 8, 9, 10, 11, and 12 GHz. Because a fixed phase shift is not a true
+time delay, the predicted angle moves toward broadside as frequency rises:
+this is beam squint.
+
+On the reference 1 mm FDTD mesh, the sampled forward-hemisphere peaks are
+approximately 35, 32, 28, 25, and 23 degrees. They need not exactly equal the
+array-factor angles because the radiating apertures have a non-isotropic
+element pattern, interact through mutual coupling, and are represented on a
+finite grid. The plot labels both angles and places these cuts beside the four
+driven-port active-reflection traces so antenna engineers can see mismatch and
+beam squint from the same coherent array state. Treat the one-degree sampled
+peaks as a visual demonstration rather than converged antenna data.
+
+An ordinary matrix entry :math:`S_{ij}` is the outgoing wave at channel
+:math:`i` divided by the independent incident wave at channel :math:`j`, with
+all other independent drives zero (or after the full incident matrix has been
+de-embedded). It is a property of the linear multiport. For a simultaneous
+incident vector :math:`\mathbf a`, the active reflection at a driven channel is
+
+.. math::
+
+   \Gamma_{\mathrm{active},i}(f) = \frac{b_i(f)}{a_i(f)}
+   = \frac{[S(f)\mathbf a(f)]_i}{a_i(f)}.
+
+It therefore depends on the chosen amplitudes, phases, and delays. It is the
+appropriate input-match result for this array state, but it is not a column of
+the S matrix and cannot replace the independent cases needed to recover the
+complete matrix. A simultaneous run writes
+``phased_array_active_sparameters.csv`` rather than inventing a new
+``F``-parameter definition. The HDF5 port groups retain the raw waves and add
+``active_S`` plus explicit coefficient- and power-validity masks.
+
+Example 6: calculate S-parameters near and below cutoff
+-------------------------------------------------------
+
+Example 6 crosses the analytical TE10 cutoff of a 6 mm wide rectangular
+guide:
+
+.. literalinclude:: ../../examples/features/eigenmode_ports/example_6_near_cutoff/near_cutoff.in
+   :language: none
+   :caption: ``example_6_near_cutoff/near_cutoff.in``
+   :linenos:
+
+Run and plot it with:
+
+.. code-block:: console
+
+   python -m gprMax examples/features/eigenmode_ports/example_6_near_cutoff/near_cutoff.in --geometry-only
+   python -m gprMax examples/features/eigenmode_ports/example_6_near_cutoff/near_cutoff.in -outputfile examples/features/eigenmode_ports/example_6_near_cutoff/near_cutoff
+   python examples/features/eigenmode_ports/example_6_near_cutoff/plot_results.py
+
+Near cutoff, :math:`\beta` and modal impedance vary too rapidly for a sparse
+pair of anchors on opposite sides of cutoff. The example places anchors at
+every requested below-cutoff point, at the first several propagating points,
+and at wider intervals only after the branch has settled. Extra candidates
+cover the automatic waveform's transition spectrum. This keeps interpolation
+on a contiguous evanescent branch and prevents a propagating normalization
+from being interpolated through the singular cutoff transition.
+
+Below cutoff the correct forward solution is the passive decaying wave, not a
+one-watt propagating wave. gprMax tracks it with an E/H-balanced reference and
+can report a finite generalized amplitude ratio. That ratio is useful for
+evanescent attenuation and phase comparison, but its magnitude squared is not
+transmitted power. For an ordinary power S-parameter, use only bins where
+``power_wave_valid`` is true. For a below-cutoff generalized coefficient, use
+``coefficient_valid`` and state the reference convention explicitly.
+
+Clearer validity names
+^^^^^^^^^^^^^^^^^^^^^^
+
+The output now provides descriptive aliases while retaining the older names
+for file compatibility:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 25 47
+
+   * - Preferred name
+     - Older name
+     - Meaning
+   * - ``reference_basis_valid``
+     - ``decomposition_valid``
+     - A tracked reference field exists before solving for modal amplitudes.
+   * - ``power_basis_valid``
+     - ``power_normalization_valid``
+     - The reference supports a forward real-power normalization.
+   * - ``coefficient_valid``
+     - ``generalized_valid``
+     - The conditioned incident/outgoing coefficient exists; it may be
+       evanescent and must not automatically be interpreted as power.
+   * - ``power_wave_valid``
+     - ``valid``
+     - The coefficient also represents a physical real-power wave.
+   * - ``coefficient_valid_S``
+     - ``generalized_valid_S``
+     - The S or active-S ratio is coefficient-valid and its incident
+       denominator is sufficiently excited.
+   * - ``power_wave_valid_S``
+     - ``valid_S``
+     - The ratio is valid under the stricter physical power-wave convention.
+
+The same preferred prefixes appear on study columns/matrices and on
+``active_S``. The compact rule is: use ``coefficient_valid*`` to plot a
+generalized modal-amplitude result, and use ``power_wave_valid*`` before
+calling :math:`|S|^2` a reflected or transmitted power fraction.
 
 Direct eigenmode ports inside an HSG subgrid
 =============================================
@@ -884,49 +1050,47 @@ by moving the DFT grid and refining the modal anchors.
 Far-field output details
 ========================
 
-The pyramidal horn example uses a five-face free-space Huygens surface around
-the flare and aperture:
+The pyramidal horn example uses a closed six-face free-space surface around
+the complete physical antenna:
 
 .. literalinclude:: ../../examples/features/eigenmode_ports/example_3_antenna_and_farfield/horn_antenna.in
    :language: none
    :caption: ``horn_antenna.in``
 
 The rectangular feed's fundamental TE10-like mode is isolated over the
-8--12 GHz requested band. A single explicit 10 GHz anchor avoids attempting
-to track the automatic waveform's lower spectral tail through guide cutoff.
-That propagating anchor satisfies the required forward-power anchor check and
-is intentionally extrapolated as a constant source basis; it does not claim
-that an independently solved mode below cutoff would be a one-watt power wave.
+8--12 GHz requested band. Automatic modal anchors track its broadband field
+profile independently of the direct-DFT output grid. The automatic policy
+also considers the generated waveform's significant spectral guards and
+retains only source-usable propagating anchor coverage; it does not treat a
+below-cutoff field as a one-watt power wave.
 
-The optional final ``x0`` on ``#ntff_surface`` omits that physical face from
-the frequency-domain equivalent-current integral. The source plane is on the
-feed side of the omitted face, while the uniform hollow feed continues
-without a discontinuity through the rear PML. Backward guide waves therefore
-leave the Huygens volume and are absorbed instead of being re-radiated by a
-finite feed termination inside the far-field surface.
+The physical guide starts at the reference plane and its matched continuation
+is supplied by ``#virtual_waveguide``. The source and auxiliary PML are outside
+the main grid. The feed-side NTFF face can therefore lie in homogeneous air
+behind the port without cutting the guide. Every sampled face must remain
+outside the domain PML, avoid the port aperture, and lie in the homogeneous
+exterior. Check convergence by moving and enlarging the sampled surface and by
+changing the virtual-guide length and PML thickness.
 
-One to five faces may be omitted, and only ``#ntff_frequency`` supports this
-open-surface form. The Ramahi/KSIR formulation and the transient
-equivalent-current transform still require a closed or symmetry-completed
-surface. Every sampled face must remain outside the PML and in the homogeneous
-exterior. An impressed source outside the Huygens volume may enter only through
-one of the omitted faces. Multiple omissions are useful when a waveguide passes
-through the surface to a passive output port, or when the surface terminates on
-a PEC backplane. An open Huygens surface is not an exact mathematical closure;
-check convergence by moving and enlarging its sampled faces.
+Without a virtual guide, the traditional arrangement continues the real guide
+through a domain PML and omits the Huygens face it crosses. That open
+frequency-domain equivalent-current surface remains supported, but Ramahi/KSIR
+and transient equivalent-current transforms require all six physical faces.
 
-The frequency-transform bins must exactly equal the eigenmode-port DFT bins.
+Every frequency-transform bin must be present in the eigenmode-port DFT grid;
+the NTFF grid may be a strict subset of a denser S-parameter sweep. Add exact
+user-selected bins as trailing values on the hash command
+``#eigenmode_band: id fmin fmax points [frequency ...]``, or with the Python
+keyword ``EigenmodeBand(..., frequencies=(...))``. The final union is sorted
+and deduplicated before being shared by all eigenmode ports.
 Gain normalization currently requires a rectangular window.
 ``#ntff_antenna_ports`` must list every physical port, including passive modal
 receivers when present. Other active sources that do not expose port power
 cannot contribute to the same gain result.
 
-.. warning::
-
-   Direct eigenmode sources are incompatible with the Ramahi/KSIR formulation.
-   Use the frequency-domain equivalent-current Huygens interface, or attach a
-   virtual waveguide to move the impressed source outside the main grid. The
-   latter permits a closed KSIR or equivalent-current surface.
+There is no eigenmode-source-specific KSIR restriction. The validation rule is
+simply that a KSIR surface must be closed. A virtual guide is the practical way
+to satisfy that closure while preserving a matched waveguide port.
 
 Run and plot the example with:
 

--- a/docs/source/examples_advanced.rst
+++ b/docs/source/examples_advanced.rst
@@ -7,8 +7,9 @@ This section provides example models of some of the more advanced features of gp
 Eigenmode ports
 ===============
 
-The three numbered examples under ``examples/features/eigenmode_ports`` cover
-a straight waveguide, a curved waveguide, and an eigenmode-fed pyramidal horn.
+The six numbered examples under ``examples/features/eigenmode_ports`` progress
+from straight and curved guides to a closed-surface horn, a complete modal
+matrix study, a phase-steered array, and a guide crossing cutoff.
 :doc:`eigenmode_port` provides a step-by-step tutorial for users who primarily
 want S-parameters and far fields.
 

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -142,9 +142,9 @@ with
 
 The planar-layered frequency transform is the exception to the homogeneous
 background restriction: its surface may cross the declared interfaces.
-Eigenmode sources are not supported by the Ramahi/KSIR formulation. Use the
-frequency-domain equivalent-current Huygens commands (the ``#ntff_*`` family)
-for eigenmode-fed antenna far fields, gain, and realized gain.
+Ramahi/KSIR requires a closed six-face surface, independently of source type.
+A virtual waveguide lets an eigenmode-fed antenna retain a matched guide port
+while placing all six surface faces in the homogeneous main-domain exterior.
 
 The unit normal :math:`\hat{\mathbf n}` points out of the enclosed volume,
 :math:`\mathbf r'` denotes a source point on :math:`S`, and

--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -1037,6 +1037,7 @@ not repeat the DFT range or waveform:
 
     scene.add(gprMax.EigenmodeBand(
         id='wg_band', fmin=45e9, fmax=65e9, points=81,
+        frequencies=(50.1e9, 55.1e9, 60.1e9),
     ))
     scene.add(gprMax.EigenmodePort(
         port=1,
@@ -1057,6 +1058,15 @@ not repeat the DFT range or waveform:
     scene.add(gprMax.EigenmodeExcitation(
         port=1, mode=1, waveform='auto', plot_waveform=True,
     ))
+
+The optional ``frequencies`` values are inserted into the uniform
+``fmin``--``fmax`` grid. The final union is sorted and deduplicated and is
+shared by every port. This lets an S-parameter sweep include exact frequencies
+needed by a sparser NTFF request. When an ``NTFFAntennaPorts`` association uses
+modal power, every NTFF transform frequency must be present in this union, but
+the NTFF grid may be a strict subset. ``frequencies`` changes direct-DFT/output
+bins; it is independent of the ``anchors`` policy used to solve and interpolate
+the modal fields.
 
 For simultaneous excitation, add further distinct port/mode channels using
 the same base waveform. ``power`` and ``amplitude`` are mutually exclusive;
@@ -1751,12 +1761,12 @@ class. Hash
 commands use the default surface centre, save the surface DFT, and associate
 an enclosed plane wave automatically.
 
-A direct eigenmode excitation cannot be combined with any of the ``KSIR*``
-classes. When its active port has a ``VirtualWaveguide``, the impressed source
-is instead outside the main FDTD domain and either a closed KSIR surface or a
-closed equivalent-current surface may be used. Without a virtual guide, use
-``NTFFFrequencyTransform``, ``NTFFFarField`` or ``NTFFFarFieldArray``, and
-``NTFFAntennaPorts`` for an eigenmode-fed antenna.
+The ``KSIR*`` classes require a closed ``NTFFSurface``; this rule is independent
+of whether an eigenmode source is present. Traditionally a real guide extends
+through the domain PML and the crossed Huygens face is omitted, which makes
+that open surface unsuitable for KSIR. A ``VirtualWaveguide`` moves the matched
+continuation outside the main domain, allowing the eigenmode-fed antenna to be
+enclosed by either a closed KSIR or closed equivalent-current surface.
 
 ``NTFFSurface(omit_faces=('x0', 'xmax'))`` creates an open frequency-domain
 Huygens surface. ``omit_faces`` accepts one to five distinct Cartesian face
@@ -1840,8 +1850,9 @@ owning subgrid's finer time step.
 For voltage sources, use the source's ``id`` (or its automatic ``portN`` ID); automatic
 transmission-line and magnetic-frill IDs are ``tl1``, ... and ``frill1``, ...
 respectively. An eigenmode source is ``portN`` for its explicit port index;
-an eigenmode receiver uses its configured ID. Eigenmode transform
-frequencies must exactly match the modal direct-DFT bins. Their gain
+an eigenmode receiver uses its configured ID. Every eigenmode transform
+frequency must be one of the modal direct-DFT bins; the modal grid may contain
+additional bins. Their gain
 normalization uses the full modal power matrix rather than an artificial
 voltage/current or reference impedance. For example:
 

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1714,12 +1714,16 @@ Defines the single frequency band shared by every eigenmode port in the model:
 
 .. code-block:: none
 
-    #eigenmode_band: str1 f1 f2 i1
+    #eigenmode_band: str1 f1 f2 i1 [f3 ...]
 
 * ``str1`` is a non-empty band identifier.
 * ``f1`` and ``f2`` are the inclusive DFT start and stop frequencies in Hertz.
 * ``i1`` is the number of uniformly spaced DFT points. A one-point band
   requires ``f1=f2``; a multi-point band requires ``f2>f1``.
+* ``f3 ...`` are optional additional DFT frequencies inside the inclusive
+  band. gprMax sorts and deduplicates their union with the uniform grid. This
+  is useful when a dense S-parameter sweep must also contain specific NTFF
+  frequencies exactly.
 
 Exactly one band is required when eigenmode ports are present. Defining the
 band once guarantees identical DFT bins at every port.
@@ -2647,8 +2651,23 @@ equivalent-current method of Luebbers *et al.* [LUE1991]_:
     #ntff_frequency: surface_id transform_id f1 [f2 ...] [window]
 
 The frequency, window, engineering convention, Nyquist check, and globally
-unique transform-ID rules are identical to ``#ksir_frequency``. The
-tangential Yee fields are arithmetically collocated on common cell-face
+unique transform-ID rules are identical to ``#ksir_frequency``.
+
+When ``#ntff_antenna_ports`` associates an eigenmode port with this transform,
+every transform frequency must be present in the final ``#eigenmode_band``
+DFT grid. The transform frequencies may be a strict subset. If a requested
+NTFF frequency is not one of the uniformly spaced modal bins, append it after
+the point count; gprMax sorts and deduplicates the combined grid. For example:
+
+.. code-block:: none
+
+    #eigenmode_band: antenna_band 8e9 12e9 101 8.5e9 9.5e9 10.5e9 11.5e9
+    #ntff_frequency: radiation_surface antenna_pattern 8e9 8.5e9 9e9 9.5e9 10e9 10.5e9 11e9 11.5e9 12e9 rectangular
+
+The extra modal bins affect the S-parameter DFT grid; they do not replace the
+``auto`` or explicit modal anchor policy on ``#eigenmode_port``.
+
+The tangential Yee fields are arithmetically collocated on common cell-face
 centres and form
 
 .. math::
@@ -2783,12 +2802,13 @@ creation order. The association is not required for electric or magnetic far
 fields, radiation intensity, RCS, or directivity. It is required when a
 far-field command asks for gain or efficiency.
 
-A direct eigenmode source cannot be used with any Ramahi/KSIR command. When
-its active port has a ``#virtual_waveguide``, the source is moved outside the
-main FDTD domain and a closed KSIR or equivalent-current surface may be used.
-Without a virtual guide, use the frequency-domain equivalent-current Huygens
-commands ``#ntff_frequency``, ``#ntff_far_field`` or
-``#ntff_far_field_array``, and ``#ntff_antenna_ports`` instead.
+Every Ramahi/KSIR command requires a closed six-face ``#ntff_surface``; this
+rule is independent of whether an eigenmode source is present. Traditionally
+a real guide extends through the domain PML and the crossed Huygens face is
+omitted, so that open surface cannot be reused for KSIR. With
+``#virtual_waveguide`` the matched continuation and source are outside the
+main domain, permitting a closed KSIR or equivalent-current surface around
+the physical antenna.
 
 A port on a subgrid is named as ``subgrid_id/port_id``. For example,
 ``fine_grid/feed`` identifies a voltage source called ``feed`` on subgrid
@@ -2846,10 +2866,11 @@ number. The listed set must include every physical conventional and modal
 port in the model. A passive eigenmode port has zero generator incident power
 and contributes signed net modal power to the accepted-power balance.
 
-For every associated eigenmode port, the transform frequencies must exactly
-match that port's direct-DFT bins. Degenerate modes and mode crossings should
-use a single-frequency modal solve rather than broadband profile
-interpolation.
+For every associated eigenmode port, every transform frequency must be present
+in that port's direct-DFT bins. The eigenmode grid may contain additional bins,
+so S-parameters may use a denser grid than the NTFF. Degenerate modes and mode
+crossings should use a single-frequency modal solve rather than broadband
+profile interpolation.
 
 #ksir_time_rx: and #ksir_time_rx_spherical:
 --------------------------------------------

--- a/docs/source/output.rst
+++ b/docs/source/output.rst
@@ -376,7 +376,8 @@ Every eigenmode-study case instead contains
 nominal incident modal channel. ``incident`` and ``outgoing`` contain the
 complete measured modal vectors for that run, ordered by ``channel_ports``
 and ``channel_modes``; ``valid_wave`` and ``generalized_valid_wave`` are their
-validity masks. ``S_column`` is the single-source-normalized per-run
+validity masks. Preferred aliases ``power_wave_valid`` and
+``coefficient_valid_wave`` state their meanings directly. ``S_column`` is the single-source-normalized per-run
 diagnostic retained alongside those raw waves. It is not the authoritative
 column when passive ports have residual incident waves.
 
@@ -384,7 +385,10 @@ The eigenmode aggregate ``<output>_study.h5`` contains ``frequency``,
 ``channel_ports``, ``channel_modes``, ``case_ids``, ``incident_matrix``,
 ``outgoing_matrix``, ``valid_wave_matrix``,
 ``generalized_valid_wave_matrix``, ``deembedding_condition_number``,
-``deembedding_valid``, ``S``, ``valid_S``, and ``generalized_valid_S``. Its convention is
+``deembedding_valid``, ``S``, ``valid_S``, and ``generalized_valid_S``.
+Preferred aliases ``power_wave_valid_matrix``,
+``coefficient_valid_wave_matrix``, ``power_wave_valid_S``, and
+``coefficient_valid_S`` are stored alongside the legacy names. Its convention is
 ``S[frequency, output_channel, input_channel]``. Modal channels can represent
 different mode counts on different ports; the two channel-index datasets are
 therefore authoritative and should be used instead of assuming one mode per
@@ -572,15 +576,24 @@ text when it came from a JSON file.
                 anchor_mode_propagating
                 anchor_balanced_power
                 decomposition_valid
+                reference_basis_valid
                 generalized_valid
+                coefficient_valid
                 power_normalization_valid
+                power_basis_valid
                 power_matrix_valid
                 valid
+                power_wave_valid
                 condition_number
                 S
                 generalized_valid_S
+                coefficient_valid_S
                 valid_S
                 power_wave_valid_S
+                active_S
+                active_S_driven
+                coefficient_valid_active_S
+                power_wave_valid_active_S
 
 Within each individual ``rx`` group are the following attributes:
 
@@ -1039,15 +1052,17 @@ exactly orthogonal. The incident and outgoing arrays are generalized modal
 travelling-wave coefficients; an individual coefficient magnitude squared is
 not an additive power when ``power_matrix`` is non-diagonal. The electric
 cross-power matrix is retained to reconstruct total-field flux in lossy
-ports. ``decomposition_valid`` has shape ``(nfrequencies, nmodes)`` and records
-pre-solve reference eligibility. ``generalized_valid`` has shape
+ports. ``decomposition_valid`` (preferred alias ``reference_basis_valid``) has
+shape ``(nfrequencies, nmodes)`` and records pre-solve reference eligibility.
+``generalized_valid`` (preferred alias ``coefficient_valid``) has shape
 ``(nmodes, nfrequencies)`` and records conditioned incident/outgoing
 coefficients. Legacy ``valid`` has the same latter shape and is the stricter
-physical power-wave mask. ``power_normalization_valid`` has shape
+physical power-wave mask, also stored as ``power_wave_valid``.
+``power_normalization_valid`` (preferred alias ``power_basis_valid``) has shape
 ``(nfrequencies, nmodes)``, while ``power_matrix_valid`` has shape
 ``(nfrequencies,)``. The anchor masks have shape ``(ncandidates, nmodes)``.
 
-For scattering output, ``generalized_valid_S``, ``valid_S``, and
+For scattering output, ``generalized_valid_S``/``coefficient_valid_S``, ``valid_S``, and
 ``power_wave_valid_S`` all have shape ``(nmodes, nfrequencies)``.
 ``generalized_valid_S`` identifies conditioned generalized coefficient
 ratios, including the source-spectrum check. ``valid_S`` preserves the legacy
@@ -1074,10 +1089,12 @@ When two or more modal channels are excited simultaneously, the groups also
 contain the raw ``incident`` and ``outgoing`` spectra and have
 ``ResponseType=driven``. Source groups record ``ExcitationModes``,
 ``DriveAmplitudes``, ``DrivePowers``, ``DrivePhasesDegrees``, ``DriveDelays``,
-and ``DriveWaveformIDs``. No ``S`` datasets or S-parameter CSV are written:
-normalizing a superposed response by one incident channel would not be an
-independently excited S-matrix column. Use an ``EigenmodeStudy`` for that
-matrix.
+and ``DriveWaveformIDs``. Ordinary ``S`` datasets are not written because the
+response is not an independently excited S-matrix column. Driven rows instead
+store ``active_S=b_i/a_i``, ``coefficient_valid_active_S``, and
+``power_wave_valid_active_S``; ``<output>_active_sparameters.csv`` contains the
+same driven-state reflection data and drive weights. Use an
+``EigenmodeStudy`` for the complete state-independent matrix.
 
 .. _output-ntff:
 
@@ -1333,9 +1350,13 @@ ordinary gain outputs. Summing the two accepted coupling efficiencies gives
 
 For a ``#ksir_antenna_ports`` or ``#ntff_antenna_ports`` association, per-port
 powers have shape ``(nports, nfrequencies)``. Total powers and all validity
-masks have shape ``(nfrequencies,)``. Eigenmode ports are supported only by
-the equivalent-current ``#ntff_antenna_ports`` path; an eigenmode source
-cannot be combined with Ramahi/KSIR. Conventional terminal ports use
+masks have shape ``(nfrequencies,)``. Eigenmode ports can normalize either a
+closed KSIR or equivalent-current transform. KSIR rejects an open surface,
+regardless of source type. Here ``nfrequencies`` is the transform frequency
+count: when the eigenmode DFT grid is denser, the per-port modal arrays in the
+far-field ``port_power`` group contain only the matching transform subset. The
+complete modal grid remains in the top-level eigenmode-port group.
+Conventional terminal ports use
 
 .. math::
 

--- a/examples/features/eigenmode_ports/README.rst
+++ b/examples/features/eigenmode_ports/README.rst
@@ -2,7 +2,7 @@
 Eigenmode port examples
 =======================
 
-These three numbered examples form the beginner tutorial in
+These six numbered examples form the tutorial in
 ``docs/source/eigenmode_port.rst``:
 
 ``example_1_straight_waveguide``
@@ -15,8 +15,23 @@ These three numbered examples form the beginner tutorial in
 
 ``example_3_antenna_and_farfield``
     Feed a pyramidal horn through a rectangular-waveguide eigenmode port and
-    calculate S11, a 3D directivity pattern, and E-/H-plane directivity, gain,
-    and realized gain.
+    virtual waveguide. Calculate S11 and antenna patterns using a closed NTFF
+    surface.
+
+``example_4_complete_s_matrix``
+    Drive the dominant quasi-TEM mode at each end of a gapped microstrip in one
+    study, assemble its complete 2 by 2 S matrix without rebuilding, and
+    compare the magnitude and phase of ``S21`` and ``S12`` for reciprocity.
+
+``example_5_phased_array``
+    Drive four waveguide antenna elements with a progressive phase and plot
+    both driven-port active S-parameters and a dense xy-plane far-field cut
+    that demonstrates beam squint.
+
+``example_6_near_cutoff``
+    Resolve TE10 immediately above and below cutoff with dense, branch-aware
+    anchor points and distinguish coefficient validity from power-wave
+    validity.
 
 Run every command below from the repository root.
 
@@ -41,14 +56,39 @@ Example 2
 Example 3
 =========
 
-The 3D horn is more expensive. Eigenmode sources currently require the CPU
-solver, so do not add ``-gpu`` to this example command.
+The 3D horn is more expensive than Examples 1 and 2.
 
 .. code-block:: console
 
     python -m gprMax examples/features/eigenmode_ports/example_3_antenna_and_farfield/horn_antenna.in --geometry-only
     python -m gprMax examples/features/eigenmode_ports/example_3_antenna_and_farfield/horn_antenna.in -outputfile examples/features/eigenmode_ports/example_3_antenna_and_farfield/horn_antenna
     python examples/features/eigenmode_ports/example_3_antenna_and_farfield/plot_results.py
+
+Example 4
+=========
+
+.. code-block:: console
+
+    python -m gprMax examples/features/eigenmode_ports/example_4_complete_s_matrix/complete_s_matrix.in -outputfile examples/features/eigenmode_ports/example_4_complete_s_matrix/complete_s_matrix
+    python examples/features/eigenmode_ports/example_4_complete_s_matrix/plot_results.py
+
+Example 5
+=========
+
+.. code-block:: console
+
+    python -m gprMax examples/features/eigenmode_ports/example_5_phased_array/phased_array.in --geometry-only
+    python -m gprMax examples/features/eigenmode_ports/example_5_phased_array/phased_array.in -outputfile examples/features/eigenmode_ports/example_5_phased_array/phased_array
+    python examples/features/eigenmode_ports/example_5_phased_array/plot_results.py
+
+Example 6
+=========
+
+.. code-block:: console
+
+    python -m gprMax examples/features/eigenmode_ports/example_6_near_cutoff/near_cutoff.in --geometry-only
+    python -m gprMax examples/features/eigenmode_ports/example_6_near_cutoff/near_cutoff.in -outputfile examples/features/eigenmode_ports/example_6_near_cutoff/near_cutoff
+    python examples/features/eigenmode_ports/example_6_near_cutoff/plot_results.py
 
 Generated CSV, HDF5, VTK-HDF, modal-field, snapshot, and result-plot files are
 ignored by Git and can be recreated by rerunning the examples. The larger

--- a/examples/features/eigenmode_ports/example_3_antenna_and_farfield/horn_antenna.in
+++ b/examples/features/eigenmode_ports/example_3_antenna_and_farfield/horn_antenna.in
@@ -5,13 +5,13 @@
 #time_window: 4e-9
 #pml_cells: 8
 
-## The uniform hollow waveguide extends through the x0 PML. The source plane
-## is outside the Huygens volume, and the omitted x0 face cuts only the
-## uniform guide. Reflected guide waves therefore leave through the PML.
-#box: 0 0.032 0.028 0.035 0.033 0.042 pec
-#box: 0 0.057 0.028 0.035 0.058 0.042 pec
-#box: 0 0.032 0.028 0.035 0.058 0.029 pec
-#box: 0 0.032 0.041 0.035 0.058 0.042 pec
+## The physical feed begins at the internal port plane. A virtual waveguide
+## supplies the matched continuation behind it, leaving free space between
+## the feed and the closed NTFF x0 face.
+#box: 0.012 0.032 0.028 0.035 0.033 0.042 pec
+#box: 0.012 0.057 0.028 0.035 0.058 0.042 pec
+#box: 0.012 0.032 0.028 0.035 0.058 0.029 pec
+#box: 0.012 0.032 0.041 0.035 0.058 0.042 pec
 
 ## Nine expanding hollow PEC sections form a closed, finely staircased
 ## approximation of a pyramidal flare. Each 5 mm section grows by only
@@ -103,12 +103,13 @@
 #box: 0.075 0.016 0.057 0.080 0.074 0.058 pec
 
 ## Launch the fundamental TE10-like mode of the rectangular feed.
-#eigenmode_band: eigenmode_band 8e9 12e9 9
-#eigenmode_port: 1 0.012 0.033 0.029 0.012 0.057 0.041 + 1 10e9
+#eigenmode_band: eigenmode_band 8e9 12e9 101 8e9 8.5e9 9e9 9.5e9 10e9 10.5e9 11e9 11.5e9 12e9
+#eigenmode_port: 1 0.012 0.033 0.029 0.012 0.057 0.041 + 1 auto
+#virtual_waveguide: 1 30 12 6
 #eigenmode_excitation: 1 1 auto
 
-## The x0 Huygens face is omitted because the feed waveguide crosses it.
-#ntff_surface: 0.025 0.011 0.011 0.118 0.079 0.059 horn_surface x0
+## The virtual feed permits a closed six-face surface in homogeneous air.
+#ntff_surface: 0.010 0.011 0.011 0.118 0.079 0.059 horn_surface
 #ntff_frequency: horn_surface antenna_band 8e9 8.5e9 9e9 9.5e9 10e9 10.5e9 11e9 11.5e9 12e9 rectangular
 #ntff_antenna_ports: antenna_band port1
 #ntff_far_field_array: 0 180 5 0 355 5 antenna_band full_sphere Etheta Ephi radiation_intensity directivity_dbi gain_dbi realized_gain_dbi radiation_efficiency total_efficiency

--- a/examples/features/eigenmode_ports/example_4_complete_s_matrix/complete_s_matrix.in
+++ b/examples/features/eigenmode_ports/example_4_complete_s_matrix/complete_s_matrix.in
@@ -1,0 +1,32 @@
+#title: Example 4 - complete dominant-mode microstrip S matrix
+
+#domain: 0.080 0.030 0.025
+#dx_dy_dz: 0.001 0.001 0.001
+#time_window: 2e-9
+#pml_cells: 8 0 0 8 0 0
+
+## A lossless microstrip with a centred 2 mm series gap connects two internal
+## reference planes. The 2 mm substrate has relative permittivity 4, the strip
+## is 4 mm wide, and air surrounds its fringing fields.
+#material: 4 0 1 0 substrate
+#box: 0 0.004 0.006 0.080 0.026 0.007 pec
+#box: 0 0.004 0.007 0.080 0.026 0.009 substrate
+#box: 0 0.013 0.009 0.039 0.017 0.010 pec
+#box: 0.041 0.013 0.009 0.080 0.017 0.010 pec
+
+## Only the dominant quasi-TEM mode is retained at each port. Identical
+## cross-sections and inward-pointing directions give compatible reciprocal
+## references. Each uniform feed continues through its x-directed PML to
+## provide a matched termination; the gap remains between the reference planes.
+#eigenmode_band: matrix_band 4e9 8e9 101
+#eigenmode_port: 1 0.008 0.004 0.006 0.008 0.026 0.018 + 1 auto n
+#eigenmode_port: 2 0.072 0.004 0.006 0.072 0.026 0.018 - 1 auto n
+
+## The study changes this one reusable source to each declared channel. The
+## modal anchor solutions and geometry are built once, then two FDTD cases
+## assemble the complete 2 x 2 dominant-mode S matrix. For this reciprocal
+## structure, S21 and S12 should agree within numerical error.
+#eigenmode_excitation: 1 1 auto n
+#study: eigenmode modal_cases.csv
+
+#geometry_view: 0 0.002 0.004 0.080 0.028 0.020 0.001 0.001 0.001 microstrip_gap n

--- a/examples/features/eigenmode_ports/example_4_complete_s_matrix/plot_results.py
+++ b/examples/features/eigenmode_ports/example_4_complete_s_matrix/plot_results.py
@@ -1,0 +1,88 @@
+"""Plot magnitude and phase for each dominant-mode microstrip S parameter."""
+
+from pathlib import Path
+
+import h5py
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+ROOT = Path(__file__).resolve().parent
+INPUT = ROOT / "complete_s_matrix_study.h5"
+OUTPUT = ROOT / "complete_s_matrix.png"
+
+
+def magnitude_db(values, floor=-80):
+    with np.errstate(divide="ignore"):
+        result = 20 * np.log10(np.abs(values))
+    return np.maximum(result, floor)
+
+
+def main():
+    with h5py.File(INPUT, "r") as result:
+        frequency = result["frequency"][...] * 1e-9
+        ports = result["channel_ports"][...].astype(int)
+        modes = result["channel_modes"][...].astype(int)
+        matrix = result["S"][...]
+        valid_name = (
+            "power_wave_valid_S" if "power_wave_valid_S" in result else "valid_S"
+        )
+        valid = result[valid_name][...].astype(bool)
+
+    if set(zip(ports, modes)) != {(1, 1), (2, 1)}:
+        raise ValueError("Expected dominant mode 1 at ports 1 and 2")
+    port1 = int(np.flatnonzero((ports == 1) & (modes == 1))[0])
+    port2 = int(np.flatnonzero((ports == 2) & (modes == 1))[0])
+    s11 = matrix[:, port1, port1]
+    s21 = matrix[:, port2, port1]
+    s12 = matrix[:, port1, port2]
+    s22 = matrix[:, port2, port2]
+
+    figure, axes = plt.subplots(2, 2, figsize=(13, 8), constrained_layout=True)
+    entries = (
+        (r"$S_{11}$", s11, valid[:, port1, port1]),
+        (r"$S_{21}$", s21, valid[:, port2, port1]),
+        (r"$S_{12}$", s12, valid[:, port1, port2]),
+        (r"$S_{22}$", s22, valid[:, port2, port2]),
+    )
+    for magnitude_axis, (label, values, mask) in zip(axes.flat, entries):
+        phase_axis = magnitude_axis.twinx()
+        selected_frequency = frequency[mask]
+        selected_values = values[mask]
+        magnitude_line = magnitude_axis.plot(
+            selected_frequency,
+            magnitude_db(selected_values),
+            color="tab:blue",
+            label="Magnitude",
+        )[0]
+        phase_line = phase_axis.plot(
+            selected_frequency,
+            np.degrees(np.unwrap(np.angle(selected_values))),
+            color="tab:orange",
+            linestyle="--",
+            label="Unwrapped phase",
+        )[0]
+        magnitude_axis.set_title(label)
+        magnitude_axis.set_xlabel("Frequency (GHz)")
+        magnitude_axis.set_ylabel("Magnitude (dB; floor -80 dB)", color="tab:blue")
+        phase_axis.set_ylabel("Phase (degrees)", color="tab:orange")
+        magnitude_axis.tick_params(axis="y", labelcolor="tab:blue")
+        phase_axis.tick_params(axis="y", labelcolor="tab:orange")
+        magnitude_axis.grid(True, alpha=0.3)
+        magnitude_axis.legend(
+            [magnitude_line, phase_line],
+            [magnitude_line.get_label(), phase_line.get_label()],
+            loc="best",
+        )
+
+    figure.suptitle("Complete dominant-mode S matrix of a gapped microstrip")
+
+    figure.savefig(OUTPUT, dpi=180)
+    print(f"Wrote {OUTPUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/features/eigenmode_ports/example_5_phased_array/phased_array.in
+++ b/examples/features/eigenmode_ports/example_5_phased_array/phased_array.in
@@ -1,0 +1,61 @@
+#title: Example 5 - four-element phase-steered waveguide array
+
+#domain: 0.100 0.104 0.060
+#dx_dy_dz: 0.001 0.001 0.001
+#time_window: 4e-9
+#pml_cells: 8
+
+## Four open-ended 10 mm x 24 mm rectangular guides radiate in +x. Their
+## centres are 18 mm apart along y. Each guide begins at its internal port
+## plane and is matched behind that plane by an independent virtual guide.
+## Element 1, y centre 25 mm
+#box: 0.018 0.019 0.017 0.045 0.020 0.043 pec
+#box: 0.018 0.030 0.017 0.045 0.031 0.043 pec
+#box: 0.018 0.019 0.017 0.045 0.031 0.018 pec
+#box: 0.018 0.019 0.042 0.045 0.031 0.043 pec
+## Element 2, y centre 43 mm
+#box: 0.018 0.037 0.017 0.045 0.038 0.043 pec
+#box: 0.018 0.048 0.017 0.045 0.049 0.043 pec
+#box: 0.018 0.037 0.017 0.045 0.049 0.018 pec
+#box: 0.018 0.037 0.042 0.045 0.049 0.043 pec
+## Element 3, y centre 61 mm
+#box: 0.018 0.055 0.017 0.045 0.056 0.043 pec
+#box: 0.018 0.066 0.017 0.045 0.067 0.043 pec
+#box: 0.018 0.055 0.017 0.045 0.067 0.018 pec
+#box: 0.018 0.055 0.042 0.045 0.067 0.043 pec
+## Element 4, y centre 79 mm
+#box: 0.018 0.073 0.017 0.045 0.074 0.043 pec
+#box: 0.018 0.084 0.017 0.045 0.085 0.043 pec
+#box: 0.018 0.073 0.017 0.045 0.085 0.018 pec
+#box: 0.018 0.073 0.042 0.045 0.085 0.043 pec
+
+## The ten uniform S-parameter bins do not land on 9, 10, or 11 GHz, so add
+## those exact frequencies for the five-bin NTFF request below.
+#eigenmode_band: array_band 8e9 12e9 10 9e9 10e9 11e9
+#eigenmode_port: 1 0.018 0.020 0.018 0.018 0.030 0.042 + 1 10e9 n
+#eigenmode_port: 2 0.018 0.038 0.018 0.018 0.048 0.042 + 1 10e9 n
+#eigenmode_port: 3 0.018 0.056 0.018 0.018 0.066 0.042 + 1 10e9 n
+#eigenmode_port: 4 0.018 0.074 0.018 0.018 0.084 0.042 + 1 10e9 n
+#virtual_waveguide: 1 30 12 6
+#virtual_waveguide: 2 30 12 6
+#virtual_waveguide: 3 30 12 6
+#virtual_waveguide: 4 30 12 6
+
+## A constant -108 degree progressive phase targets about +30 degrees in the
+## xy plane at 10 GHz. Because the phase does not vary with frequency, the
+## beam squints over the 8--12 GHz band.
+#eigenmode_excitation: 1 1 auto 1 0 0 n
+#eigenmode_excitation: 2 1 auto 1 -108 0 n
+#eigenmode_excitation: 3 1 auto 1 -216 0 n
+#eigenmode_excitation: 4 1 auto 1 -324 0 n
+
+## The virtual feeds leave enough air for a closed six-face NTFF surface.
+#ntff_surface: 0.010 0.010 0.010 0.088 0.094 0.050 array_surface
+#ntff_frequency: array_surface array_band 8e9 9e9 10e9 11e9 12e9 rectangular
+#ntff_antenna_ports: array_band port1 port2 port3 port4
+## Store only the dense theta=90 degree xy-plane cut used by the plot. Gain,
+## directivity, and efficiency still use gprMax's internal full-sphere
+## quadrature; that temporary normalization grid is not written to HDF5.
+#ntff_far_field_array: 90 90 1 0 359 1 array_band array_pattern Etheta Ephi radiation_intensity directivity_dbi gain_dbi realized_gain_dbi radiation_efficiency total_efficiency
+
+#geometry_view: 0 0 0 0.100 0.104 0.060 0.001 0.001 0.001 phased_array n

--- a/examples/features/eigenmode_ports/example_5_phased_array/plot_results.py
+++ b/examples/features/eigenmode_ports/example_5_phased_array/plot_results.py
@@ -1,0 +1,118 @@
+"""Plot active reflection and beam squint for Example 5."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import h5py
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+ROOT = Path(__file__).resolve().parent
+STEM = ROOT / "phased_array"
+ACTIVE_CSV = ROOT / "phased_array_active_sparameters.csv"
+FAR_FIELD_GROUP = "ntff/array_surface/frequency/array_band/far_field/array_pattern"
+OUTPUT = ROOT / "phased_array_active_s_and_beam_squint.png"
+LIGHT_SPEED = 299_792_458.0
+ELEMENT_SPACING = 18e-3
+PROGRESSIVE_PHASE_DEG = -108.0
+
+
+def read_active_s():
+    traces = {}
+    with ACTIVE_CSV.open(newline="", encoding="utf-8") as stream:
+        for row in csv.DictReader(stream):
+            if not bool(int(row["power_wave_valid"])):
+                continue
+            port = int(row["port"])
+            traces.setdefault(port, []).append(
+                (float(row["frequency_hz"]) * 1e-9,
+                 float(row["active_S_magnitude_db"]))
+            )
+    if len(traces) != 4:
+        raise ValueError(f"Expected four driven-port active-S traces in {ACTIVE_CSV}")
+    return {port: np.asarray(sorted(rows)) for port, rows in traces.items()}
+
+
+def read_xy_patterns():
+    with h5py.File(STEM.with_suffix(".h5"), "r") as output:
+        group = output[FAR_FIELD_GROUP]
+        frequency = group.parent.parent["frequencies"][...] * 1e-9
+        theta = group["theta"][...]
+        phi = group["phi"][...]
+        directivity = group["fields/directivity_dbi"][...]
+    theta_axis = np.unique(theta)
+    phi_axis = np.unique(phi)
+    theta_broadside = int(np.argmin(np.abs(theta_axis - 90)))
+    signed_phi = (phi_axis + 180) % 360 - 180
+    order = np.argsort(signed_phi)
+    patterns = directivity.reshape(frequency.size, theta_axis.size, phi_axis.size)
+    return frequency, signed_phi[order], patterns[:, theta_broadside, :][:, order]
+
+
+def predicted_array_factor_angles(frequencies_ghz):
+    frequency = np.asarray(frequencies_ghz) * 1e9
+    phase_step = np.deg2rad(PROGRESSIVE_PHASE_DEG)
+    argument = -phase_step * LIGHT_SPEED / (
+        2 * np.pi * frequency * ELEMENT_SPACING
+    )
+    return np.degrees(np.arcsin(np.clip(argument, -1, 1)))
+
+
+def main():
+    active_s = read_active_s()
+    frequencies, angles, patterns = read_xy_patterns()
+    predicted_angles = predicted_array_factor_angles(frequencies)
+    figure, (s_axis, pattern_axis) = plt.subplots(
+        1, 2, figsize=(13, 5), constrained_layout=True
+    )
+
+    for port, trace in sorted(active_s.items()):
+        s_axis.plot(trace[:, 0], trace[:, 1], marker="o", label=f"Port {port}")
+    s_axis.set_title(r"Driven-state active reflection $\Gamma_{active,i}=b_i/a_i$")
+    s_axis.set_xlabel("Frequency (GHz)")
+    s_axis.set_ylabel("Active S (dB)")
+    s_axis.grid(True, alpha=0.3)
+    s_axis.legend()
+
+    peak_angles = []
+    forward = np.abs(angles) <= 90
+    for frequency, pattern, predicted_angle in zip(
+        frequencies, patterns, predicted_angles
+    ):
+        normalized = pattern - np.nanmax(pattern[forward])
+        peak_angle = angles[forward][np.nanargmax(pattern[forward])]
+        peak_angles.append(peak_angle)
+        pattern_axis.plot(
+            angles[forward], normalized[forward],
+            label=(
+                f"{frequency:g} GHz "
+                f"(FDTD {peak_angle:g} deg, array factor {predicted_angle:.1f} deg)"
+            ),
+        )
+    pattern_axis.set_title("Frequency-dependent xy-plane beam direction")
+    pattern_axis.set_xlabel("Angle from +x toward +y (degrees)")
+    pattern_axis.set_ylabel("Normalized directivity (dB)")
+    pattern_axis.set_xlim(-90, 90)
+    pattern_axis.set_ylim(-35, 1)
+    pattern_axis.grid(True, alpha=0.3)
+    pattern_axis.legend(fontsize="small")
+    figure.suptitle(
+        "Four-element phase-steered array: active S-parameters and beam squint"
+    )
+    figure.savefig(OUTPUT, dpi=180)
+    print(f"Wrote {OUTPUT}")
+    print("FDTD peak angles by frequency:", dict(zip(frequencies, peak_angles)))
+    print(
+        "Ideal array-factor angles by frequency:",
+        dict(zip(frequencies, predicted_angles)),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/features/eigenmode_ports/example_6_near_cutoff/near_cutoff.in
+++ b/examples/features/eigenmode_ports/example_6_near_cutoff/near_cutoff.in
@@ -1,0 +1,25 @@
+#title: Example 6 - rectangular-waveguide S parameters across TE10 cutoff
+
+#domain: 0.028 0.008 0.006
+#dx_dy_dz: 0.0002 0.0002 0.0002
+#time_window: 4e-9
+#pml_cells: 12 0 0 12 0 0
+
+## The air-filled guide is 6 mm wide and 4 mm high, so its analytical TE10
+## cutoff is c/(2a) = 24.9827048 GHz. Seven of the 100 requested DFT points
+## are below cutoff and the first propagating point is 24.9924242 GHz.
+#box: 0 0 0 0.028 0.001 0.006 pec
+#box: 0 0.007 0 0.028 0.008 0.006 pec
+#box: 0 0 0 0.028 0.008 0.001 pec
+#box: 0 0 0.005 0.028 0.008 0.006 pec
+
+#eigenmode_band: cutoff_band 24.25e9 34.75e9 100
+
+## Near cutoff, beta and modal impedance change rapidly. Put reference
+## anchors at every below-cutoff DFT point, the first nine propagating points,
+## and then about every 0.5 GHz. The extra 15, 20, 40 and 45 GHz candidates
+## cover the automatic waveform's transition spectrum without interpolating
+## the tracked evanescent branch through cutoff.
+#eigenmode_port: 1 0.004 0.001 0.001 0.004 0.007 0.005 + 1 15e9 20e9 24.25e9 24.3560606061e9 24.4621212121e9 24.5681818182e9 24.6742424242e9 24.7803030303e9 24.8863636364e9 24.9924242424e9 25.0984848485e9 25.2045454545e9 25.3106060606e9 25.4166666667e9 25.5227272727e9 25.6287878788e9 25.7348484848e9 25.8409090909e9 26.25e9 26.75e9 27.25e9 27.75e9 28.25e9 28.75e9 29.25e9 29.75e9 30.25e9 30.75e9 31.25e9 31.75e9 32.25e9 32.75e9 33.25e9 33.75e9 34.25e9 34.75e9 40e9 45e9 n
+#eigenmode_port: 2 0.016 0.001 0.001 0.016 0.007 0.005 - 1 15e9 20e9 24.25e9 24.3560606061e9 24.4621212121e9 24.5681818182e9 24.6742424242e9 24.7803030303e9 24.8863636364e9 24.9924242424e9 25.0984848485e9 25.2045454545e9 25.3106060606e9 25.4166666667e9 25.5227272727e9 25.6287878788e9 25.7348484848e9 25.8409090909e9 26.25e9 26.75e9 27.25e9 27.75e9 28.25e9 28.75e9 29.25e9 29.75e9 30.25e9 30.75e9 31.25e9 31.75e9 32.25e9 32.75e9 33.25e9 33.75e9 34.25e9 34.75e9 40e9 45e9 n
+#eigenmode_excitation: 1 1 auto n

--- a/examples/features/eigenmode_ports/example_6_near_cutoff/plot_results.py
+++ b/examples/features/eigenmode_ports/example_6_near_cutoff/plot_results.py
@@ -1,0 +1,111 @@
+"""Plot generalized and physical TE10 S parameters across cutoff."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+ROOT = Path(__file__).resolve().parent
+CSV_PATH = ROOT / "near_cutoff_sparameters.csv"
+OUTPUT = ROOT / "near_cutoff_sparameters.png"
+C = 299_792_458.0
+WIDTH = 0.006
+CUTOFF = C / (2 * WIDTH)
+
+
+def series(destination_port):
+    with CSV_PATH.open(newline="", encoding="utf-8") as stream:
+        rows = [
+            row for row in csv.DictReader(stream)
+            if int(row["source_port"]) == 1
+            and int(row["source_mode"]) == 1
+            and int(row["destination_port"]) == destination_port
+            and int(row["destination_mode"]) == 1
+        ]
+    rows.sort(key=lambda row: float(row["frequency_hz"]))
+    return {
+        "frequency": np.asarray([float(row["frequency_hz"]) for row in rows]),
+        "value": np.asarray([
+            float(row["S_real"]) + 1j * float(row["S_imag"]) for row in rows
+        ]),
+        "coefficient_valid": np.asarray([
+            bool(int(row.get("coefficient_valid", row["generalized_valid"])))
+            for row in rows
+        ]),
+        "power_wave_valid": np.asarray([
+            bool(int(row.get("power_wave_valid", row["valid"]))) for row in rows
+        ]),
+    }
+
+
+def analytical_s21(frequency):
+    k0 = 2 * np.pi * frequency / C
+    kc = np.pi / WIDTH
+    beta = np.empty(frequency.shape, dtype=complex)
+    propagating = frequency > CUTOFF
+    beta[propagating] = np.sqrt(k0[propagating] ** 2 - kc ** 2)
+    beta[~propagating] = -1j * np.sqrt(kc ** 2 - k0[~propagating] ** 2)
+    return np.exp(-1j * beta * 0.012)
+
+
+def main():
+    s11 = series(1)
+    s21 = series(2)
+    frequency_ghz = s21["frequency"] * 1e-9
+    theory = analytical_s21(s21["frequency"])
+    with np.errstate(divide="ignore"):
+        s11_db = 20 * np.log10(np.abs(s11["value"]))
+        s21_db = 20 * np.log10(np.abs(s21["value"]))
+        theory_db = 20 * np.log10(np.abs(theory))
+
+    figure, (magnitude_axis, phase_axis) = plt.subplots(
+        2, 1, figsize=(9, 8), sharex=True, constrained_layout=True
+    )
+    for axis in (magnitude_axis, phase_axis):
+        axis.axvspan(frequency_ghz[0], CUTOFF * 1e-9, color="0.9")
+        axis.axvline(CUTOFF * 1e-9, color="0.3", linestyle="--")
+        axis.grid(True, alpha=0.3)
+    for label, values, valid in (
+        ("S11 generalized coefficient", s11_db, s11["coefficient_valid"]),
+        ("S21 generalized coefficient", s21_db, s21["coefficient_valid"]),
+    ):
+        magnitude_axis.plot(frequency_ghz[valid], values[valid], label=label)
+    magnitude_axis.plot(frequency_ghz, theory_db, "k:", label="Analytical TE10 S21")
+    magnitude_axis.set_ylabel("Magnitude (dB)")
+    magnitude_axis.legend()
+    magnitude_axis.set_title(
+        "Below cutoff, a generalized coefficient exists but no real-power wave does"
+    )
+
+    valid = s21["coefficient_valid"]
+    phase_axis.plot(
+        frequency_ghz[valid],
+        np.rad2deg(np.unwrap(np.angle(s21["value"][valid]))),
+        label="gprMax S21",
+    )
+    phase_axis.plot(
+        frequency_ghz,
+        np.rad2deg(np.unwrap(np.angle(theory))),
+        "k:", label="Analytical TE10",
+    )
+    phase_axis.set_xlabel("Frequency (GHz)")
+    phase_axis.set_ylabel("Unwrapped phase (degrees)")
+    phase_axis.legend()
+    figure.savefig(OUTPUT, dpi=180)
+    print(f"Wrote {OUTPUT}")
+    print(
+        "Below cutoff:", int(np.count_nonzero(s21["coefficient_valid"] &
+                                               ~s21["power_wave_valid"])),
+        "coefficient-valid bins are not power-wave-valid."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/gprMax/eigenmode_config.py
+++ b/gprMax/eigenmode_config.py
@@ -241,10 +241,23 @@ class EigenmodeBandSpec:
     fmin: float
     fmax: float
     points: int
+    frequencies: tuple[float, ...] = field(default_factory=tuple)
     transition: str | float = 'auto'
     spectral_threshold: float = 1e-3
     representative_frequency: float | None = None
     significant_range: tuple[float, float] | None = None
+
+    @property
+    def dft_frequencies(self) -> tuple[float, ...]:
+        """Return the sorted union of the uniform band and requested extra bins."""
+
+        uniform = np.linspace(self.fmin, self.fmax, self.points, dtype=np.float64)
+        if not self.frequencies:
+            return tuple(float(value) for value in uniform)
+        combined = np.unique(
+            np.concatenate((uniform, np.asarray(self.frequencies, dtype=np.float64)))
+        )
+        return tuple(float(value) for value in combined)
 
     def resolve_spectrum(self, grid, waveform, *, generated_waveform: bool):
         _, frequencies, spectrum = sampled_waveform_spectrum(

--- a/gprMax/eigenmode_ports.py
+++ b/gprMax/eigenmode_ports.py
@@ -303,6 +303,7 @@ class EigenmodePortMonitor:
         anchor_mode_propagating=None,
         anchor_balanced_power=None,
         mode_anchor_policies=None,
+        dft_frequencies=None,
     ):
         self.owner = owner
         self.port_index = int(port_index)
@@ -355,11 +356,20 @@ class EigenmodePortMonitor:
         self.dft_start = float(dft_start)
         self.dft_stop = float(dft_stop)
         self.dft_points = int(dft_points)
+        self.dft_frequencies = (
+            None
+            if dft_frequencies is None
+            else np.asarray(dft_frequencies, dtype=np.float64)
+        )
         self.result = None
         self.s_parameters = None
         self.s_valid = None
         self.s_generalized_valid = None
         self.s_power_wave_valid = None
+        self.active_s_parameters = None
+        self.active_s_valid = None
+        self.active_s_coefficient_valid = None
+        self.active_s_driven = None
 
     def set_drive_metadata(self, drives):
         """Record all active modal drives represented by this physical port."""
@@ -414,6 +424,18 @@ class EigenmodePortMonitor:
             raise ValueError("A one-point eigenmode DFT requires equal start and stop frequencies.")
         if self.dft_points > 1 and self.dft_stop == self.dft_start:
             raise ValueError("A multi-point eigenmode DFT requires stop greater than start.")
+        if self.dft_frequencies is not None:
+            if self.dft_frequencies.ndim != 1 or self.dft_frequencies.size == 0:
+                raise ValueError("Eigenmode port DFT frequencies must be one-dimensional and non-empty.")
+            if (
+                not np.all(np.isfinite(self.dft_frequencies))
+                or np.any(self.dft_frequencies <= 0)
+            ):
+                raise ValueError("Eigenmode port DFT frequencies must be finite and positive.")
+            if np.any(np.diff(self.dft_frequencies) <= 0):
+                raise ValueError(
+                    "Eigenmode port DFT frequencies must be unique and strictly increasing."
+                )
         expected_shape = (self.anchor_frequencies.size, len(self.mode_indices))
         if self.anchor_mode_valid.shape != expected_shape:
             raise ValueError(
@@ -558,13 +580,22 @@ class EigenmodePortMonitor:
 
         real_dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
         complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
-        nominal_frequency = np.linspace(
-            self.dft_start,
-            self.dft_stop,
-            self.dft_points,
-            dtype=np.float64,
+        nominal_frequency = (
+            np.linspace(
+                self.dft_start,
+                self.dft_stop,
+                self.dft_points,
+                dtype=np.float64,
+            )
+            if self.dft_frequencies is None
+            else self.dft_frequencies
         )
         self.frequency = np.asarray(nominal_frequency, dtype=real_dtype)
+        if np.any(np.diff(self.frequency) <= 0):
+            raise ValueError(
+                f"Eigenmode port {self.port_id!r} DFT frequencies are not distinct "
+                "at the configured simulation precision."
+            )
         if self.frequency[-1] > 0.5 / grid.dt:
             raise ValueError(
                 f"Eigenmode port {self.port_id!r} DFT stop frequency exceeds the FDTD Nyquist frequency."
@@ -928,6 +959,10 @@ class EigenmodePortMonitor:
         self.s_valid = None
         self.s_generalized_valid = None
         self.s_power_wave_valid = None
+        self.active_s_parameters = None
+        self.active_s_valid = None
+        self.active_s_coefficient_valid = None
+        self.active_s_driven = None
         self.response_type = "driven" if self.is_source else "passive"
 
     def finalise(self, grid):
@@ -1079,12 +1114,18 @@ class EigenmodePortMonitor:
         group["incident"] = self.result.incident
         group["outgoing"] = self.result.outgoing
         group["valid"] = self.result.valid.astype(np.uint8)
-        group["generalized_valid"] = _generalized_result_valid(self.result).astype(np.uint8)
+        coefficient_valid = _generalized_result_valid(self.result).astype(np.uint8)
+        power_wave_valid = self.result.valid.astype(np.uint8)
+        group["generalized_valid"] = coefficient_valid
+        group["coefficient_valid"] = coefficient_valid
+        group["power_wave_valid"] = power_wave_valid
         group["condition_number"] = self.result.condition_number
         group["electric_cross_power_matrix"] = self.electric_gram
         group["power_matrix"] = self.power_matrix
         group["decomposition_valid"] = self.mode_decomposition_valid.astype(np.uint8)
+        group["reference_basis_valid"] = self.mode_decomposition_valid.astype(np.uint8)
         group["power_normalization_valid"] = self.power_wave_valid.astype(np.uint8)
+        group["power_basis_valid"] = self.power_wave_valid.astype(np.uint8)
         group["anchor_mode_valid"] = self.anchor_mode_valid.astype(np.uint8)
         group["anchor_mode_reference_valid"] = self.anchor_mode_reference_valid.astype(np.uint8)
         group["anchor_mode_propagating"] = self.anchor_mode_propagating.astype(np.uint8)
@@ -1095,6 +1136,159 @@ class EigenmodePortMonitor:
             group["valid_S"] = self.s_valid.astype(np.uint8)
             group["power_wave_valid_S"] = self.s_valid.astype(np.uint8)
             group["generalized_valid_S"] = self.s_generalized_valid.astype(np.uint8)
+            group["coefficient_valid_S"] = self.s_generalized_valid.astype(np.uint8)
+        if getattr(self, "active_s_parameters", None) is not None:
+            group["active_S"] = self.active_s_parameters
+            group["active_S_driven"] = self.active_s_driven.astype(np.uint8)
+            group["coefficient_valid_active_S"] = self.active_s_coefficient_valid.astype(
+                np.uint8
+            )
+            group["power_wave_valid_active_S"] = self.active_s_valid.astype(np.uint8)
+
+
+def _incident_ratio_valid(denominator, coefficient_valid, power_wave_mask):
+    """Apply the incident-spectrum floor independently to both modal bases."""
+
+    denominator = np.asarray(denominator)
+    coefficient_valid = np.asarray(coefficient_valid, dtype=bool)
+    power_wave_mask = np.asarray(power_wave_mask, dtype=bool)
+    ratio_valid = np.zeros(denominator.shape, dtype=bool)
+    for normalization_class in (power_wave_mask, ~power_wave_mask):
+        candidates = coefficient_valid & normalization_class & np.isfinite(denominator)
+        peak = float(np.max(np.abs(denominator[candidates]), initial=0.0))
+        if peak > 0:
+            ratio_valid |= candidates & (
+                np.abs(denominator) >= peak * 10 ** (INCIDENT_FLOOR_DB / 20)
+            )
+    return ratio_valid
+
+
+def _complex_csv_fields(value):
+    """Return portable rectangular and polar fields for one complex coefficient."""
+
+    magnitude = abs(value)
+    if np.isfinite(magnitude) and magnitude > 0:
+        magnitude_db = float(20 * np.log10(magnitude))
+    elif magnitude == 0:
+        magnitude_db = -np.inf
+    else:
+        magnitude_db = np.nan
+    return (
+        float(np.real(value)),
+        float(np.imag(value)),
+        float(magnitude),
+        magnitude_db,
+        float(np.angle(value, deg=True)),
+        float(magnitude**2),
+    )
+
+
+def _write_active_sparameters(grid, sources, excitation_modes):
+    """Form state-dependent active reflection coefficients for driven channels."""
+
+    reference_frequency = np.asarray(grid.eigenmodeports[0].result.frequency)
+    for port in grid.eigenmodeports:
+        if not np.array_equal(port.result.frequency, reference_frequency):
+            raise ValueError("All eigenmode ports must use identical DFT frequency bins.")
+        port.active_s_parameters = np.full_like(
+            port.result.outgoing,
+            np.nan + 1j * np.nan,
+        )
+        port.active_s_coefficient_valid = np.zeros(port.result.outgoing.shape, dtype=bool)
+        port.active_s_valid = np.zeros(port.result.outgoing.shape, dtype=bool)
+        port.active_s_driven = np.zeros(port.result.outgoing.shape, dtype=bool)
+
+    rows = []
+    for port in sources:
+        port_power_wave_valid_value = getattr(port, "power_wave_valid", None)
+        if port_power_wave_valid_value is None:
+            port_power_wave_valid_value = port.mode_power_valid
+        port_power_wave_valid = np.asarray(port_power_wave_valid_value, dtype=bool)
+        result_coefficient_valid = _generalized_result_valid(port.result)
+        drive_by_mode = {
+            int(metadata["mode"]): metadata
+            for metadata in getattr(port, "drive_metadata", ())
+        }
+        for mode_index in excitation_modes(port):
+            mode_position = port.mode_indices.index(mode_index)
+            port.active_s_driven[mode_position] = True
+            denominator = port.result.incident[mode_position]
+            power_wave_mask = port_power_wave_valid[:, mode_position]
+            ratio_valid = _incident_ratio_valid(
+                denominator,
+                result_coefficient_valid[mode_position],
+                power_wave_mask,
+            )
+            np.divide(
+                port.result.outgoing[mode_position],
+                denominator,
+                out=port.active_s_parameters[mode_position],
+                where=ratio_valid,
+            )
+            coefficient_valid = result_coefficient_valid[mode_position] & ratio_valid
+            power_valid = (
+                coefficient_valid
+                & np.asarray(port.result.valid[mode_position], dtype=bool)
+                & power_wave_mask
+                & np.asarray(port.power_matrix_valid, dtype=bool)
+            )
+            port.active_s_coefficient_valid[mode_position] = coefficient_valid
+            port.active_s_valid[mode_position] = power_valid
+            port.active_s_parameters[mode_position, ~coefficient_valid] = np.nan + 1j * np.nan
+            metadata = drive_by_mode.get(
+                int(mode_index),
+                {
+                    "amplitude": np.nan,
+                    "power": np.nan,
+                    "phase_deg": np.nan,
+                    "delay_s": np.nan,
+                },
+            )
+            for frequency_index, frequency in enumerate(port.result.frequency):
+                value = port.active_s_parameters[mode_position, frequency_index]
+                rows.append(
+                    (
+                        float(frequency),
+                        port.port_index,
+                        mode_index,
+                        *_complex_csv_fields(value),
+                        int(coefficient_valid[frequency_index]),
+                        int(power_valid[frequency_index]),
+                        float(metadata["amplitude"]),
+                        float(metadata["power"]),
+                        float(metadata["phase_deg"]),
+                        float(metadata["delay_s"]),
+                    )
+                )
+
+    suffix = "" if grid.name == "main_grid" else f"_{grid.name}"
+    output_path = config.get_model_config().output_file_path.with_name(
+        config.get_model_config().output_file_path.name + f"{suffix}_active_sparameters.csv"
+    )
+    with output_path.open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream, lineterminator="\n")
+        writer.writerow(
+            (
+                "frequency_hz",
+                "port",
+                "mode",
+                "active_S_real",
+                "active_S_imag",
+                "active_S_magnitude",
+                "active_S_magnitude_db",
+                "active_S_phase_deg",
+                "coefficient_magnitude_squared",
+                "coefficient_valid",
+                "power_wave_valid",
+                "drive_amplitude",
+                "drive_power",
+                "drive_phase_deg",
+                "drive_delay_s",
+            )
+        )
+        writer.writerows(rows)
+    logger.info(f"Eigenmode active S-parameter CSV written to {output_path}")
+    return output_path
 
 
 def finalise_eigenmode_ports(grid):
@@ -1119,13 +1313,13 @@ def finalise_eigenmode_ports(grid):
         return () if mode is None else (mode,)
 
     drive_count = sum(len(excitation_modes(port)) for port in sources)
-    # A simultaneous driven state is not an S-matrix column. Preserve its
-    # decomposed incident/outgoing waves and drive metadata without inventing
-    # an ambiguous normalization.
+    # A simultaneous driven state is not an S-matrix column. Report the active
+    # reflection coefficient b_i/a_i only for each deliberately driven modal
+    # channel, while preserving every raw incident/outgoing wave in HDF5.
     if drive_count != 1:
         for port in grid.eigenmodeports:
             port.response_type = "driven"
-        return None
+        return _write_active_sparameters(grid, sources, excitation_modes)
 
     source = sources[0]
     for port in grid.eigenmodeports:
@@ -1145,18 +1339,15 @@ def finalise_eigenmode_ports(grid):
         source_power_wave_valid_value,
         dtype=bool,
     )[:, source_mode_position]
-    source_ratio_valid = np.zeros(denominator.shape, dtype=bool)
     # Balanced generalized amplitudes and one-watt power-wave amplitudes use
     # different reference normalizations. Apply the incident floor within
     # each class so a large evanescent coefficient cannot suppress an
     # otherwise well-excited propagating bin (or vice versa).
-    for normalization_class in (source_power_wave_mask, ~source_power_wave_mask):
-        candidates = source_generalized_result_valid & normalization_class
-        peak = float(np.max(np.abs(denominator[candidates]), initial=0.0))
-        if peak > 0:
-            source_ratio_valid |= candidates & (
-                np.abs(denominator) >= peak * 10 ** (INCIDENT_FLOOR_DB / 20)
-            )
+    source_ratio_valid = _incident_ratio_valid(
+        denominator,
+        source_generalized_result_valid,
+        source_power_wave_mask,
+    )
     source_power_wave_valid = (
         source_ratio_valid
         & np.asarray(source.result.valid[source_mode_position], dtype=bool)
@@ -1208,6 +1399,7 @@ def finalise_eigenmode_ports(grid):
                 "coefficient_magnitude_squared",
                 "valid",
                 "power_wave_valid",
+                "coefficient_valid",
                 "generalized_valid",
             )
         )
@@ -1216,13 +1408,6 @@ def finalise_eigenmode_ports(grid):
                 values = port.s_parameters[mode_position]
                 for frequency_index, frequency in enumerate(port.result.frequency):
                     value = values[frequency_index]
-                    magnitude = abs(value)
-                    if np.isfinite(magnitude) and magnitude > 0:
-                        magnitude_db = float(20 * np.log10(magnitude))
-                    elif magnitude == 0:
-                        magnitude_db = -np.inf
-                    else:
-                        magnitude_db = np.nan
                     writer.writerow(
                         (
                             float(frequency),
@@ -1230,14 +1415,10 @@ def finalise_eigenmode_ports(grid):
                             source.excitation_mode_index,
                             port.port_index,
                             mode_index,
-                            float(np.real(value)),
-                            float(np.imag(value)),
-                            float(magnitude),
-                            magnitude_db,
-                            float(np.angle(value, deg=True)),
-                            float(magnitude**2),
+                            *_complex_csv_fields(value),
                             int(port.s_valid[mode_position, frequency_index]),
                             int(port.s_valid[mode_position, frequency_index]),
+                            int(port.s_generalized_valid[mode_position, frequency_index]),
                             int(port.s_generalized_valid[mode_position, frequency_index]),
                         )
                     )

--- a/gprMax/hash_cmds_multiuse.py
+++ b/gprMax/hash_cmds_multiuse.py
@@ -448,16 +448,20 @@ def process_multicmds(multicmds):
 
     for cmdinstance in eigenmode_band_cmds:
         tmp = cmdinstance.split()
-        if len(tmp) != 4:
-            raise ValueError("#eigenmode_band requires id fmin fmax points.")
-        scene_objects.append(
-            EigenmodeBand(
-                id=tmp[0],
-                fmin=float(tmp[1]),
-                fmax=float(tmp[2]),
-                points=int(tmp[3]),
+        if len(tmp) < 4:
+            raise ValueError(
+                "#eigenmode_band requires id fmin fmax points "
+                "[frequency ...]."
             )
-        )
+        kwargs = {
+            "id": tmp[0],
+            "fmin": float(tmp[1]),
+            "fmax": float(tmp[2]),
+            "points": int(tmp[3]),
+        }
+        if len(tmp) > 4:
+            kwargs["frequencies"] = tuple(float(value) for value in tmp[4:])
+        scene_objects.append(EigenmodeBand(**kwargs))
 
     for cmdinstance in eigenmode_port_cmds:
         tmp = cmdinstance.split()

--- a/gprMax/ntff/interface.py
+++ b/gprMax/ntff/interface.py
@@ -61,7 +61,12 @@ from gprMax.ntff.layered import (
 )
 from gprMax.ntff.surfaces import COMPONENT_OFFSETS, COMPONENTS, build_component_surface
 from gprMax.ntff.time_domain import KSIRTimeDomainMonitor
-from gprMax.ports import evaluate_port_power_spectrum, model_port_ids, model_port_output_registry
+from gprMax.ports import (
+    evaluate_port_power_spectrum,
+    frequency_subset_indices,
+    model_port_ids,
+    model_port_output_registry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -2188,23 +2193,6 @@ def compile_ntff_outputs(model, grid) -> Optional[NTFFCompiledOutputs]:
         transform_specs or time_requests or frequency_requests or far_requests or time_far_requests
     ):
         return None
-    has_eigenmode_source = any(
-        getattr(source_grid, "eigenmodesources", ()) for source_grid in (model.G, *model.subgrids)
-    )
-    has_ksir_request = bool(
-        ksir_transform_specs
-        or time_requests
-        or frequency_requests
-        or ksir_far_requests
-        or ksir_antenna_port_specs
-    )
-    if has_eigenmode_source and has_ksir_request:
-        raise ValueError(
-            "eigenmode sources cannot be used with the Ramahi/KSIR NTFF "
-            "formulation; use the equivalent-current Huygens NTFF commands "
-            "(#ntff_frequency, #ntff_far_field or #ntff_far_field_array, and "
-            "#ntff_antenna_ports when gain is requested) instead"
-        )
     if config.sim_config.general["solver"] not in ("cpu", "cuda", "opencl", "metal"):
         raise ValueError(
             "the reusable NTFF interface supports CPU, CUDA, OpenCL, and Metal solvers"
@@ -2302,15 +2290,13 @@ def compile_ntff_outputs(model, grid) -> Optional[NTFFCompiledOutputs]:
             output = eigenmode_port_registry.get(port_id)
             if output is None:
                 continue
-            expected = np.asarray(
-                transform.frequencies,
-                dtype=np.asarray(output.frequency).dtype,
-            )
-            if not np.array_equal(expected, output.frequency):
+            try:
+                frequency_subset_indices(output.frequency, transform.frequencies)
+            except ValueError as exc:
                 raise ValueError(
-                    f"NTFF transform {transform_id!r} frequencies must exactly match "
-                    f"eigenmode port {port_id!r} DFT frequencies"
-                )
+                    f"NTFF transform {transform_id!r} frequencies must be a subset "
+                    f"of eigenmode port {port_id!r} DFT frequencies"
+                ) from exc
     for transform_id in port_normalized_transforms:
         if transform_id not in antenna_port_specs:
             raise ValueError(

--- a/gprMax/ports.py
+++ b/gprMax/ports.py
@@ -222,6 +222,45 @@ def _finite_source_gap_admittance(output, frequency, dt, complex_dtype):
     return np.asarray(admittance, dtype=complex_dtype)
 
 
+def frequency_subset_indices(available_frequencies, requested_frequencies):
+    """Map a requested frequency subset onto a sorted available grid.
+
+    Frequencies are compared at the available grid's precision. A small
+    precision-scaled tolerance also accepts values produced through an
+    equivalent floating-point construction rather than the same literal.
+    """
+
+    available = np.asarray(available_frequencies)
+    if available.ndim != 1 or available.size == 0:
+        raise ValueError("available frequencies must be one-dimensional and non-empty")
+    requested = np.asarray(requested_frequencies, dtype=available.dtype)
+    if requested.ndim != 1 or requested.size == 0:
+        raise ValueError("requested frequencies must be one-dimensional and non-empty")
+    if np.any(np.diff(available) <= 0):
+        raise ValueError("available frequencies must be unique and strictly increasing")
+
+    insertion = np.searchsorted(available, requested)
+    right_indices = np.minimum(insertion, available.size - 1)
+    left_indices = np.maximum(insertion - 1, 0)
+    choose_left = (
+        np.abs(available[left_indices] - requested)
+        <= np.abs(available[right_indices] - requested)
+    )
+    safe_indices = np.where(choose_left, left_indices, right_indices)
+    real_dtype = np.asarray(available.real).dtype
+    tolerance = 8 * np.finfo(real_dtype).eps
+    matched = np.isclose(
+        available[safe_indices],
+        requested,
+        rtol=tolerance,
+        atol=0,
+    )
+    if not np.all(matched):
+        missing = ", ".join(f"{float(value):g}" for value in requested[~matched])
+        raise ValueError(f"requested frequencies are not available DFT bins: {missing} Hz")
+    return np.asarray(safe_indices, dtype=np.intp)
+
+
 def evaluate_port_power_spectrum(
     output,
     grid: "FDTDGrid",
@@ -229,7 +268,7 @@ def evaluate_port_power_spectrum(
     *,
     window: str = "rectangular",
 ) -> PortPowerSpectrum:
-    """Evaluate one supported port at the exact antenna-transform frequencies.
+    """Evaluate one supported port at the antenna-transform frequencies.
 
     Conventional ports use terminal voltage/current rather than S11, so an
     unexcited but coupled port remains measurable. Eigenmode ports use their
@@ -254,15 +293,32 @@ def evaluate_port_power_spectrum(
     from gprMax.eigenmode_ports import EigenmodePortMonitor
 
     if isinstance(output, EigenmodePortMonitor):
-        if not np.array_equal(frequency, output.result.frequency):
-            raise ValueError(
-                f"eigenmode port {output.output_id!r} DFT frequencies must exactly "
-                "match the antenna transform frequencies"
+        try:
+            frequency_indices = frequency_subset_indices(
+                output.result.frequency,
+                frequency,
             )
-        incident_modal = np.asarray(output.result.incident, dtype=complex_dtype)
-        outgoing_modal = np.asarray(output.result.outgoing, dtype=complex_dtype)
-        power_matrix = np.asarray(output.power_matrix, dtype=complex_dtype)
-        cross_power_matrix = np.asarray(output.electric_gram, dtype=complex_dtype)
+        except ValueError as exc:
+            raise ValueError(
+                f"antenna-transform frequencies for eigenmode port "
+                f"{output.output_id!r} must be a subset of its DFT frequencies"
+            ) from exc
+        incident_modal = np.asarray(
+            output.result.incident[:, frequency_indices],
+            dtype=complex_dtype,
+        )
+        outgoing_modal = np.asarray(
+            output.result.outgoing[:, frequency_indices],
+            dtype=complex_dtype,
+        )
+        power_matrix = np.asarray(
+            output.power_matrix[frequency_indices],
+            dtype=complex_dtype,
+        )
+        cross_power_matrix = np.asarray(
+            output.electric_gram[frequency_indices],
+            dtype=complex_dtype,
+        )
         if incident_modal.shape != outgoing_modal.shape:
             raise ValueError(f"eigenmode port {output.output_id!r} has inconsistent modal arrays")
         if incident_modal.shape != (len(output.mode_indices), frequency.size):
@@ -304,9 +360,11 @@ def evaluate_port_power_spectrum(
         power_wave_valid_value = getattr(output, "power_wave_valid", None)
         if power_wave_valid_value is None:
             power_wave_valid_value = output.mode_power_valid
-        power_wave_valid = np.asarray(power_wave_valid_value, dtype=bool)
-        result_valid = np.asarray(output.result.valid, dtype=bool)
-        power_matrix_valid = np.asarray(output.power_matrix_valid, dtype=bool)
+        power_wave_valid = np.asarray(power_wave_valid_value, dtype=bool)[frequency_indices]
+        result_valid = np.asarray(output.result.valid, dtype=bool)[:, frequency_indices]
+        power_matrix_valid = np.asarray(output.power_matrix_valid, dtype=bool)[
+            frequency_indices
+        ]
         modal_valid = result_valid & power_wave_valid.T & power_matrix_valid[np.newaxis, :]
         physical_power_valid = np.zeros(frequency.shape, dtype=bool)
         for frequency_index in range(frequency.size):

--- a/gprMax/sources.py
+++ b/gprMax/sources.py
@@ -357,6 +357,7 @@ class EigenmodeSource(Source):
         self.dft_start = None
         self.dft_stop = None
         self.dft_points = None
+        self.dft_frequencies = None
         self.port_monitor = None
         self.drive_specs = ()
         self.drive_amplitude = 1.0
@@ -588,6 +589,7 @@ class EigenmodeSource(Source):
             dft_start=self.dft_start,
             dft_stop=self.dft_stop,
             dft_points=self.dft_points,
+            dft_frequencies=self.dft_frequencies,
             anchor_mode_valid=self.port_anchor_mode_valid,
             anchor_mode_reference_valid=self.port_anchor_mode_reference_valid,
             anchor_mode_propagating=self.port_anchor_mode_propagating,
@@ -2494,6 +2496,7 @@ class EigenmodeReceiver(EigenmodeSource):
             dft_start=self.dft_start,
             dft_stop=self.dft_stop,
             dft_points=self.dft_points,
+            dft_frequencies=self.dft_frequencies,
             anchor_mode_valid=self.port_anchor_mode_valid,
             anchor_mode_reference_valid=self.port_anchor_mode_reference_valid,
             anchor_mode_propagating=self.port_anchor_mode_propagating,

--- a/gprMax/studies.py
+++ b/gprMax/studies.py
@@ -2556,15 +2556,25 @@ class EigenmodeStudy(Study):
         group.create_dataset("frequency", data=data["frequency"])
         group.create_dataset("S_column", data=data["column"])
         group.create_dataset("valid_S_column", data=data["valid"].astype(np.uint8))
+        group.create_dataset("power_wave_valid_S_column", data=data["valid"].astype(np.uint8))
         group.create_dataset(
             "generalized_valid_S_column",
+            data=data["generalized_valid"].astype(np.uint8),
+        )
+        group.create_dataset(
+            "coefficient_valid_S_column",
             data=data["generalized_valid"].astype(np.uint8),
         )
         group.create_dataset("incident", data=data["incident"])
         group.create_dataset("outgoing", data=data["outgoing"])
         group.create_dataset("valid_wave", data=data["wave_valid"].astype(np.uint8))
+        group.create_dataset("power_wave_valid", data=data["wave_valid"].astype(np.uint8))
         group.create_dataset(
             "generalized_valid_wave",
+            data=data["generalized_wave_valid"].astype(np.uint8),
+        )
+        group.create_dataset(
+            "coefficient_valid_wave",
             data=data["generalized_wave_valid"].astype(np.uint8),
         )
         if self._aggregate_output_path is not None:
@@ -2902,7 +2912,12 @@ class EigenmodeStudy(Study):
             output.create_dataset("case_ids", data=np.asarray(result.case_ids, dtype="S"))
             output.create_dataset("S", data=result.s)
             output.create_dataset("valid_S", data=result.valid_s.astype(np.uint8))
+            output.create_dataset("power_wave_valid_S", data=result.valid_s.astype(np.uint8))
             output.create_dataset("generalized_valid_S", data=result.generalized_valid_s.astype(np.uint8))
+            output.create_dataset(
+                "coefficient_valid_S",
+                data=result.generalized_valid_s.astype(np.uint8),
+            )
             output.create_dataset("incident_matrix", data=result.incident_matrix)
             output.create_dataset("outgoing_matrix", data=result.outgoing_matrix)
             output.create_dataset(
@@ -2918,7 +2933,15 @@ class EigenmodeStudy(Study):
                 data=result.wave_valid_matrix.astype(np.uint8),
             )
             output.create_dataset(
+                "power_wave_valid_matrix",
+                data=result.wave_valid_matrix.astype(np.uint8),
+            )
+            output.create_dataset(
                 "generalized_valid_wave_matrix",
+                data=result.generalized_wave_valid_matrix.astype(np.uint8),
+            )
+            output.create_dataset(
+                "coefficient_valid_wave_matrix",
                 data=result.generalized_wave_valid_matrix.astype(np.uint8),
             )
             if self.codebook is not None:

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -2199,7 +2199,12 @@ class DiscretePlaneWaveAxial(GridUserObject):
 
 
 class EigenmodeBand(GridUserObject):
-    """Define the single frequency band shared by all eigenmode ports."""
+    """Define the frequency band and optional extra DFT bins shared by all ports.
+
+    ``fmin``, ``fmax``, and ``points`` define the usual uniform grid.
+    ``frequencies`` may contain additional in-band frequencies; gprMax sorts
+    and deduplicates their union with the uniform grid.
+    """
 
     @property
     def order(self):
@@ -2228,6 +2233,21 @@ class EigenmodeBand(GridUserObject):
                 f"{self.params_str()} id must be a non-empty token without whitespace."
             )
         _validate_eigenmode_dft(self.params_str(), fmin, fmax, points)
+        requested_frequencies = self.kwargs.get("frequencies")
+        if requested_frequencies is None:
+            requested_frequencies = ()
+        elif np.isscalar(requested_frequencies):
+            requested_frequencies = (float(requested_frequencies),)
+        else:
+            requested_frequencies = tuple(float(value) for value in requested_frequencies)
+        if any(
+            not np.isfinite(value) or value < fmin or value > fmax
+            for value in requested_frequencies
+        ):
+            raise ValueError(
+                f"{self.params_str()} additional DFT frequencies must be finite and "
+                "lie inside the inclusive band limits."
+            )
         threshold = float(self.kwargs.get("spectral_threshold", 1e-3))
         if not 0 < threshold < 1:
             raise ValueError(
@@ -2243,12 +2263,20 @@ class EigenmodeBand(GridUserObject):
             fmin=fmin,
             fmax=fmax,
             points=points,
+            frequencies=requested_frequencies,
             transition=transition,
             spectral_threshold=threshold,
         )
+        dft_points = len(grid.eigenmodeband.dft_frequencies)
+        extra_description = (
+            f", including {dft_points - points} additional requested bin(s) after deduplication"
+            if requested_frequencies
+            else ""
+        )
         logger.info(
             f"{self.grid_name(grid)}Eigenmode band {band_id!r}, frequencies "
-            f"{fmin:g} to {fmax:g} Hz with {points} common DFT point(s), created."
+            f"{fmin:g} to {fmax:g} Hz with {dft_points} common DFT point(s)"
+            f"{extra_description}, created."
         )
 
 
@@ -2494,6 +2522,7 @@ class EigenmodeExcitation(GridUserObject):
             "dft_start": band.fmin,
             "dft_stop": band.fmax,
             "dft_points": band.points,
+            "dft_frequencies": band.dft_frequencies,
             "plot_fields": port.plot_fields,
         }
         if len(port.resolved_anchors) == 1:
@@ -2676,6 +2705,16 @@ def _validate_eigenmode_dft(label, start, stop, points):
         raise ValueError(f"{label} a one-point DFT requires equal start and stop.")
     if points > 1 and stop == start:
         raise ValueError(f"{label} a multi-point DFT requires stop greater than start.")
+
+
+def _validate_eigenmode_dft_frequencies(label, frequencies):
+    values = np.asarray(frequencies, dtype=np.float64)
+    if values.ndim != 1 or values.size == 0:
+        raise ValueError(f"{label} DFT frequencies must be one-dimensional and non-empty.")
+    if not np.all(np.isfinite(values)) or np.any(values <= 0):
+        raise ValueError(f"{label} DFT frequencies must be finite and positive.")
+    if np.any(np.diff(values) <= 0):
+        raise ValueError(f"{label} DFT frequencies must be unique and strictly increasing.")
 
 
 def build_passive_virtual_eigenmode_ports(grid):
@@ -2872,6 +2911,13 @@ class _EigenmodeSourceBuilder(GridUserObject):
         else:
             frequencies = tuple(float(value) for value in frequencies_arg)
         spectral_threshold = float(self.kwargs.get("spectral_threshold", 1e-3))
+        dft_frequencies = tuple(
+            float(value)
+            for value in self.kwargs.get(
+                "dft_frequencies",
+                np.linspace(dft_start, dft_stop, dft_points),
+            )
+        )
         plot_fields = self.kwargs.get("plot_fields")
         if plot_fields is not None and not isinstance(plot_fields, (bool, np.bool_)):
             raise ValueError(f"{self.params_str()} plot_fields must be True, False, or None.")
@@ -2898,6 +2944,7 @@ class _EigenmodeSourceBuilder(GridUserObject):
             raise ValueError(f"{self.params_str()} port_index must be one or greater.")
 
         _validate_eigenmode_dft(self.params_str(), dft_start, dft_stop, dft_points)
+        _validate_eigenmode_dft_frequencies(self.params_str(), dft_frequencies)
 
         if not frequencies:
             raise ValueError(f"{self.params_str()} requires at least one frequency.")
@@ -3020,6 +3067,7 @@ class _EigenmodeSourceBuilder(GridUserObject):
         source.dft_start = dft_start
         source.dft_stop = dft_stop
         source.dft_points = dft_points
+        source.dft_frequencies = dft_frequencies
         source.waveformID = waveform_id
         source.waveform = next(x for x in grid.waveforms if x.ID == waveform_id)
         source.start = 0
@@ -3088,6 +3136,13 @@ class _EigenmodeReceiverBuilder(GridUserObject):
             (float(values),) if np.isscalar(values) else tuple(float(value) for value in values)
         )
         plot_fields = self.kwargs.get("plot_fields")
+        dft_frequencies = tuple(
+            float(value)
+            for value in self.kwargs.get(
+                "dft_frequencies",
+                np.linspace(dft_start, dft_stop, dft_points),
+            )
+        )
         if plot_fields is not None and not isinstance(plot_fields, (bool, np.bool_)):
             raise ValueError(f"{self.params_str()} plot_fields must be True, False, or None.")
 
@@ -3107,6 +3162,7 @@ class _EigenmodeReceiverBuilder(GridUserObject):
                 f"{self.params_str()} frequencies must be unique and strictly increasing."
             )
         _validate_eigenmode_dft(self.params_str(), dft_start, dft_stop, dft_points)
+        _validate_eigenmode_dft_frequencies(self.params_str(), dft_frequencies)
 
         axis_map = {"x": 0, "y": 1, "z": 2}
         normal_axis = axis_map[normal]
@@ -3215,6 +3271,7 @@ class _EigenmodeReceiverBuilder(GridUserObject):
         receiver.dft_start = dft_start
         receiver.dft_stop = dft_stop
         receiver.dft_points = dft_points
+        receiver.dft_frequencies = dft_frequencies
         grid.eigenmodereceivers.append(receiver)
         logger.info(
             f"{self.grid_name(grid)}Eigenmode receiver {port_id!r}, normal {normal}{direction}, "

--- a/gprMax/user_objects/cmds_output.py
+++ b/gprMax/user_objects/cmds_output.py
@@ -1751,8 +1751,8 @@ class NTFFAntennaPorts(KSIRAntennaPorts):
 
     In addition to conventional terminal ports, eigenmode sources use ``portN``
     for their explicit port index and eigenmode receivers use their configured
-    ID. The transform frequencies must exactly match every associated modal
-    port's direct-DFT bins.
+    ID. Every transform frequency must be present in each associated modal
+    port's direct-DFT bins; the modal DFT grid may contain additional bins.
     """
 
     @property

--- a/tests/cmds_multiuse/test_eigenmode_commands.py
+++ b/tests/cmds_multiuse/test_eigenmode_commands.py
@@ -32,8 +32,20 @@ def _configure_grid(monkeypatch):
     return grid
 
 
-def _build_definitions(grid, *, source_anchors="auto", receiver_anchors="auto"):
-    EigenmodeBand(id="wg", fmin=4e9, fmax=6e9, points=21).build(grid)
+def _build_definitions(
+    grid,
+    *,
+    source_anchors="auto",
+    receiver_anchors="auto",
+    band_frequencies=(),
+):
+    EigenmodeBand(
+        id="wg",
+        fmin=4e9,
+        fmax=6e9,
+        points=21,
+        frequencies=band_frequencies,
+    ).build(grid)
     EigenmodePort(
         port=1,
         p1=(0.01, 0.005, 0),
@@ -121,6 +133,59 @@ def test_hash_commands_parse_global_band_per_port_anchors_and_excitation(monkeyp
         "waveform": "auto",
         "plot_waveform": False,
     }
+
+
+def test_band_additional_frequencies_are_sorted_deduplicated_and_shared(monkeypatch):
+    grid = _configure_grid(monkeypatch)
+    _build_definitions(
+        grid,
+        band_frequencies=(4.55e9, 5.05e9, 4.55e9),
+    )
+    EigenmodeExcitation(port=1, mode=1, waveform="auto").build(grid)
+    build_eigenmode_runtime_ports(grid)
+
+    expected = tuple(
+        np.unique(
+            np.concatenate(
+                (
+                    np.linspace(4e9, 6e9, 21),
+                    np.asarray((4.55e9, 5.05e9)),
+                )
+            )
+        )
+    )
+    assert grid.eigenmodeband.dft_frequencies == expected
+    assert grid.eigenmodesources[0].dft_frequencies == expected
+    assert grid.eigenmodereceivers[0].dft_frequencies == expected
+
+
+def test_hash_band_parses_additional_dft_frequencies():
+    commands = defaultdict(lambda: None)
+    commands["#eigenmode_band"] = ["wg 4e9 6e9 10 5e9 5.5e9"]
+
+    objects = process_multicmds(commands)
+
+    band = next(obj for obj in objects if isinstance(obj, EigenmodeBand))
+    assert band.kwargs == {
+        "id": "wg",
+        "fmin": 4e9,
+        "fmax": 6e9,
+        "points": 10,
+        "frequencies": (5e9, 5.5e9),
+    }
+
+
+def test_band_rejects_additional_frequency_outside_limits(monkeypatch):
+    grid = _configure_grid(monkeypatch)
+
+    with pytest.raises(ValueError, match="inside the inclusive band limits"):
+        EigenmodeBand(
+            id="wg",
+            fmin=4e9,
+            fmax=6e9,
+            points=10,
+            frequencies=(3.9e9,),
+        ).build(grid)
 
 
 def test_hash_excitation_plot_control_does_not_require_waveform_argument():

--- a/tests/ntff/test_hash_command.py
+++ b/tests/ntff/test_hash_command.py
@@ -169,6 +169,35 @@ def test_open_huygens_surface_rejects_ksir_ramahi(tmp_path):
         )
 
 
+def test_closed_ksir_surface_accepts_direct_eigenmode_source(tmp_path):
+    inputfile = tmp_path / "closed_ksir_eigenmode.in"
+    inputfile.write_text(
+        "#domain: 0.08 0.08 0.08\n"
+        "#dx_dy_dz: 0.002 0.002 0.002\n"
+        "#time_window: 2e-10\n"
+        "#pml_cells: 3\n"
+        "#box: 0.020 0.024 0.034 0.050 0.026 0.046 pec\n"
+        "#box: 0.020 0.054 0.034 0.050 0.056 0.046 pec\n"
+        "#box: 0.020 0.024 0.032 0.050 0.056 0.034 pec\n"
+        "#box: 0.020 0.024 0.046 0.050 0.056 0.048 pec\n"
+        "#waveform: contsine 1 10e9 wave\n"
+        "#eigenmode_band: band 10e9 10e9 1\n"
+        "#eigenmode_port: 1 0.030 0.026 0.034 0.030 0.054 0.046 + 1 10e9 n\n"
+        "#eigenmode_excitation: 1 1 wave n\n"
+        "#ntff_surface: 0.012 0.012 0.012 0.060 0.068 0.060 surf\n"
+        "#ksir_frequency: surf spectrum 10e9\n"
+        "#ksir_far_field: 90 0 spectrum pattern Etheta Ephi\n"
+    )
+
+    gprMax.run(
+        inputfile=str(inputfile),
+        n=1,
+        outputfile=tmp_path / "closed_ksir_eigenmode",
+        geometry_only=True,
+        hide_progress_bars=True,
+    )
+
+
 def test_open_huygens_surface_allows_source_through_omitted_face(tmp_path):
     inputfile = tmp_path / "open_huygens.in"
     inputfile.write_text(
@@ -649,9 +678,24 @@ def test_eigenmode_port_normalises_gain_and_realized_gain(tmp_path):
         directivity_dbi = far_field["fields/directivity_dbi"][...]
         gain_dbi = far_field["fields/gain_dbi"][...]
         realized_gain_dbi = far_field["fields/realized_gain_dbi"][...]
-        assert np.all((0 < radiation_efficiency) & (radiation_efficiency <= 1))
+        # The closed surface adds the feed-side contribution that the former
+        # open Huygens surface omitted. On this deliberately coarse smoke-test
+        # mesh, independent radiated- and accepted-power discretisation can
+        # exceed unity by a few parts per thousand.
+        assert np.all((0 < radiation_efficiency) & (radiation_efficiency <= 1.01))
         assert np.all((0 < total_efficiency) & (total_efficiency <= 1))
-        assert np.all(gain_dbi <= directivity_dbi + 1e-12)
+        np.testing.assert_allclose(
+            gain_dbi,
+            directivity_dbi + 10 * np.log10(radiation_efficiency)[:, np.newaxis],
+            rtol=0,
+            atol=2e-5,
+        )
+        np.testing.assert_allclose(
+            realized_gain_dbi,
+            directivity_dbi + 10 * np.log10(total_efficiency)[:, np.newaxis],
+            rtol=0,
+            atol=2e-5,
+        )
         assert np.all(realized_gain_dbi <= gain_dbi + 1e-12)
         assert np.isfinite(gain_dbi).all()
         assert np.isfinite(realized_gain_dbi).all()

--- a/tests/ntff/test_port_power.py
+++ b/tests/ntff/test_port_power.py
@@ -16,6 +16,7 @@ from gprMax.ports import (
     TransmissionLinePortOutput,
     VoltageSourcePortMonitor,
     evaluate_port_power_spectrum,
+    frequency_subset_indices,
     modal_power_spectrum,
 )
 
@@ -158,6 +159,49 @@ def test_eigenmode_port_incident_power_uses_all_driven_modes_and_cross_terms(mon
         spectrum.incident_power,
         modal_power_spectrum(monitor.result.incident, monitor.power_matrix),
     )
+
+
+def test_eigenmode_port_power_selects_antenna_frequency_subset(monkeypatch):
+    monitor = _eigenmode_port(is_source=True)
+    monitor.mode_indices = (1,)
+    monitor.excitation_mode_indices = (1,)
+    monitor.mode_power_valid = np.ones((3, 1), dtype=bool)
+    monitor.power_matrix_valid = np.ones(3, dtype=bool)
+    monitor.power_matrix = np.ones((3, 1, 1), dtype=np.complex128)
+    monitor.electric_gram = np.ones((3, 1, 1), dtype=np.complex128)
+    monitor.result = EigenmodePortResult(
+        frequency=np.asarray([5.0, 6.0, 7.0]),
+        incident=np.asarray([[1.0, 2.0, 3.0]], dtype=np.complex128),
+        outgoing=np.zeros((1, 3), dtype=np.complex128),
+        valid=np.ones((1, 3), dtype=bool),
+        condition_number=np.ones(3),
+    )
+    monkeypatch.setattr(
+        ports,
+        "_port_mesh_valid",
+        lambda output, grid, frequency: np.ones(frequency.shape, dtype=bool),
+    )
+
+    spectrum = evaluate_port_power_spectrum(monitor, SimpleNamespace(), [5.0, 7.0])
+
+    assert_allclose(spectrum.incident_modal_amplitudes, [[1.0, 3.0]])
+    assert_allclose(spectrum.incident_power, [1.0, 9.0])
+    assert_allclose(spectrum.accepted_power, [1.0, 9.0])
+
+
+def test_frequency_subset_matching_allows_simulation_precision_roundoff():
+    available = np.asarray([8.9999995e9, 10e9, 11.000001e9], dtype=np.float32)
+
+    indices = frequency_subset_indices(available, [9e9, 11e9])
+
+    assert indices.tolist() == [0, 2]
+
+
+def test_eigenmode_port_power_rejects_frequency_outside_dft_grid():
+    monitor = _eigenmode_port(is_source=True)
+
+    with pytest.raises(ValueError, match="must be a subset"):
+        evaluate_port_power_spectrum(monitor, SimpleNamespace(), [5.5])
 
 
 def test_lossy_eigenmode_accepted_power_keeps_interference_term(monkeypatch):

--- a/tests/ntff/test_validation_guards.py
+++ b/tests/ntff/test_validation_guards.py
@@ -23,30 +23,6 @@ SURFACE_LOWER = (0.012, 0.012, 0.012)
 SURFACE_UPPER = (0.028, 0.028, 0.028)
 
 
-def test_eigenmode_source_is_incompatible_with_ramahi_ksir():
-    grid = SimpleNamespace(
-        ntff_surface_specs={"surface": object()},
-        ksir_transform_specs={"spectrum": object()},
-        ntff_transform_specs={},
-        ksir_time_requests=[],
-        ksir_frequency_requests=[],
-        ksir_far_field_requests=[],
-        ntff_far_field_requests=[],
-        ntff_time_far_field_requests=[],
-        ksir_antenna_port_specs={},
-        ntff_antenna_port_specs={},
-        eigenmodesources=[object()],
-    )
-    model = SimpleNamespace(G=grid, subgrids=[])
-
-    with pytest.raises(
-        ValueError,
-        match="eigenmode sources cannot be used with the Ramahi/KSIR.*"
-        "equivalent-current Huygens NTFF",
-    ):
-        compile_ntff_outputs(model, grid)
-
-
 def _base_scene():
     scene = gprMax.Scene()
     scene.add(gprMax.Discretisation(p1=(DL,) * 3))
@@ -342,7 +318,7 @@ def test_exterior_metrics_require_planar_layered_transform(tmp_path):
         )
 
 
-def test_eigenmode_antenna_transform_must_use_exact_port_dft_bins(tmp_path):
+def test_eigenmode_antenna_transform_must_use_port_dft_subset(tmp_path):
     example = (
         Path(__file__).parents[2]
         / "examples"
@@ -360,7 +336,7 @@ def test_eigenmode_antenna_transform_must_use_exact_port_dft_bins(tmp_path):
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError, match="must exactly match eigenmode port"):
+    with pytest.raises(ValueError, match="must be a subset of eigenmode port"):
         gprMax.run(
             inputfile=str(inputfile),
             n=1,

--- a/tests/test_eigenmode_ports.py
+++ b/tests/test_eigenmode_ports.py
@@ -882,6 +882,7 @@ def test_hdf5_metadata_distinguishes_power_and_reference_anchor_banks():
     monitor.s_generalized_valid = np.ones((1, 1), dtype=bool)
     monitor.s_valid = np.zeros((1, 1), dtype=bool)
     monitor.s_power_wave_valid = monitor.s_valid.copy()
+    monitor.active_s_parameters = None
 
     base = MemoryGroup()
     monitor.write_hdf5(base)
@@ -895,8 +896,13 @@ def test_hdf5_metadata_distinguishes_power_and_reference_anchor_banks():
     np.testing.assert_array_equal(group["anchor_mode_reference_valid"], [[1], [1], [1]])
     np.testing.assert_allclose(group["anchor_balanced_power"], [[1.0], [2.0], [3.0]])
     np.testing.assert_array_equal(group["generalized_valid"], [[1]])
+    np.testing.assert_array_equal(group["coefficient_valid"], group["generalized_valid"])
     np.testing.assert_array_equal(group["valid"], [[0]])
+    np.testing.assert_array_equal(group["power_wave_valid"], group["valid"])
+    np.testing.assert_array_equal(group["reference_basis_valid"], group["decomposition_valid"])
+    np.testing.assert_array_equal(group["power_basis_valid"], group["power_normalization_valid"])
     np.testing.assert_array_equal(group["generalized_valid_S"], [[1]])
+    np.testing.assert_array_equal(group["coefficient_valid_S"], group["generalized_valid_S"])
     np.testing.assert_array_equal(group["valid_S"], [[0]])
     np.testing.assert_array_equal(group["power_wave_valid_S"], group["valid_S"])
     assert group["generalized_valid"].shape == group["valid"].shape == (1, 1)
@@ -968,8 +974,11 @@ def test_sparameter_csv_contains_s11_and_each_s21_mode(tmp_path, monkeypatch):
     assert {int(row["source_mode"]) for row in rows} == {2}
 
 
-def test_multiple_drives_are_not_labelled_as_an_sparameter_column():
-    frequency = np.asarray([5e9])
+def test_multiple_drives_write_active_sparameters_not_an_sparameter_column(
+    tmp_path,
+    monkeypatch,
+):
+    frequency = np.asarray([5e9, 6e9])
 
     def monitor(port_index, modes):
         return SimpleNamespace(
@@ -980,21 +989,48 @@ def test_multiple_drives_are_not_labelled_as_an_sparameter_column():
             mode_indices=tuple(modes),
             result=EigenmodePortResult(
                 frequency=frequency,
-                incident=np.ones((len(modes), 1), dtype=np.complex128),
-                outgoing=np.zeros((len(modes), 1), dtype=np.complex128),
-                valid=np.ones((len(modes), 1), dtype=bool),
-                condition_number=np.ones(1),
+                incident=np.full((len(modes), 2), 2 * port_index, dtype=np.complex128),
+                outgoing=np.full((len(modes), 2), 0.5 * port_index, dtype=np.complex128),
+                valid=np.tile([[True, False]], (len(modes), 1)),
+                condition_number=np.ones(2),
+                generalized_valid=np.ones((len(modes), 2), dtype=bool),
             ),
             finalise=lambda grid: None,
+            mode_power_valid=np.tile([[True], [False]], (1, len(modes))),
+            power_matrix_valid=np.ones(2, dtype=bool),
+            drive_metadata=tuple(
+                {
+                    "mode": mode,
+                    "amplitude": 1.0,
+                    "power": 1.0,
+                    "phase_deg": 30.0 * port_index,
+                    "delay_s": 0.0,
+                }
+                for mode in modes
+            ),
         )
 
     grid = SimpleNamespace(
         name="main_grid",
         eigenmodeports=[monitor(1, (1,)), monitor(2, (1,))],
     )
+    monkeypatch.setattr(
+        config,
+        "get_model_config",
+        lambda: SimpleNamespace(output_file_path=tmp_path / "driven"),
+    )
 
-    assert finalise_eigenmode_ports(grid) is None
+    csv_path = finalise_eigenmode_ports(grid)
+
+    assert csv_path == tmp_path / "driven_active_sparameters.csv"
     assert all(not hasattr(port, "s_parameters") for port in grid.eigenmodeports)
+    with csv_path.open(newline="", encoding="utf-8") as stream:
+        rows = list(csv.DictReader(stream))
+    assert len(rows) == 4
+    assert all(float(row["active_S_magnitude"]) == pytest.approx(0.25) for row in rows)
+    assert all(row["coefficient_valid"] == "1" for row in rows)
+    assert [row["power_wave_valid"] for row in rows] == ["1", "0", "1", "0"]
+    assert all(port.response_type == "driven" for port in grid.eigenmodeports)
 
 
 def test_invalid_source_bin_does_not_invalidate_other_sparameter_bins(tmp_path, monkeypatch):

--- a/tests/test_eigenmode_study.py
+++ b/tests/test_eigenmode_study.py
@@ -484,6 +484,17 @@ def test_hash_eigenmode_study_runs_and_writes_complete_smatrix(tmp_path):
         np.testing.assert_array_equal(output["channel_ports"], (1, 2))
         np.testing.assert_array_equal(output["channel_modes"], (1, 1))
         assert output["S"].shape[1:] == (2, 2)
+        np.testing.assert_array_equal(output["power_wave_valid_S"], output["valid_S"])
+        np.testing.assert_array_equal(
+            output["coefficient_valid_S"], output["generalized_valid_S"]
+        )
+        np.testing.assert_array_equal(
+            output["power_wave_valid_matrix"], output["valid_wave_matrix"]
+        )
+        np.testing.assert_array_equal(
+            output["coefficient_valid_wave_matrix"],
+            output["generalized_valid_wave_matrix"],
+        )
         assert output["array_codebook"].attrs["Schema"] == "gprMax-array-codebook-v1"
         assert "array_states/p1_only/tarc" in output
 

--- a/tests/test_virtual_waveguide_integration.py
+++ b/tests/test_virtual_waveguide_integration.py
@@ -125,6 +125,11 @@ def test_virtual_waveguide_supports_two_simultaneous_modes_on_one_aperture(tmp_p
         assert np.all(np.isfinite(port_output["incident"][...]))
         assert np.all(np.isfinite(port_output["outgoing"][...]))
         assert "S" not in port_output
+        assert "active_S" in port_output
+        np.testing.assert_array_equal(port_output["active_S_driven"], [[1], [1]])
+        assert "coefficient_valid_active_S" in port_output
+        assert "power_wave_valid_active_S" in port_output
+    assert outputfile.with_name(outputfile.name + "_active_sparameters.csv").is_file()
 
 
 @pytest.mark.integration


### PR DESCRIPTION
# PR Description

This PR expands the eigenmode-port workflow for multiport, antenna, and near-cutoff simulations.

Previously, eigenmode-port DFT frequencies had to match NTFF frequencies exactly. This prevented users from requesting a dense S-parameter sweep while evaluating the far field at a smaller set of frequencies. Simultaneously driven ports also exposed modal waves but did not directly report the state-dependent active reflection coefficients commonly used for phased arrays.

The main changes are:

- Allow `#eigenmode_band` to include optional user-defined DFT frequencies in addition to its uniform frequency grid.
- Allow NTFF frequencies to be a subset of the eigenmode-port DFT grid.
- Calculate active S-parameters, \(b_i/a_i\), for simultaneously driven modal channels.
- Write active S-parameters to CSV and HDF5, including drive amplitude, power, phase, and delay metadata.
- Add clearer validity aliases:
  - `reference_basis_valid`
  - `power_basis_valid`
  - `coefficient_valid`
  - `power_wave_valid`
  - corresponding S-parameter and active-S masks
- Retain the existing validity names for backward compatibility.
- Remove the eigenmode-source-specific KSIR restriction. KSIR compatibility now depends on whether the NTFF surface is closed.
- Update the horn example to use a virtual waveguide with a closed six-face NTFF surface.
- Add three tutorial examples:
  - A reusable two-case study that constructs the complete dominant-mode S matrix of a gapped microstrip without rebuilding.
  - A coherently driven four-element phased array that plots active S-parameters and an xy-plane far-field cut demonstrating beam squint.
  - A near-cutoff waveguide example explaining modal anchors, evanescent generalized coefficients, and power-wave validity.
- Expand the eigenmode-port documentation and regression tests accordingly.

These changes support the common antenna-engineering workflow where S-parameters require a dense frequency grid, while NTFF patterns are needed only at selected frequencies. They also allow virtual waveguides to provide matched ports while retaining a closed surface suitable for KSIR and equivalent-current NTFF calculations.

Validation performed:

- 136 focused CPU tests passed.
- 10 GPU-marked tests were deselected because CUDA compiler tooling was unavailable.
- The complete microstrip S-matrix example ran successfully with 101 valid frequency bins.
- The phased-array example ran successfully with active-S output and a 360-direction xy-plane NTFF cut.
- Python plotting scripts compiled and ran successfully.
- `git diff --check` passed.

A local Sphinx build and pre-commit run were not performed in the current environment.

## 🛠️ Related Issue (Number)

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update.

## Checklist

- [ ] Did pre-commit pass all checks?
- [x] I have performed a self-review of my code.
- [x] I have added comments for my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] The title of my pull request is a short description of my changes.