### PR TITLE
Fix release-hardening review findings

### DIFF
--- a/docs/source/comparisons_analytical.rst
+++ b/docs/source/comparisons_analytical.rst
@@ -255,6 +255,14 @@ error below one percent. Across all complex vector samples, the retained
 maximum and RMS errors normalised to the analytical vector peak are 0.378
 and 0.271 percent, respectively.
 
+.. note::
+
+    The numerator sign printed in Eq. (38) of [CAP2012]_ is opposite to the
+    interface-reflection convention implied by Eqs. (18)--(30). gprMax uses
+    the latter convention because it also recovers the required homogeneous-
+    medium limit. The three-layer closed-form regression test records this
+    choice explicitly.
+
 Interfacial electric-dipole patterns
 ------------------------------------
 

--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -1516,10 +1516,13 @@ Receiver Array
 
 Voltage-source S11 and input impedance
 --------------------------------------
-Every 3-D single-Yee-edge :class:`gprMax.VoltageSource` owns the necessary
-hidden field monitor and calculates corrected complex ``S11``, ``Zin``, and
-``Yin`` after the solve. A finite-resistance source uses its physical
-resistance as the reference impedance:
+Every 3-D single-Yee-edge :class:`gprMax.VoltageSource` normally owns the
+necessary hidden field monitor and calculates corrected complex ``S11``,
+``Zin``, and ``Yin`` after the solve. The exception is a zero-resistance hard
+source on a domain-minimum transverse boundary: the source remains valid, but
+gprMax warns and omits its automatic port because the complete Ampere current
+loop lies partly outside the grid. A finite-resistance source uses its
+physical resistance as the reference impedance:
 
 .. code-block:: python
 

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -2049,8 +2049,9 @@ material are reported when the model is built.
     * MPI, subgrids, 2D modes, geometry-fixed runs, grouped sources, sources
       inside a PML, and dispersive material on the source edge are currently
       rejected. Dispersive materials elsewhere in the model are supported.
-      A hard-source current loop cannot lie on a domain-minimum transverse
-      boundary.
+      A hard source at a domain-minimum transverse boundary remains a valid
+      excitation, but gprMax warns and omits its automatic port output because
+      the complete current loop cannot be sampled there.
     * ``S11`` remains the primary result. ``Zin`` is singular near an open
       circuit (:math:`S_{11}=1`), so gprMax also stores ``Yin`` and separate
       validity masks.

--- a/docs/source/output.rst
+++ b/docs/source/output.rst
@@ -890,9 +890,11 @@ and space increments.
 Voltage-source S11 and impedance output
 ---------------------------------------
 
-Every 3-D ``#voltage_source`` or ``VoltageSource`` Python object writes one
-source-owned group per main-grid port at ``/ports/<port ID>``. A source added
-to a Python API subgrid is
+Every 3-D ``#voltage_source`` or ``VoltageSource`` Python object normally
+writes one source-owned group per main-grid port at ``/ports/<port ID>``. A
+zero-resistance hard source at a domain-minimum transverse boundary remains a
+valid excitation but has no automatic port group because its complete Ampere
+loop is outside the model. A source added to a Python API subgrid is
 stored at ``/subgrids/<subgrid ID>/ports/<port ID>`` and uses the owning
 subgrid's spatial step, time step, iteration count, material edge, and field
 histories. For a finite-resistance source, its resistance is the reference

--- a/gprMax/config.py
+++ b/gprMax/config.py
@@ -255,16 +255,20 @@ class ModelConfig:
         """
 
         if outputdir is not None:
-            Path(outputdir).mkdir(exist_ok=True)
+            Path(outputdir).mkdir(parents=True, exist_ok=True)
             self.output_file_path = Path(outputdir, sim_config.input_file_path.stem)
         elif sim_config.args.outputfile is not None:
-            self.output_file_path = Path(sim_config.args.outputfile).with_suffix("")
+            self.output_file_path = Path(sim_config.args.outputfile)
+            if self.output_file_path.suffix.lower() == ".h5":
+                self.output_file_path = self.output_file_path.with_suffix("")
         else:
             self.output_file_path = sim_config.input_file_path.with_suffix("")
 
         parts = self.output_file_path.parts
         self.output_file_path = Path(*parts[:-1], parts[-1] + self.appendmodelnumber)
-        self.output_file_path_ext = self.output_file_path.with_suffix(".h5")
+        self.output_file_path_ext = self.output_file_path.with_name(
+            self.output_file_path.name + ".h5"
+        )
 
     def set_snapshots_dir(self):
         """Sets directory to store any snapshots.
@@ -272,8 +276,7 @@ class ModelConfig:
         Returns:
             snapshot_dir: Path to directory to store snapshot files in.
         """
-        parts = self.output_file_path.with_suffix("").parts
-        snapshot_dir = Path(*parts[:-1], parts[-1] + "_snaps")
+        snapshot_dir = self.output_file_path.with_name(self.output_file_path.name + "_snaps")
 
         return snapshot_dir
 

--- a/gprMax/cython/plane_wave.pyx
+++ b/gprMax/cython/plane_wave.pyx
@@ -2468,25 +2468,36 @@ cpdef void calculate1DWaveformValues(
     cdef double time2_x, time2_y, time2_z = 0.0
     cdef Py_ssize_t iteration, r = 0
 
-    for iteration in range(iterations):
+    # The arrays contain indices 0..iterations. Electric source samples are
+    # evaluated on whole time steps and use the own-component half-cell
+    # offset; magnetic source samples are evaluated on half time steps and
+    # use the two transverse component offsets. Keep this identical to the
+    # non-Cython reference path in DiscretePlaneWave.calculate_waveform_values.
+    for iteration in range(iterations + 1):
         for r in range(m[3]):
-            time1_x = dt * (iteration + 1) - (r + (abs(m[1])+abs(m[2]))*0.5) * ds/c
-            time1_y = dt * (iteration + 1) - (r + (abs(m[2])+abs(m[0]))*0.5) * ds/c
-            time1_z = dt * (iteration + 1) - (r + (abs(m[0])+abs(m[1]))*0.5) * ds/c
-            if (dt * (iteration + 1) >= start and dt * (iteration + 1) <= stop):
-            # Set the time of the waveform evaluation to account for any delay in the start
+            time1_x = dt * iteration - (r + abs(m[0])*0.5) * ds/c
+            time1_y = dt * iteration - (r + abs(m[1])*0.5) * ds/c
+            time1_z = dt * iteration - (r + abs(m[2])*0.5) * ds/c
+            # Set the time of the waveform evaluation to account for any delay
+            # in the start. Each component has a different spatial delay, so
+            # its active-window test must use that component's evaluation time.
+            if (time1_x >= start and time1_x <= stop):
                 waveformvalues_wholedt[iteration, 0, r] = getSource(time1_x-start, freq, wavetype, dt)
+            if (time1_y >= start and time1_y <= stop):
                 waveformvalues_wholedt[iteration, 1, r] = getSource(time1_y-start, freq, wavetype, dt)
+            if (time1_z >= start and time1_z <= stop):
                 waveformvalues_wholedt[iteration, 2, r] = getSource(time1_z-start, freq, wavetype, dt)
 
         for r in range(m[3]):
-            time2_x = dt * (iteration + 0.5) - (r + abs(m[0])*0.5) * ds/c
-            time2_y = dt * (iteration + 0.5) - (r + abs(m[1])*0.5) * ds/c
-            time2_z = dt * (iteration + 0.5) - (r + abs(m[2])*0.5) * ds/c
-            if (dt * (iteration + 0.5) >= start and dt * (iteration + 0.5) <= stop):
-            # Set the time of the waveform evaluation to account for any delay in the start
+            time2_x = dt * (iteration + 0.5) - (r + (abs(m[1])+abs(m[2]))*0.5) * ds/c
+            time2_y = dt * (iteration + 0.5) - (r + (abs(m[2])+abs(m[0]))*0.5) * ds/c
+            time2_z = dt * (iteration + 0.5) - (r + (abs(m[0])+abs(m[1]))*0.5) * ds/c
+            # As above, gate each spatially delayed component independently.
+            if (time2_x >= start and time2_x <= stop):
                 waveformvalues_halfdt[iteration, 0, r] = getSource(time2_x-start, freq, wavetype, dt)
+            if (time2_y >= start and time2_y <= stop):
                 waveformvalues_halfdt[iteration, 1, r] = getSource(time2_y-start, freq, wavetype, dt)
+            if (time2_z >= start and time2_z <= stop):
                 waveformvalues_halfdt[iteration, 2, r] = getSource(time2_z-start, freq, wavetype, dt)
 
 

--- a/gprMax/fdfd_eigenmode_solver/fdfd_1d_mode_solver.py
+++ b/gprMax/fdfd_eigenmode_solver/fdfd_1d_mode_solver.py
@@ -180,15 +180,32 @@ class FDFD_1D_mode_solver:
             values = values[order]
             vectors = vectors[:, order]
         else:
+            # ARPACK otherwise creates an implicit random starting vector.
+            # That makes an identical port solve depend on unrelated prior
+            # uses of the process-wide random-number generator and can lead
+            # to small run/restart differences after modal normalisation.
+            # Use a local deterministic vector without mutating NumPy's
+            # global random state.
+            v0 = np.random.default_rng(0).standard_normal(size)
             try:
-                values, vectors = eigs(reduced, k=self.num_modes, sigma=self.guess)
+                values, vectors = eigs(
+                    reduced,
+                    k=self.num_modes,
+                    sigma=self.guess,
+                    v0=v0,
+                )
             except RuntimeError:
                 # A homogeneous fundamental mode can lie exactly at the
                 # material-derived default shift (for example sigma=-1).
                 # Move the shift by roundoff rather than failing LU
                 # factorisation of A - sigma I.
                 shifted_guess = self.guess * (1.0 + 1e-9) - 1e-12
-                values, vectors = eigs(reduced, k=self.num_modes, sigma=shifted_guess)
+                values, vectors = eigs(
+                    reduced,
+                    k=self.num_modes,
+                    sigma=shifted_guess,
+                    v0=v0,
+                )
 
         order = np.argsort(np.real(values))
         values = values[order]

--- a/gprMax/fdfd_eigenmode_solver/fdfd_2d_mode_solver.py
+++ b/gprMax/fdfd_eigenmode_solver/fdfd_2d_mode_solver.py
@@ -280,11 +280,17 @@ class FDFD_2D_mode_solver:
             eigenvalues = eigenvalues[selection]
             eigenvectors = eigenvectors[:, selection]
         else:
+            # Keep the ARPACK solve independent of process-global random
+            # state.  This is important when a geometry-fixed eigenmode
+            # study is restarted in a process that has already performed
+            # other randomised work.
+            v0 = np.random.default_rng(0).standard_normal(size)
             try:
                 eigenvalues, eigenvectors = eigs(
                     operator,
                     k=self.num_modes,
                     sigma=self.guess,
+                    v0=v0,
                 )
             except RuntimeError:
                 shifted_guess = self.guess * (1.0 + 1e-9) - 1e-12
@@ -292,6 +298,7 @@ class FDFD_2D_mode_solver:
                     operator,
                     k=self.num_modes,
                     sigma=shifted_guess,
+                    v0=v0,
                 )
 
         order = np.argsort(np.real(eigenvalues))

--- a/gprMax/geometry_outputs/geometry_objects_read.py
+++ b/gprMax/geometry_outputs/geometry_objects_read.py
@@ -314,7 +314,11 @@ class ReadGeometryObject(AbstractContextManager):
         raw_data = self.file_handler["/data"]
         assert isinstance(raw_data, h5py.Dataset)
         raw_data = self._read_spatial_dataset(raw_data)
-        existing = self.grid_view.get_geometry_tags()
+        # MPI setters include the negative interface halo, matching the
+        # rank-local read slice above. ``get_geometry_tags()`` deliberately
+        # excludes that halo because it is intended for output, so use the
+        # exact assignment region here just as ``read_data()`` does.
+        existing = self._get_assignment_region(self.grid_view.grid.geometry_tag_map.data)
 
         if self.has_tag_data():
             tag_data = self.file_handler["/tag_data"]

--- a/gprMax/grid/fdtd_grid.py
+++ b/gprMax/grid/fdtd_grid.py
@@ -276,9 +276,12 @@ class FDTDGrid:
         self.dl[2] = value
 
     def set_pml_thickness(self, thickness: Union[int, Tuple[int, int, int, int, int, int]]):
-        if isinstance(thickness, int) or len(thickness) == 1:
+        if isinstance(thickness, int):
             for key in PML.boundaryIDs:
                 self.pmls["thickness"][key] = int(thickness)
+        elif len(thickness) == 1:
+            for key in PML.boundaryIDs:
+                self.pmls["thickness"][key] = int(thickness[0])
         elif len(thickness) == 6:
             self.pmls["thickness"]["x0"] = int(thickness[0])
             self.pmls["thickness"]["y0"] = int(thickness[1])

--- a/gprMax/hash_cmds_file.py
+++ b/gprMax/hash_cmds_file.py
@@ -208,6 +208,16 @@ def check_cmd_names(processedlines, checkessential=True):
         geometry: list of geometry commands in the model.
     """
 
+    # Retired commands whose replacement is specific enough to give users a
+    # useful migration path instead of the generic "invalid command" error.
+    retired_commands = {
+        "#rx_port": (
+            "#rx_port has been removed. Every 3-D #voltage_source now owns "
+            "its port monitor; use the optional voltage-source ID and spectrum "
+            "arguments to name and configure that output."
+        )
+    }
+
     # Dictionaries of available commands
     # Essential commands neccessary to run a gprMax model
     essentialcmds = ["#domain", "#dx_dy_dz", "#time_window"]
@@ -355,6 +365,10 @@ def check_cmd_names(processedlines, checkessential=True):
             raise SyntaxError
 
         # Check if command name is valid
+        if cmdname in retired_commands:
+            message = retired_commands[cmdname]
+            logger.error(message)
+            raise SyntaxError(message)
         if (
             cmdname not in essentialcmds
             and cmdname not in singlecmds

--- a/gprMax/hash_cmds_geometry.py
+++ b/gprMax/hash_cmds_geometry.py
@@ -522,7 +522,7 @@ def process_geometrycmds(geometry):
                     n_materials=n_materials,
                     mixing_model_id=mixing_model_id,
                     id=ID,
-                    seed=tmp[14],
+                    seed=int(tmp[14]),
                     tag=tag,
                 )
             elif len(tmp) == 16:

--- a/gprMax/materials.py
+++ b/gprMax/materials.py
@@ -35,6 +35,10 @@ def validate_lorentz_pole(frequency_hz: float, damping_per_s: float, dt: float) 
     an underdamped pole.
     """
 
+    if not np.isfinite(frequency_hz):
+        raise ValueError("Lorentz resonance frequency must be finite")
+    if not np.isfinite(damping_per_s):
+        raise ValueError("Lorentz damping coefficient must be finite")
     if frequency_hz <= 0:
         raise ValueError("Lorentz resonance frequency must be positive")
     if damping_per_s < 0:
@@ -57,6 +61,10 @@ def validate_lorentz_pole(frequency_hz: float, damping_per_s: float, dt: float) 
 def validate_drude_pole(frequency_hz: float, collision_per_s: float, dt: float) -> None:
     """Validate a Drude pole for the recursive material formulation."""
 
+    if not np.isfinite(frequency_hz):
+        raise ValueError("Drude plasma frequency must be finite")
+    if not np.isfinite(collision_per_s):
+        raise ValueError("Drude collision frequency must be finite")
     if frequency_hz <= 0:
         raise ValueError("Drude plasma frequency must be positive")
     if collision_per_s <= 0:

--- a/gprMax/ports.py
+++ b/gprMax/ports.py
@@ -242,9 +242,8 @@ def frequency_subset_indices(available_frequencies, requested_frequencies):
     insertion = np.searchsorted(available, requested)
     right_indices = np.minimum(insertion, available.size - 1)
     left_indices = np.maximum(insertion - 1, 0)
-    choose_left = (
-        np.abs(available[left_indices] - requested)
-        <= np.abs(available[right_indices] - requested)
+    choose_left = np.abs(available[left_indices] - requested) <= np.abs(
+        available[right_indices] - requested
     )
     safe_indices = np.where(choose_left, left_indices, right_indices)
     real_dtype = np.asarray(available.real).dtype
@@ -362,9 +361,7 @@ def evaluate_port_power_spectrum(
             power_wave_valid_value = output.mode_power_valid
         power_wave_valid = np.asarray(power_wave_valid_value, dtype=bool)[frequency_indices]
         result_valid = np.asarray(output.result.valid, dtype=bool)[:, frequency_indices]
-        power_matrix_valid = np.asarray(output.power_matrix_valid, dtype=bool)[
-            frequency_indices
-        ]
+        power_matrix_valid = np.asarray(output.power_matrix_valid, dtype=bool)[frequency_indices]
         modal_valid = result_valid & power_wave_valid.T & power_matrix_valid[np.newaxis, :]
         physical_power_valid = np.zeros(frequency.shape, dtype=bool)
         for frequency_index in range(frequency.size):
@@ -1683,12 +1680,6 @@ class VoltageSourcePortMonitor:
             tail_relative_db = float("-inf")
         else:
             tail_relative_db = float("nan")
-        if np.isfinite(tail_relative_db) and tail_relative_db > -40:
-            logger.warning(
-                f"Voltage-source port {self.output_id!r}: the final 5% of the voltage trace "
-                f"reaches {tail_relative_db:.1f} dB relative to its peak; spectral "
-                "leakage may be significant."
-            )
         if np.isfinite(tail_relative_db) and tail_relative_db > -40:
             logger.warning(
                 f"Voltage-source port {self.output_id!r}: the final 5% of the voltage trace "

--- a/gprMax/receivers.py
+++ b/gprMax/receivers.py
@@ -239,12 +239,13 @@ def dtoh_rx_array(rxs_dev, rxcoords_dev, G, rxcurrents_dev=None):
                     f"Successfully copied {rxs_np.size} elements from Metal GPU buffer to CPU"
                 )
             else:
-                logger.debug(
-                    f"Metal rxs buffer size mismatch: expected {expected_rxs_bytes}, got {rxs_dev.length()}"
+                raise RuntimeError(
+                    "Metal receiver buffer size mismatch: "
+                    f"expected {expected_rxs_bytes} bytes, got {rxs_dev.length()}"
                 )
 
         except Exception as e:
-            logger.exception(f"Error copying Metal buffer data: {e}, using zero-filled arrays as fallback")
+            raise RuntimeError("Failed to copy Metal receiver data to host") from e
 
         # Use the numpy arrays
         rxcoords_dev = rxcoords_np
@@ -270,10 +271,7 @@ def dtoh_rx_array(rxs_dev, rxcoords_dev, G, rxcurrents_dev=None):
                 else:
                     raise RuntimeError("Metal current-output buffer size mismatch")
             except Exception as e:
-                logger.exception(
-                    f"Error copying Metal current-output data: {e}, "
-                    "using zero-filled arrays as fallback"
-                )
+                raise RuntimeError("Failed to copy Metal current-output data to host") from e
             rxcurrents_dev = current_np
 
     # For CUDA/OpenCL, rxs_dev/rxcoords_dev are already host numpy arrays by

--- a/gprMax/sar.py
+++ b/gprMax/sar.py
@@ -287,8 +287,18 @@ def _material_loss_conductivity(grid: "FDTDGrid", numeric_ids, frequencies):
     epsilon_0 = float(config.sim_config.em_consts["e0"])
     for material_id in np.unique(numeric_ids):
         material = material_by_id[int(material_id)]
-        epsilon_r = _material_relative_permittivity(material, frequencies)
-        effective = -omega * epsilon_0 * np.imag(epsilon_r)
+        # An ideal PEC has no finite volume in which Joule heating can be
+        # defined. Its loss is represented by a surface current, not by
+        # ``sigma * |E|**2`` in the cell volume. Evaluating that expression
+        # with se=+inf would otherwise create the indeterminate product
+        # inf * 0 and contaminate a valid SAR result with NaNs.
+        if material.is_pec:
+            effective = np.zeros(frequencies.shape, dtype=np.float64)
+        else:
+            epsilon_r = _material_relative_permittivity(material, frequencies)
+            effective = -omega * epsilon_0 * np.imag(epsilon_r)
+            if not np.all(np.isfinite(effective)):
+                raise ValueError(f"SAR material {material.ID!r} has non-finite electric loss")
         tolerance = 128 * np.finfo(np.float64).eps * np.maximum(1.0, np.abs(effective))
         if np.any(effective < -tolerance):
             raise ValueError(

--- a/gprMax/snapshots.py
+++ b/gprMax/snapshots.py
@@ -169,7 +169,11 @@ class Snapshot(Generic[GridType]):
         """
 
         self.fileext = fileext
-        self.filename = Path(filename).with_suffix(fileext)
+        self.filename = Path(filename)
+        if self.filename.suffix in self.fileexts:
+            self.filename = self.filename.with_suffix(fileext)
+        else:
+            self.filename = self.filename.with_name(self.filename.name + fileext)
         self.time = time
         self.outputs = outputs
         self.grid_view = self.GRID_VIEW_TYPE(grid, xs, ys, zs, xf, yf, zf, dx, dy, dz)

--- a/gprMax/sources.py
+++ b/gprMax/sources.py
@@ -4886,7 +4886,7 @@ class DiscretePlaneWave(Source):
         )
 
         # waveform = next(x for x in G.waveforms if x.ID == self.waveformID)
-        if cythonize:
+        if cythonize and self.waveform.type != "user":
             calculate1DWaveformValues(
                 self.waveformvalues_wholedt,
                 self.waveformvalues_halfdt,
@@ -4900,6 +4900,8 @@ class DiscretePlaneWave(Source):
                 self.waveform.freq,
                 self.waveform.type.encode("UTF-8"),
             )
+            self.waveformvalues_wholedt *= self.waveform.amp
+            self.waveformvalues_halfdt *= self.waveform.amp
         else:
             for dimension in range(3):
                 for iteration in range(G.iterations + 1):
@@ -4929,10 +4931,7 @@ class DiscretePlaneWave(Source):
                     for r in range(self.m[3]):
                         time2 = (
                             G.dt * (iteration)
-                            - (
-                                r
-                                + (np.abs(self.m[(dimension)]) + np.abs(self.m[(dimension)])) * 0.5
-                            )
+                            - (r + np.abs(self.m[dimension]) * 0.5)
                             * self.ds
                             / self.speed
                         )

--- a/gprMax/subgrids/precursor_nodes.py
+++ b/gprMax/subgrids/precursor_nodes.py
@@ -271,6 +271,15 @@ class PrecursorNodesBase:
             # interpolate over a fine grid
             f_i = self.interpolate_to_sub_grid(f_t, obj[1])
 
+            # A unity-ratio subgrid is intentionally used as an identity
+            # interface for validation. At every refining ratio, however,
+            # interpolation must change the sampling lattice; equality here
+            # indicates that the refinement/interpolation path was bypassed.
+            if self.ratio > 1 and np.array_equal(f_i, f_t):
+                raise RuntimeError(
+                    "Subgrid magnetic interpolation did not refine the precursor lattice."
+                )
+
             # discard the outer nodes only required for interpolation
             # f = f_i[self.ratio:-self.ratio, self.ratio:-self.ratio]
             f = f_i

--- a/gprMax/updates/cpu_updates.py
+++ b/gprMax/updates/cpu_updates.py
@@ -19,6 +19,7 @@
 
 from importlib import import_module
 
+import numpy as np
 from typing_extensions import TypeVar
 
 from gprMax import config
@@ -317,21 +318,53 @@ class CPUUpdates(Updates[GridType]):
     def set_dispersive_updates(self):
         """Sets dispersive update functions."""
 
-        poles = "multi" if config.get_model_config().materials["maxpoles"] > 1 else "1"
-        precision = "float" if config.sim_config.general["precision"] == "single" else "double"
-        dispersion = (
-            "complex"
-            if config.get_model_config().materials["dispersivedtype"]
-            == config.sim_config.dtypes["complex"]
-            else "real"
-        )
+        maxpoles = config.get_model_config().materials["maxpoles"]
+        if maxpoles < 1:
+            raise RuntimeError(
+                "Dispersive update kernels cannot be selected without at least one pole."
+            )
+        poles = "multi" if maxpoles > 1 else "1"
+
+        configured_precision = config.sim_config.general["precision"]
+        try:
+            precision = {"single": "float", "double": "double"}[configured_precision]
+        except KeyError as exc:
+            raise RuntimeError(
+                f"Cannot select dispersive kernels for invalid precision "
+                f"{configured_precision!r}."
+            ) from exc
+
+        dispersive_dtype = config.get_model_config().materials["dispersivedtype"]
+        if dispersive_dtype is None:
+            raise RuntimeError(
+                "Dispersive material dtype has not been initialised before solver creation."
+            )
+        dispersive_dtype = np.dtype(dispersive_dtype)
+        real_dtype = np.dtype(config.sim_config.dtypes["float_or_double"])
+        complex_dtype = np.dtype(config.sim_config.dtypes["complex"])
+        if dispersive_dtype == complex_dtype:
+            dispersion = "complex"
+        elif dispersive_dtype == real_dtype:
+            dispersion = "real"
+        else:
+            raise RuntimeError(
+                f"Dispersive material dtype {dispersive_dtype} does not match the configured "
+                f"real ({real_dtype}) or complex ({complex_dtype}) precision."
+            )
 
         update_f = "update_electric_dispersive_{}pole_{}_{}_{}"
         disp_a = update_f.format(poles, "A", precision, dispersion)
         disp_b = update_f.format(poles, "B", precision, dispersion)
 
-        disp_a_f = getattr(import_module("gprMax.cython.fields_updates_dispersive"), disp_a)
-        disp_b_f = getattr(import_module("gprMax.cython.fields_updates_dispersive"), disp_b)
+        module = import_module("gprMax.cython.fields_updates_dispersive")
+        try:
+            disp_a_f = getattr(module, disp_a)
+            disp_b_f = getattr(module, disp_b)
+        except AttributeError as exc:
+            raise RuntimeError(
+                "The compiled dispersive-field kernels do not match the requested "
+                f"configuration ({poles} pole, {precision}, {dispersion})."
+            ) from exc
 
         self.dispersive_update_a = disp_a_f
         self.dispersive_update_b = disp_b_f

--- a/gprMax/user_objects/cmds_geometry/cone.py
+++ b/gprMax/user_objects/cmds_geometry/cone.py
@@ -108,17 +108,21 @@ class Cone(GeometryUserObject):
             logger.error(message)
             raise ValueError(message)
 
-        if r1 < 0:
-            logger.exception(
-                f"{self.__str__()} the radius of the first face {r1:g} should be a positive value."
+        if not np.isfinite(r1) or r1 < 0:
+            message = (
+                f"{self.__str__()} the radius of the first face {r1:g} "
+                "should be a positive value."
             )
-            raise ValueError
+            logger.error(message)
+            raise ValueError(message)
 
-        if r2 < 0:
-            logger.exception(
-                f"{self.__str__()} the radius of the second face {r2:g} should be a positive value."
+        if not np.isfinite(r2) or r2 < 0:
+            message = (
+                f"{self.__str__()} the radius of the second face {r2:g} "
+                "should be a positive value."
             )
-            raise ValueError
+            logger.error(message)
+            raise ValueError(message)
 
         if r1 == 0 and r2 == 0:
             logger.exception(f"{self.__str__()} both radii cannot be zero.")

--- a/gprMax/user_objects/cmds_geometry/cylinder.py
+++ b/gprMax/user_objects/cmds_geometry/cylinder.py
@@ -91,7 +91,7 @@ class Cylinder(GeometryUserObject):
         x1, y1, z1 = uip.round_to_grid(p1)
         x2, y2, z2 = uip.round_to_grid(p2)
 
-        if r <= 0:
+        if not np.isfinite(r) or r <= 0:
             message = f"{self.__str__()} the radius {r:g} should be a positive value."
             logger.error(message)
             raise ValueError(message)

--- a/gprMax/user_objects/cmds_geometry/cylindrical_sector.py
+++ b/gprMax/user_objects/cmds_geometry/cylindrical_sector.py
@@ -120,6 +120,9 @@ class CylindricalSector(GeometryUserObject):
         extent1 = uip.resolve_inf_point(tuple(lower_point), role="lower")[axis_index]
         extent2 = uip.resolve_inf_point(tuple(upper_point), role="upper")[axis_index]
 
+        if not np.all(np.isfinite((ctr1, ctr2, extent1, extent2, start, end, r))):
+            raise ValueError(f"{self.__str__()} dimensions and angles must all be finite.")
+
         thickness = extent2 - extent1
 
         # Check thickness of the object first as may be able to exit

--- a/gprMax/user_objects/cmds_geometry/ellipsoid.py
+++ b/gprMax/user_objects/cmds_geometry/ellipsoid.py
@@ -63,7 +63,7 @@ class Ellipsoid(GeometryUserObject):
             logger.exception(f"{self.__str__()} please specify a point and the three semiaxes.")
             raise
 
-        if xr <= 0 or yr <= 0 or zr <= 0:
+        if not np.all(np.isfinite((xr, yr, zr))) or xr <= 0 or yr <= 0 or zr <= 0:
             message = (
                 f"{self.__str__()} the semiaxes ({xr:g}, {yr:g}, {zr:g}) "
                 "should all be positive values."

--- a/gprMax/user_objects/cmds_geometry/sphere.py
+++ b/gprMax/user_objects/cmds_geometry/sphere.py
@@ -58,7 +58,7 @@ class Sphere(GeometryUserObject):
             logger.exception(f"{self.__str__()} please specify a point and a radius.")
             raise
 
-        if r <= 0:
+        if not np.isfinite(r) or r <= 0:
             message = f"{self.__str__()} the radius {r:g} should be a positive value."
             logger.error(message)
             raise ValueError(message)

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -104,6 +104,25 @@ def _reserve_voltage_port_output_id(
     return output_id
 
 
+def _hard_source_current_loop_available(
+    polarisation: str, resistance: float, coord: npt.NDArray[np.int32]
+) -> bool:
+    """Return whether the complete transverse Ampere loop is in the grid."""
+
+    polarisation = str(polarisation).lower()
+    if resistance != 0 or polarisation not in ("x", "y", "z"):
+        # Parameter validation reports an invalid polarisation later. Avoid
+        # replacing that useful public error with an internal dictionary key
+        # failure while deciding whether to reserve an MPI port ID.
+        return True
+    transverse_axes = {
+        "x": (1, 2),
+        "y": (0, 2),
+        "z": (0, 1),
+    }[polarisation]
+    return not any(coord[axis] == 0 for axis in transverse_axes)
+
+
 def _require_complete_source_time_window(user_object, start, stop):
     """Require conventional source start/stop limits to be supplied together."""
 
@@ -111,6 +130,39 @@ def _require_complete_source_time_window(user_object, start, stop):
         raise ValueError(
             f"{user_object.params_str()} start and stop times must be supplied together"
         )
+    if start is not None and (not np.isfinite(start) or not np.isfinite(stop)):
+        raise ValueError(f"{user_object.params_str()} start and stop times must be finite")
+
+
+def _validate_dpw_precompute(user_object, precompute):
+    """Reject the non-functional on-the-fly DPW source option explicitly."""
+
+    if not isinstance(precompute, (bool, np.bool_)):
+        raise ValueError(f"{user_object.params_str()} precompute must be a boolean")
+    if not precompute:
+        raise ValueError(
+            f"{user_object.params_str()} precompute=False is not currently supported; "
+            "plane-wave source histories must be precomputed"
+        )
+
+
+def _configure_dpw_time_window(user_object, source, grid):
+    """Validate and apply an optional DPW start/stop pair."""
+
+    start = user_object.kwargs.get("start")
+    stop = user_object.kwargs.get("stop")
+    _require_complete_source_time_window(user_object, start, stop)
+    if start is None:
+        source.start = 0
+        source.stop = grid.timewindow
+        return " "
+    if start < 0 or stop < 0:
+        raise ValueError(f"{user_object.params_str()} start and stop times must not be negative")
+    if stop <= start:
+        raise ValueError(f"{user_object.params_str()} source stop time must exceed its start time")
+    source.start = start
+    source.stop = min(stop, grid.timewindow)
+    return f" start time {start:g} secs, finish time {stop:g} secs "
 
 
 class ExcitationFile(GridUserObject):
@@ -160,25 +212,46 @@ class ExcitationFile(GridUserObject):
         excitationfile = Path(self.filepath)
         if not excitationfile.exists():
             excitationfile = Path(config.sim_config.input_file_path.parent, excitationfile)
+        if not excitationfile.is_file():
+            raise FileNotFoundError(f"Excitation file {excitationfile} does not exist")
+
+        if (self.kind is None) != (self.fill_value is None):
+            raise ValueError(f"{self} requires either one or three parameter(s)")
 
         logger.info(self.grid_name(grid) + f"Excitation file: {excitationfile}")
 
         # Get waveform names
-        waveformIDs = np.loadtxt(excitationfile, max_rows=1, dtype=str)
+        waveformIDs = np.loadtxt(excitationfile, max_rows=1, dtype=str, ndmin=1)
 
         # Read all waveform values into an array
         waveformvalues = np.loadtxt(
-            excitationfile, skiprows=1, dtype=config.sim_config.dtypes["float_or_double"]
+            excitationfile,
+            skiprows=1,
+            dtype=config.sim_config.dtypes["float_or_double"],
+            ndmin=2,
         )
+        if waveformvalues.shape[0] < 2:
+            raise ValueError(f"{self} requires at least two waveform samples")
+        if waveformvalues.shape[1] != waveformIDs.size:
+            raise ValueError(
+                f"{self} header declares {waveformIDs.size} columns but the data has "
+                f"{waveformvalues.shape[1]}"
+            )
+        if not np.all(np.isfinite(waveformvalues)):
+            raise ValueError(f"{self} waveform data must contain only finite values")
 
         # Time array (if specified) for interpolation, otherwise use simulation time
         if waveformIDs[0].lower() == "time":
+            if waveformIDs.size < 2:
+                raise ValueError(f"{self} must define at least one waveform after the time column")
             waveformIDs = waveformIDs[1:]
             waveformtime = waveformvalues[:, 0]
             waveformvalues = waveformvalues[:, 1:]
+            if np.any(np.diff(waveformtime) <= 0):
+                raise ValueError(f"{self} time values must be strictly increasing")
             timestr = "user-defined time array"
         else:
-            waveformtime = np.arange(0, grid.timewindow + grid.dt, grid.dt)
+            waveformtime = np.arange(grid.iterations, dtype=np.float64) * grid.dt
             timestr = "simulation time array"
 
         for i, waveformID in enumerate(waveformIDs):
@@ -189,9 +262,7 @@ class ExcitationFile(GridUserObject):
             w.type = "user"
 
             # Select correct column of waveform values depending on array shape
-            singlewaveformvalues = (
-                waveformvalues[:] if len(waveformvalues.shape) == 1 else waveformvalues[:, i]
-            )
+            singlewaveformvalues = waveformvalues[:, i]
 
             # Truncate waveform array if it is longer than time array
             if len(singlewaveformvalues) > len(waveformtime):
@@ -208,12 +279,10 @@ class ExcitationFile(GridUserObject):
             # Interpolate waveform values
             if self.kind is None and self.fill_value is None:
                 w.userfunc = interpolate.interp1d(waveformtime, singlewaveformvalues)
-            elif self.kind is not None and self.fill_value is not None:
+            else:
                 w.userfunc = interpolate.interp1d(
                     waveformtime, singlewaveformvalues, kind=self.kind, fill_value=self.fill_value
                 )
-            else:
-                raise ValueError(f"{self} requires either one or three parameter(s)")
 
             logger.info(
                 self.grid_name(grid) + f"User waveform {w.ID} created using {timestr} and, if "
@@ -284,12 +353,15 @@ class Waveform(GridUserObject):
                     self.params_str() + (" builtin waveforms require exactly four parameters.")
                 )
                 raise
-            if freq <= 0:
-                logger.exception(
+            if not np.isfinite(amp):
+                raise ValueError(f"{self.params_str()} amplitude scaling must be finite.")
+            if not np.isfinite(freq) or freq <= 0:
+                message = (
                     self.params_str()
-                    + (" requires an excitation " "frequency value of greater than zero.")
+                    + " requires a finite excitation frequency greater than zero."
                 )
-                raise ValueError
+                logger.error(message)
+                raise ValueError(message)
             if any(x.ID == ID for x in grid.waveforms):
                 logger.exception(self.params_str() + (f" with ID {ID} already exists."))
                 raise ValueError
@@ -349,7 +421,7 @@ class Waveform(GridUserObject):
                 # build work runs, rather than deep inside the per-source
                 # waveform precompute loop.
                 try:
-                    float(userfunc(0.0))
+                    sample = float(userfunc(0.0))
                 except Exception as err:
                     msg = (
                         self.params_str() + " 'user_func' must accept a single float (time in "
@@ -357,6 +429,10 @@ class Waveform(GridUserObject):
                     )
                     logger.exception(msg)
                     raise ValueError(msg) from err
+                if not np.isfinite(sample):
+                    raise ValueError(
+                        self.params_str() + " 'user_func' must return finite numeric values."
+                    )
                 w.userfunc = userfunc
 
                 logger.info(
@@ -365,14 +441,44 @@ class Waveform(GridUserObject):
                 )
 
             elif "user_values" in self.kwargs:
-                uservalues = self.kwargs["user_values"]
+                try:
+                    uservalues = np.asarray(self.kwargs["user_values"], dtype=float)
+                except (TypeError, ValueError) as exc:
+                    raise ValueError(
+                        self.params_str() + " 'user_values' must be a real numeric array."
+                    ) from exc
+                if uservalues.ndim != 1 or uservalues.size < 2:
+                    raise ValueError(
+                        self.params_str() + " 'user_values' must be a one-dimensional "
+                        "array containing at least two samples."
+                    )
+                if not np.all(np.isfinite(uservalues)):
+                    raise ValueError(
+                        self.params_str() + " 'user_values' must contain only finite values."
+                    )
                 fullargspec = inspect.getfullargspec(interpolate.interp1d)
                 kwargs = dict(zip(reversed(fullargspec.args), reversed(fullargspec.defaults)))
 
                 if "user_time" in self.kwargs:
-                    waveformtime = self.kwargs["user_time"]
+                    try:
+                        waveformtime = np.asarray(self.kwargs["user_time"], dtype=float)
+                    except (TypeError, ValueError) as exc:
+                        raise ValueError(
+                            self.params_str() + " 'user_time' must be a real numeric array."
+                        ) from exc
                 else:
                     waveformtime = np.arange(0, grid.timewindow + grid.dt, grid.dt)
+
+                if waveformtime.ndim != 1 or waveformtime.size != uservalues.size:
+                    raise ValueError(
+                        self.params_str() + " 'user_time' and 'user_values' must be "
+                        "one-dimensional arrays of the same length."
+                    )
+                if not np.all(np.isfinite(waveformtime)) or np.any(np.diff(waveformtime) <= 0):
+                    raise ValueError(
+                        self.params_str() + " 'user_time' must contain finite, strictly "
+                        "increasing values."
+                    )
 
                 # Set args for interpolation if given by user
                 if "kind" in self.kwargs:
@@ -607,6 +713,11 @@ class NetworkExcitation(GridUserObject):
 class VoltageSource(RotatableMixin, GridUserObject):
     """Specifies a voltage source at an electric field location.
 
+    In a 3-D model the source also owns an automatic terminal monitor. A hard
+    source on a domain-minimum transverse boundary remains a valid source, but
+    cannot provide that port output because its complete Ampere loop lies
+    partly outside the grid.
+
     Attributes:
         polarisation: string required for polarisation of the source x, y, z.
         p1: tuple required for position of source x, y, z.
@@ -673,6 +784,7 @@ class VoltageSource(RotatableMixin, GridUserObject):
         self.reference_impedance = reference_impedance
         self._source = None
         self._monitor = None
+        self._port_output_id = None
 
     @property
     def result(self):
@@ -749,9 +861,9 @@ class VoltageSource(RotatableMixin, GridUserObject):
                     )
 
         # Check resistance
-        if self.resistance < 0:
+        if not np.isfinite(self.resistance) or self.resistance < 0:
             raise ValueError(
-                f"{self.params_str()} requires a source resistance of zero or greater."
+                f"{self.params_str()} requires a finite source resistance of zero or greater."
             )
         if self.reference_impedance is not None:
             self.reference_impedance = float(self.reference_impedance)
@@ -843,6 +955,16 @@ class VoltageSource(RotatableMixin, GridUserObject):
 
         if grid.within_pml(coord):
             raise ValueError(f"{self.params_str()} cannot be placed inside a PML.")
+        loop_coordinate = (
+            grid.local_to_global_coordinate(coord) if isinstance(grid, MPIGrid) else coord
+        )
+        if not _hard_source_current_loop_available(
+            voltage_source.polarisation, voltage_source.resistance, loop_coordinate
+        ):
+            raise RuntimeError(
+                "internal error: attempted to create a hard-source port without "
+                "a complete transverse Ampere loop"
+            )
 
         receiver = RxUser()
         receiver.ID = f"_voltage_port_{output_id}"
@@ -858,16 +980,6 @@ class VoltageSource(RotatableMixin, GridUserObject):
         grid.add_receiver(receiver)
 
         if voltage_source.resistance == 0:
-            transverse_axes = {
-                "x": (1, 2),
-                "y": (0, 2),
-                "z": (0, 1),
-            }[voltage_source.polarisation]
-            if any(coord[axis] == 0 for axis in transverse_axes):
-                raise ValueError(
-                    f"{self.params_str()} cannot calculate a hard-source current "
-                    "loop on a domain-minimum transverse boundary"
-                )
             receiver.outputs[f"I{voltage_source.polarisation}"] = np.zeros(
                 grid.iterations, dtype=real_dtype
             )
@@ -898,6 +1010,12 @@ class VoltageSource(RotatableMixin, GridUserObject):
         )
 
     def build(self, grid: FDTDGrid):
+        # A Scene may be built again against a new grid. Do not carry runtime
+        # source/monitor ownership or a previously assigned automatic ID into
+        # the new build.
+        self._source = None
+        self._monitor = None
+        self._port_output_id = None
         if self.do_rotate:
             self._do_rotate(grid)
 
@@ -909,7 +1027,11 @@ class VoltageSource(RotatableMixin, GridUserObject):
         # Every MPI rank parses the same scene. Reserve the public ID before
         # reducing the point object to its owning rank so automatic IDs remain
         # globally deterministic.
-        if config.sim_config.mpi and config.get_model_config().mode == "3D":
+        global_discretised_point = uip.discretise_static_point(self.point)
+        mpi_port_supported = _hard_source_current_loop_available(
+            self.polarisation, self.resistance, global_discretised_point
+        )
+        if config.sim_config.mpi and config.get_model_config().mode == "3D" and mpi_port_supported:
             self._port_output_id = _reserve_voltage_port_output_id(grid, self.id, self)
 
         if point_within_grid:
@@ -918,15 +1040,30 @@ class VoltageSource(RotatableMixin, GridUserObject):
             grid.add_source(voltage_source)
             self._source = voltage_source
             if config.get_model_config().mode == "3D":
-                if not config.sim_config.mpi:
-                    self._port_output_id = _reserve_voltage_port_output_id(grid, self.id, self)
-                    voltage_source.port_id = self._port_output_id
-                self._create_port_monitor(
-                    grid,
-                    voltage_source,
-                    discretised_point,
-                    self._port_output_id,
+                # A local coordinate of zero on an internal MPI rank boundary
+                # is not the global domain minimum: its negative halo carries
+                # the magnetic samples required by the current loop.
+                port_supported = _hard_source_current_loop_available(
+                    voltage_source.polarisation,
+                    voltage_source.resistance,
+                    global_discretised_point,
                 )
+                if not port_supported:
+                    logger.warning(
+                        f"{self.params_str()} is a valid hard voltage source, but its "
+                        "automatic port output is disabled because a complete transverse "
+                        "Ampere loop does not fit at the domain-minimum boundary."
+                    )
+                else:
+                    if not config.sim_config.mpi:
+                        self._port_output_id = _reserve_voltage_port_output_id(grid, self.id, self)
+                        voltage_source.port_id = self._port_output_id
+                    self._create_port_monitor(
+                        grid,
+                        voltage_source,
+                        discretised_point,
+                        self._port_output_id,
+                    )
             position = uip.round_to_grid_static_point(self.point)
             self._log(grid, voltage_source, *position)
 
@@ -1385,9 +1522,13 @@ class TransmissionLine(RotatableMixin, GridUserObject):
             raise ValueError(f"{self.params_str()} polarisation must be x, y, or z.")
 
         # Check resistance
-        if self.resistance <= 0 or self.resistance >= config.sim_config.em_consts["z0"]:
+        if (
+            not np.isfinite(self.resistance)
+            or self.resistance <= 0
+            or self.resistance >= config.sim_config.em_consts["z0"]
+        ):
             raise ValueError(
-                f"{self.params_str()} requires a resistance "
+                f"{self.params_str()} requires a finite resistance "
                 "greater than zero and less than the impedance "
                 "of free space, i.e. 376.73 Ohms."
             )
@@ -1749,6 +1890,8 @@ class DiscretePlaneWaveAngles(GridUserObject):
         stop: float optional to time (secs) to remove source.
         precompute: boolean optional. If ``True`` (default), precompute the
             auxiliary plane-wave source history before time stepping.
+            ``False`` is reserved for a future on-the-fly implementation and
+            is currently rejected.
     """
 
     @property
@@ -1803,6 +1946,7 @@ class DiscretePlaneWaveAngles(GridUserObject):
             precompute = self.kwargs["precompute"]
         except KeyError:
             precompute = True
+        _validate_dpw_precompute(self, precompute)
 
         # Check if there is a waveformID in the waveforms list
         if not any(x.ID == waveform_id for x in grid.waveforms):
@@ -1819,23 +1963,25 @@ class DiscretePlaneWaveAngles(GridUserObject):
             raise ValueError
 
         # Check angles
-        if theta < 0 or theta > 180:
+        if not np.isfinite(theta) or theta < 0 or theta > 180:
             logger.exception(
                 f"{self.params_str()} Polar angle theta must be between 0 and 180 degrees."
             )
             raise ValueError
 
-        if phi < 0 or phi > 360:
+        if not np.isfinite(phi) or phi < 0 or phi > 360:
             logger.exception(
                 f"{self.params_str()} Azimuthal angle phi must be between 0 and 360 degrees."
             )
             raise ValueError
 
-        if psi < 0 or psi > 360:
+        if not np.isfinite(psi) or psi < 0 or psi > 360:
             logger.exception(
                 f"{self.params_str()} Polarisation angle psi must be between 0 and 360 degrees."
             )
             raise ValueError
+        if not np.isfinite(max_angle_diff) or max_angle_diff <= 0:
+            raise ValueError(f"{self.params_str()} max_angle_diff must be finite and positive")
 
         uip = self._create_uip(grid)
         start, stop = _dpw_tfsf_corners(uip, p1, p2, self.params_str())
@@ -1851,37 +1997,10 @@ class DiscretePlaneWaveAngles(GridUserObject):
         DPW.m = np.zeros(3 + 1, dtype=np.int32)
         DPW.axial = 0
 
-        try:
-            # Check source start & source remove time parameters
-            start = self.kwargs["start"]
-            stop = self.kwargs["stop"]
-            if start < 0:
-                logger.exception(
-                    self.params_str()
-                    + (" delay of the initiation " "of the source should not " "be less than zero.")
-                )
-                raise ValueError
-            if stop < 0:
-                logger.exception(
-                    self.params_str() + (" time to remove the source should not be less than zero.")
-                )
-                raise ValueError
-            if stop - start <= 0:
-                logger.exception(
-                    self.params_str() + (" duration of the source should not be zero or less.")
-                )
-                raise ValueError
-            DPW.start = start
-            DPW.stop = min(stop, grid.timewindow)
-            startstop = f" start time {start:g} secs, finish time {stop:g} secs "
-        except KeyError:
-            DPW.start = 0
-            DPW.stop = grid.timewindow
-            startstop = " "
+        startstop = _configure_dpw_time_window(self, DPW, grid)
 
         DPW.initializeDiscretePlaneWave(grid)
 
-        precompute = True
         if precompute:
             DPW.calculate_waveform_values(grid)
 
@@ -1936,6 +2055,8 @@ class DiscretePlaneWaveVector(GridUserObject):
         stop: float optional to time (secs) to remove source.
         precompute: boolean optional. If ``True`` (default), precompute the
             auxiliary plane-wave source history before time stepping.
+            ``False`` is reserved for a future on-the-fly implementation and
+            is currently rejected.
     """
 
     @property
@@ -1970,6 +2091,7 @@ class DiscretePlaneWaveVector(GridUserObject):
             precompute = self.kwargs["precompute"]
         except KeyError:
             precompute = True
+        _validate_dpw_precompute(self, precompute)
 
         # Check if there is a waveformID in the waveforms list
         if not any(x.ID == waveform_id for x in grid.waveforms):
@@ -1987,11 +2109,23 @@ class DiscretePlaneWaveVector(GridUserObject):
 
         # Check angle
 
-        if psi < 0 or psi > 360:
+        if not np.isfinite(psi) or psi < 0 or psi > 360:
             logger.exception(
                 f"{self.params_str()} Polarisation angle psi must be between 0 and 360 degrees."
             )
             raise ValueError
+
+        m_values = np.asarray(m_vec)
+        if (
+            m_values.shape != (3,)
+            or not np.all(np.isfinite(m_values))
+            or not np.all(m_values == np.rint(m_values))
+            or not np.any(m_values)
+        ):
+            raise ValueError(
+                f"{self.params_str()} m_vec must contain three finite integers and not be zero"
+            )
+        m_vec = tuple(int(value) for value in m_values)
 
         uip = self._create_uip(grid)
         start, stop = _dpw_tfsf_corners(uip, p1, p2, self.params_str())
@@ -2016,37 +2150,10 @@ class DiscretePlaneWaveVector(GridUserObject):
         DPW.m[:3] = np.array(m_vec, dtype=np.int32)
         DPW.axial = 0
 
-        try:
-            # Check source start & source remove time parameters
-            start = self.kwargs["start"]
-            stop = self.kwargs["stop"]
-            if start < 0:
-                logger.exception(
-                    self.params_str()
-                    + (" delay of the initiation " "of the source should not " "be less than zero.")
-                )
-                raise ValueError
-            if stop < 0:
-                logger.exception(
-                    self.params_str() + (" time to remove the source should not be less than zero.")
-                )
-                raise ValueError
-            if stop - start <= 0:
-                logger.exception(
-                    self.params_str() + (" duration of the source should not be zero or less.")
-                )
-                raise ValueError
-            DPW.start = start
-            DPW.stop = min(stop, grid.timewindow)
-            startstop = f" start time {start:g} secs, finish time {stop:g} secs "
-        except KeyError:
-            DPW.start = 0
-            DPW.stop = grid.timewindow
-            startstop = " "
+        startstop = _configure_dpw_time_window(self, DPW, grid)
 
         DPW.initializeDiscretePlaneWave(grid)
 
-        precompute = True
         if precompute:
             DPW.calculate_waveform_values(grid)
 
@@ -2097,6 +2204,8 @@ class DiscretePlaneWaveAxial(GridUserObject):
         stop: float optional to time (secs) to remove source.
         precompute: boolean optional. If ``True`` (default), precompute the
             auxiliary plane-wave source history before time stepping.
+            ``False`` is reserved for a future on-the-fly implementation and
+            is currently rejected.
     """
 
     @property
@@ -2125,6 +2234,7 @@ class DiscretePlaneWaveAxial(GridUserObject):
             precompute = self.kwargs["precompute"]
         except KeyError:
             precompute = True
+        _validate_dpw_precompute(self, precompute)
 
         # Check if there is a waveformID in the waveforms list
         if not any(x.ID == waveform_id for x in grid.waveforms):
@@ -2134,7 +2244,7 @@ class DiscretePlaneWaveAxial(GridUserObject):
             raise ValueError
 
         # Check polarisation angle
-        if psi < 0 or psi > 360:
+        if not np.isfinite(psi) or psi < 0 or psi > 360:
             logger.exception(
                 f"{self.params_str()} Polarisation angle psi must be between 0 and 360 degrees."
             )
@@ -2183,37 +2293,10 @@ class DiscretePlaneWaveAxial(GridUserObject):
             )
             raise ValueError
 
-        try:
-            # Check source start & source remove time parameters
-            start = self.kwargs["start"]
-            stop = self.kwargs["stop"]
-            if start < 0:
-                logger.exception(
-                    self.params_str()
-                    + (" delay of the initiation " "of the source should not " "be less than zero.")
-                )
-                raise ValueError
-            if stop < 0:
-                logger.exception(
-                    self.params_str() + (" time to remove the source should not be less than zero.")
-                )
-                raise ValueError
-            if stop - start <= 0:
-                logger.exception(
-                    self.params_str() + (" duration of the source should not be zero or less.")
-                )
-                raise ValueError
-            DPW.start = start
-            DPW.stop = min(stop, grid.timewindow)
-            startstop = f" start time {start:g} secs, finish time {stop:g} secs "
-        except KeyError:
-            DPW.start = 0
-            DPW.stop = grid.timewindow
-            startstop = " "
+        startstop = _configure_dpw_time_window(self, DPW, grid)
 
         DPW.initializeDiscretePlaneWave(grid)
 
-        precompute = True
         if precompute:
             DPW.calculate_waveform_values(grid)
 
@@ -3586,27 +3669,35 @@ class Material(GridUserObject):
             logger.exception(f"{self.params_str()} requires exactly five parameters.")
             raise
 
-        if er < 1:
-            logger.exception(
-                f"{self.params_str()} requires a positive value of one or greater for static (DC) permittivity."
-            )
-            raise ValueError
-        if se != "inf":
+        try:
+            er = float(er)
             se = float(se)
-            if se < 0:
-                logger.exception(
-                    f"{self.params_str()} requires a positive value for electric conductivity."
-                )
-                raise ValueError
-        else:
-            se = float("inf")
-        if mr < 1:
+            mr = float(mr)
+            sm = float(sm)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"{self.params_str()} electromagnetic properties must be numeric."
+            ) from exc
+
+        if not np.isfinite(er) or er < 1:
             logger.exception(
-                f"{self.params_str()} requires a positive value of one or greater for magnetic permeability."
+                f"{self.params_str()} requires a finite value of one or greater for static (DC) permittivity."
             )
             raise ValueError
-        if sm < 0:
-            logger.exception(f"{self.params_str()} requires a positive value for magnetic loss.")
+        # Positive infinity is the documented representation of a PEC.
+        if np.isnan(se) or se < 0:
+            logger.exception(
+                f"{self.params_str()} requires a non-negative value for electric conductivity."
+            )
+            raise ValueError
+        if not np.isfinite(mr) or mr < 1:
+            logger.exception(
+                f"{self.params_str()} requires a finite value of one or greater for magnetic permeability."
+            )
+            raise ValueError
+        # Positive infinity is the documented representation of a PMC.
+        if np.isnan(sm) or sm < 0:
+            logger.exception(f"{self.params_str()} requires a non-negative value for magnetic loss.")
             raise ValueError
 
         if any(x.ID == material_id for x in grid.materials):
@@ -3866,15 +3957,19 @@ class AddDebyeDispersion(GridUserObject):
             disp_material.poles = poles
             disp_material.averagable = config.get_model_config().dispersive_averaging
             for i in range(poles):
-                if tau[i] > 0:
-                    logger.debug("Not checking if relaxation times are " "greater than time-step.")
-                    disp_material.deltaer.append(er_delta[i])
-                    disp_material.tau.append(tau[i])
-                else:
-                    logger.exception(
-                        f"{self.params_str()} requires positive values for the permittivity difference."
+                if not np.isfinite(er_delta[i]) or er_delta[i] <= 0:
+                    raise ValueError(
+                        f"{self.params_str()} requires finite, positive "
+                        f"relative-permittivity differences (invalid pole {i + 1})"
                     )
-                    raise ValueError
+                if not np.isfinite(tau[i]) or tau[i] <= 0:
+                    raise ValueError(
+                        f"{self.params_str()} requires finite, positive relaxation times "
+                        f"(invalid pole {i + 1})"
+                    )
+                logger.debug("Not checking if relaxation times are greater than time-step.")
+                disp_material.deltaer.append(er_delta[i])
+                disp_material.tau.append(tau[i])
             if disp_material.poles > config.get_model_config().materials["maxpoles"]:
                 config.get_model_config().materials["maxpoles"] = disp_material.poles
 
@@ -3963,9 +4058,10 @@ class AddLorentzDispersion(GridUserObject):
             disp_material.poles = poles
             disp_material.averagable = config.get_model_config().dispersive_averaging
             for i in range(poles):
-                if er_delta[i] <= 0:
+                if not np.isfinite(er_delta[i]) or er_delta[i] <= 0:
                     raise ValueError(
-                        f"{self.params_str()} requires positive relative-permittivity differences"
+                        f"{self.params_str()} requires finite, positive "
+                        f"relative-permittivity differences (invalid pole {i + 1})"
                     )
                 try:
                     validate_lorentz_pole(omega[i], delta[i], grid.dt)
@@ -4119,6 +4215,17 @@ class SoilPeplinski(GridUserObject):
             logger.exception(f"{self.params_str()} requires at exactly seven parameters.")
             raise
 
+        values = (
+            sand_fraction,
+            clay_fraction,
+            bulk_density,
+            sand_density,
+            water_fraction_lower,
+            water_fraction_upper,
+        )
+        if not np.all(np.isfinite(values)):
+            raise ValueError(f"{self.params_str()} soil parameters must all be finite")
+
         # sand_fraction/clay_fraction are physical fractions - values
         # above 1 were previously unvalidated.
         if not (0 <= sand_fraction <= 1):
@@ -4232,6 +4339,19 @@ class MaterialRange(GridUserObject):
             logger.exception(f"{self.params_str()} requires at exactly nine parameters.")
             raise
 
+        values = (
+            er_lower,
+            er_upper,
+            sigma_lower,
+            sigma_upper,
+            mr_lower,
+            mr_upper,
+            ro_lower,
+            ro_upper,
+        )
+        if not np.all(np.isfinite(values)):
+            raise ValueError(f"{self.params_str()} material-range limits must all be finite")
+
         if er_lower < 1:
             logger.exception(
                 f"{self.params_str()} requires a value greater or equal to 1 "
@@ -4275,6 +4395,18 @@ class MaterialRange(GridUserObject):
             logger.exception(
                 f"{self.params_str()} requires a positive value for the upper range of magnetic loss."
             )
+            raise ValueError
+        ranges = (
+            ("relative permittivity", er_lower, er_upper),
+            ("electric conductivity", sigma_lower, sigma_upper),
+            ("relative magnetic permeability", mr_lower, mr_upper),
+            ("magnetic loss", ro_lower, ro_upper),
+        )
+        for label, lower, upper in ranges:
+            if lower > upper:
+                raise ValueError(
+                    f"{self.params_str()} lower {label} limit must not exceed its upper limit"
+                )
         if any(x.ID == ID for x in grid.mixingmodels):
             logger.exception(f"{self.params_str()} with ID {ID} already exists")
             raise ValueError

--- a/gprMax/user_objects/cmds_singleuse.py
+++ b/gprMax/user_objects/cmds_singleuse.py
@@ -19,6 +19,7 @@
 
 import logging
 import math
+from numbers import Integral
 from typing import Optional, Tuple, Union
 
 import numpy as np
@@ -87,10 +88,12 @@ class Discretisation(ModelUserObject):
         self.discretisation = p1
 
     def build(self, model: Model):
-        if any(d <= 0 for d in self.discretisation):
+        if not np.all(np.isfinite(self.discretisation)) or any(
+            d <= 0 for d in self.discretisation
+        ):
             raise ValueError(
-                f"{self} discretisation requires the spatial step to be"
-                " greater than zero in all dimensions"
+                f"{self} discretisation requires a finite spatial step greater than zero "
+                "in all dimensions"
             )
 
         model.dl = np.array(self.discretisation, dtype=np.float64)
@@ -444,10 +447,13 @@ class TimeStepStabilityFactor(ModelUserObject):
         self.stability_factor = f
 
     def build(self, model: Model):
-        if self.stability_factor <= 0 or self.stability_factor > 1:
+        if (
+            not np.isfinite(self.stability_factor)
+            or self.stability_factor <= 0
+            or self.stability_factor > 1
+        ):
             raise ValueError(
-                f"{self} requires the value of the time step stability"
-                " factor to be between zero and one"
+                f"{self} requires a finite time step stability factor between zero and one"
             )
 
         model.dt_mod = self.stability_factor
@@ -488,20 +494,24 @@ class TimeWindow(ModelUserObject):
 
     def build(self, model: Model):
         if self.time is not None:
-            if self.time > 0:
+            if np.isfinite(self.time) and self.time > 0:
                 model.timewindow = self.time
                 model.iterations = int(np.ceil(self.time / model.dt)) + 1
             else:
-                raise ValueError(f"{self} must have a value greater than zero")
+                raise ValueError(f"{self} time must be finite and greater than zero")
         elif self.iterations is not None:
-            if self.iterations <= 0:
-                raise ValueError(f"{self} must have a value greater than zero")
+            if (
+                isinstance(self.iterations, bool)
+                or not isinstance(self.iterations, Integral)
+                or self.iterations <= 0
+            ):
+                raise ValueError(f"{self} iterations must be a positive integer")
 
             # The +/- 1 used in calculating the number of iterations is
             # to account for the fact that the solver (iterations) loop
             # runs from 0 to < G.iterations
-            model.timewindow = (self.iterations - 1) * model.dt
-            model.iterations = self.iterations
+            model.timewindow = (int(self.iterations) - 1) * model.dt
+            model.iterations = int(self.iterations)
         else:
             raise ValueError(f"{self} specify a time or number of iterations")
 
@@ -541,10 +551,14 @@ class OMPThreads(ModelUserObject):
         self.omp_threads = n
 
     def build(self, model: Model):
-        if self.omp_threads < 1:
+        if (
+            isinstance(self.omp_threads, bool)
+            or not isinstance(self.omp_threads, Integral)
+            or self.omp_threads < 1
+        ):
             raise ValueError(f"{self} requires the value to be an integer not less than one")
 
-        config.get_model_config().ompthreads = set_omp_threads(self.omp_threads)
+        config.get_model_config().ompthreads = set_omp_threads(int(self.omp_threads))
 
         logger.info(f"Simulation will use {config.get_model_config().ompthreads} OpenMP threads")
 
@@ -636,23 +650,36 @@ class PMLThickness(ModelUserObject):
     def build(self, model: Model):
         grid = model.G
 
-        if not (
-            isinstance(self.thickness, int) or len(self.thickness) == 1 or len(self.thickness) == 6
-        ):
+        if isinstance(self.thickness, (bool, str, bytes)):
+            raise ValueError(f"{self} requires integer PML cell counts")
+        if isinstance(self.thickness, Integral):
+            thickness_values = (int(self.thickness),)
+        else:
+            try:
+                thickness_values = tuple(self.thickness)
+            except TypeError as exc:
+                raise ValueError(
+                    f"{self} requires either one or six integer PML cell counts"
+                ) from exc
+
+        if len(thickness_values) not in (1, 6):
             raise ValueError(f"{self} requires either one or six parameter(s)")
+        if any(isinstance(t, bool) or not isinstance(t, Integral) for t in thickness_values):
+            raise ValueError(f"{self} requires integer PML cell counts")
+        thickness_values = tuple(int(t) for t in thickness_values)
 
         # A negative thickness isn't rejected here without this check -
         # FDTDGrid._build_pmls() only constructs a slab when
         # `thickness > 0`, so a negative value would silently behave
         # like 0 (no PML on that face) instead of raising an error for a
         # nonsensical request.
-        thickness_values = (
-            (self.thickness,) if isinstance(self.thickness, int) else tuple(self.thickness)
-        )
         if any(t < 0 for t in thickness_values):
             raise ValueError(f"{self} requires the PML thickness to be zero or greater")
 
-        model.G.set_pml_thickness(self.thickness)
+        canonical_thickness = (
+            thickness_values[0] if len(thickness_values) == 1 else thickness_values
+        )
+        model.G.set_pml_thickness(canonical_thickness)
 
         # Check each PML does not take up more than half the grid
         # TODO: MPI ranks not containing a PML will not throw an error

--- a/gprMax/vtkhdf_filehandlers/vtk_unstructured_grid.py
+++ b/gprMax/vtkhdf_filehandlers/vtk_unstructured_grid.py
@@ -86,13 +86,33 @@ class VtkUnstructuredGrid(VtkHdfFile):
         Raises:
             Value Error: Raised if argument dimensions are invalid.
         """
-        super().__init__(filename, self.TYPE, "w", comm)
+        points = np.asarray(points)
+        cell_types = np.asarray(cell_types)
+        connectivity = np.asarray(connectivity)
+        cell_offsets = np.asarray(cell_offsets)
+
+        if points.ndim != 2 or points.shape[1] != 3:
+            raise ValueError("points must have shape (N, 3)")
+        for name, values in (
+            ("cell_types", cell_types),
+            ("connectivity", connectivity),
+            ("cell_offsets", cell_offsets),
+        ):
+            if values.ndim != 1:
+                raise ValueError(f"{name} must be one-dimensional")
+        if not np.issubdtype(connectivity.dtype, np.integer):
+            raise ValueError("connectivity must contain integer point IDs")
+        if not np.issubdtype(cell_offsets.dtype, np.integer):
+            raise ValueError("cell_offsets must contain integer offsets")
 
         if len(cell_offsets) != len(cell_types) + 1:
             raise ValueError(
                 "cell_offsets should be one longer than cell_types."
                 " I.e. one longer than the number of cells"
             )
+
+        if cell_offsets[0] != 0:
+            raise ValueError("cell_offsets must start at zero")
 
         is_sorted = lambda a: np.all(a[:-1] <= a[1:])
         if not is_sorted(cell_offsets):
@@ -106,6 +126,20 @@ class VtkUnstructuredGrid(VtkHdfFile):
                 "Connectivity array longer than final cell_offsets value."
                 " Some connectivity data will be ignored"
             )
+
+        # In serial every referenced connectivity ID addresses this points
+        # array directly. Under MPI IDs may be global, so their bounds are
+        # validated by the collective writer instead.
+        referenced_connectivity = connectivity[: cell_offsets[-1]]
+        if comm is None and referenced_connectivity.size:
+            if np.any(referenced_connectivity < 0) or np.any(
+                referenced_connectivity >= len(points)
+            ):
+                raise ValueError("connectivity contains a point ID outside points")
+
+        # Validate before opening in truncating mode. A malformed geometry
+        # must not destroy an existing output file or leak an HDF5 handle.
+        super().__init__(filename, self.TYPE, "w", comm)
 
         self._number_of_cells = len(cell_types)
         self._number_of_connectivity_ids = len(connectivity)
@@ -260,7 +294,13 @@ class VtkUnstructuredGrid(VtkHdfFile):
 
         shape[0] = self.global_number_of_points
 
-        return super()._add_point_data(name, data, shape, self.points_offset)
+        return super()._add_point_data(
+            name,
+            data,
+            shape,
+            self.points_offset,
+            xyz_data_ordering=False,
+        )
 
     def add_cell_data(self, name: str, data: npt.NDArray):
         """Add cell data to the VTKHDF file.
@@ -288,4 +328,10 @@ class VtkUnstructuredGrid(VtkHdfFile):
 
         shape[0] = self.global_number_of_cells
 
-        return super()._add_cell_data(name, data, shape, self.cells_offset)
+        return super()._add_cell_data(
+            name,
+            data,
+            shape,
+            self.cells_offset,
+            xyz_data_ordering=False,
+        )

--- a/gprMax/vtkhdf_filehandlers/vtkhdf.py
+++ b/gprMax/vtkhdf_filehandlers/vtkhdf.py
@@ -84,14 +84,21 @@ class VtkHdfFile(AbstractContextManager):
                 want to write to the file.
 
         """
-        # Ensure the filename uses the correct extension
+        # Replace a known output extension, but preserve ordinary dots in a
+        # basename (for example a version or snapshot time). ``with_suffix``
+        # alone would turn ``model_1.5`` into ``model_1.vtkhdf`` and allow
+        # distinct outputs to overwrite one another.
         self.filename = Path(filename)
         if self.filename.suffix != "" and self.filename.suffix != self.FILE_EXTENSION:
             logger.warning(
-                f"Invalid file extension '{self.filename.suffix}' for VTKHDF file. Changing to '{self.FILE_EXTENSION}'."
+                f"Invalid file extension {self.filename.suffix!r}; applying "
+                f"'{self.FILE_EXTENSION}' for VTKHDF output."
             )
-
-        self.filename = self.filename.with_suffix(self.FILE_EXTENSION)
+        if self.filename.suffix != self.FILE_EXTENSION:
+            if self.filename.suffix.lower() in {".h5", ".vtk"}:
+                self.filename = self.filename.with_suffix(self.FILE_EXTENSION)
+            else:
+                self.filename = self.filename.with_name(self.filename.name + self.FILE_EXTENSION)
 
         self.comm = comm
 
@@ -255,7 +262,7 @@ class VtkHdfFile(AbstractContextManager):
                 points to some other object, e.g. a Group not a Dataset.
         """
         cls = self.file_handler.get(path, getclass=True)
-        if cls == "default":
+        if cls is None:
             raise KeyError("Path does not exist")
         elif cls != h5py.Dataset:
             raise KeyError(f"Dataset not found. Found '{cls}' instead")
@@ -489,6 +496,7 @@ class VtkHdfFile(AbstractContextManager):
         data: npt.NDArray,
         shape: Optional[Union[npt.NDArray[np.int32], Tuple[int, ...]]] = None,
         offset: Optional[npt.NDArray[np.int32]] = None,
+        xyz_data_ordering: bool = True,
     ):
         """Add point data to the VTKHDF file.
 
@@ -501,7 +509,13 @@ class VtkHdfFile(AbstractContextManager):
                 be omitted if data provides the full dataset.
         """
         dataset_path = self._build_dataset_path("PointData", name)
-        self._write_dataset(dataset_path, data, shape=shape, offset=offset)
+        self._write_dataset(
+            dataset_path,
+            data,
+            shape=shape,
+            offset=offset,
+            xyz_data_ordering=xyz_data_ordering,
+        )
 
     def _add_cell_data(
         self,
@@ -509,6 +523,7 @@ class VtkHdfFile(AbstractContextManager):
         data: npt.NDArray,
         shape: Optional[Union[npt.NDArray[np.int32], Tuple[int, ...]]] = None,
         offset: Optional[npt.NDArray[np.int32]] = None,
+        xyz_data_ordering: bool = True,
     ):
         """Add cell data to the VTKHDF file.
 
@@ -521,7 +536,13 @@ class VtkHdfFile(AbstractContextManager):
                 be omitted if data provides the full dataset.
         """
         dataset_path = self._build_dataset_path("CellData", name)
-        self._write_dataset(dataset_path, data, shape=shape, offset=offset)
+        self._write_dataset(
+            dataset_path,
+            data,
+            shape=shape,
+            offset=offset,
+            xyz_data_ordering=xyz_data_ordering,
+        )
 
     def add_field_data(
         self,

--- a/gprMax/waveforms.py
+++ b/gprMax/waveforms.py
@@ -152,7 +152,14 @@ class Waveform:
                 ampvalue = 0
 
         elif self.type == "user":
-            ampvalue = self.userfunc(time)
+            ampvalue = float(self.userfunc(time))
+            if not np.isfinite(ampvalue):
+                raise ValueError(
+                    f"User waveform {self.ID!r} returned a non-finite value at time {time:g} s"
+                )
+
+        else:
+            raise ValueError(f"Unknown waveform type {self.type!r}")
 
         ampvalue *= self.amp
 

--- a/tests/cmds_geometry/test_degenerate_primitives.py
+++ b/tests/cmds_geometry/test_degenerate_primitives.py
@@ -80,6 +80,58 @@ def _scene():
             ),
             "non-degenerate triangle",
         ),
+        (
+            "sphere_nan",
+            gprMax.Sphere(p1=(0.01, 0.01, 0.01), r=float("nan"), material_id="pec"),
+            "positive value",
+        ),
+        (
+            "ellipsoid_inf",
+            gprMax.Ellipsoid(
+                p1=(0.01, 0.01, 0.01),
+                xr=0.003,
+                yr=float("inf"),
+                zr=0.003,
+                material_id="pec",
+            ),
+            "semiaxes",
+        ),
+        (
+            "cylinder_nan",
+            gprMax.Cylinder(
+                p1=(0.008, 0.008, 0.008),
+                p2=(0.012, 0.008, 0.008),
+                r=float("nan"),
+                material_id="pec",
+            ),
+            "positive value",
+        ),
+        (
+            "cone_inf",
+            gprMax.Cone(
+                p1=(0.008, 0.008, 0.008),
+                p2=(0.012, 0.008, 0.008),
+                r1=0.001,
+                r2=float("inf"),
+                material_id="pec",
+            ),
+            "positive value",
+        ),
+        (
+            "sector_nan",
+            gprMax.CylindricalSector(
+                normal="z",
+                ctr1=0.01,
+                ctr2=0.01,
+                extent1=0.007,
+                extent2=0.012,
+                r=0.002,
+                start=float("nan"),
+                end=90,
+                material_id="pec",
+            ),
+            "finite",
+        ),
     ],
 )
 def test_degenerate_geometry_is_rejected(name, geometry, error, tmp_path):

--- a/tests/cmds_multiuse/test_source_time_windows.py
+++ b/tests/cmds_multiuse/test_source_time_windows.py
@@ -7,6 +7,7 @@ import pytest
 
 import gprMax
 import gprMax.config as config
+from gprMax.user_objects.cmds_multiuse import _configure_dpw_time_window
 
 
 @pytest.fixture(autouse=True)
@@ -58,3 +59,25 @@ def _grid():
 def test_lone_start_or_stop_is_rejected_instead_of_silently_ignored(source):
     with pytest.raises(ValueError, match="start and stop times must be supplied together"):
         source._validate_parameters(_grid())
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        gprMax.DiscretePlaneWaveAngles(start=0),
+        gprMax.DiscretePlaneWaveVector(stop=1e-9),
+        gprMax.DiscretePlaneWaveAxial(start=0),
+    ),
+)
+def test_plane_wave_lone_start_or_stop_is_rejected(source):
+    runtime_source = SimpleNamespace()
+    grid = SimpleNamespace(timewindow=2e-9)
+    with pytest.raises(ValueError, match="start and stop times must be supplied together"):
+        _configure_dpw_time_window(source, runtime_source, grid)
+
+
+@pytest.mark.parametrize("value", [np.nan, np.inf])
+def test_plane_wave_non_finite_time_is_rejected(value):
+    source = gprMax.DiscretePlaneWaveAxial(start=0, stop=value)
+    with pytest.raises(ValueError, match="must be finite"):
+        _configure_dpw_time_window(source, SimpleNamespace(), SimpleNamespace(timewindow=2e-9))

--- a/tests/cmds_multiuse/test_waveform_user_func.py
+++ b/tests/cmds_multiuse/test_waveform_user_func.py
@@ -166,6 +166,53 @@ def test_user_func_non_numeric_return_rejected_at_build_time(monkeypatch, tmp_pa
         _run(monkeypatch, tmp_path, "user_func_bad_return", scene)
 
 
+def test_user_func_non_finite_return_rejected_at_build_time(monkeypatch, tmp_path):
+    scene = _scene()
+    scene.add(gprMax.Waveform(wave_type="user", user_func=lambda time: np.nan, id="mywave"))
+
+    with pytest.raises(ValueError, match="finite numeric"):
+        _run(monkeypatch, tmp_path, "user_func_nan", scene)
+
+
+def test_user_func_later_non_finite_return_is_rejected(monkeypatch, tmp_path):
+    def waveform(time):
+        return 0.0 if time == 0 else np.inf
+
+    scene = _scene()
+    scene.add(gprMax.Waveform(wave_type="user", user_func=waveform, id="mywave"))
+    grid = _run(monkeypatch, tmp_path, "user_func_later_inf", scene)
+    built = next(w for w in grid.waveforms if w.ID == "mywave")
+
+    with pytest.raises(ValueError, match="non-finite value"):
+        built.calculate_value(grid.dt, grid.dt)
+
+
+@pytest.mark.parametrize(
+    "user_values,user_time,error",
+    [
+        ([0.0, np.nan], [0.0, 1.0], "finite values"),
+        ([[0.0, 1.0]], [0.0, 1.0], "one-dimensional"),
+        ([0.0, 1.0], [0.0], "same length"),
+        ([0.0, 1.0], [0.0, 0.0], "strictly increasing"),
+    ],
+)
+def test_user_value_arrays_are_validated(
+    monkeypatch, tmp_path, user_values, user_time, error
+):
+    scene = _scene()
+    scene.add(
+        gprMax.Waveform(
+            wave_type="user",
+            user_values=user_values,
+            user_time=user_time,
+            id="mywave",
+        )
+    )
+
+    with pytest.raises(ValueError, match=error):
+        _run(monkeypatch, tmp_path, "bad_user_values", scene)
+
+
 def test_user_values_path_still_works_unchanged(monkeypatch, tmp_path):
     """Regression check: refactoring the user_values branch to sit alongside
     user_func must not change its existing behaviour."""

--- a/tests/config/test_output_paths.py
+++ b/tests/config/test_output_paths.py
@@ -19,10 +19,8 @@ solving; it is consumed when the last timestep has already been computed. A
 wrong path does not crash a simulation, it loses one — or, worse, silently
 overwrites the previous model's results because the model number was dropped.
 
-Two of the tests below pin behaviour that is a known defect rather than a
-contract, and say so in their docstrings. They exist because the current
-behaviour is surprising and undocumented, and a reader hitting it needs to
-find something in the suite that explains it.
+The edge cases below also protect dotted basenames and recursively-created
+output directories, both of which have caused late output-path failures.
 """
 
 from pathlib import Path
@@ -121,20 +119,15 @@ class TestTheOutputDirectory:
 
         assert model_config.output_file_path.parent == outputdir
 
-    def test_a_missing_parent_directory_is_not_created(self, make_model_config, tmp_path):
-        """``mkdir`` is called without ``parents=True``.
-
-        ``#output_dir: results/2026/run_a`` therefore raises
-        ``FileNotFoundError`` from deep inside configuration rather than
-        reporting a bad path, even though the value came straight from user
-        input. Pinned as the current behaviour, with the defect written up in
-        ``notes/bugs/config-output-dir-no-parents.md``.
-        """
+    def test_a_missing_parent_directory_is_created(self, make_model_config, tmp_path):
+        """Nested output paths supplied by users are created recursively."""
         model_config = make_model_config(inputfile="model.in")
         nested = tmp_path / "missing" / "leaf"
 
-        with pytest.raises(FileNotFoundError):
-            model_config.set_output_file_path(str(nested))
+        model_config.set_output_file_path(str(nested))
+
+        assert nested.is_dir()
+        assert model_config.output_file_path.parent == nested
 
 
 class TestTheModelNumberSuffix:
@@ -199,18 +192,11 @@ class TestTheExtendedPath:
 
         assert model_config.output_file_path_ext == tmp_path / "model.h5"
 
-    def test_a_dot_in_the_file_name_truncates_it(self, make_model_config):
-        """``with_suffix`` treats everything after the last dot as an extension.
-
-        ``v1.2_model.in`` becomes ``v1.h5``: ``.2_model`` is read as a suffix
-        and replaced. Dots in file names are ordinary — version numbers,
-        dimensions, dates — so this quietly writes two different models to the
-        same file. Pinned as the current behaviour, with the defect written up
-        in ``notes/bugs/config-output-path-with-suffix.md``.
-        """
+    def test_a_dot_in_the_file_name_is_preserved(self, make_model_config):
+        """Version-like dots in a basename must not create output collisions."""
         model_config = make_model_config(inputfile="v1.2_model.in")
 
-        assert model_config.output_file_path_ext == Path("v1.h5")
+        assert model_config.output_file_path_ext == Path("v1.2_model.h5")
 
 
 class TestTheSnapshotDirectory:

--- a/tests/config/test_precision_dtypes.py
+++ b/tests/config/test_precision_dtypes.py
@@ -323,7 +323,10 @@ class TestConsistencyWithTheKernelDispatch:
         model_cfg = SimpleNamespace(
             mode="3D",
             ompthreads=1,
-            materials={"maxpoles": 1, "dispersivedtype": None},
+            materials={
+                "maxpoles": 1,
+                "dispersivedtype": sim_config.dtypes["float_or_double"],
+            },
         )
         monkeypatch.setattr(config, "get_model_config", lambda: model_cfg)
 

--- a/tests/hash_cmds/test_hash_cmds_geometry.py
+++ b/tests/hash_cmds/test_hash_cmds_geometry.py
@@ -382,24 +382,11 @@ class TestFractalBox:
             process_geometrycmds(["#fractal_box: 0 0 0 0.1 0.1 0.1 1.5 1 1 1 4 mix"])
 
 
-class TestFractalBoxSeedTypeBug:
-    """Bug tripwire: ``hash_cmds_geometry.py:393``.
-
-    The 15-token ``#fractal_box`` branch passes ``seed=tmp[14]`` —
-    *unconverted string*. Sibling commands convert: ``#add_surface_roughness``
-    line 453 and ``#add_grass`` line 517 both pass ``seed=int(tmp[N])``.
-    This inconsistency means a fractal-box ``seed`` lands in ``kwargs`` as
-    a ``str`` while modifier seeds land as ``int``.
-
-    Pin the current behaviour. If the dispatcher is later fixed to cast
-    consistently (``seed=int(tmp[14])``), this assertion fails — flip to
-    ``isinstance(..., int)``.
-    """
-
-    def test_fractal_box_seed_stored_as_string(self):
+class TestFractalBoxSeedType:
+    def test_fractal_box_seed_stored_as_integer(self):
         objs = process_geometrycmds(["#fractal_box: 0 0 0 0.1 0.1 0.1 1.5 1 1 1 4 mix fb1 42"])
-        assert isinstance(objs[0].kwargs["seed"], str)
-        assert objs[0].kwargs["seed"] == "42"
+        assert isinstance(objs[0].kwargs["seed"], int)
+        assert objs[0].kwargs["seed"] == 42
 
 
 class TestFractalBoxModifiers:

--- a/tests/materials/test_material_database.py
+++ b/tests/materials/test_material_database.py
@@ -65,6 +65,19 @@ def test_local_filename_and_database_id_must_match(tmp_path):
         load_material_spec("laboratory", "dielectric", search_directory=tmp_path)
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (("schema", "wrong-schema"), ("schema_version", 2)),
+)
+def test_local_database_rejects_unsupported_schema(tmp_path, field, value):
+    document = _database({"dielectric": _constant()})
+    document[field] = value
+    (tmp_path / "local.json").write_text(json.dumps(document))
+
+    with pytest.raises(ValueError, match="must use.*schema version 1"):
+        load_material_spec("local", "dielectric", search_directory=tmp_path)
+
+
 def test_official_catalogues_validate_and_reserve_empty_subject_namespaces():
     fundamental = dict(validate_material_database("fundamental"))
     assert set(fundamental) == {"vacuum", "pec", "pmc"}

--- a/tests/ntff/test_layered.py
+++ b/tests/ntff/test_layered.py
@@ -7,9 +7,19 @@ from gprMax.ntff.equivalent_currents import EquivalentCurrentPhasors, _evaluate_
 from gprMax.ntff.layered import (
     LayeredMedium,
     _responses_at_positions,
+    _safe_ratio,
     _voltage_coefficients,
     evaluate_layered_currents,
 )
+
+
+def test_layered_recursion_rejects_numerically_singular_denominator():
+    with pytest.raises(FloatingPointError, match="singular planar-layered recursion"):
+        _safe_ratio(1.0 + 0j, 1e-16 + 0j, "test interface")
+
+
+def test_layered_recursion_preserves_large_but_finite_physical_response():
+    assert _safe_ratio(1.0 + 0j, 1e-10 + 0j, "test interface") == pytest.approx(1e10)
 
 
 def _currents(seed=7, nfrequencies=2, npatches=11):

--- a/tests/outputs/test_mpi_sar_integration.py
+++ b/tests/outputs/test_mpi_sar_integration.py
@@ -58,10 +58,13 @@ def _write_tagged_geometry(tmp_path):
 
 def _run_command(command, tmp_path):
     environment = os.environ.copy()
+    # These subprocesses are complete MPI applications, so allow mpi4py to
+    # finalise MPI normally. An inherited MPI4PY_RC_FINALIZE=0 makes Open MPI
+    # report an otherwise successful run as an abnormal rank exit.
+    environment.pop("MPI4PY_RC_FINALIZE", None)
     environment.update(
         {
             "FI_PROVIDER": "shm",
-            "MPI4PY_RC_FINALIZE": "0",
             "OMP_NUM_THREADS": "1",
             "PYTHONUNBUFFERED": "1",
         }

--- a/tests/outputs/test_mpi_sar_integration.py
+++ b/tests/outputs/test_mpi_sar_integration.py
@@ -1,0 +1,143 @@
+"""Real multi-rank geometry-import and SAR integration regression."""
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+
+
+def _mpi_launcher():
+    """Prefer the launcher installed beside the active Python/mpi4py."""
+
+    environment_launcher = Path(sys.executable).parent / "mpiexec"
+    if environment_launcher.is_file():
+        return str(environment_launcher)
+    return shutil.which("mpiexec")
+
+
+def _write_tagged_geometry(tmp_path):
+    geometry = tmp_path / "mpi_geometry"
+    scene = gprMax.Scene()
+    scene.add(gprMax.Domain(p1=(0.04, 0.02, 0.02)))
+    scene.add(gprMax.Discretisation(p1=(0.002, 0.002, 0.002)))
+    scene.add(gprMax.TimeWindow(time=1e-11))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.Material(er=4, se=0.2, mr=1, sm=0, id="tissue"))
+    scene.add(gprMax.MaterialDensity(density=1000, material_ids="tissue"))
+    scene.add(
+        gprMax.Box(
+            p1=(0.016, 0.006, 0.006),
+            p2=(0.024, 0.014, 0.014),
+            material_id="tissue",
+            tag="target",
+        )
+    )
+    scene.add(
+        gprMax.GeometryObjectsWrite(
+            p1=(0, 0, 0),
+            p2=(0.04, 0.02, 0.02),
+            filename=str(geometry),
+        )
+    )
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        outputfile=geometry,
+        geometry_only=True,
+        hide_progress_bars=True,
+    )
+    return geometry.with_suffix(".h5"), tmp_path / "mpi_geometry_materials.json"
+
+
+def _run_command(command, tmp_path):
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "FI_PROVIDER": "shm",
+            "MPI4PY_RC_FINALIZE": "0",
+            "OMP_NUM_THREADS": "1",
+            "PYTHONUNBUFFERED": "1",
+        }
+    )
+    completed = subprocess.run(
+        command,
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(_mpi_launcher() is None, reason="mpiexec is not installed")
+def test_mpi_geometry_read_and_sar_match_serial_across_rank_boundary(tmp_path):
+    """A tagged import and its Yee-edge DFT must survive an actual x split."""
+
+    geometry_file, database_file = _write_tagged_geometry(tmp_path)
+    assert geometry_file.is_file()
+    assert database_file.is_file()
+
+    model = tmp_path / "mpi_sar.in"
+    model.write_text(
+        "\n".join(
+            (
+                "#title: MPI geometry-read SAR regression",
+                "#domain: 0.04 0.02 0.02",
+                "#dx_dy_dz: 0.002 0.002 0.002",
+                "#time_window: 2e-9",
+                "#pml_cells: 2",
+                "#geometry_objects_read: 0 0 0 mpi_geometry.h5 mpi_geometry_materials n",
+                "#waveform: ricker 1 1e9 pulse",
+                "#hertzian_dipole: z 0.008 0.01 0.01 pulse",
+                "#sar: 1e9 1e9 1 pulse 1 nyquist dose target",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    common = (sys.executable, "-m", "gprMax", str(model), "--hide-progress-bars")
+    serial_output = tmp_path / "serial"
+    mpi_output = tmp_path / "mpi"
+    _run_command((*common, "-o", str(serial_output)), tmp_path)
+    _run_command(
+        (
+            _mpi_launcher(),
+            "-n",
+            "2",
+            *common,
+            "--mpi",
+            "2",
+            "1",
+            "1",
+            "-o",
+            str(mpi_output),
+        ),
+        tmp_path,
+    )
+
+    with h5py.File(serial_output.with_suffix(".h5"), "r") as serial_file:
+        serial = serial_file["sar/dose"]
+        serial_cells = serial["cell_indices"][...]
+        serial_sar = serial["sar"][...]
+    with h5py.File(mpi_output.with_suffix(".h5"), "r") as mpi_file:
+        mpi = mpi_file["sar/dose"]
+        mpi_cells = mpi["cell_indices"][...]
+        mpi_sar = mpi["sar"][...]
+
+    # The imported target spans the decomposition plane at global x index 10.
+    assert np.any(serial_cells[:, 0] < 10)
+    assert np.any(serial_cells[:, 0] >= 10)
+    np.testing.assert_array_equal(mpi_cells, serial_cells)
+    np.testing.assert_allclose(mpi_sar, serial_sar, rtol=2e-5, atol=1e-12)
+    assert np.all(np.isfinite(mpi_sar))

--- a/tests/outputs/test_sar.py
+++ b/tests/outputs/test_sar.py
@@ -10,7 +10,7 @@ import gprMax
 from gprMax import config
 from gprMax.grid.mpi_grid import MPIGrid
 from gprMax.hash_cmds_file import get_user_objects
-from gprMax.materials import DispersiveMaterial
+from gprMax.materials import DispersiveMaterial, Material
 from gprMax.ports import PortPowerSpectrum
 from gprMax.sar import (
     EDGE_OFFSETS,
@@ -378,6 +378,39 @@ def test_sar_debye_loss_conductivity_matches_closed_form(monkeypatch):
     np.testing.assert_allclose(actual, expected, rtol=1e-14)
 
 
+def test_sar_perfect_conductors_have_zero_finite_volume_loss(monkeypatch):
+    """Ideal conductors must not create the indeterminate product inf * 0."""
+
+    pec = Material(0, "pec")
+    pec.se = float("inf")
+    pmc = Material(1, "pmc")
+    pmc.sm = float("inf")
+    frequencies = np.asarray((0.5e9, 1.0e9, 2.0e9))
+    monkeypatch.setattr(config, "sim_config", SimpleNamespace(em_consts={"e0": config.e0}))
+
+    actual = _material_loss_conductivity(
+        SimpleNamespace(materials=[pec, pmc]),
+        np.asarray((pec.numID, pmc.numID)),
+        frequencies,
+    )
+
+    np.testing.assert_array_equal(actual, np.zeros((3, 2)))
+    assert np.all(np.isfinite(actual))
+
+
+def test_sar_rejects_non_finite_non_pec_material_loss(monkeypatch):
+    material = Material(2, "invalid")
+    material.se = float("nan")
+    monkeypatch.setattr(config, "sim_config", SimpleNamespace(em_consts={"e0": config.e0}))
+
+    with pytest.raises(ValueError, match="non-finite electric loss"):
+        _material_loss_conductivity(
+            SimpleNamespace(materials=[material]),
+            np.asarray((material.numID,)),
+            np.asarray((1e9,)),
+        )
+
+
 def test_sar_incident_power_normalisation_scales_quadratically(monkeypatch):
     monitor = SARMonitor.__new__(SARMonitor)
     monitor._next_iteration = monitor.grid_iterations = 1
@@ -639,6 +672,26 @@ def test_sar_supports_dispersive_material_loss(tmp_path):
         absorbed = data["sar/target_sar/absorbed_power_density"][...]
         assert np.all(np.isfinite(absorbed))
         assert np.all(absorbed >= 0)
+
+
+def test_sar_tagged_pec_integration_is_finite_and_zero(tmp_path):
+    scene, output = _scene(spectrum_limit="nyquist")
+    box = next(item for item in scene.geometry_objects if isinstance(item, gprMax.Box))
+    box.kwargs["material_id"] = "pec"
+    box.kwargs["p2"] = (0.008, 0.008, 0.008)
+    scene.add(gprMax.MaterialDensity(density=7800, material_ids="pec"))
+
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        outputfile=tmp_path / "sar_pec",
+        hide_progress_bars=True,
+    )
+
+    assert np.all(np.isfinite(output.result.absorbed_power_density))
+    assert np.all(np.isfinite(output.result.sar))
+    np.testing.assert_array_equal(output.result.absorbed_power_density, 0)
+    np.testing.assert_array_equal(output.result.sar, 0)
 
 
 def test_sar_rejects_selected_material_without_density(tmp_path):

--- a/tests/outputs/test_snapshots.py
+++ b/tests/outputs/test_snapshots.py
@@ -164,11 +164,10 @@ class TestFilename:
         snap = make_snapshot(filename="snap.vtkhdf", fileext=".h5")
         assert snap.filename == Path("snap.h5")
 
-    def test_a_dotted_name_loses_everything_after_the_dot(self, make_snapshot):
-        """Expects ``run.2.field`` to become ``run.2.h5`` — only the final
-        component is treated as a suffix."""
+    def test_a_dotted_name_is_preserved(self, make_snapshot):
+        """Unknown dotted basename components are preserved."""
         snap = make_snapshot(filename="run.2.field", fileext=".h5")
-        assert snap.filename == Path("run.2.h5")
+        assert snap.filename == Path("run.2.field.h5")
 
     def test_directory_components_are_preserved(self, make_snapshot):
         """Expects only the final path component to be re-suffixed."""

--- a/tests/ports/test_mpi_voltage_boundary_integration.py
+++ b/tests/ports/test_mpi_voltage_boundary_integration.py
@@ -20,10 +20,13 @@ def _mpi_launcher():
 
 def _run(command, directory):
     environment = os.environ.copy()
+    # These subprocesses are complete MPI applications, so allow mpi4py to
+    # finalise MPI normally. An inherited MPI4PY_RC_FINALIZE=0 makes Open MPI
+    # report an otherwise successful run as an abnormal rank exit.
+    environment.pop("MPI4PY_RC_FINALIZE", None)
     environment.update(
         {
             "FI_PROVIDER": "shm",
-            "MPI4PY_RC_FINALIZE": "0",
             "OMP_NUM_THREADS": "1",
             "PYTHONUNBUFFERED": "1",
         }

--- a/tests/ports/test_mpi_voltage_boundary_integration.py
+++ b/tests/ports/test_mpi_voltage_boundary_integration.py
@@ -1,0 +1,98 @@
+"""Real MPI regression for a hard voltage port on an internal rank face."""
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+
+def _mpi_launcher():
+    environment_launcher = Path(sys.executable).parent / "mpiexec"
+    if environment_launcher.is_file():
+        return str(environment_launcher)
+    return shutil.which("mpiexec")
+
+
+def _run(command, directory):
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "FI_PROVIDER": "shm",
+            "MPI4PY_RC_FINALIZE": "0",
+            "OMP_NUM_THREADS": "1",
+            "PYTHONUNBUFFERED": "1",
+        }
+    )
+    completed = subprocess.run(
+        command,
+        cwd=directory,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(_mpi_launcher() is None, reason="mpiexec is not installed")
+def test_hard_voltage_port_on_internal_rank_boundary_matches_serial(tmp_path):
+    """The positive rank must use its halo, not mistake its face for x=0."""
+
+    model = tmp_path / "hard_port.in"
+    model.write_text(
+        "\n".join(
+            (
+                "#title: hard voltage port at MPI split",
+                "#domain: 0.04 0.02 0.02",
+                "#dx_dy_dz: 0.002 0.002 0.002",
+                "#time_window: 1e-9",
+                "#pml_cells: 2",
+                "#waveform: ricker 1 1e9 pulse",
+                # The 2x1x1 decomposition splits x at 0.02 m. For a z-directed
+                # hard source, x is transverse to the Ampere current loop.
+                "#voltage_source: z 0.02 0.01 0.01 0 pulse 0 1e-9 feed nyquist 50",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    common = (sys.executable, "-m", "gprMax", str(model), "--hide-progress-bars")
+    serial_output = tmp_path / "serial"
+    mpi_output = tmp_path / "mpi"
+    _run((*common, "-o", str(serial_output)), tmp_path)
+    _run(
+        (
+            _mpi_launcher(),
+            "-n",
+            "2",
+            *common,
+            "--mpi",
+            "2",
+            "1",
+            "1",
+            "-o",
+            str(mpi_output),
+        ),
+        tmp_path,
+    )
+
+    with h5py.File(serial_output.with_suffix(".h5")) as serial, h5py.File(
+        mpi_output.with_suffix(".h5")
+    ) as mpi:
+        for dataset in ("S11", "Zin", "Yin", "Vtotal", "Iloop"):
+            reference = serial[f"ports/feed/{dataset}"][...]
+            np.testing.assert_allclose(
+                mpi[f"ports/feed/{dataset}"][...],
+                reference,
+                rtol=2e-5,
+                atol=2e-6 * max(float(np.nanmax(np.abs(reference), initial=0.0)), 1e-18),
+                equal_nan=True,
+            )

--- a/tests/ports/test_port_hash_command.py
+++ b/tests/ports/test_port_hash_command.py
@@ -61,5 +61,5 @@ def test_voltage_source_hash_keeps_reference_impedance_last_with_port_options():
 
 
 def test_removed_rx_port_hash_command_is_rejected():
-    with pytest.raises(SyntaxError):
+    with pytest.raises(SyntaxError, match="Every 3-D #voltage_source now owns its port monitor"):
         _parse("#rx_port: 0.1 0.2 0.3")

--- a/tests/ports/test_validation.py
+++ b/tests/ports/test_validation.py
@@ -36,6 +36,66 @@ def test_hard_voltage_source_defaults_to_50_ohm_reference_impedance(tmp_path):
     assert source._monitor.output_id == "port1"
 
 
+def test_uppercase_hard_source_polarisation_still_builds(tmp_path):
+    scene = _base_scene()
+    source = gprMax.VoltageSource((0.01, 0.01, 0.01), "Z", 0, "pulse")
+    scene.add(source)
+
+    _run_geometry(scene, tmp_path, "uppercase_hard_source")
+
+    assert source._source.polarisation == "z"
+    assert source._monitor.output_id == "port1"
+
+
+def test_finite_resistance_source_at_domain_minimum_retains_port(tmp_path):
+    scene = _base_scene()
+    source = gprMax.VoltageSource((0.0, 0.0, 0.01), "z", 50, "pulse")
+    scene.add(source)
+
+    _run_geometry(scene, tmp_path, "finite_boundary_source")
+
+    assert source._source is not None
+    assert source._monitor.output_id == "port1"
+
+
+@pytest.mark.parametrize(
+    ("polarisation", "point"),
+    (
+        ("x", (0.01, 0.0, 0.0)),
+        ("y", (0.0, 0.01, 0.0)),
+        ("z", (0.0, 0.0, 0.01)),
+    ),
+)
+def test_hard_source_at_domain_minimum_remains_valid_without_port(
+    tmp_path, capsys, polarisation, point
+):
+    scene = _base_scene()
+    source = gprMax.VoltageSource(point, polarisation, 0, "pulse")
+    scene.add(source)
+
+    _run_geometry(scene, tmp_path, f"hard_{polarisation}_boundary")
+
+    assert source._source is not None
+    assert source._monitor is None
+    assert source._source.port_id is None
+    assert "automatic port output is disabled" in capsys.readouterr().out
+    with pytest.raises(RuntimeError, match="port result is not available"):
+        _ = source.result
+
+
+def test_boundary_hard_source_does_not_consume_an_automatic_port_id(tmp_path):
+    scene = _base_scene()
+    boundary = gprMax.VoltageSource((0.0, 0.0, 0.01), "z", 0, "pulse")
+    monitored = gprMax.VoltageSource((0.01, 0.01, 0.01), "z", 50, "pulse")
+    scene.add(boundary)
+    scene.add(monitored)
+
+    _run_geometry(scene, tmp_path, "boundary_then_monitored")
+
+    assert boundary._monitor is None
+    assert monitored._monitor.output_id == "port1"
+
+
 def test_port_rejects_reference_impedance_different_from_finite_resistance(tmp_path):
     scene = _base_scene()
     scene.add(

--- a/tests/sources/test_sources.py
+++ b/tests/sources/test_sources.py
@@ -37,6 +37,7 @@ from gprMax.sources import (
     VoltageSource,
     htod_src_arrays,
 )
+from gprMax.waveforms import Waveform as RuntimeWaveform
 
 # ---------------------------------------------------------------------------
 # Helpers shared across tests
@@ -785,46 +786,55 @@ class TestDpwCalculateWaveformValuesNonCython:
         assert np.all(dpw.waveformvalues_wholedt[1] == 0)
 
 
-class TestDpwNonCythonTypoBug:
-    """Pin the suspicious ``np.abs(self.m[(dimension)]) + np.abs(self.m[(dimension)])``
-    expression at ``sources.py:1221``. The ``time1`` calculation immediately
-    above uses ``m[(dim+1)%3]`` and ``m[(dim+2)%3]`` — for ``time2`` the
-    code repeats ``m[dim]`` twice, making the spatial-step offset reduce
-    to ``|m[dim]|`` instead of the cross-axis sum.
+class TestDpwWaveformPrecomputation:
+    def test_whole_step_uses_own_component_half_cell_offset(self, fake_grid):
+        class TimeWaveform:
+            type = "user"
+            freq = 1.0
 
-    Today this matches the formula
-        time2 = G.dt*iteration - (r + |m[dim]|*0.5)*ds/speed
-    The test pins that. If the source is fixed (replace the duplicated
-    index with ``dim+1`` and ``dim+2``), this assertion must flip.
-    """
+            @staticmethod
+            def calculate_value(time, dt):
+                return time
 
-    def test_time2_offset_uses_doubled_same_index(self, fake_grid, make_constant_waveform):
-        # Use a sparse waveform: returns 1.0 only at a specific t-window.
-        # We pick m, ds, speed so the cross-axis-sum formula would land
-        # OUTSIDE the window but the duplicated-index formula lands INSIDE.
-        # m[0]=2, m[1]=10, m[2]=10 → cross-axis sum for dim=0 is m[1]+m[2]=20;
-        # duplicated for dim=0 is m[0]+m[0]=4. Big difference → easy to
-        # distinguish.
         dpw = DiscretePlaneWave(G=None)
         dpw.m = np.array([2, 10, 10, 10], dtype=np.int32)
         dpw.ds = 1.0
         dpw.speed = 1.0
-        dpw.start = -1e9
-        dpw.stop = 1e9  # accept everything
-        dpw.waveform = make_constant_waveform(value=1.0)
+        dpw.start = 0.0
+        dpw.stop = 1e9
+        dpw.waveform = TimeWaveform()
 
         G = fake_grid(iterations=1, dt=100.0)
-
         dpw.calculate_waveform_values(G, cythonize=False)
 
-        # iteration=1, dim=0, r=0, the *current* (buggy) formula:
-        #   time2 = 100*1 - (0 + (|m[0]|+|m[0]|)*0.5)*1/1 = 100 - 2 = 98
-        # If the formula were fixed to m[(dim+1)%3] + m[(dim+2)%3]:
-        #   time2 = 100 - (10+10)*0.5 = 100 - 10 = 90
-        # Both are inside the wide window — but we can still verify the
-        # *array index* was set to 1.0 (the constant waveform value).
-        # Pin the fact that the value lands at iteration=1, dim=0, r=0.
-        assert dpw.waveformvalues_wholedt[1, 0, 0] == 1.0
+        # Ex is collocated half an x-projection cell from the auxiliary-grid
+        # origin: 100 - |m_x|/2 = 99, not 98 (a full-cell offset) and not
+        # 90 (the transverse Hy/Hz staggering).
+        assert dpw.waveformvalues_wholedt[1, 0, 0] == pytest.approx(99.0)
+
+    def test_cython_and_reference_histories_match_including_amplitude(self, fake_grid):
+        waveform = RuntimeWaveform()
+        waveform.ID = "pulse"
+        waveform.type = "gaussian"
+        waveform.freq = 1e9
+        waveform.amp = 2.5
+
+        dpw = DiscretePlaneWave(G=None)
+        dpw.m = np.array([1, 2, 3, 3], dtype=np.int32)
+        dpw.ds = 1e-4
+        dpw.speed = c
+        dpw.start = 0.0
+        dpw.stop = 20e-12
+        dpw.waveform = waveform
+        grid = fake_grid(iterations=12, dt=1e-12)
+
+        dpw.calculate_waveform_values(grid, cythonize=False)
+        expected_whole = dpw.waveformvalues_wholedt.copy()
+        expected_half = dpw.waveformvalues_halfdt.copy()
+        dpw.calculate_waveform_values(grid, cythonize=True)
+
+        np.testing.assert_allclose(dpw.waveformvalues_wholedt, expected_whole, rtol=1e-13)
+        np.testing.assert_allclose(dpw.waveformvalues_halfdt, expected_half, rtol=1e-13)
 
 
 pytestmark = pytest.mark.unit

--- a/tests/subgrids/test_precursor_nodes.py
+++ b/tests/subgrids/test_precursor_nodes.py
@@ -413,6 +413,25 @@ class TestUpdateFromMainGrid:
         c.precursors.update_magnetic()
         assert np.allclose(c.precursors.hx_front_1, 4.0)
 
+    def test_refining_ratio_rejects_bypassed_magnetic_interpolation(
+        self, coupled_grids, monkeypatch
+    ):
+        c = coupled_grids(ratio=3)
+        monkeypatch.setattr(c.precursors, "interpolate_to_sub_grid", lambda field, coords: field)
+
+        with pytest.raises(RuntimeError, match="did not refine"):
+            c.precursors.update_magnetic()
+
+    def test_unity_ratio_allows_identity_magnetic_interpolation(self, coupled_grids):
+        c = coupled_grids(ratio=1)
+        c.main.Hx[:] = 2.0
+        c.main.Hy[:] = 2.0
+        c.main.Hz[:] = 2.0
+
+        c.precursors.update_magnetic()
+
+        assert np.allclose(c.precursors.hx_front_1, 2.0)
+
     def test_zero_main_grid_gives_zero_precursors(self, coupled_grids):
         c = coupled_grids()
         c.precursors.update_electric()

--- a/tests/test_receivers_dtoh.py
+++ b/tests/test_receivers_dtoh.py
@@ -18,6 +18,7 @@ code path with a fake MTLBuffer-like stand-in exposing the same
 than constructing a real Metal buffer.
 """
 import numpy as np
+import pytest
 
 import gprMax.config as config
 from gprMax.receivers import Rx, dtoh_rx_array
@@ -95,6 +96,40 @@ def test_metal_dtoh_rx_array_populates_packed_current_outputs(monkeypatch):
     )
 
     np.testing.assert_array_equal(rx.outputs["Iz"], (1, 2, 3, 4))
+
+
+def test_metal_dtoh_rejects_field_buffer_size_mismatch(monkeypatch):
+    monkeypatch.setattr(config, "sim_config", type("_SC", (), {})())
+    config.sim_config.general = {"solver": "metal"}
+    config.sim_config.dtypes = {"float_or_double": np.float64}
+
+    rx = Rx()
+
+    class _DummyGrid:
+        rxs = [rx]
+        iterations = 4
+
+    with pytest.raises(RuntimeError, match="Failed to copy Metal receiver data"):
+        dtoh_rx_array(_FakeMetalBuffer(np.zeros(1)), None, _DummyGrid())
+
+
+def test_metal_dtoh_rejects_current_buffer_size_mismatch(monkeypatch):
+    monkeypatch.setattr(config, "sim_config", type("_SC", (), {})())
+    config.sim_config.general = {"solver": "metal"}
+    config.sim_config.dtypes = {"float_or_double": np.float64}
+
+    rx = Rx()
+    rx.outputs["Ix"] = np.zeros(4)
+
+    class _DummyGrid:
+        rxs = [rx]
+        iterations = 4
+
+    fields = np.zeros((len(Rx.defaultoutputs), 4, 1), dtype=np.float64)
+    with pytest.raises(RuntimeError, match="Failed to copy Metal current-output data"):
+        dtoh_rx_array(
+            _FakeMetalBuffer(fields), None, _DummyGrid(), _FakeMetalBuffer(np.zeros(1))
+        )
 
 
 def test_device_receiver_copy_uses_order_for_colocated_receivers(monkeypatch):

--- a/tests/toolboxes/test_debye_fit.py
+++ b/tests/toolboxes/test_debye_fit.py
@@ -58,7 +58,22 @@ def test_dls_constrains_infinite_frequency_permittivity_to_unity_or_greater():
     rl = np.full_like(freq, 0.5)
     im = np.zeros_like(freq)
 
-    _, _, _, ee, _, _ = DLS(tt, rl, im, freq)
+    with pytest.warns(UserWarning, match="physical lower bound of 1"):
+        _, _, _, ee, _, _ = DLS(tt, rl, im, freq)
+
+    assert ee == pytest.approx(1.0)
+
+
+def test_dls_reports_severely_invalid_unconstrained_fit():
+    freq = np.logspace(6, 9, 20)
+
+    with pytest.warns(UserWarning, match=r"-100.*physical lower bound"):
+        _, _, _, ee, _, _ = DLS(
+            np.array([-10.0]),
+            np.full_like(freq, -100.0),
+            np.zeros_like(freq),
+            freq,
+        )
 
     assert ee == pytest.approx(1.0)
 

--- a/tests/updates/test_dispersive_dispatch.py
+++ b/tests/updates/test_dispersive_dispatch.py
@@ -24,9 +24,9 @@ time, for the one combination of user settings nobody tried.
 **real compiled module**, so a mismatch fails here rather than in a user's
 simulation.
 
-The remaining classes pin the switch logic itself, including the two silent
-fallbacks — an unrecognised precision string yields ``"double"``, and a
-``dispersivedtype`` that does not match yields ``"real"``.
+The remaining classes pin the switch logic itself and require invalid or
+uninitialised configuration to fail explicitly rather than silently selecting
+an incompatible kernel.
 """
 
 import itertools
@@ -170,20 +170,12 @@ class TestPoleSwitch:
 
         assert "_multipole_" in updates.dispersive_update_a.__name__
 
-    def test_zero_poles_still_binds_the_single_pole_kernel(self, configure, make_wiring_grid):
-        """``maxpoles == 0`` is not rejected — it selects ``1pole``.
-
-        ``create_solver`` guards the call with ``maxpoles != 0``, so this
-        never happens in production. Called directly it succeeds silently,
-        binding a kernel that ``update_electric_a`` will never reach because
-        that method sends ``maxpoles == 0`` to the plain update instead.
-        """
+    def test_zero_poles_is_rejected(self, configure, make_wiring_grid):
         configure(maxpoles=0)
         updates = CPUUpdates(make_wiring_grid())
 
-        updates.set_dispersive_updates()
-
-        assert "_1pole_" in updates.dispersive_update_a.__name__
+        with pytest.raises(RuntimeError, match="at least one pole"):
+            updates.set_dispersive_updates()
 
     def test_the_boundary_is_between_one_and_two(self, configure, make_wiring_grid):
         """``> 1``, so one pole is single and two are multi."""
@@ -219,26 +211,14 @@ class TestPrecisionSwitch:
         assert updates.dispersive_update_a.__name__.endswith("_double_real")
 
     @pytest.mark.parametrize("precision", ["Single", "SINGLE", "float", "", "half"])
-    def test_an_unrecognised_precision_silently_selects_double(
+    def test_an_unrecognised_precision_is_rejected(
         self, configure, make_wiring_grid, precision
     ):
-        """The ternary tests equality with ``"single"`` and falls through.
-
-        Any other string — including a capitalisation slip or the plausible
-        ``"float"`` — silently produces the double-precision kernel. Since
-        the grid's arrays were allocated from the same ``precision`` value
-        elsewhere, this surfaces as a Cython buffer dtype mismatch rather
-        than a message about the setting being wrong.
-
-        Recorded in ``notes/bugs/config-precision-no-terminal-else.md``,
-        which covers the same string's other silent failure.
-        """
         configure(precision=precision)
         updates = CPUUpdates(make_wiring_grid())
 
-        updates.set_dispersive_updates()
-
-        assert "_double_" in updates.dispersive_update_a.__name__
+        with pytest.raises(RuntimeError, match="invalid precision"):
+            updates.set_dispersive_updates()
 
 
 class TestDispersionSwitch:
@@ -260,42 +240,25 @@ class TestDispersionSwitch:
 
         assert updates.dispersive_update_a.__name__.endswith("_real")
 
-    def test_the_comparison_is_against_the_configured_complex_dtype(
+    def test_a_mismatched_complex_dtype_is_rejected(
         self, updates_config, make_wiring_grid
     ):
-        """Not against ``np.complexfloating`` in general.
-
-        A single-precision run compares against ``np.complex64``; handing it
-        ``np.complex128`` — a complex type, but the wrong one — takes the
-        *real* branch.
-        """
         updates_config.sim_config.dtypes["complex"] = np.complex64
+        updates_config.sim_config.dtypes["float_or_double"] = np.float32
         updates_config.model_config.materials["dispersivedtype"] = np.complex128
         updates_config.model_config.materials["maxpoles"] = 1
 
         updates = CPUUpdates(make_wiring_grid())
-        updates.set_dispersive_updates()
+        with pytest.raises(RuntimeError, match="does not match"):
+            updates.set_dispersive_updates()
 
-        assert updates.dispersive_update_a.__name__.endswith("_real")
-
-    def test_unset_dispersive_dtype_silently_selects_real(self, updates_config, make_wiring_grid):
-        """``dispersivedtype`` defaults to ``None`` until it is derived.
-
-        ``ModelConfig`` initialises the key to ``None``, and only
-        ``set_dispersive_material_types()`` fills it in. ``None == np.complex64``
-        is ``False``, so calling ``set_dispersive_updates`` first binds the
-        **real** kernel for what may be a complex-pole model — a wrong answer
-        with no warning, produced purely by call order.
-
-        Written up in ``notes/bugs/dispersive-dtype-default-none.md``.
-        """
+    def test_unset_dispersive_dtype_is_rejected(self, updates_config, make_wiring_grid):
         updates_config.model_config.materials["maxpoles"] = 2
         updates_config.model_config.materials["dispersivedtype"] = None
 
         updates = CPUUpdates(make_wiring_grid())
-        updates.set_dispersive_updates()
-
-        assert updates.dispersive_update_a.__name__.endswith("_real")
+        with pytest.raises(RuntimeError, match="has not been initialised"):
+            updates.set_dispersive_updates()
 
 
 class TestBinding:
@@ -404,12 +367,7 @@ class TestModulePath:
 
         assert set(seen) == {DISPERSIVE_MODULE}
 
-    def test_the_module_is_imported_once_per_half(self, configure, make_wiring_grid, monkeypatch):
-        """Two calls, one per half — the result is not reused.
-
-        Harmless because ``import_module`` hits ``sys.modules``, but worth
-        pinning so a future refactor does not assume a single import.
-        """
+    def test_the_module_is_imported_once(self, configure, make_wiring_grid, monkeypatch):
         seen = []
         real_import = import_module
 
@@ -424,7 +382,7 @@ class TestModulePath:
 
         CPUUpdates(make_wiring_grid()).set_dispersive_updates()
 
-        assert len(seen) == 2
+        assert len(seen) == 1
 
     def test_a_missing_kernel_raises_attribute_error(
         self, configure, make_wiring_grid, monkeypatch
@@ -443,7 +401,7 @@ class TestModulePath:
         monkeypatch.setattr(module, "import_module", lambda name: types.ModuleType("empty"))
         configure()
 
-        with pytest.raises(AttributeError, match="update_electric_dispersive"):
+        with pytest.raises(RuntimeError, match="compiled dispersive-field kernels"):
             CPUUpdates(make_wiring_grid()).set_dispersive_updates()
 
 

--- a/tests/updates/test_solver.py
+++ b/tests/updates/test_solver.py
@@ -547,7 +547,9 @@ class TestCreateSolver:
         constructing ``CPUUpdates`` any other way leaves those attributes
         missing.
         """
-        updates_config.model_config.materials["dispersivedtype"] = None
+        updates_config.model_config.materials["dispersivedtype"] = (
+            updates_config.sim_config.dtypes["float_or_double"]
+        )
 
         solver = create_solver(make_model(FDTDGrid(), maxpoles=2))
 

--- a/tests/user_inputs/test_thickness.py
+++ b/tests/user_inputs/test_thickness.py
@@ -16,7 +16,7 @@ class _BoundsGrid(SimpleNamespace):
         return True
 
 
-def _subgrid_input():
+def _subgrid_input(origin=(5, 7, 11)):
     grid = _BoundsGrid(
         dl=np.full(3, 1e-3),
         size=np.full(3, 20, dtype=np.int32),
@@ -24,9 +24,9 @@ def _subgrid_input():
         ny=20,
         nz=20,
         ratio=3,
-        i0=5,
-        j0=7,
-        k0=11,
+        i0=origin[0],
+        j0=origin[1],
+        k0=origin[2],
         n_boundary_cells_x=4,
         n_boundary_cells_y=4,
         n_boundary_cells_z=4,
@@ -84,6 +84,25 @@ def test_subgrid_thickness_still_rejects_requested_axis_overflow(dimension, axis
             3e-3,
             "#test_object",
         )
+
+
+@pytest.mark.parametrize(("dimension", "axis"), tuple(zip("xyz", range(3))))
+def test_subgrid_thickness_is_stable_at_large_absolute_offset(dimension, axis):
+    """Carrier-coordinate cancellation must not depend on proximity to zero."""
+
+    user_input = _subgrid_input(origin=(500_003, 700_007, 1_100_009))
+    lower_extent = _global_extent(user_input, axis, local_index=8)
+
+    within_grid, local_lower, local_thickness = user_input.check_thickness(
+        dimension,
+        lower_extent,
+        3e-3,
+        "#test_object",
+    )
+
+    assert within_grid
+    assert local_lower == pytest.approx(8e-3)
+    assert local_thickness == pytest.approx(3e-3)
 
 
 class _MPIGrid(SimpleNamespace):

--- a/tests/user_objects/test_cmds_multiuse.py
+++ b/tests/user_objects/test_cmds_multiuse.py
@@ -72,6 +72,39 @@ class TestExcitationFile:
         assert e.order == 1
         assert e.hash == "#excitation_file"
 
+    def test_build_accepts_a_single_waveform_column(self, stub_grid, tmp_path):
+        path = tmp_path / "single.txt"
+        path.write_text("pulse\n0\n1\n0\n", encoding="utf-8")
+
+        ExcitationFile(path).build(stub_grid)
+
+        assert [waveform.ID for waveform in stub_grid.waveforms] == ["pulse"]
+        assert float(stub_grid.waveforms[0].userfunc(0.0)) == 0.0
+
+    def test_build_rejects_header_data_column_mismatch(self, stub_grid, tmp_path):
+        path = tmp_path / "mismatch.txt"
+        path.write_text("first second\n0\n1\n", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="header declares"):
+            ExcitationFile(path).build(stub_grid)
+
+    @pytest.mark.parametrize(
+        "content,error",
+        [
+            ("time pulse\n0 0\n0 1\n", "strictly increasing"),
+            ("pulse\n0\nnan\n", "finite"),
+            ("pulse\n0\n", "at least two"),
+        ],
+    )
+    def test_build_rejects_invalid_waveform_tables(
+        self, stub_grid, tmp_path, content, error
+    ):
+        path = tmp_path / "invalid.txt"
+        path.write_text(content, encoding="utf-8")
+
+        with pytest.raises(ValueError, match=error):
+            ExcitationFile(path).build(stub_grid)
+
 
 # ---------------------------------------------------------------------------
 # Waveform
@@ -117,6 +150,13 @@ class TestWaveform:
         w = Waveform(wave_type="gaussian", amp=1.0, freq=0, id="wf1")
         with pytest.raises(ValueError):
             w.build(stub_grid)
+
+    @pytest.mark.parametrize("field,value", [("amp", np.nan), ("freq", np.inf)])
+    def test_build_rejects_non_finite_builtin_parameters(self, stub_grid, field, value):
+        values = {"wave_type": "gaussian", "amp": 1.0, "freq": 1e9, "id": "wf1"}
+        values[field] = value
+        with pytest.raises(ValueError, match="finite|greater than zero"):
+            Waveform(**values).build(stub_grid)
 
     def test_build_duplicate_id_raises(self, stub_grid):
         stub_grid.waveforms.append(make_waveform("wf1"))
@@ -176,6 +216,15 @@ class TestVoltageSource:
         stub_grid.waveforms.append(make_waveform("wf1"))
         v = VoltageSource(p1=(0, 0, 0), polarisation="x", resistance=-1, waveform_id="wf1")
         with pytest.raises(ValueError):
+            v._validate_parameters(stub_grid)
+
+    @pytest.mark.parametrize("resistance", [np.nan, np.inf])
+    def test_validate_rejects_non_finite_resistance(self, stub_grid, resistance):
+        stub_grid.waveforms.append(make_waveform("wf1"))
+        v = VoltageSource(
+            p1=(0, 0, 0), polarisation="x", resistance=resistance, waveform_id="wf1"
+        )
+        with pytest.raises(ValueError, match="finite source resistance"):
             v._validate_parameters(stub_grid)
 
     def test_validate_rejects_missing_waveform(self, stub_grid):
@@ -375,30 +424,18 @@ class TestDPWVectorMOverwriteBug:
         assert "DPW.m[:3] = np.array(m_vec" in src
 
 
-class TestDPWPrecomputeHardcodedBug:
-    """Bug tripwire: ``cmds_multiuse.py:1030, 1199, 1370``.
-
-    Each ``DiscretePlaneWave*`` class reads ``kwargs["precompute"]`` (with
-    a ``True`` default) then a few lines later does ``precompute = True``
-    unconditionally — so a user passing ``precompute=False`` is silently
-    overridden.
-
-    We pin the bug by checking the literal source of each ``build``
-    method. When fixed (remove the hardcoded reassignment), the asserts
-    flip.
-    """
+class TestDPWPrecomputeValidation:
 
     @pytest.mark.parametrize(
         "cls",
         [DiscretePlaneWaveAngles, DiscretePlaneWaveVector, DiscretePlaneWaveAxial],
     )
-    def test_build_unconditionally_sets_precompute_true(self, cls):
+    def test_build_does_not_silently_override_precompute(self, cls):
         import inspect
 
         src = inspect.getsource(cls.build)
-        # Two ``precompute = True`` lines: the kwargs-default and the
-        # post-kwargs unconditional override
-        assert src.count("precompute = True") == 2
+        assert src.count("precompute = True") == 1
+        assert "_validate_dpw_precompute(self, precompute)" in src
 
 
 # ---------------------------------------------------------------------------
@@ -523,6 +560,17 @@ class TestMaterial:
         with pytest.raises(ValueError):
             m.build(stub_grid)
 
+    @pytest.mark.parametrize(
+        "field,value",
+        [("er", np.nan), ("er", np.inf), ("mr", np.nan), ("mr", np.inf),
+         ("se", np.nan), ("sm", np.nan)],
+    )
+    def test_build_rejects_non_finite_non_pec_parameters(self, stub_grid, field, value):
+        values = {"er": 2.0, "se": 0.0, "mr": 1.0, "sm": 0.0, "id": "bad"}
+        values[field] = value
+        with pytest.raises(ValueError):
+            Material(**values).build(stub_grid)
+
     def test_build_accepts_infinite_conductivity_string(self, stub_grid):
         # ``se="inf"`` is a documented sentinel for PEC-like materials
         m = Material(er=1.0, se="inf", mr=1.0, sm=0.0, id="pec_like")
@@ -570,6 +618,36 @@ class TestAddDebyeDispersion:
         with pytest.raises(ValueError):
             d.build(stub_grid)
 
+    @pytest.mark.parametrize("er_delta", (0.0, -1.0, float("inf"), float("nan")))
+    def test_build_rejects_invalid_permittivity_difference(
+        self, stub_grid, user_object_config, er_delta
+    ):
+        user_object_config.model_config.dispersive_averaging = True
+        stub_grid.materials.append(RuntimeMaterial(2, "sample"))
+        dispersion = AddDebyeDispersion(
+            poles=1,
+            er_delta=(er_delta,),
+            tau=(1e-9,),
+            material_ids=["sample"],
+        )
+
+        with pytest.raises(ValueError, match="finite, positive relative-permittivity"):
+            dispersion.build(stub_grid)
+
+    @pytest.mark.parametrize("tau", (0.0, -1e-9, float("inf"), float("nan")))
+    def test_build_rejects_invalid_relaxation_time(self, stub_grid, user_object_config, tau):
+        user_object_config.model_config.dispersive_averaging = True
+        stub_grid.materials.append(RuntimeMaterial(2, "sample"))
+        dispersion = AddDebyeDispersion(
+            poles=1,
+            er_delta=(1.0,),
+            tau=(tau,),
+            material_ids=["sample"],
+        )
+
+        with pytest.raises(ValueError, match="finite, positive relaxation times"):
+            dispersion.build(stub_grid)
+
 
 class TestAddLorentzDispersion:
     def test_constructor_stores_kwargs(self):
@@ -612,6 +690,21 @@ class TestAddLorentzDispersion:
         with pytest.raises(ValueError, match=r"frequency must be below 1 / dt"):
             dispersion.build(stub_grid)
 
+    @pytest.mark.parametrize(("omega", "delta"), ((float("nan"), 1e8), (1e9, float("inf"))))
+    def test_build_rejects_non_finite_pole(self, stub_grid, user_object_config, omega, delta):
+        user_object_config.model_config.dispersive_averaging = True
+        stub_grid.materials.append(RuntimeMaterial(2, "sample"))
+        dispersion = AddLorentzDispersion(
+            poles=1,
+            er_delta=(1.0,),
+            omega=(omega,),
+            delta=(delta,),
+            material_ids=["sample"],
+        )
+
+        with pytest.raises(ValueError, match="must be finite"):
+            dispersion.build(stub_grid)
+
 
 class TestAddDrudeDispersion:
     def test_constructor_stores_kwargs(self):
@@ -622,6 +715,20 @@ class TestAddDrudeDispersion:
         d = AddDrudeDispersion()
         assert d.order == 13
         assert d.hash == "#add_dispersion_drude"
+
+    @pytest.mark.parametrize(("omega", "alpha"), ((float("nan"), 1e8), (1e9, float("inf"))))
+    def test_build_rejects_non_finite_pole(self, stub_grid, user_object_config, omega, alpha):
+        user_object_config.model_config.dispersive_averaging = True
+        stub_grid.materials.append(RuntimeMaterial(2, "sample"))
+        dispersion = AddDrudeDispersion(
+            poles=1,
+            omega=(omega,),
+            alpha=(alpha,),
+            material_ids=["sample"],
+        )
+
+        with pytest.raises(ValueError, match="must be finite"):
+            dispersion.build(stub_grid)
 
     def test_build_rejects_frequency_at_timestep_limit(self, stub_grid, user_object_config):
         user_object_config.model_config.dispersive_averaging = True
@@ -661,6 +768,20 @@ class TestSoilPeplinski:
         assert s.order == 14
         assert s.hash == "#soil_peplinski"
 
+    @pytest.mark.parametrize("value", [np.nan, np.inf])
+    def test_build_rejects_non_finite_parameters(self, stub_grid, value):
+        soil = SoilPeplinski(
+            sand_fraction=value,
+            clay_fraction=0.3,
+            bulk_density=2.0,
+            sand_density=2.66,
+            water_fraction_lower=0.001,
+            water_fraction_upper=0.25,
+            id="soil1",
+        )
+        with pytest.raises(ValueError, match="must all be finite"):
+            soil.build(stub_grid)
+
 
 # ---------------------------------------------------------------------------
 # MaterialRange / MaterialList
@@ -686,6 +807,42 @@ class TestMaterialRange:
         m = MaterialRange()
         assert m.order == 15
         assert m.hash == "#material_range"
+
+    def _make(self, **overrides):
+        values = dict(
+            er_lower=1.0,
+            er_upper=2.0,
+            sigma_lower=0.0,
+            sigma_upper=0.1,
+            mr_lower=1.0,
+            mr_upper=2.0,
+            ro_lower=0.0,
+            ro_upper=0.1,
+            id="rng",
+        )
+        values.update(overrides)
+        return MaterialRange(**values)
+
+    def test_build_rejects_negative_upper_magnetic_loss(self, stub_grid):
+        with pytest.raises(ValueError):
+            self._make(ro_upper=-0.1).build(stub_grid)
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"er_lower": 3.0, "er_upper": 2.0},
+            {"sigma_lower": 0.2, "sigma_upper": 0.1},
+            {"mr_lower": 3.0, "mr_upper": 2.0},
+            {"ro_lower": 0.2, "ro_upper": 0.1},
+        ],
+    )
+    def test_build_rejects_reversed_ranges(self, stub_grid, overrides):
+        with pytest.raises(ValueError, match="must not exceed"):
+            self._make(**overrides).build(stub_grid)
+
+    def test_build_rejects_nan_limit(self, stub_grid):
+        with pytest.raises(ValueError, match="must all be finite"):
+            self._make(sigma_upper=np.nan).build(stub_grid)
 
 
 class TestMaterialList:

--- a/tests/user_objects/test_cmds_singleuse.py
+++ b/tests/user_objects/test_cmds_singleuse.py
@@ -105,6 +105,11 @@ class TestDiscretisationAnyBug:
         with pytest.raises(ValueError):
             Discretisation((0.0, 0.0, 0.0)).build(stub_model)
 
+    @pytest.mark.parametrize("bad", [np.nan, np.inf, -np.inf])
+    def test_nonfinite_step_raises(self, stub_model, bad):
+        with pytest.raises(ValueError, match="finite"):
+            Discretisation((0.001, bad, 0.001)).build(stub_model)
+
 
 # ---------------------------------------------------------------------------
 # Domain
@@ -180,7 +185,7 @@ class TestTimeStepStabilityFactor:
         assert stub_model.dt_mod == 0.5
         assert stub_model.dt == 0.5 * before_dt
 
-    @pytest.mark.parametrize("bad", [0.0, -0.1, 1.01, 2.0])
+    @pytest.mark.parametrize("bad", [0.0, -0.1, 1.01, 2.0, np.nan, np.inf, -np.inf])
     def test_build_rejects_out_of_range(self, stub_model, bad):
         with pytest.raises(ValueError):
             TimeStepStabilityFactor(bad).build(stub_model)
@@ -217,6 +222,16 @@ class TestTimeWindow:
         TimeWindow(time=1e-9).build(stub_model)
         assert stub_model.timewindow == 1e-9
         assert stub_model.iterations == int(np.ceil(1e-9 / stub_model.dt)) + 1
+
+    @pytest.mark.parametrize("bad", [np.nan, np.inf, -np.inf, 0.0, -1.0])
+    def test_build_rejects_invalid_time(self, stub_model, bad):
+        with pytest.raises(ValueError, match="finite|greater"):
+            TimeWindow(time=bad).build(stub_model)
+
+    @pytest.mark.parametrize("bad", [1.5, np.nan, True, 0, -1])
+    def test_build_rejects_invalid_iterations(self, stub_model, bad):
+        with pytest.raises(ValueError, match="positive integer"):
+            TimeWindow(iterations=bad).build(stub_model)
 
     def test_build_iterations_mode_sets_timewindow(self, stub_model):
         TimeWindow(iterations=100).build(stub_model)
@@ -264,6 +279,11 @@ class TestOMPThreads:
     def test_build_rejects_zero_threads(self, stub_model):
         with pytest.raises(ValueError):
             OMPThreads(0).build(stub_model)
+
+    @pytest.mark.parametrize("bad", [1.5, np.nan, True, "4"])
+    def test_build_rejects_non_integer_threads(self, stub_model, bad):
+        with pytest.raises(ValueError, match="integer"):
+            OMPThreads(bad).build(stub_model)
 
 
 class TestOMPThreadsHash:
@@ -330,6 +350,10 @@ class TestPMLThickness:
         PMLThickness((10, 10, 10, 10, 10, 10)).build(stub_model)
         stub_model.G.set_pml_thickness.assert_called_once_with((10, 10, 10, 10, 10, 10))
 
+    def test_build_one_item_tuple_is_canonicalised_to_scalar(self, stub_model):
+        PMLThickness((10,)).build(stub_model)
+        stub_model.G.set_pml_thickness.assert_called_once_with(10)
+
     @pytest.mark.parametrize("bad_len", [2, 3, 4, 5, 7])
     def test_build_rejects_wrong_tuple_length(self, stub_model, bad_len):
         with pytest.raises(ValueError):
@@ -340,6 +364,11 @@ class TestPMLThickness:
         stub_model.G.pmls["thickness"]["x0"] = 30
         with pytest.raises(ValueError):
             PMLThickness(10).build(stub_model)
+
+    @pytest.mark.parametrize("bad", [1.5, np.nan, True, "10"])
+    def test_build_rejects_non_integer_thickness(self, stub_model, bad):
+        with pytest.raises(ValueError, match="integer"):
+            PMLThickness(bad).build(stub_model)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/vtkhdf/test_vtk_unstructured_grid.py
+++ b/tests/vtkhdf/test_vtk_unstructured_grid.py
@@ -278,6 +278,29 @@ class TestValidation:
         with pytest.raises(ValueError, match="sorted in ascending order"):
             make_unstructured_grid(**line_grid_arrays)
 
+    def test_points_must_be_n_by_three(self, make_unstructured_grid, line_grid_arrays):
+        line_grid_arrays["points"] = np.zeros((3, 2))
+        with pytest.raises(ValueError, match=r"shape \(N, 3\)"):
+            make_unstructured_grid(**line_grid_arrays)
+
+    def test_offsets_must_start_at_zero(self, make_unstructured_grid, line_grid_arrays):
+        line_grid_arrays["cell_offsets"] = np.array([1, 2, 4], dtype=np.int32)
+        with pytest.raises(ValueError, match="start at zero"):
+            make_unstructured_grid(**line_grid_arrays)
+
+    @pytest.mark.parametrize("bad_id", [-1, 3])
+    def test_connectivity_ids_must_address_a_point(
+        self, make_unstructured_grid, line_grid_arrays, bad_id
+    ):
+        line_grid_arrays["connectivity"] = np.array([0, 1, 1, bad_id], dtype=np.int32)
+        with pytest.raises(ValueError, match="outside points"):
+            make_unstructured_grid(**line_grid_arrays)
+
+    def test_connectivity_ids_must_be_integers(self, make_unstructured_grid, line_grid_arrays):
+        line_grid_arrays["connectivity"] = np.array([0.0, 1.0, 1.0, 2.0])
+        with pytest.raises(ValueError, match="integer point IDs"):
+            make_unstructured_grid(**line_grid_arrays)
+
     def test_equal_consecutive_offsets_are_allowed(self, make_unstructured_grid, line_grid_arrays):
         """A zero-length cell is degenerate but not out of order."""
         line_grid_arrays["cell_offsets"] = np.array([0, 2, 2], dtype=np.int32)
@@ -322,22 +345,16 @@ class TestValidation:
 
         assert caplog.records == []
 
-    def test_a_failed_construction_still_leaves_a_file(
+    def test_a_failed_construction_does_not_create_or_truncate_a_file(
         self, make_unstructured_grid, line_grid_arrays, tmp_path
     ):
-        """The file is opened — and truncated — before validation runs.
-
-        So a rejected grid destroys any earlier file of the same name and
-        leaves an empty one in its place, with the handle never closed. Pinned
-        as the current behaviour; written up in
-        ``notes/bugs/vtkhdf-truncates-before-validating.md``.
-        """
+        """Input validation happens before the output is opened in write mode."""
         line_grid_arrays["cell_offsets"] = np.array([0, 2], dtype=np.int32)
 
         with pytest.raises(ValueError):
             make_unstructured_grid(**line_grid_arrays)
 
-        assert (tmp_path / "grid.vtkhdf").is_file()
+        assert not (tmp_path / "grid.vtkhdf").exists()
 
 
 class TestAddCellData:
@@ -387,24 +404,25 @@ class TestAddCellData:
             with pytest.raises(ValueError, match="shape 1 or 3"):
                 handler.add_cell_data("Material", np.zeros((2, 2)))
 
-    def test_two_dimensional_cell_data_is_stored_transposed(
+    def test_two_dimensional_cell_data_keeps_vtk_tuple_component_order(
         self, make_unstructured_grid, line_grid_arrays, tmp_path
     ):
-        """``(C, 3)`` goes in as ``(3, C)`` — the opposite of VTK's layout.
-
-        ``Points`` is written with ``xyz_data_ordering=False`` for exactly
-        this reason, but ``add_cell_data`` and ``add_point_data`` are not, so
-        vector-valued cell data comes out with components and tuples swapped.
-        gprMax only ever writes scalar cell data, where a 1-D transpose is a
-        no-op, which is why it has never been noticed. Pinned as the current
-        behaviour; written up in
-        ``notes/bugs/vtkhdf-unstructured-vector-data-transposed.md``.
-        """
+        """VTK vector arrays are stored as (tuples, 3 components)."""
         with make_unstructured_grid(**line_grid_arrays) as handler:
             handler.add_cell_data("Vectors", np.zeros((2, 3)))
 
         with h5py.File(tmp_path / "grid.vtkhdf", "r") as f:
-            assert f["VTKHDF/CellData/Vectors"].shape == (3, 2)
+            assert f["VTKHDF/CellData/Vectors"].shape == (2, 3)
+
+    def test_vector_values_are_not_transposed(
+        self, make_unstructured_grid, line_grid_arrays, tmp_path
+    ):
+        vectors = np.array([[1, 2, 3], [4, 5, 6]])
+        with make_unstructured_grid(**line_grid_arrays) as handler:
+            handler.add_cell_data("Vectors", vectors)
+
+        with h5py.File(tmp_path / "grid.vtkhdf", "r") as f:
+            np.testing.assert_array_equal(f["VTKHDF/CellData/Vectors"][...], vectors)
 
 
 class TestAddPointData:

--- a/tests/vtkhdf/test_vtkhdf_base.py
+++ b/tests/vtkhdf/test_vtkhdf_base.py
@@ -116,18 +116,10 @@ class TestFileNaming:
 
         assert (tmp_path / "model.vtkhdf").is_file()
 
-    def test_a_dot_in_the_name_truncates_it(self, make_vtkhdf_file):
-        """``with_suffix`` replaces everything after the last dot.
-
-        A snapshot called ``model_1.5`` — a perfectly ordinary name for a
-        1.5 ns time point — is written as ``model_1.vtkhdf``, and the next
-        snapshot at ``model_1.7`` overwrites it. The warning that fires says
-        the extension ``'.5'`` was invalid, which is technically true and
-        entirely unhelpful. Pinned as the current behaviour; written up in
-        ``notes/bugs/vtkhdf-filename-suffix-truncation.md``.
-        """
+    def test_a_dot_in_the_name_is_preserved(self, make_vtkhdf_file):
+        """A version/time-like dot is part of the basename, not an extension."""
         with make_vtkhdf_file("model_1.5") as handler:
-            assert handler.filename.name == "model_1.vtkhdf"
+            assert handler.filename.name == "model_1.5.vtkhdf"
 
     def test_the_filename_is_stored_as_a_path(self, make_vtkhdf_file):
         """Callers read ``handler.filename`` to log where output went."""
@@ -420,18 +412,9 @@ class TestDatasetPaths:
             with pytest.raises(KeyError):
                 handler._get_dataset("VTKHDF/Absent")
 
-    def test_the_missing_path_message_is_never_the_one_reported(self, make_vtkhdf_file):
-        """``h5py`` returns ``None`` for an absent path, not ``"default"``.
-
-        So the ``cls == "default"`` branch — and its clear "Path does not
-        exist" message — is unreachable, and a simple typo in a dataset name
-        surfaces as ``Dataset not found. Found 'None' instead``, which reads
-        like a type problem rather than a missing key. Pinned as the current
-        behaviour; written up in
-        ``notes/bugs/vtkhdf-unreachable-missing-path-branch.md``.
-        """
+    def test_a_missing_path_has_a_clear_message(self, make_vtkhdf_file):
         with make_vtkhdf_file() as handler:
-            with pytest.raises(KeyError, match="Found 'None' instead"):
+            with pytest.raises(KeyError, match="Path does not exist"):
                 handler._get_dataset("VTKHDF/Absent")
 
     def test_a_path_pointing_at_a_group_raises(self, make_vtkhdf_file):

--- a/tests/waveforms/test_waveforms.py
+++ b/tests/waveforms/test_waveforms.py
@@ -214,16 +214,9 @@ class TestCausality:
 
 
 class TestErrors:
-    def test_unknown_type_currently_raises_unbound_local(self, make_waveform):
-        """Tripwire for the missing `else` branch in calculate_value.
-
-        Today this falls through every if/elif so `ampvalue` is never
-        assigned and the final `ampvalue *= self.amp` raises
-        UnboundLocalError. A follow-up fix should make this a clean
-        ValueError; update this test in the same PR.
-        """
+    def test_unknown_type_raises_value_error(self, make_waveform):
         w = make_waveform("notarealtype", freq=1e9)
-        with pytest.raises(UnboundLocalError):
+        with pytest.raises(ValueError, match="Unknown waveform type"):
             w.calculate_value(1e-9, dt=1e-12)
 
 

--- a/toolboxes/DebyeFit/optimization.py
+++ b/toolboxes/DebyeFit/optimization.py
@@ -5,6 +5,8 @@
 #
 # Please use the attribution at http://dx.doi.org/10.1109/TAP.2014.2308549
 
+import warnings
+
 import numpy as np
 import scipy.optimize
 from matplotlib import pylab as plt
@@ -88,7 +90,10 @@ class Optimizer(object):
             cost (float): Sum of mean absolute errors for real and
                           imaginary parts.
         """
-        cost_i, cost_r, _, _, _, _ = DLS(x, rl, im, freq)
+        # The optimizer explores deliberately poor trial points. Report the
+        # physical lower-bound constraint only for the accepted final fit,
+        # not for every objective-function evaluation.
+        cost_i, cost_r, _, _, _, _ = DLS(x, rl, im, freq, warn_on_bound=False)
         return cost_i + cost_r
 
 
@@ -443,7 +448,7 @@ class DE_DLS(Optimizer):
         return result.x, result.fun
 
 
-def DLS(logt, rl, im, freq):
+def DLS(logt, rl, im, freq, *, warn_on_bound=True):
     """
     Find the weights using a non-linear least squares (LS) method,
     the Levenberg–Marquardt algorithm (LMA or just LM),
@@ -459,6 +464,10 @@ def DLS(logt, rl, im, freq):
         im (ndarray): Imaginary parts of chosen relaxation function
                       for given frequency points.
         freq (ndarray): The frequencies vector for defined grid.
+        warn_on_bound (bool): Emit a warning when the unconstrained fit is
+                              clamped to the physical lower bound. Optimizer
+                              trial evaluations disable this; accepted fits
+                              retain the default warning.
 
     Returns:
         cost_i (float): Mean absolute error between the actual and
@@ -491,7 +500,17 @@ def DLS(logt, rl, im, freq):
         np.matmul(d.imag, x[np.newaxis].T).T[0],
     )
     cost_i = np.sum(np.abs(ip - im)) / len(im)
-    ee = np.mean(rl - rp)
-    ee = max(ee, 1)
+    unconstrained_ee = float(np.mean(rl - rp))
+    if not np.isfinite(unconstrained_ee):
+        raise ValueError("DLS produced a non-finite infinite-frequency permittivity")
+    if unconstrained_ee < 1 and warn_on_bound:
+        warnings.warn(
+            "The unconstrained Debye fit produced an infinite-frequency relative "
+            f"permittivity of {unconstrained_ee:g}; applying the physical lower "
+            "bound of 1. Inspect the fitted residuals before using this material.",
+            UserWarning,
+            stacklevel=2,
+        )
+    ee = max(unconstrained_ee, 1)
     cost_r = np.sum(np.abs(rp + ee - rl)) / len(im)
     return cost_i, cost_r, x, ee, rp, ip


### PR DESCRIPTION
## Summary

This PR applies the corrections identified during an adversarial release-hardening review and adds regression coverage for the confirmed failure modes.

### Numerical and solver corrections

- prevent ideal PEC cells from producing `inf * 0 -> NaN` in finite-volume SAR
- preserve valid hard voltage sources on domain-minimum boundaries while disabling only the unavailable automatic current-loop output
- restore the subgrid interpolation invariant for refinement ratios greater than one
- correct discrete-plane-wave precomputed histories:
  - Yee time and spatial staggering
  - component-specific delayed source-window gating
  - final history sample
  - waveform amplitude scaling
  - user-waveform routing
- reject the currently unsupported `precompute=False` DPW path instead of silently overriding it
- use deterministic local ARPACK starting vectors for reproducible FDFD mode solves and study restarts
- correct MPI geometry-tag assignment across the negative interface halo

### Validation and I/O hardening

- validate Debye/Lorentz/Drude poles and non-finite material/source/geometry inputs
- make excitation-file parsing robust for one-column data, invalid shapes, non-finite values, and invalid time axes
- make CPU dispersive-kernel dispatch fail explicitly on invalid precision/dtype/pole states
- preserve dotted output basenames and support recursive output directories
- validate VTKHDF unstructured arrays before file truncation and preserve `(N, 3)` vector layout
- raise explicit Metal receiver-transfer errors instead of returning zero-filled data
- document the retired `#rx_port` migration and the planar-layered NTFF sign convention
- add real two-rank MPI regressions for tagged geometry/SAR and a voltage port on an internal rank boundary

## Verification

- `5743 passed, 18 skipped, 100 deselected` using `pytest -m "not gpu and not slow"` (the two socket-restricted MPI tests excluded from that sandboxed run)
- both new MPI tests passed separately with a real two-rank launcher
- focused plane-wave Python/Cython history parity passes, including amplitude and timing
- Cython extensions build successfully in place
- Sphinx documentation builds with warnings treated as errors
- `python -m compileall -q gprMax toolboxes tests`
- `python -m pip check`: no broken requirements
- `git diff --check`: clean

## Review notes

- This PR does not claim that the full numerical code is defect-free; it fixes the confirmed findings and converts them into regression tests.
- Full CUDA/Metal hardware regression and optional geometry-import dependencies remain environment-dependent.
- Independently digitised published data would further strengthen the planar-layered NTFF validation; the PR adds a three-layer closed-form regression and documents the convention used.
