### PR TITLE
Fix geometry building and MPI geometry outputs

### DIFF
--- a/gprMax/geometry_outputs/geometry_view_lines.py
+++ b/gprMax/geometry_outputs/geometry_view_lines.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
 #                          and Nathan Mannall
 #
 # This file is part of gprMax.
@@ -32,6 +32,45 @@ from gprMax.vtkhdf_filehandlers.vtk_unstructured_grid import VtkUnstructuredGrid
 from gprMax.vtkhdf_filehandlers.vtkhdf import VtkCellType, VtkHdfFile
 
 logger = logging.getLogger(__name__)
+
+
+def _remove_duplicate_partition_edges(
+    connectivity: np.ndarray,
+    material_data: np.ndarray,
+    size: np.ndarray,
+    has_positive_neighbour: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Remove Yee edges duplicated on upper MPI partition faces.
+
+    An edge normal to a partition face spans a unique interval and remains
+    owned by the rank. Edges tangential to the face are present in both
+    adjoining rank-local point lattices; the rank on the negative side drops
+    its upper-face copy so the positive-side rank is the single owner. This
+    matches the side containing the canonical local Yee-edge material IDs.
+    """
+    if not np.any(has_positive_neighbour):
+        return connectivity, material_data
+
+    nx, ny, nz = (int(value) for value in size)
+    y_step = nz + 1
+    x_step = (ny + 1) * y_step
+    segments = connectivity.reshape(-1, 2)
+
+    def point_coordinate(point_ids: np.ndarray, axis: int) -> np.ndarray:
+        if axis == 0:
+            return point_ids // x_step
+        if axis == 1:
+            return (point_ids % x_step) // y_step
+        return point_ids % y_step
+
+    keep = np.ones(len(segments), dtype=bool)
+    for axis in np.flatnonzero(has_positive_neighbour):
+        first = point_coordinate(segments[:, 0], int(axis))
+        second = point_coordinate(segments[:, 1], int(axis))
+        boundary = int(size[int(axis)])
+        keep &= ~((first == boundary) & (second == boundary))
+
+    return segments[keep].reshape(-1), material_data[keep]
 
 
 class GeometryViewLines(GeometryView[GridType]):
@@ -70,18 +109,12 @@ class GeometryViewLines(GeometryView[GridType]):
             self.points += self.grid.local_to_global(np.zeros(3, dtype=np.int32))
 
         nx, ny, nz = self.grid_view.size
-        n_lines = (
-            nx * (ny + 1) * (nz + 1)
-            + ny * (nx + 1) * (nz + 1)
-            + nz * (nx + 1) * (ny + 1)
-        )
+        n_lines = nx * (ny + 1) * (nz + 1) + ny * (nx + 1) * (nz + 1) + nz * (nx + 1) * (ny + 1)
 
         self.cell_types = np.full(n_lines, VtkCellType.LINE)
         self.cell_offsets = np.arange(0, 2 * n_lines + 2, 2, dtype=np.intc)
 
-        self.connectivity, self.material_data = get_line_properties(
-            n_lines, *self.grid_view.size, ID
-        )
+        self.connectivity, self.material_data = get_line_properties(n_lines, *self.grid_view.size, ID)
 
         assert isinstance(self.connectivity, np.ndarray)
         assert isinstance(self.material_data, np.ndarray)
@@ -141,21 +174,22 @@ class MPIGeometryViewLines(GeometryViewLines[MPIGrid]):
         self.points *= self.grid_view.step * self.grid.dl
 
         nx, ny, nz = self.grid_view.size
-        n_lines = (
-            nx * (ny + 1) * (nz + 1)
-            + ny * (nx + 1) * (nz + 1)
-            + nz * (nx + 1) * (ny + 1)
-        )
+        n_lines = nx * (ny + 1) * (nz + 1) + ny * (nx + 1) * (nz + 1) + nz * (nx + 1) * (ny + 1)
 
-        self.cell_types = np.full(n_lines, VtkCellType.LINE)
-        self.cell_offsets = np.arange(0, 2 * n_lines + 2, 2, dtype=np.intc)
-
-        self.connectivity, self.material_data = get_line_properties(
-            n_lines, *self.grid_view.size, ID
-        )
+        self.connectivity, self.material_data = get_line_properties(n_lines, *self.grid_view.size, ID)
 
         assert isinstance(self.connectivity, np.ndarray)
         assert isinstance(self.material_data, np.ndarray)
+
+        self.connectivity, self.material_data = _remove_duplicate_partition_edges(
+            self.connectivity,
+            self.material_data,
+            self.grid_view.size,
+            self.grid_view.has_positive_neighbour,
+        )
+        n_lines = len(self.material_data)
+        self.cell_types = np.full(n_lines, VtkCellType.LINE)
+        self.cell_offsets = np.arange(0, 2 * n_lines + 2, 2, dtype=np.intc)
 
         # Write information about any PMLs, sources, receivers
         self.metadata = MPIMetadata(self.grid_view, averaged_materials=True, materials_only=True)

--- a/gprMax/geometry_outputs/grid_view.py
+++ b/gprMax/geometry_outputs/grid_view.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
 #                          and Nathan Mannall
 #
 # This file is part of gprMax.
@@ -19,7 +19,7 @@
 
 import logging
 from itertools import chain
-from typing import Generic, List, Tuple
+from typing import Generic, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -33,6 +33,23 @@ from gprMax.materials import Material
 logger = logging.getLogger(__name__)
 
 GridType = TypeVar("GridType", bound=FDTDGrid)
+
+
+def _merge_rank_materials(
+    materials_by_rank: list[npt.NDArray[np.object_]],
+) -> tuple[npt.NDArray[np.object_], list[npt.NDArray[np.int32]]]:
+    """Create one global material table and an ordered map for each rank."""
+    all_materials = np.fromiter(chain.from_iterable(materials_by_rank), dtype=Material)
+    materials = np.unique(all_materials)
+    global_index_by_id = {material.ID: index for index, material in enumerate(materials)}
+    material_ids_by_rank = [
+        np.asarray(
+            [global_index_by_id[material.ID] for material in rank_materials],
+            dtype=np.int32,
+        )
+        for rank_materials in materials_by_rank
+    ]
+    return materials, material_ids_by_rank
 
 
 class GridView(Generic[GridType]):
@@ -116,7 +133,7 @@ class GridView(Generic[GridType]):
     @property
     def nz(self) -> int:
         return self.size[2]
-    
+
     @property
     def dx(self) -> int:
         return self.step[0]
@@ -294,9 +311,7 @@ class GridView(Generic[GridType]):
             self.get_read_slice(2, upper_bound_exclusive),
         )
 
-    def get_array_slice(
-        self, array: npt.NDArray, upper_bound_exclusive: bool = True
-    ) -> npt.NDArray:
+    def get_array_slice(self, array: npt.NDArray, upper_bound_exclusive: bool = True) -> npt.NDArray:
         """Slice an array according to the dimensions of the grid view.
 
         It is assumed the last 3 dimensions of the provided array
@@ -325,9 +340,7 @@ class GridView(Generic[GridType]):
             ]
         )
 
-    def set_array_slice(
-        self, array: npt.NDArray, value: npt.NDArray, upper_bound_exclusive: bool = True
-    ):
+    def set_array_slice(self, array: npt.NDArray, value: npt.NDArray, upper_bound_exclusive: bool = True):
         """Set value of an array according to the dimensions of the grid view.
 
         It is assumed the last 3 dimensions of the array represent the
@@ -593,8 +606,7 @@ class MPIGridView(GridView[MPIGrid]):
         # start must still be aligned with the provided step.
         self.start = np.where(
             self.has_negative_neighbour,
-            self.grid.negative_halo_offset
-            + ((self.start - self.grid.negative_halo_offset) % self.step),
+            self.grid.negative_halo_offset + ((self.start - self.grid.negative_halo_offset) % self.step),
             self.start,
         )
 
@@ -615,9 +627,7 @@ class MPIGridView(GridView[MPIGrid]):
         )
 
         # Calculate offset for the local grid view
-        self.offset = (
-            self.grid.local_to_global_coordinate(self.start) - self.global_start
-        ) // self.step
+        self.offset = (self.grid.local_to_global_coordinate(self.start) - self.global_start) // self.step
 
         # Update local size
         self.size = np.ceil((self.stop - self.start) / self.step).astype(np.int32)
@@ -805,39 +815,21 @@ class MPIGridView(GridView[MPIGrid]):
         # Send all materials to the coordinating rank
         materials_by_rank = self.comm.gather(local_materials, root=0)
 
-        requests: List[MPI.Request] = []
-
         if materials_by_rank is not None:
-            # Filter out duplicate materials and sort by material ID
-            all_materials = np.fromiter(chain.from_iterable(materials_by_rank), dtype=Material)
-            self.materials = np.unique(all_materials)
-
-            # The new material IDs corespond to each material's index in
-            # the sorted self.materials array. For each rank, get the
-            # new IDs of each material it sent to send back
-            for rank in range(1, self.comm.size):
-                new_material_ids = np.where(np.isin(self.materials, materials_by_rank[rank]))[0]
-
-                # astype() always returns a copy, so it should be safe to use Isend here
-                request = self.comm.Isend([new_material_ids.astype(np.int32), MPI.INT], rank)
-                requests.append(request)
-
-            new_material_ids = np.where(np.isin(self.materials, materials_by_rank[0]))[0]
-            new_material_ids = new_material_ids.astype(np.int32)
+            # Preserve each rank's local material ordering. np.isin returns
+            # indices in global order and, if a local material ID occurs more
+            # than once, can also return fewer entries than the receiving
+            # rank allocated. Build one index for every local Material and
+            # scatter the variable-length maps as Python objects instead.
+            self.materials, material_ids_by_rank = _merge_rank_materials(materials_by_rank)
         else:
             self.materials = None
+            material_ids_by_rank = None
 
-            # Get list of global IDs for this rank's local materials
-            new_material_ids = np.empty(len(local_materials), dtype=np.int32)
-            self.comm.Recv([new_material_ids, MPI.INT], 0)
+        new_material_ids = self.comm.scatter(material_ids_by_rank, root=0)
 
         # Create map from local material ID to global material ID
-        materials_map = {
-            local_material_ids[index]: new_id for index, new_id in enumerate(new_material_ids)
-        }
+        materials_map = {local_material_ids[index]: new_id for index, new_id in enumerate(new_material_ids)}
 
         # Create map from material ID to 0 - number of materials
         self.map_materials_func = np.vectorize(lambda id: materials_map[id])
-
-        if len(requests) > 0:
-            requests[0].Waitall(requests)

--- a/gprMax/user_objects/cmds_geometry/triangle.py
+++ b/gprMax/user_objects/cmds_geometry/triangle.py
@@ -126,10 +126,7 @@ class Triangle(RotatableMixin, GeometryUserObject):
         # modelling error.
         normal_vector = np.cross(dp2 - dp1, dp3 - dp1)
         if not np.any(normal_vector):
-            message = (
-                f"{self.__str__()} the vertices must define a non-degenerate "
-                "triangle after discretisation."
-            )
+            message = f"{self.__str__()} the vertices must define a non-degenerate " "triangle after discretisation."
             logger.error(message)
             raise ValueError(message)
         # Convert points to metres
@@ -223,8 +220,11 @@ class Triangle(RotatableMixin, GeometryUserObject):
 
             # Uniaxial anisotropic case
             elif len(materials) == 3:
-                # numID requires a value but it will not be used
-                numID = None
+                # build_triangle has a typed integer argument for the
+                # volumetric material ID. Surface triangles do not use that
+                # value, but still need a valid integer at the Python/Cython
+                # boundary.
+                numID = materials[0].numID
                 numIDx = materials[0].numID
                 numIDy = materials[1].numID
                 numIDz = materials[2].numID

--- a/tests/geometry_primitives/test_build_dispatch.py
+++ b/tests/geometry_primitives/test_build_dispatch.py
@@ -115,12 +115,8 @@ class TestPlateBuild:
         plate = Plate(p1=(1 * DL, 1 * DL, 2 * DL), p2=(4 * DL, 3 * DL, 2 * DL), material_id="metal")
         plate.build(g)
 
-        expected_id0 = {(i, j, 2) for (i, j) in self.CELLS} | {
-            (i, j + 1, 2) for (i, j) in self.CELLS
-        }
-        expected_id1 = {(i, j, 2) for (i, j) in self.CELLS} | {
-            (i + 1, j, 2) for (i, j) in self.CELLS
-        }
+        expected_id0 = {(i, j, 2) for (i, j) in self.CELLS} | {(i, j + 1, 2) for (i, j) in self.CELLS}
+        expected_id1 = {(i, j, 2) for (i, j) in self.CELLS} | {(i + 1, j, 2) for (i, j) in self.CELLS}
         assert nonzero_set(g.ID[0]) == expected_id0
         assert nonzero_set(g.ID[1]) == expected_id1
         assert not g.ID[2].any()
@@ -195,6 +191,22 @@ class TestTriangleBuild:
         assert g.ID[0].any()
         assert g.ID[1].any()
 
+    def test_anisotropic_zero_thickness_uses_directional_materials(self, dispatch_grid):
+        g = dispatch_grid()
+        Triangle(
+            p1=self.KWARGS["p1"],
+            p2=self.KWARGS["p2"],
+            p3=self.KWARGS["p3"],
+            thickness=0.0,
+            material_ids=["mat_a", "mat_b", "metal"],
+        ).build(g)
+
+        # The triangle lies in the xy plane, so only its x- and y-directed
+        # electric edges are written with the corresponding material IDs.
+        assert all(g.ID[0][slot] == 3 for slot in nonzero_set(g.ID[0]))
+        assert all(g.ID[1][slot] == 4 for slot in nonzero_set(g.ID[1]))
+        assert not g.ID[2].any()
+
     def test_non_coplanar_vertices_raise(self, dispatch_grid):
         g = dispatch_grid()
         triangle = Triangle(
@@ -254,9 +266,7 @@ class TestCylinderBuild:
 
     def test_non_positive_radius_raises(self, dispatch_grid):
         g = dispatch_grid()
-        cylinder = Cylinder(
-            p1=(5 * DL, 5 * DL, 2 * DL), p2=(5 * DL, 5 * DL, 6 * DL), r=0.0, material_id="metal"
-        )
+        cylinder = Cylinder(p1=(5 * DL, 5 * DL, 2 * DL), p2=(5 * DL, 5 * DL, 6 * DL), r=0.0, material_id="metal")
         with pytest.raises(ValueError):
             cylinder.build(g)
 
@@ -273,9 +283,7 @@ class TestCylinderBuild:
 
     def test_missing_radius_raises(self, dispatch_grid):
         g = dispatch_grid()
-        cylinder = Cylinder(
-            p1=(5 * DL, 5 * DL, 2 * DL), p2=(5 * DL, 5 * DL, 6 * DL), material_id="metal"
-        )
+        cylinder = Cylinder(p1=(5 * DL, 5 * DL, 2 * DL), p2=(5 * DL, 5 * DL, 6 * DL), material_id="metal")
         with pytest.raises(KeyError):
             cylinder.build(g)
 

--- a/tests/outputs/test_geometry_view_lines.py
+++ b/tests/outputs/test_geometry_view_lines.py
@@ -28,7 +28,11 @@ import numpy as np
 import pytest
 
 from gprMax.cython.geometry_outputs import get_line_properties
-from gprMax.geometry_outputs.geometry_view_lines import GeometryViewLines, MPIGeometryViewLines
+from gprMax.geometry_outputs.geometry_view_lines import (
+    GeometryViewLines,
+    MPIGeometryViewLines,
+    _remove_duplicate_partition_edges,
+)
 from gprMax.geometry_outputs.geometry_views import GeometryView
 
 from .conftest import DL, DL_ANISO
@@ -441,6 +445,48 @@ class TestMpiVariant:
         view.set_filename()
         view.prep_vtk()
         assert view.points.min() == pytest.approx(10 * DL)
+
+    @pytest.mark.parametrize(
+        "axis, expected_removed",
+        [(0, 4), (1, 4), (2, 4)],
+        ids=["x-face", "y-face", "z-face"],
+    )
+    def test_upper_partition_face_has_one_owner(self, axis, expected_removed):
+        """A one-cell cube has four edges tangential to each upper face.
+
+        The negative-side MPI rank drops its four upper-face copies while
+        retaining the four normal edges that end on the same face.
+        """
+        nx = ny = nz = 1
+        n_lines = _total_lines(nx, ny, nz)
+        ID = np.zeros((6, 2, 2, 2), dtype=np.uint32)
+        connectivity, material_data = get_line_properties(n_lines, nx, ny, nz, ID)
+        neighbours = np.zeros(3, dtype=bool)
+        neighbours[axis] = True
+
+        filtered_connectivity, filtered_materials = _remove_duplicate_partition_edges(
+            connectivity, material_data, np.asarray((nx, ny, nz)), neighbours
+        )
+
+        assert len(filtered_materials) == n_lines - expected_removed
+        assert len(filtered_connectivity) == 2 * len(filtered_materials)
+
+    def test_partition_corner_drops_each_shared_edge_only_once(self):
+        nx = ny = nz = 1
+        n_lines = _total_lines(nx, ny, nz)
+        ID = np.zeros((6, 2, 2, 2), dtype=np.uint32)
+        connectivity, material_data = get_line_properties(n_lines, nx, ny, nz, ID)
+
+        _, filtered_materials = _remove_duplicate_partition_edges(
+            connectivity,
+            material_data,
+            np.asarray((nx, ny, nz)),
+            np.asarray((True, True, True)),
+        )
+
+        # Three edges emerge from the opposite lower corner; the other nine
+        # lie on at least one shared upper partition face.
+        assert len(filtered_materials) == 3
 
 
 pytestmark = pytest.mark.unit

--- a/tests/outputs/test_mpi_grid_view.py
+++ b/tests/outputs/test_mpi_grid_view.py
@@ -29,7 +29,8 @@ import numpy as np
 import pytest
 from mpi4py import MPI
 
-from gprMax.geometry_outputs.grid_view import GridView, MPIGridView
+from gprMax.geometry_outputs.grid_view import GridView, MPIGridView, _merge_rank_materials
+from gprMax.materials import Material
 
 
 @pytest.fixture
@@ -418,9 +419,7 @@ class TestDegeneratesToTheSerialClass:
         (3 parameter sets)"""
         serial = make_grid_view(start=(0, 0, 0), stop=(10, 10, 10), nx=10, ny=10, nz=10)
         for exclusive in (True, False):
-            assert edge_view.getter_slice(dimension, exclusive) == serial.getter_slice(
-                dimension, exclusive
-            )
+            assert edge_view.getter_slice(dimension, exclusive) == serial.getter_slice(dimension, exclusive)
 
     @pytest.mark.parametrize("dimension", [0, 1, 2])
     def test_setter_slices_match(self, edge_view, make_grid_view, dimension):
@@ -484,6 +483,34 @@ class TestMaterialsAcrossRanks:
         material_view.initialise_materials(filter_materials=False)
         numids = [m.numID for m in material_view.materials]
         assert numids == sorted(set(numids))
+
+    def test_variable_rank_material_lists_keep_one_map_entry_per_local_material(self):
+        """Compound material IDs are stable even when their local numIDs differ.
+
+        This reproduces the variable-length condition that previously made a
+        receiving MPI rank allocate more IDs than the coordinator sent.
+        """
+        free0 = Material(2, "free_space")
+        mix0 = Material(8, "free_space+sand")
+        free1 = Material(2, "free_space")
+        sand1 = Material(3, "sand")
+        mix1 = Material(15, "free_space+sand")
+
+        materials, maps = _merge_rank_materials(
+            [
+                np.asarray([free0, mix0], dtype=Material),
+                np.asarray([free1, sand1, mix1], dtype=Material),
+            ]
+        )
+
+        assert [material.ID for material in materials] == [
+            "free_space",
+            "sand",
+            "free_space+sand",
+        ]
+        assert [len(mapping) for mapping in maps] == [2, 3]
+        assert maps[0].tolist() == [0, 2]
+        assert maps[1].tolist() == [0, 1, 2]
 
 
 pytestmark = pytest.mark.unit


### PR DESCRIPTION
## Summary

- pass a valid typed material ID to the Cython builder for anisotropic zero-thickness triangles, while retaining the three directional material IDs
- preserve every rank-local material entry and its ordering when constructing the global MPI geometry-output material table
- remove duplicate Yee edges on upper MPI partition faces so shared tangential edges have one canonical owner
- add focused regression tests for the triangle dispatch, variable-length rank material maps, face ownership, and partition corners

## Validation

- `python -m pytest tests/geometry_primitives/test_build_dispatch.py tests/outputs/test_geometry_view_lines.py tests/outputs/test_mpi_grid_view.py -q`: **141 passed**
- Black checks for all six changed files: passed
- `git diff --check`: passed

## Scope

This PR contains only geometry construction and geometry-output corrections. Cross-platform installation and packaging changes will be developed separately so their CI, dependency, compiler, and deployment decisions can be reviewed independently.