### PR TITLE
Refactor MPI imports behind a runtime boundary

### DIFF
--- a/gprMax/contexts.py
+++ b/gprMax/contexts.py
@@ -17,19 +17,23 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import datetime
 import gc
 import logging
 import sys
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import humanize
 import numpy as np
 from colorama import Fore, Style, init
 
 from gprMax.hash_cmds_file import parse_hash_commands
-from gprMax.mpi_model import MPIModel
 from gprMax.scene import Scene
+
+if TYPE_CHECKING:
+    from gprMax.mpi_model import MPIModel
 
 init()
 
@@ -194,8 +198,9 @@ class Context:
 class MPIContext(Context):
     def __init__(self):
         super().__init__()
-        from mpi4py import MPI
+        from gprMax.mpi_support import require_mpi
 
+        MPI = require_mpi("MPI domain decomposition")
         self.comm = MPI.COMM_WORLD
         self.rank = self.comm.rank
 
@@ -216,6 +221,8 @@ class MPIContext(Context):
             exit()
 
     def _create_model(self) -> MPIModel:
+        from gprMax.mpi_model import MPIModel
+
         return MPIModel()
 
     def run(self) -> Dict:
@@ -289,10 +296,10 @@ class TaskfarmContext(Context):
 
     def __init__(self):
         super().__init__()
-        from mpi4py import MPI
-
+        from gprMax.mpi_support import require_mpi
         from gprMax.taskfarm import TaskfarmExecutor
 
+        MPI = require_mpi("MPI task farming")
         self.comm = MPI.COMM_WORLD
         self.rank = self.comm.rank
         self.TaskfarmExecutor = TaskfarmExecutor

--- a/gprMax/fractals/fractal_surface.py
+++ b/gprMax/fractals/fractal_surface.py
@@ -17,19 +17,22 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
-from typing import List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import numpy as np
 import numpy.typing as npt
-from mpi4py import MPI
 from scipy import fftpack
 
 from gprMax import config
 from gprMax.cython.fractals_generate import generate_fractal2D
 from gprMax.fractals.grass import Grass
-from gprMax.fractals.mpi_utilities import calculate_starts_and_subshape, create_mpi_type
-from gprMax.utilities.mpi import Dim, Dir, get_relative_neighbour
+from gprMax.grid.axes import Dim, Dir
+
+if TYPE_CHECKING:
+    from mpi4py import MPI
 
 logger = logging.getLogger(__name__)
 np.seterr(divide="raise")
@@ -291,6 +294,12 @@ class MPIFractalSurface(FractalSurface):
 
     def generate_fractal_surface(self) -> bool:
         """Generate a 2D array with a fractal distribution."""
+
+        from gprMax.fractals.mpi_utilities import calculate_starts_and_subshape, create_mpi_type
+        from gprMax.mpi_support import require_mpi
+        from gprMax.utilities.mpi import get_relative_neighbour
+
+        MPI = require_mpi("distributed fractal-surface generation")
 
         # Import from mpi4py_fft
         # This is an optional dependency so only import if required

--- a/gprMax/fractals/fractal_volume.py
+++ b/gprMax/fractals/fractal_volume.py
@@ -17,20 +17,23 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
-from typing import List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
 import numpy as np
 import numpy.typing as npt
-from mpi4py import MPI
 from scipy import fftpack
 
 from gprMax import config
 from gprMax.cython.fractals_generate import generate_fractal3D
 from gprMax.fractals.fractal_surface import FractalSurface
-from gprMax.fractals.mpi_utilities import calculate_starts_and_subshape, create_mpi_type
+from gprMax.grid.axes import Dim, Dir
 from gprMax.materials import CrimMixture, ListMaterial, PeplinskiSoil, RangeMaterial
-from gprMax.utilities.mpi import Dim, Dir, get_relative_neighbour
+
+if TYPE_CHECKING:
+    from mpi4py import MPI
 
 logger = logging.getLogger(__name__)
 np.seterr(divide="raise")
@@ -364,6 +367,12 @@ class MPIFractalVolume(FractalVolume):
 
     def generate_fractal_volume(self) -> bool:
         """Generate a 3D volume with a fractal distribution."""
+
+        from gprMax.fractals.mpi_utilities import calculate_starts_and_subshape, create_mpi_type
+        from gprMax.mpi_support import require_mpi
+        from gprMax.utilities.mpi import get_relative_neighbour
+
+        MPI = require_mpi("distributed fractal-volume generation")
 
         # Import from mpi4py_fft
         # This is an optional dependency so only import if required

--- a/gprMax/fractals/mpi_utilities.py
+++ b/gprMax/fractals/mpi_utilities.py
@@ -23,7 +23,8 @@ import numpy as np
 import numpy.typing as npt
 from mpi4py import MPI
 
-from gprMax.utilities.mpi import Dir, mpi_datatype_for_dtype
+from gprMax.grid.axes import Dir
+from gprMax.utilities.mpi import mpi_datatype_for_dtype
 
 
 def calculate_starts_and_subshape(

--- a/gprMax/geometry_outputs/geometry_objects.py
+++ b/gprMax/geometry_outputs/geometry_objects.py
@@ -17,20 +17,20 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import re
 from pathlib import Path
-from typing import Generic
+from typing import TYPE_CHECKING, Generic
 
 import h5py
 import numpy as np
-from mpi4py import MPI
 from tqdm import tqdm
 
 from gprMax import config
 from gprMax._version import __version__
 from gprMax.geometry_outputs.grid_view import GridType, GridView, MPIGridView
 from gprMax.grid.fdtd_grid import FDTDGrid
-from gprMax.grid.mpi_grid import MPIGrid
 from gprMax.material_database import (
     create_database_document,
     make_database_id,
@@ -38,6 +38,9 @@ from gprMax.material_database import (
     write_database,
 )
 from gprMax.materials import Material
+
+if TYPE_CHECKING:
+    from gprMax.grid.mpi_grid import MPIGrid
 
 
 class GeometryObject(Generic[GridType]):
@@ -172,7 +175,7 @@ class GeometryObject(Generic[GridType]):
         write_database(self.filename_materials, self._material_document(material_keys))
 
 
-class MPIGeometryObject(GeometryObject[MPIGrid]):
+class MPIGeometryObject(GeometryObject["MPIGrid"]):
     @property
     def GRID_VIEW_TYPE(self) -> type[MPIGridView]:
         return MPIGridView
@@ -189,6 +192,9 @@ class MPIGeometryObject(GeometryObject[MPIGrid]):
         IDs already have node ownership rules; cell-based rigid arrays need
         this one-plane maximum reduction before their non-overlapping write.
         """
+        from gprMax.mpi_support import require_mpi
+
+        MPI = require_mpi("distributed geometry-object output")
         for dimension in range(3):
             negative, positive = self.grid_view.comm.Shift(dimension, 1)
             send_plane = None

--- a/gprMax/geometry_outputs/geometry_objects_read.py
+++ b/gprMax/geometry_outputs/geometry_objects_read.py
@@ -25,11 +25,9 @@ from typing import Optional
 import h5py
 import numpy as np
 import numpy.typing as npt
-from mpi4py import MPI
 
 from gprMax.geometry_outputs.grid_view import GridView, MPIGridView
 from gprMax.grid.fdtd_grid import FDTDGrid
-from gprMax.grid.mpi_grid import MPIGrid
 
 
 class ReadGeometryObject(AbstractContextManager):
@@ -81,15 +79,18 @@ class ReadGeometryObject(AbstractContextManager):
             stop = stop.copy()
             stop[invariant_axis] = start[invariant_axis] + target_invariant_size
 
-        if isinstance(grid, MPIGrid):
+        if getattr(grid, "is_distributed", False) is True:
             if grid.local_bounds_overlap_grid(start, stop):
                 self.grid_view = MPIGridView(
                     grid, start[0], start[1], start[2], stop[0], stop[1], stop[2]
                 )
             else:
+                from gprMax.mpi_support import require_mpi
+
                 # The MPIGridView will create a new communicator using
                 # MPI_Split. Calling this here prevents deadlock if not
                 # all ranks need to read the geometry object.
+                MPI = require_mpi("distributed geometry-object input")
                 grid.comm.Split(MPI.UNDEFINED)
                 self.grid_view = None
 

--- a/gprMax/geometry_outputs/geometry_view_lines.py
+++ b/gprMax/geometry_outputs/geometry_view_lines.py
@@ -17,7 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -26,10 +29,12 @@ from gprMax.cython.geometry_outputs import get_line_properties
 from gprMax.geometry_outputs.geometry_views import GeometryView, Metadata, MPIMetadata
 from gprMax.geometry_outputs.grid_view import GridType, MPIGridView
 from gprMax.grid.fdtd_grid import FDTDGrid
-from gprMax.grid.mpi_grid import MPIGrid
 from gprMax.subgrids.grid import SubGridBaseGrid
 from gprMax.vtkhdf_filehandlers.vtk_unstructured_grid import VtkUnstructuredGrid
 from gprMax.vtkhdf_filehandlers.vtkhdf import VtkCellType, VtkHdfFile
+
+if TYPE_CHECKING:
+    from gprMax.grid.mpi_grid import MPIGrid
 
 logger = logging.getLogger(__name__)
 
@@ -149,7 +154,7 @@ class GeometryViewLines(GeometryView[GridType]):
             self.metadata.write_to_vtkhdf(f)
 
 
-class MPIGeometryViewLines(GeometryViewLines[MPIGrid]):
+class MPIGeometryViewLines(GeometryViewLines["MPIGrid"]):
     """Image data for a per-cell geometry view."""
 
     @property

--- a/gprMax/geometry_outputs/geometry_view_voxels.py
+++ b/gprMax/geometry_outputs/geometry_view_voxels.py
@@ -17,17 +17,22 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from gprMax._version import __version__
 from gprMax.geometry_outputs.geometry_views import GeometryView, Metadata, MPIMetadata
 from gprMax.geometry_outputs.grid_view import GridType, MPIGridView
-from gprMax.grid.mpi_grid import MPIGrid
 from gprMax.subgrids.grid import SubGridBaseGrid
 from gprMax.vtkhdf_filehandlers.vtk_image_data import VtkImageData
 from gprMax.vtkhdf_filehandlers.vtkhdf import VtkHdfFile
+
+if TYPE_CHECKING:
+    from gprMax.grid.mpi_grid import MPIGrid
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +79,7 @@ class GeometryViewVoxels(GeometryView[GridType]):
             self.metadata.write_to_vtkhdf(f)
 
 
-class MPIGeometryViewVoxels(GeometryViewVoxels[MPIGrid]):
+class MPIGeometryViewVoxels(GeometryViewVoxels["MPIGrid"]):
     """Image data for a per-cell geometry view."""
 
     @property

--- a/gprMax/geometry_outputs/geometry_views.py
+++ b/gprMax/geometry_outputs/geometry_views.py
@@ -17,27 +17,30 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
 import sys
 from abc import abstractmethod
 from pathlib import Path
-from typing import Dict, Generic, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Generic, List, Optional, Sequence, Tuple, Union
 
 import h5py
 import numpy as np
 import numpy.typing as npt
-from mpi4py import MPI
 from tqdm import tqdm
 
 import gprMax.config as config
 from gprMax._version import __version__
 from gprMax.geometry_outputs.grid_view import GridType, GridView, MPIGridView
-from gprMax.grid.mpi_grid import MPIGrid
 from gprMax.receivers import Rx
-from gprMax.subgrids.grid import SubGridBaseGrid
 from gprMax.sources import Source
+from gprMax.subgrids.grid import SubGridBaseGrid
 from gprMax.utilities.utilities import get_terminal_width
 from gprMax.vtkhdf_filehandlers.vtkhdf import VtkHdfFile
+
+if TYPE_CHECKING:
+    from gprMax.grid.mpi_grid import MPIGrid
 
 logger = logging.getLogger(__name__)
 
@@ -259,7 +262,7 @@ class Metadata(Generic[GridType]):
             return [m.ID for m in materials]
 
 
-class MPIMetadata(Metadata[MPIGrid]):
+class MPIMetadata(Metadata["MPIGrid"]):
     def nx_ny_nz_comment(self) -> npt.NDArray[np.int32]:
         return self.grid.global_size
 

--- a/gprMax/geometry_outputs/grid_view.py
+++ b/gprMax/geometry_outputs/grid_view.py
@@ -17,18 +17,21 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
 from itertools import chain
-from typing import Generic, Tuple
+from typing import TYPE_CHECKING, Generic, Tuple
 
 import numpy as np
 import numpy.typing as npt
-from mpi4py import MPI
 from typing_extensions import TypeVar
 
 from gprMax.grid.fdtd_grid import FDTDGrid
-from gprMax.grid.mpi_grid import MPIGrid
 from gprMax.materials import Material
+
+if TYPE_CHECKING:
+    from gprMax.grid.mpi_grid import MPIGrid
 
 logger = logging.getLogger(__name__)
 
@@ -550,7 +553,7 @@ class GridView(Generic[GridType]):
         return self.get_array_slice(self.grid.Hz, upper_bound_exclusive=False)
 
 
-class MPIGridView(GridView[MPIGrid]):
+class MPIGridView(GridView["MPIGrid"]):
     def __init__(
         self,
         grid: MPIGrid,
@@ -583,6 +586,9 @@ class MPIGridView(GridView[MPIGrid]):
         """
         super().__init__(grid, xs, ys, zs, xf, yf, zf, dx, dy, dz)
 
+        from gprMax.mpi_support import require_mpi
+
+        MPI = require_mpi("distributed geometry views")
         comm = grid.comm.Split()
         assert isinstance(comm, MPI.Intracomm)
 

--- a/gprMax/gprMax.py
+++ b/gprMax/gprMax.py
@@ -20,7 +20,7 @@ import argparse
 
 import gprMax.config as config
 
-from .contexts import Context, MPIContext, TaskfarmContext
+from .contexts import Context
 from .utilities.logging import logging_config
 
 # Arguments (used for API) and their default values (used for API and CLI)
@@ -374,9 +374,17 @@ def run_main(args):
 
     # MPI taskfarm running with (OpenMP/CUDA/OpenCL)
     if config.sim_config.args.taskfarm:
+        from gprMax.contexts import TaskfarmContext
+        from gprMax.mpi_support import require_mpi
+
+        require_mpi("MPI task farming")
         context = TaskfarmContext()
     # MPI running to divide model between ranks
     elif config.sim_config.args.mpi is not None:
+        from gprMax.contexts import MPIContext
+        from gprMax.mpi_support import require_mpi
+
+        require_mpi("MPI domain decomposition")
         context = MPIContext()
     # Standard running (OpenMP/CUDA/OpenCL/Metal)
     else:

--- a/gprMax/grid/axes.py
+++ b/gprMax/grid/axes.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Axis and direction identifiers shared by serial and distributed grids."""
+
+from enum import IntEnum, unique
+
+
+@unique
+class Dim(IntEnum):
+    X = 0
+    Y = 1
+    Z = 2
+
+
+@unique
+class Dir(IntEnum):
+    NONE = -1
+    NEG = 0
+    POS = 1

--- a/gprMax/grid/fdtd_grid.py
+++ b/gprMax/grid/fdtd_grid.py
@@ -80,6 +80,7 @@ class FDTDGrid:
     """
 
     IDlookup = {"Ex": 0, "Ey": 1, "Ez": 2, "Hx": 3, "Hy": 4, "Hz": 5}
+    is_distributed = False
     pml_type = PML
 
     def __init__(self):

--- a/gprMax/grid/mpi_grid.py
+++ b/gprMax/grid/mpi_grid.py
@@ -33,11 +33,12 @@ from gprMax import config
 from gprMax.cython.pml_build import pml_sum_er_mr
 from gprMax.fractals.fractal_surface import MPIFractalSurface
 from gprMax.fractals.fractal_volume import MPIFractalVolume
+from gprMax.grid.axes import Dim, Dir
 from gprMax.grid.fdtd_grid import FDTDGrid
 from gprMax.pml import MPIPML, PML, InternalPMLSpec
 from gprMax.receivers import Rx
 from gprMax.sources import Source
-from gprMax.utilities.mpi import Dim, Dir, mpi_datatype_for_dtype
+from gprMax.utilities.mpi import mpi_datatype_for_dtype
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,7 @@ ObjectType = TypeVar("ObjectType")
 class MPIGrid(FDTDGrid):
     HALO_SIZE = 1
     COORDINATOR_RANK = 0
+    is_distributed = True
     pml_type = MPIPML
 
     def __init__(self, comm: MPI.Cartcomm):

--- a/gprMax/impedance_surfaces.py
+++ b/gprMax/impedance_surfaces.py
@@ -542,12 +542,11 @@ def _check_supported_configuration(grid, boundary_keys: set[tuple[int, int, int,
         raise ValueError("impedance volumes currently support only 3-D models")
     if config.sim_config.general["solver"] != "cpu":
         raise ValueError("impedance volumes currently support only the CPU solver")
-    from gprMax.grid.mpi_grid import MPIGrid
     from gprMax.subgrids.grid import SubGridBaseGrid
 
     if isinstance(grid, SubGridBaseGrid):
         raise ValueError("impedance volumes are not yet supported in subgrids")
-    if isinstance(grid, MPIGrid):
+    if getattr(grid, "is_distributed", False) is True:
         raise ValueError("impedance volumes are not yet supported with MPI domain decomposition")
     if config.sim_config.general.get("subgrid", False):
         raise ValueError("impedance volumes are not yet supported in subgridded models")

--- a/gprMax/mpi_support.py
+++ b/gprMax/mpi_support.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
+#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
+#                          and Nathan Mannall
+#
+# This file is part of gprMax.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Runtime boundary for gprMax MPI functionality."""
+
+from types import ModuleType
+
+
+class MPIUnavailableError(RuntimeError):
+    """Raised when a requested MPI feature cannot initialise mpi4py."""
+
+
+def require_mpi(feature: str = "MPI functionality") -> ModuleType:
+    """Import and return :mod:`mpi4py.MPI` for a requested MPI feature."""
+
+    try:
+        from mpi4py import MPI
+    except (ImportError, RuntimeError) as exc:
+        raise MPIUnavailableError(
+            f"{feature} requires a working MPI runtime and the mpi4py package. "
+            "Install an MPI implementation supported by your platform, then "
+            "install mpi4py."
+        ) from exc
+
+    return MPI

--- a/gprMax/pml.py
+++ b/gprMax/pml.py
@@ -17,16 +17,20 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
 from copy import deepcopy
 from dataclasses import dataclass
 from importlib import import_module
-from typing import List
+from typing import TYPE_CHECKING, List
 
 import numpy as np
-from mpi4py import MPI
 
 import gprMax.config as config
+
+if TYPE_CHECKING:
+    from mpi4py import MPI
 
 from .cython.pml_build import pml_average_er_mr, pml_sum_er_mr
 

--- a/gprMax/scene.py
+++ b/gprMax/scene.py
@@ -23,10 +23,8 @@ import numpy as np
 
 from gprMax.geometry_tags import GeometryTagMap, GeometryTagRegistry
 from gprMax.grid.fdtd_grid import FDTDGrid
-from gprMax.grid.mpi_grid import MPIGrid
 from gprMax.materials import create_built_in_materials
 from gprMax.model import Model
-from gprMax.mpi_model import MPIModel
 from gprMax.subgrids.grid import SubGridBaseGrid
 from gprMax.subgrids.user_objects import SubGridBase as SubGridUserBase
 from gprMax.user_objects.cmds_geometry.add_grass import AddGrass
@@ -185,7 +183,7 @@ class Scene:
 
         limits = (
             tuple(grid.global_size)
-            if isinstance(grid, MPIGrid)
+            if getattr(grid, "is_distributed", False) is True
             else (grid.nx, grid.ny, grid.nz)
         )
         for spec in grid.pmls["internal_specs"]:

--- a/gprMax/snapshots.py
+++ b/gprMax/snapshots.py
@@ -17,22 +17,27 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
 import sys
 from pathlib import Path
-from typing import Dict, Generic, List
+from typing import TYPE_CHECKING, Dict, Generic, List
 
 import h5py
 import numpy as np
-from mpi4py import MPI
 from tqdm import tqdm
 
 import gprMax.config as config
 from gprMax.geometry_outputs.grid_view import GridType, GridView, MPIGridView
-from gprMax.grid.mpi_grid import MPIGrid
+from gprMax.grid.axes import Dim, Dir
 from gprMax.subgrids.grid import SubGridBaseGrid
-from gprMax.utilities.mpi import Dim, Dir
 from gprMax.vtkhdf_filehandlers.vtk_image_data import VtkImageData
+
+if TYPE_CHECKING:
+    from mpi4py import MPI
+
+    from gprMax.grid.mpi_grid import MPIGrid
 
 from ._version import __version__
 from .cython.snapshots import calculate_snapshot_fields
@@ -364,7 +369,7 @@ class Snapshot(Generic[GridType]):
         return origin
 
 
-class MPISnapshot(Snapshot[MPIGrid]):
+class MPISnapshot(Snapshot["MPIGrid"]):
     H_TAG = 0
     EX_TAG = 1
     EY_TAG = 2

--- a/gprMax/solvers.py
+++ b/gprMax/solvers.py
@@ -20,9 +20,7 @@
 import logging
 
 import gprMax.config as config
-from gprMax.grid.mpi_grid import MPIGrid
 from gprMax.model import Model
-from gprMax.updates.mpi_updates import MPIUpdates
 
 from .grid.cuda_grid import CUDAGrid
 from .grid.fdtd_grid import FDTDGrid
@@ -76,7 +74,7 @@ class Solver:
             self.updates.update_eigenmode_sources_magnetic(iteration)
             self.updates.update_plane_waves_magnetic(iteration)
 
-            if isinstance(self.updates, MPIUpdates):
+            if getattr(self.updates, "is_distributed", False) is True:
                 self.updates.halo_swap_magnetic()
                 self.updates.update_magnetic_edge_devices(iteration)
                 # Modal H projections interpolate across transverse Yee
@@ -113,7 +111,7 @@ class Solver:
             self.updates.update_impedance_surfaces()
             self.updates.update_network_terminals(iteration)
 
-            if isinstance(self.updates, MPIUpdates):
+            if getattr(self.updates, "is_distributed", False) is True:
                 self.updates.halo_swap_electric()
             if isinstance(self.updates, CUDAUpdates):
                 self.memused = self.updates.calculate_memory_used(iteration)
@@ -153,7 +151,9 @@ def create_solver(model: Model) -> Solver:
         updates = CPUUpdates(grid)
         if config.get_model_config().materials["maxpoles"] != 0:
             updates.set_dispersive_updates()
-    elif type(grid) is MPIGrid:
+    elif getattr(grid, "is_distributed", False) is True:
+        from gprMax.updates.mpi_updates import MPIUpdates
+
         updates = MPIUpdates(grid)
         if config.get_model_config().materials["maxpoles"] != 0:
             updates.set_dispersive_updates()

--- a/gprMax/updates/mpi_updates.py
+++ b/gprMax/updates/mpi_updates.py
@@ -24,6 +24,8 @@ from gprMax.updates.cpu_updates import CPUUpdates
 class MPIUpdates(CPUUpdates[MPIGrid]):
     """Defines update functions for MPI CPU-based solver."""
 
+    is_distributed = True
+
     def update_magnetic_sources(self, iteration):
         """Apply magnetic-field writers before exchanging magnetic halos.
 

--- a/gprMax/updates/updates.py
+++ b/gprMax/updates/updates.py
@@ -29,6 +29,8 @@ GridType = TypeVar("GridType", bound=FDTDGrid)
 class Updates(Generic[GridType], ABC):
     """Defines update functions for a solver."""
 
+    is_distributed = False
+
     def __init__(self, G: GridType):
         """
         Args:

--- a/gprMax/user_inputs.py
+++ b/gprMax/user_inputs.py
@@ -20,17 +20,19 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import Generic, Optional, Tuple
+from typing import TYPE_CHECKING, Generic, Optional, Tuple
 
 import numpy as np
 import numpy.typing as npt
 from typing_extensions import TypeVar
 
 from gprMax import config
+from gprMax.grid.axes import Dim, Dir
 from gprMax.grid.fdtd_grid import FDTDGrid
-from gprMax.grid.mpi_grid import MPIGrid
 from gprMax.subgrids.grid import SubGridBaseGrid
-from gprMax.utilities.mpi import Dim, Dir
+
+if TYPE_CHECKING:
+    from gprMax.grid.mpi_grid import MPIGrid
 
 from .utilities.utilities import round_int
 
@@ -395,7 +397,7 @@ class MainGridUserInput(UserInput[GridType]):
         )
 
 
-class MPIUserInput(MainGridUserInput[MPIGrid]):
+class MPIUserInput(MainGridUserInput["MPIGrid"]):
     """Handles (x, y, z) points supplied by the user for MPI grids.
 
     This class autotranslates points from the global coordinate system

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -37,7 +37,6 @@ from gprMax.eigenmode_config import (
     VirtualWaveguideSpec,
 )
 from gprMax.grid.fdtd_grid import FDTDGrid
-from gprMax.grid.mpi_grid import MPIGrid
 from gprMax.impedance_surfaces import SurfaceImpedanceModel, is_reserved_impedance_id
 from gprMax.material_database import build_material_from_spec, load_material_spec
 from gprMax.materials import CrimMixture as CrimMixtureUser
@@ -1220,7 +1219,9 @@ class VoltageSource(RotatableMixin, GridUserObject):
         if grid.within_pml(coord):
             raise ValueError(f"{self.params_str()} cannot be placed inside a PML.")
         loop_coordinate = (
-            grid.local_to_global_coordinate(coord) if isinstance(grid, MPIGrid) else coord
+            grid.local_to_global_coordinate(coord)
+            if getattr(grid, "is_distributed", False) is True
+            else coord
         )
         if not _hard_source_current_loop_available(
             voltage_source.polarisation, voltage_source.resistance, loop_coordinate
@@ -5090,7 +5091,7 @@ class PMLSlab(GridUserObject):
 
         uip = self._create_uip(grid)
         within_grid, lower, upper = uip.check_box_points(p1, p2, self.__str__())
-        if isinstance(grid, MPIGrid):
+        if getattr(grid, "is_distributed", False) is True:
             # Every rank retains the same immutable global declaration. Local
             # clipping is deferred until PML construction, where the global
             # CFS depth can be preserved across rank boundaries.

--- a/gprMax/user_objects/user_objects.py
+++ b/gprMax/user_objects/user_objects.py
@@ -22,7 +22,6 @@ from typing import List, Union
 
 from gprMax import config
 from gprMax.grid.fdtd_grid import FDTDGrid
-from gprMax.grid.mpi_grid import MPIGrid
 from gprMax.model import Model
 from gprMax.subgrids.grid import SubGridBaseGrid
 from gprMax.user_inputs import MainGridUserInput, MPIUserInput, SubgridUserInput
@@ -97,7 +96,7 @@ class UserObject(ABC):
             and self.autotranslate
         ):
             return SubgridUserInput(grid)
-        elif isinstance(grid, MPIGrid):
+        elif getattr(grid, "is_distributed", False) is True:
             return MPIUserInput(grid)
         else:
             return MainGridUserInput(grid)

--- a/gprMax/utilities/mpi.py
+++ b/gprMax/utilities/mpi.py
@@ -1,23 +1,10 @@
-from enum import IntEnum, unique
 from typing import Union
 
 import numpy as np
 import numpy.typing as npt
 from mpi4py import MPI
 
-
-@unique
-class Dim(IntEnum):
-    X = 0
-    Y = 1
-    Z = 2
-
-
-@unique
-class Dir(IntEnum):
-    NONE = -1
-    NEG = 0
-    POS = 1
+from gprMax.grid.axes import Dim, Dir
 
 
 def mpi_datatype_for_dtype(dtype: npt.DTypeLike) -> MPI.Datatype:

--- a/gprMax/vtkhdf_filehandlers/vtk_image_data.py
+++ b/gprMax/vtkhdf_filehandlers/vtk_image_data.py
@@ -17,12 +17,16 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from os import PathLike
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
 import numpy.typing as npt
-from mpi4py.MPI import Intracomm
+
+if TYPE_CHECKING:
+    from mpi4py.MPI import Intracomm
 
 from gprMax.vtkhdf_filehandlers.vtkhdf import VtkFileType, VtkHdfFile
 

--- a/gprMax/vtkhdf_filehandlers/vtk_unstructured_grid.py
+++ b/gprMax/vtkhdf_filehandlers/vtk_unstructured_grid.py
@@ -17,15 +17,19 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
 from os import PathLike
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
 import numpy.typing as npt
-from mpi4py import MPI
 
 from gprMax.vtkhdf_filehandlers.vtkhdf import VtkCellType, VtkFileType, VtkHdfFile
+
+if TYPE_CHECKING:
+    from mpi4py import MPI
 
 logger = logging.getLogger(__name__)
 
@@ -161,6 +165,9 @@ class VtkUnstructuredGrid(VtkHdfFile):
             self._write_root_dataset(self.Dataset.CONNECTIVITY, connectivity)
             self._write_root_dataset(self.Dataset.OFFSETS, cell_offsets)
         else:
+            from gprMax.mpi_support import require_mpi
+
+            MPI = require_mpi("parallel VTKHDF output")
             # Write partition information for each rank
             self.partition = self.comm.rank
             partition_offset = np.array([self.partition], dtype=np.int32)

--- a/gprMax/vtkhdf_filehandlers/vtkhdf.py
+++ b/gprMax/vtkhdf_filehandlers/vtkhdf.py
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
 from abc import abstractmethod
 from contextlib import AbstractContextManager
@@ -24,12 +26,14 @@ from enum import Enum
 from os import PathLike
 from pathlib import Path
 from types import TracebackType
-from typing import Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 import h5py
 import numpy as np
 import numpy.typing as npt
-from mpi4py.MPI import Intracomm
+
+if TYPE_CHECKING:
+    from mpi4py.MPI import Intracomm
 
 logger = logging.getLogger(__name__)
 

--- a/tests/outputs/test_geometry_objects_read.py
+++ b/tests/outputs/test_geometry_objects_read.py
@@ -422,17 +422,9 @@ class TestMpiPaths:
         return make_mpi_grid(size=(8, 8, 8), negative_halo_offset=(0, 0, 0), arrays=arrays)
 
     @pytest.fixture
-    def as_mpi_grid(self, monkeypatch, overlapping_grid):
-        """Make the reader treat the fake grid as an ``MPIGrid``.
-
-        The branch under test is ``isinstance(grid, MPIGrid)`` against the name
-        imported into ``geometry_objects_read``. ``MPIGrid`` is a concrete
-        class with a real constructor and no ABC registration hook, so the
-        cleanest way in is to rebind that one name.
-        """
-        import gprMax.geometry_outputs.geometry_objects_read as module
-
-        monkeypatch.setattr(module, "MPIGrid", type(overlapping_grid))
+    def as_mpi_grid(self, overlapping_grid):
+        """Mark the fake grid as distributed through the grid capability flag."""
+        overlapping_grid.is_distributed = True
         return overlapping_grid
 
     def test_an_overlapping_rank_gets_an_mpi_grid_view(self, geometry_file, as_mpi_grid):

--- a/tests/user_objects/test_user_objects_base.py
+++ b/tests/user_objects/test_user_objects_base.py
@@ -145,6 +145,7 @@ class TestCreateUIPDispatch:
         from gprMax.user_objects import user_objects as uo_mod
 
         grid = MagicMock(spec=MPIGrid)
+        grid.is_distributed = True
         obj = _ConcreteUserObject()
 
         with patch.object(uo_mod, "MPIUserInput") as MPIUIP:

--- a/tests/utilities/test_mpi_support.py
+++ b/tests/utilities/test_mpi_support.py
@@ -1,0 +1,86 @@
+"""Tests for the deferred MPI runtime boundary."""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from gprMax.mpi_support import MPIUnavailableError, require_mpi
+
+
+@pytest.mark.unit
+def test_serial_run_does_not_import_mpi4py(tmp_path):
+    """A serial geometry build must not initialise an MPI runtime."""
+
+    script = textwrap.dedent(
+        """
+        import importlib.abc
+        import os
+        import sys
+
+        class BlockMPI(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "mpi4py" or fullname.startswith("mpi4py."):
+                    raise ModuleNotFoundError("mpi4py import was not deferred")
+                return None
+
+        sys.meta_path.insert(0, BlockMPI())
+        import gprMax
+
+        scene = gprMax.Scene()
+        scene.add(gprMax.Discretisation(p1=(0.001, 0.001, 0.001)))
+        scene.add(gprMax.Domain(p1=(0.01, 0.01, 0.01)))
+        scene.add(gprMax.PMLThickness(thickness=0))
+        scene.add(gprMax.TimeWindow(time=1e-12))
+        scene.add(
+            gprMax.Box(
+                p1=(0.002, 0.002, 0.002),
+                p2=(0.008, 0.008, 0.008),
+                material_id="pec",
+            )
+        )
+        gprMax.run(
+            scenes=[scene],
+            n=1,
+            geometry_only=True,
+            outputfile=os.environ["GPRMAX_TEST_OUTPUT"],
+            hide_progress_bars=True,
+        )
+
+        assert not any(
+            name == "mpi4py" or name.startswith("mpi4py.")
+            for name in sys.modules
+        )
+        """
+    )
+    env = os.environ.copy()
+    env["MPLCONFIGDIR"] = str(tmp_path / "matplotlib")
+    env["GPRMAX_TEST_OUTPUT"] = str(tmp_path / "serial_without_mpi")
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.unit
+def test_require_mpi_returns_real_mpi_module():
+    MPI = pytest.importorskip("mpi4py.MPI")
+
+    assert require_mpi("test MPI feature") is MPI
+
+
+@pytest.mark.unit
+def test_require_mpi_reports_actionable_error(monkeypatch):
+    monkeypatch.setitem(sys.modules, "mpi4py", None)
+
+    with pytest.raises(MPIUnavailableError, match="working MPI runtime.*mpi4py") as excinfo:
+        require_mpi("distributed test feature")
+
+    assert isinstance(excinfo.value.__cause__, ImportError)


### PR DESCRIPTION
## Summary

- defer mpi4py and MPI-only model imports until MPI domain decomposition or task farming is selected
- move neutral axis/direction enums outside the MPI utility module
- use explicit distributed-grid/update capability flags so serial modules no longer import MPI classes for type dispatch
- provide one actionable runtime boundary for unavailable MPI support
- add a subprocess regression test that completes a serial geometry build while all mpi4py imports are blocked

## Scope

This is PR1 of the optional-MPI refactor. It deliberately keeps mpi4py and all packaging metadata unchanged. It establishes and tests the import boundary before dependency declarations or installation extras are changed in later PRs.

## Validation

- complete unit suite: 3698 passed, 5 environment-skipped
- focused MPI, geometry-output, snapshot, PML, fractal, and user-object tests: 505 passed, 3 environment-skipped
- serial geometry build with mpi4py imports forcibly blocked: passed, with no mpi4py modules loaded
- two-rank MPI smoke model versus serial CPU: all six receiver field components had maximum absolute difference 0.0
- Python compileall and git diff checks: passed
