### PR TITLE
Make MPI support an optional installation extra

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install gprMax and test dependencies
         run: |
           python -m pip install -r requirements.txt
-          python -m pip install --editable .
+          python -m pip install --editable ".[mpi]"
 
       - name: Run standard CPU test selection
         run: python -m pytest -m "not unit and not gpu and not slow"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  serial-without-mpi:
+    name: Serial install (without MPI)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      OMP_NUM_THREADS: "1"
+      PYTHONFAULTHANDLER: "1"
+      PYTHONUNBUFFERED: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: setup.py
+
+      - name: Install core gprMax without MPI
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip uninstall --yes mpi4py
+          python -m pip install --editable . pytest
+
+      - name: Verify optional dependency metadata
+        run: |
+          python -c "from importlib.metadata import requires; r = requires('gprMax') or []; assert 'mpi4py' not in r; assert any(x.startswith('mpi4py;') and 'mpi' in x for x in r)"
+          python -c "import importlib.util; import gprMax; assert importlib.util.find_spec('mpi4py') is None"
+
+      - name: Run MPI-free serial regression tests
+        run: python -u -m pytest -q tests/utilities/test_mpi_support.py
+
   unit:
     name: Unit tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -67,7 +101,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
-          python -m pip install --editable .
+          python -m pip install --editable ".[mpi]"
 
       - name: Import smoke test
         run: python -u -c "import gprMax; from gprMax.fractals.fractal_surface import FractalSurface; print('imports ok')"

--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ Installation
 The following steps provide guidance on how to install gprMax:
 
 1. Install a C compiler which supports OpenMP
-2. Install MPI
+2. [Optional] Install MPI
 3. Install Python, required Python packages, and get the gprMax source code from GitHub
 4. [Optional] Build h5py against Parallel HDF5
 5. [Optional] Install mpi4py_fft
@@ -116,10 +116,17 @@ Microsoft Windows
 Alternatively, if you are using Windows 10/11 you can install the `Windows Subsystem for Linux <https://docs.microsoft.com/en-gb/windows/wsl/about>`_ and then follow the Linux install instructions for gprMax. Note however that currently, WSL does not aim to support GUI desktops or applications, e.g. Gnome, KDE, etc...
 
 
-2. Install MPI
---------------
+2. [Optional] Install MPI
+--------------------------
 
-If you are running gprMax on a HPC system, MPI will likely be installed already. Otherwise you will need to install it yourself.
+MPI is required only for domain decomposition and task farming. Ordinary
+serial, OpenMP, CUDA, OpenCL, and Metal simulations do not require an MPI
+runtime or the ``mpi4py`` Python package. The ``mpi4py`` binding is installed
+through the gprMax ``mpi`` extra in step 6.
+
+If you plan to use MPI and are running gprMax on an HPC system, a suitable MPI
+implementation will likely be installed already. Otherwise you will need to
+install one yourself.
 
 Linux/macOS
 ^^^^^^^^^^^
@@ -146,7 +153,9 @@ We recommend using Miniconda to install Python and the required Python packages 
     $ cd gprMax
     $ conda env create -f conda_env.yml
 
-This will make sure conda is up-to-date, install Git, get the latest gprMax source code from GitHub, and create an environment for gprMax with all the necessary Python packages.
+This will make sure conda is up-to-date, install Git, get the latest gprMax
+source code from GitHub, and create an environment containing the core gprMax
+packages. MPI is deliberately not installed in this base environment.
 
 If you prefer to install Python and the required Python packages manually, i.e. without using Anaconda/Miniconda, look in the ``conda_env.yml`` file for a list of the requirements.
 
@@ -247,6 +256,25 @@ Once you have installed the aforementioned tools follow these steps to build and
 .. code-block:: console
 
     (gprMax)$ pip install -e gprMax
+
+For MPI domain decomposition or task farming, install the MPI extra instead:
+
+.. code-block:: console
+
+    (gprMax)$ pip install -e "gprMax[mpi]"
+
+For distributed fractal generation, use the combined extra:
+
+.. code-block:: console
+
+    (gprMax)$ pip install -e "gprMax[mpi-fractals]"
+
+The ``mpi-fractals`` extra includes both ``mpi4py`` and ``mpi4py-fft``. If a
+core source installation is already built, MPI support can be added without
+recompiling gprMax by installing the system MPI runtime and then running
+``python -m pip install mpi4py`` (plus ``mpi4py-fft`` for distributed
+fractals). A compatible system MPI runtime is still required; the Python extra
+does not install or configure that runtime.
 
 **You are now ready to proceed to running gprMax.**
 

--- a/conda_env.yml
+++ b/conda_env.yml
@@ -28,8 +28,8 @@ dependencies:
 
 - pip:
   - humanize
-#  - mpi4py
-#  - mpi4py-fft
+  # MPI is optional. After creating this environment, use
+  # pip install -e ".[mpi]" or pip install -e ".[mpi-fractals]".
   - numpy-stl
 #  - pyobjc-framework-metal
 #  - pycuda

--- a/docs/source/accelerators.rst
+++ b/docs/source/accelerators.rst
@@ -62,7 +62,19 @@ By default, gprMax will try to determine and use the maximum number of OpenMP th
 MPI
 ===
 
-No additional software is required to use MPI as it is part of the standard installation of gprMax. However you will need to :ref:`build h5py with MPI support<h5py_mpi>` if you plan to use the MPI domain decomposition functionality.
+MPI support is optional and is not installed with the core gprMax package. It
+requires a system MPI implementation and the gprMax ``mpi`` extra:
+
+.. code-block:: console
+
+    (gprMax)$ python -m pip install -e ".[mpi]"
+
+The extra installs ``mpi4py`` but does not install or configure the system MPI
+runtime. You will also need to :ref:`build h5py with MPI support<h5py_mpi>` if
+you plan to use parallel HDF5 output with MPI domain decomposition.
+For an existing source installation, MPI can instead be enabled without
+recompiling gprMax by installing the runtime followed by
+``python -m pip install mpi4py``.
 
 There are two ways to use MPI with gprMax:
 

--- a/docs/source/hpc.rst
+++ b/docs/source/hpc.rst
@@ -32,7 +32,7 @@ Full installation instructions for gprMax can be found in the :ref:`Getting Star
     (gprMax)$ python -m pip install --upgrade pip
     (gprMax)$ HDF5_MPI='ON' python -m pip install --no-binary=h5py h5py
     (gprMax)$ python -m pip install -r requirements.txt
-    (gprMax)$ python -m pip install -e .
+    (gprMax)$ python -m pip install -e ".[mpi]"
 
 .. tip::
 

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -56,7 +56,11 @@ requirements and run the usual CPU selection from the repository root:
 .. code-block:: console
 
     $ python -m pip install -r requirements.txt
+    $ python -m pip install -e ".[mpi]"
     $ python -m pytest -m "not gpu and not slow"
+
+The MPI extra is needed for the complete developer test suite. Core serial
+users do not need it.
 
 This is also the selection run by the GitHub Actions workflow for pull
 requests and pushes to ``devel``. Run the complete locally available suite

--- a/gprMax/config.py
+++ b/gprMax/config.py
@@ -361,8 +361,9 @@ class SimulationConfig:
         }
 
         if self.mpi and self.general["progressbars"]:
-            from mpi4py import MPI
+            from gprMax.mpi_support import require_mpi
 
+            MPI = require_mpi("MPI progress reporting")
             self.general["progressbars"] = MPI.COMM_WORLD.rank == 0
 
         # Store information about host machine

--- a/gprMax/gprMax.py
+++ b/gprMax/gprMax.py
@@ -364,6 +364,18 @@ def run_main(args):
 
     preflight_study_args(args)
     results = {}
+
+    # Validate optional MPI support before MPI-aware logging or simulation
+    # configuration can access the runtime.
+    if args.taskfarm:
+        from gprMax.mpi_support import require_mpi
+
+        require_mpi("MPI task farming")
+    elif args.mpi is not None:
+        from gprMax.mpi_support import require_mpi
+
+        require_mpi("MPI domain decomposition")
+
     logging_config(
         level=args.log_level,
         log_file=args.log_file,
@@ -375,16 +387,12 @@ def run_main(args):
     # MPI taskfarm running with (OpenMP/CUDA/OpenCL)
     if config.sim_config.args.taskfarm:
         from gprMax.contexts import TaskfarmContext
-        from gprMax.mpi_support import require_mpi
 
-        require_mpi("MPI task farming")
         context = TaskfarmContext()
     # MPI running to divide model between ranks
     elif config.sim_config.args.mpi is not None:
         from gprMax.contexts import MPIContext
-        from gprMax.mpi_support import require_mpi
 
-        require_mpi("MPI domain decomposition")
         context = MPIContext()
     # Standard running (OpenMP/CUDA/OpenCL/Metal)
     else:

--- a/gprMax/utilities/logging.py
+++ b/gprMax/utilities/logging.py
@@ -117,8 +117,9 @@ def logging_config(
     # Don't add handlers for non-zero ranks unless logging is turned on
     # for all ranks
     if mpi_logger:
-        from mpi4py import MPI
+        from gprMax.mpi_support import require_mpi
 
+        MPI = require_mpi("MPI logging")
         rank = MPI.COMM_WORLD.rank
         if not log_all_ranks and not rank == 0:
             return

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ humanize
 jinja2
 jupyter
 matplotlib
-mpi4py
 numpy
 numpy-stl
 pandas
@@ -21,6 +20,15 @@ terminaltables
 tqdm
 typing_extensions
 wheel
+
+# MPI domain decomposition and task farming are optional. Install their
+# Python dependency through the package extra:
+#
+# pip install -e ".[mpi]"
+#
+# Distributed fractal generation additionally requires:
+#
+# pip install -e ".[mpi-fractals]"
 
 # If running with CUDA backend, the following dependencies
 # are also required:
@@ -38,11 +46,6 @@ wheel
 # are also required:
 
 # pyobjc-framework-metal
-
-
-# Distributed fractal generation additionally requires:
-
-# mpi4py-fft
 
 
 # The following are required to run the ReFrame test suite (uncomment if

--- a/setup.py
+++ b/setup.py
@@ -294,6 +294,10 @@ else:
             "tqdm",
             "typing_extensions",
         ],
+        extras_require={
+            "mpi": ["mpi4py"],
+            "mpi-fractals": ["mpi4py", "mpi4py-fft"],
+        },
         ext_modules=extensions,
         packages=find_packages(),
         include_package_data=True,

--- a/tests/utilities/test_mpi_support.py
+++ b/tests/utilities/test_mpi_support.py
@@ -84,3 +84,55 @@ def test_require_mpi_reports_actionable_error(monkeypatch):
         require_mpi("distributed test feature")
 
     assert isinstance(excinfo.value.__cause__, ImportError)
+
+
+@pytest.mark.unit
+def test_requesting_mpi_features_without_dependency_reports_actionable_error(tmp_path):
+    """Public MPI paths must fail at the optional-dependency boundary."""
+
+    script = textwrap.dedent(
+        """
+        import importlib.abc
+        import sys
+
+        class BlockMPI(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "mpi4py" or fullname.startswith("mpi4py."):
+                    raise ModuleNotFoundError("blocked optional mpi4py dependency")
+                return None
+
+        sys.meta_path.insert(0, BlockMPI())
+        import gprMax
+        from gprMax.mpi_support import MPIUnavailableError
+
+        cases = (
+            ({"mpi": (1, 1, 1)}, "MPI domain decomposition"),
+            ({"taskfarm": True}, "MPI task farming"),
+        )
+        for options, feature in cases:
+            scene = gprMax.Scene()
+            try:
+                gprMax.run(
+                    scenes=[scene],
+                    n=1,
+                    outputfile="unused",
+                    hide_progress_bars=True,
+                    **options,
+                )
+            except MPIUnavailableError as exc:
+                assert f"{feature} requires a working MPI runtime" in str(exc)
+            else:
+                raise AssertionError(f"{feature} unexpectedly passed without mpi4py")
+        """
+    )
+    env = os.environ.copy()
+    env["MPLCONFIGDIR"] = str(tmp_path / "matplotlib")
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

- add explicit mpi and mpi-fractals package extras
- remove mpi4py from the base developer requirements and keep the Conda environment MPI-free by default
- make existing MPI-enabled CI jobs install the mpi extra explicitly
- add a clean CI job that installs gprMax from package metadata without mpi4py, verifies the metadata, imports the package, and runs a serial model regression
- document core, MPI, distributed-fractal, HPC, and later-MPI installation paths
- validate MPI availability before logging and simulation configuration so missing optional support produces an actionable gprMax error rather than a raw ModuleNotFoundError

## Scope

This is PR2 of the optional-MPI refactor. It does not change MPI numerical behaviour, install a system MPI runtime, modernise the broader packaging metadata, or alter the separate cross-platform wheel work. Parallel HDF5 remains a separately documented requirement for parallel HDF5 output.

## Validation

- fresh Python 3.13 virtual environment installed editable gprMax using package metadata only, with no mpi4py present
- pip check in the MPI-free environment: no broken requirements
- MPI-free serial four-iteration FDTD model: passed
- MPI-free boundary tests: 3 passed, 1 expected MPI-enabled test skipped
- mpi and mpi-fractals extras both resolved to the intended dependencies
- adding mpi4py after the core build left the compiled Cython extension timestamp unchanged
- real two-rank MPI smoke model completed; Ex, Ey, Ez, Hx, Hy, and Hz matched the serial output exactly with maximum absolute difference 0.0
- complete unit suite: 3699 passed, 5 environment-skipped
- Sphinx documentation build with warnings treated as errors: passed
- YAML parsing, compileall, import sorting for changed compliant files, formatting checks, and git diff checks: passed
