### PR TITLE
Add optional accelerator installation extras

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   serial-without-mpi:
-    name: Serial install (without MPI)
+    name: Serial install (core only)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -42,16 +42,15 @@ jobs:
       - name: Install core gprMax without MPI
         run: |
           python -m pip install --upgrade pip
-          python -m pip uninstall --yes mpi4py
+          python -m pip uninstall --yes mpi4py pycuda pyopencl pyobjc-framework-Metal
           python -m pip install --editable . pytest
 
       - name: Verify optional dependency metadata
         run: |
-          python -c "from importlib.metadata import requires; r = requires('gprMax') or []; assert 'mpi4py' not in r; assert any(x.startswith('mpi4py;') and 'mpi' in x for x in r)"
-          python -c "import importlib.util; import gprMax; assert importlib.util.find_spec('mpi4py') is None"
+          python -c "import importlib.util; import gprMax; assert all(importlib.util.find_spec(x) is None for x in ('mpi4py', 'pycuda', 'pyopencl', 'Metal'))"
 
-      - name: Run MPI-free serial regression tests
-        run: python -u -m pytest -q tests/utilities/test_mpi_support.py
+      - name: Run core-install regression tests
+        run: python -u -m pytest -q tests/utilities/test_mpi_support.py tests/utilities/test_packaging_extras.py
 
   unit:
     name: Unit tests (${{ matrix.os }})

--- a/README.rst
+++ b/README.rst
@@ -276,6 +276,22 @@ recompiling gprMax by installing the system MPI runtime and then running
 fractals). A compatible system MPI runtime is still required; the Python extra
 does not install or configure that runtime.
 
+Accelerator bindings are also optional and can be installed independently:
+
+.. code-block:: console
+
+    (gprMax)$ pip install -e "gprMax[cuda]"       # NVIDIA CUDA; Linux/Windows
+    (gprMax)$ pip install -e "gprMax[opencl]"     # OpenCL
+    (gprMax)$ pip install -e "gprMax[metal]"      # Apple Metal; macOS
+
+Several extras can be requested together, for example
+``gprMax[cuda,opencl]``. The ``gprMax[accelerators]`` convenience extra
+requests every accelerator binding applicable to the current operating
+system. It is not the default because package installers cannot detect whether
+a compatible device, driver, CUDA toolkit, or OpenCL runtime is present, and
+building an unavailable binding can prevent installation. The backend-specific
+system software described in :ref:`accelerators` is still required.
+
 **You are now ready to proceed to running gprMax.**
 
 Running gprMax

--- a/conda_env.yml
+++ b/conda_env.yml
@@ -31,8 +31,8 @@ dependencies:
   # MPI is optional. After creating this environment, use
   # pip install -e ".[mpi]" or pip install -e ".[mpi-fractals]".
   - numpy-stl
-#  - pyobjc-framework-metal
-#  - pycuda
-#  - pyopencl
+  # Accelerator bindings are optional. After creating this environment, use
+  # pip install -e ".[cuda]", ".[opencl]", or ".[metal]" as appropriate.
+  # The ".[accelerators]" extra requests all backends for this platform.
   - terminaltables
   - tqdm

--- a/docs/source/accelerators.rst
+++ b/docs/source/accelerators.rst
@@ -17,6 +17,29 @@ Additionally, the Message Passing Interface (MPI) can be utilised to implement a
 
 Some of these accelerators and frameworks require additional software to be installed. The guidance below explains how to do that and gives examples of usage.
 
+The CPU/OpenMP solver is part of the core installation. The Python bindings
+for the other accelerators are optional package extras and can be installed
+independently from the top-level gprMax source directory:
+
+.. code-block:: console
+
+    (gprMax)$ python -m pip install -e ".[cuda]"       # Linux/Windows
+    (gprMax)$ python -m pip install -e ".[opencl]"
+    (gprMax)$ python -m pip install -e ".[metal]"      # macOS
+
+Extras can be combined, for example ``.[cuda,opencl]``. The
+``.[accelerators]`` convenience extra requests all accelerator bindings that
+apply to the current operating system. A core installation remains fully
+usable with the CPU solver when none of these extras is installed.
+
+.. warning::
+
+    Python package installers can select dependencies by operating system but
+    cannot determine whether a compatible accelerator, driver, CUDA toolkit,
+    or OpenCL runtime is installed. The ``accelerators`` convenience extra can
+    therefore fail on a machine without the necessary system software. The
+    individual backend extra is the recommended installation method.
+
 .. note::
 
     You can use the ``get_host_spec.py`` module (in ``toolboxes/Utilities``) to help you understand what hardware (CPU/GPU) you have and how gprMax can use it with the aforementioned accelerators.
@@ -186,8 +209,20 @@ Software required
 The following steps provide guidance on how to install the extra components to allow gprMax to run on your NVIDIA GPU:
 
 1. Install the `NVIDIA CUDA Toolkit <https://developer.nvidia.com/cuda-toolkit>`_. You can follow the Installation Guides in the `NVIDIA CUDA Toolkit Documentation <http://docs.nvidia.com/cuda/index.html#installation-guides>`_ You must ensure the version of CUDA you install is compatible with the compiler you are using. This information can usually be found in a table in the CUDA Installation Guide under System Requirements.
-2. You may need to add the location of the CUDA compiler (``nvcc``) to your user path environment variable, e.g. for Windows ``C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\vX.X\bin`` or Linux/macOS ``/Developer/NVIDIA/CUDA-X.X/bin``.
-3. Install the pycuda Python module. Open a Terminal (Linux/macOS) or Command Prompt (Windows), navigate into the top-level gprMax directory, and if it is not already active, activate the gprMax conda environment ``conda activate gprMax``. Run ``pip install pycuda``
+2. You may need to add the location of the CUDA compiler (``nvcc``) to your
+   user path environment variable, for example
+   ``C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\vX.X\bin`` on Windows
+   or the toolkit's ``bin`` directory on Linux.
+3. Install the CUDA extra. Open a Terminal (Linux) or Command Prompt
+   (Windows), navigate into the top-level gprMax directory, activate the
+   gprMax environment if necessary, and run:
+
+   .. code-block:: console
+
+       (gprMax)$ python -m pip install -e ".[cuda]"
+
+   This installs ``pycuda``. Modern macOS releases do not support NVIDIA CUDA,
+   so the dependency is guarded by a platform marker.
 
 Example
 -------
@@ -214,7 +249,16 @@ Software required
 
 The following steps provide guidance on how to install the extra components to allow gprMax to use OpenCL:
 
-1. Install the pyopencl Python module. Open a Terminal (Linux/macOS) or Command Prompt (Windows), navigate into the top-level gprMax directory, and if it is not already active, activate the gprMax conda environment ``conda activate gprMax``. Run ``pip install pyopencl``
+1. Install a vendor OpenCL implementation/ICD for the intended CPU or GPU.
+2. Open a Terminal (Linux/macOS) or Command Prompt (Windows), navigate into the
+   top-level gprMax directory, activate the gprMax environment if necessary,
+   and install the OpenCL extra:
+
+   .. code-block:: console
+
+       (gprMax)$ python -m pip install -e ".[opencl]"
+
+   This installs ``pyopencl``; it does not install the vendor OpenCL runtime.
 
 Example
 -------
@@ -243,8 +287,8 @@ System requirements
 
 The Apple Metal backend requires:
 
-1. **macOS 10.13 or later** - Metal is available on all modern Mac systems
-2. **Apple Silicon (M-series) based GPU** - For optimal performance
+1. **macOS 11 or later** - required by Apple Silicon Macs
+2. **Apple Silicon (M-series) based GPU**
 3. **pyobjc-framework-metal** - Python bindings for Apple Metal framework
 
 Software required
@@ -252,11 +296,20 @@ Software required
 
 The following Python package is required to use Apple Metal acceleration:
 
-1. Install the ``pyobjc-framework-metal`` Python module. Open a Terminal on macOS, navigate into the top-level gprMax directory, and if it is not already active, activate the gprMax conda environment ``conda activate gprMax``. Run ``pip install pyobjc-framework-metal``
+1. Open a Terminal on macOS, navigate into the top-level gprMax directory,
+   activate the gprMax environment if necessary, and install the Metal extra:
+
+   .. code-block:: console
+
+       (gprMax)$ python -m pip install -e ".[metal]"
+
+   This installs ``pyobjc-framework-Metal`` only on macOS.
 
 .. note::
 
-    The ``pyobjc-framework-metal`` package is included in the gprMax conda environment and requirements.txt file, so it should be automatically installed when setting up gprMax. The Metal backend will be automatically available on compatible macOS systems once this package is installed.
+    Metal is not installed by the core package or ``conda_env.yml``. This keeps
+    the same environment file portable across Linux, Windows, and macOS. It is
+    available on compatible Macs after installing the ``metal`` extra.
 
 Example
 -------
@@ -272,7 +325,8 @@ Run one of the test models with Metal acceleration:
 .. note::
 
     * The Metal backend automatically selects the best available GPU device on your Mac system
-    * Metal is currently available only on macOS systems; other platforms will fall back to CPU or alternative GPU backends
+    * Metal is available only on macOS; select the CPU, CUDA, or OpenCL backend
+      explicitly on other platforms
     * For debugging or development purposes, you can use the ``get_host_spec.py`` module (in ``toolboxes/Utilities``) to understand your hardware capabilities
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,22 +30,15 @@ wheel
 #
 # pip install -e ".[mpi-fractals]"
 
-# If running with CUDA backend, the following dependencies
-# are also required:
-
-# pycuda
-
-
-# If running with OpenCL backend, the following dependencies
-# are also required:
-
-# pyopencl
-
-
-# If running with Apple Metal backend, the following dependencies
-# are also required:
-
-# pyobjc-framework-metal
+# Accelerator bindings are optional. Install only the backend(s) required:
+#
+# pip install -e ".[cuda]"
+# pip install -e ".[opencl]"
+# pip install -e ".[metal]"       # macOS only
+#
+# Multiple extras may be combined, e.g. ".[cuda,opencl]". The
+# ".[accelerators]" convenience extra requests every backend applicable to
+# the current platform, but may require CUDA/OpenCL system software.
 
 
 # The following are required to run the ReFrame test suite (uncomment if

--- a/setup.py
+++ b/setup.py
@@ -295,6 +295,14 @@ else:
             "typing_extensions",
         ],
         extras_require={
+            "cuda": ["pycuda; sys_platform != 'darwin'"],
+            "opencl": ["pyopencl"],
+            "metal": ["pyobjc-framework-Metal; sys_platform == 'darwin'"],
+            "accelerators": [
+                "pycuda; sys_platform != 'darwin'",
+                "pyopencl",
+                "pyobjc-framework-Metal; sys_platform == 'darwin'",
+            ],
             "mpi": ["mpi4py"],
             "mpi-fractals": ["mpi4py", "mpi4py-fft"],
         },

--- a/tests/utilities/test_packaging_extras.py
+++ b/tests/utilities/test_packaging_extras.py
@@ -1,0 +1,61 @@
+"""Tests for optional dependency metadata in the installed package."""
+
+import re
+from importlib.metadata import metadata, requires
+
+import pytest
+
+OPTIONAL_REQUIREMENTS = {
+    "mpi": ("mpi4py",),
+    "mpi-fractals": ("mpi4py", "mpi4py-fft"),
+    "cuda": ("pycuda",),
+    "opencl": ("pyopencl",),
+    "metal": ("pyobjc-framework-metal",),
+    "accelerators": ("pycuda", "pyopencl", "pyobjc-framework-metal"),
+}
+
+
+def _normalised_requirements():
+    return [requirement.lower() for requirement in (requires("gprMax") or [])]
+
+
+def _has_extra(requirement, extra):
+    return re.search(rf"extra\s*==\s*['\"]{re.escape(extra)}['\"]", requirement)
+
+
+@pytest.mark.unit
+def test_optional_extras_are_declared():
+    declared = set(metadata("gprMax").get_all("Provides-Extra") or [])
+
+    assert set(OPTIONAL_REQUIREMENTS) <= declared
+
+
+@pytest.mark.unit
+def test_optional_packages_are_not_core_dependencies():
+    requirements = _normalised_requirements()
+    optional_packages = {package for packages in OPTIONAL_REQUIREMENTS.values() for package in packages}
+
+    for package in optional_packages:
+        matching = [item for item in requirements if item.startswith(f"{package};")]
+        assert matching
+        assert all("extra ==" in item for item in matching)
+
+
+@pytest.mark.unit
+def test_each_extra_selects_its_expected_packages():
+    requirements = _normalised_requirements()
+
+    for extra, packages in OPTIONAL_REQUIREMENTS.items():
+        for package in packages:
+            assert any(item.startswith(f"{package};") and _has_extra(item, extra) for item in requirements)
+
+
+@pytest.mark.unit
+def test_platform_markers_protect_cuda_and_metal():
+    requirements = _normalised_requirements()
+
+    cuda = [item for item in requirements if item.startswith("pycuda;")]
+    metal = [item for item in requirements if item.startswith("pyobjc-framework-metal;")]
+
+    assert cuda and all('sys_platform != "darwin"' in item for item in cuda)
+    assert metal and all('sys_platform == "darwin"' in item for item in metal)


### PR DESCRIPTION
## Summary

- add independent `cuda`, `opencl`, and `metal` package extras
- add an `accelerators` convenience extra for all bindings applicable to the current operating system
- keep CUDA out of modern macOS installs and Metal out of non-macOS installs through package markers
- preserve a reliable CPU/OpenMP core install with no accelerator bindings
- document backend-specific system requirements and installation commands
- extend the core-only CI job and add package-metadata regression tests

## Installation interface

```console
python -m pip install -e ".[cuda]"
python -m pip install -e ".[opencl]"
python -m pip install -e ".[metal]"
python -m pip install -e ".[accelerators]"
```

Extras can also be combined explicitly, for example `.[cuda,opencl]`. The individual backend extra is recommended because pip cannot detect accelerator hardware, drivers, the CUDA toolkit, or an OpenCL runtime.

## Platform behaviour

- Linux/Windows: `cuda` selects PyCUDA; `opencl` selects PyOpenCL
- macOS: `metal` selects `pyobjc-framework-Metal`; CUDA is excluded
- `accelerators`: PyCUDA + PyOpenCL on Linux/Windows, and PyOpenCL + Metal on macOS

This changes installation metadata and guidance only; solver implementations are unchanged.

## Validation

- `3703 passed, 5 skipped` in the complete unit-test selection
- `8 passed` in focused MPI/accelerator packaging tests
- clean core environment: `pip check` passed and a four-iteration CPU model completed without MPI or accelerator bindings
- pip dry-run resolution passed for `cuda`, `opencl`, `metal`, and `accelerators`
- Intel OpenCL end-to-end smoke model completed; receiver differences from CPU were at most `9.31e-10` for E and `1.36e-12` for H
- Sphinx HTML build passed with warnings treated as errors
- YAML parsing, Black/isort for the new test, and `git diff --check` passed
- broader non-unit CPU selection reached 52% with no failures before a deliberate 10-minute local cap; CI will run the complete time-bounded selection
