### PR TITLE
Package version-matched examples with wheel installations

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,4 +10,5 @@ recursive-include testing *
 recursive-include toolboxes *
 
 # Exclude what we don't want to include
+global-exclude *.pyc *.pyo
 global-exclude *.DS_Store

--- a/README.rst
+++ b/README.rst
@@ -301,6 +301,23 @@ gprMax is designed as a Python package, i.e. a namespace which can contain multi
 
 Open a Terminal (Linux/macOS) or Command Prompt (Windows), navigate into the top-level gprMax directory, and if it is not already active, activate the gprMax conda environment :code:`conda activate gprMax`.
 
+Examples from a wheel installation
+----------------------------------
+
+Binary wheel installations also contain the examples that match the installed
+gprMax version. Copy them from the read-only installation into a writable
+workspace with:
+
+.. code-block:: console
+
+    (gprMax)$ python -m gprMax.examples list
+    (gprMax)$ python -m gprMax.examples copy ~/gprMax-v4-examples
+    (gprMax)$ cd ~/gprMax-v4-examples
+
+The destination contains the normal ``examples/`` hierarchy, so the same
+commands work for wheel and source installations. An existing example tree is
+not overwritten unless ``--force`` is supplied.
+
 Basic usage of gprMax is:
 
 .. code-block:: console

--- a/docs/source/examples_simple_2D.rst
+++ b/docs/source/examples_simple_2D.rst
@@ -4,6 +4,18 @@ Introductory (2D) models
 
 This section provides some introductory example models in 2D that demonstrate the basic features of gprMax. Each example comes with an input file which you can download and run.
 
+If gprMax was installed from a binary wheel, all version-matched examples can
+be copied into a writable workspace before following this section:
+
+.. code-block:: console
+
+    python -m gprMax.examples list
+    python -m gprMax.examples copy ~/gprMax-v4-examples
+    cd ~/gprMax-v4-examples
+
+The copied workspace contains the same ``examples/`` paths used below. The
+source installation already provides this directory directly.
+
 .. _example-2D-Ascan:
 
 A-scan from a metal cylinder

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -2,6 +2,15 @@
 gprMax examples
 ==============
 
+This directory is part of both source checkouts and binary wheel
+installations. Wheel users can create a writable, version-matched copy with::
+
+    python -m gprMax.examples copy
+
+Run ``python -m gprMax.examples list`` to show the installed categories. The
+copy command creates a versioned workspace containing this ``examples/``
+directory, preserving the paths used throughout the documentation.
+
 The examples are organised by application so that related hash-command input
 files and Python API models can be found together.
 

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Version-matched example resources distributed with gprMax."""

--- a/gprMax/examples.py
+++ b/gprMax/examples.py
@@ -1,0 +1,159 @@
+"""List and copy the version-matched examples distributed with gprMax."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from contextlib import contextmanager
+from importlib import resources
+from pathlib import Path
+from typing import Iterator, Optional, Sequence
+
+from gprMax._version import __version__
+
+
+EXAMPLES_PACKAGE = "gprMax._examples"
+
+
+def _is_example_file(path: Path) -> bool:
+    """Return whether a path is a distributable example resource."""
+
+    return (
+        path.is_file()
+        and "__pycache__" not in path.parts
+        and path.suffix not in {".pyc", ".pyo"}
+        and path.name != "__init__.py"
+    )
+
+
+@contextmanager
+def _example_source() -> Iterator[Path]:
+    """Yield the installed example resource directory.
+
+    Editable source trees created before the resource package was installed
+    use the repository's top-level examples directory as a fallback.
+    """
+
+    try:
+        files = getattr(resources, "files", None)
+        if files is not None:
+            root = files(EXAMPLES_PACKAGE)
+            if isinstance(root, Path):
+                yield root
+                return
+
+            # Wheels are installed unpacked because gprMax is not zip safe.
+            # This fallback also supports other importers exposing Traversable
+            # resources without assuming that their directory is a real path.
+            with resources.as_file(root.joinpath("README.rst")) as readme:
+                yield readme.parent
+                return
+
+        with resources.path(EXAMPLES_PACKAGE, "README.rst") as readme:
+            yield readme.parent
+            return
+    except (ModuleNotFoundError, FileNotFoundError):
+        source_tree = Path(__file__).resolve().parents[1] / "examples"
+        if not source_tree.is_dir():
+            raise RuntimeError("The installed gprMax examples could not be located") from None
+        yield source_tree
+
+
+def default_destination() -> Path:
+    """Return the default writable workspace for copied examples."""
+
+    return Path.cwd() / f"gprMax-examples-{__version__}"
+
+
+def copy_examples(destination: Optional[Path] = None, *, force: bool = False) -> Path:
+    """Copy installed examples into ``destination/examples``.
+
+    Parameters
+    ----------
+    destination
+        Workspace directory. A versioned directory in the current working
+        directory is used when omitted.
+    force
+        Permit files in an existing ``examples`` directory to be overwritten.
+        Unrelated files are retained.
+    """
+
+    workspace = (Path(destination) if destination is not None else default_destination()).expanduser().resolve()
+    target = workspace / "examples"
+
+    if target.exists() and not force:
+        raise FileExistsError(
+            f"{target} already exists; choose another destination or pass --force to update it"
+        )
+
+    workspace.mkdir(parents=True, exist_ok=True)
+    with _example_source() as source:
+        shutil.copytree(
+            source,
+            target,
+            dirs_exist_ok=force,
+            ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "*.pyo"),
+        )
+
+    return workspace
+
+
+def list_examples() -> list[tuple[str, int]]:
+    """Return top-level example categories and their model/resource counts."""
+
+    with _example_source() as source:
+        return [
+            (directory.name, sum(1 for path in directory.rglob("*") if _is_example_file(path)))
+            for directory in sorted(source.iterdir())
+            if directory.is_dir() and directory.name != "__pycache__"
+        ]
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m gprMax.examples",
+        description="List or copy the examples matching this gprMax installation.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("list", help="list the installed example categories")
+
+    copy_parser = subparsers.add_parser("copy", help="copy examples to a writable workspace")
+    copy_parser.add_argument(
+        "destination",
+        nargs="?",
+        type=Path,
+        help=f"workspace to create (default: ./gprMax-examples-{__version__})",
+    )
+    copy_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="overwrite matching files if the destination already contains examples",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Command-line entry point."""
+
+    args = _build_parser().parse_args(argv)
+
+    if args.command == "list":
+        print(f"Examples distributed with gprMax {__version__}:")
+        for category, count in list_examples():
+            print(f"  {category:<20} {count:>3} files")
+        return 0
+
+    try:
+        workspace = copy_examples(args.destination, force=args.force)
+    except FileExistsError as error:
+        raise SystemExit(str(error)) from None
+
+    print(f"Copied gprMax {__version__} examples to {workspace / 'examples'}")
+    print(f"Run them from {workspace}, for example:")
+    print("  python -m gprMax examples/gpr/basic/cylinder_Ascan_2D.in")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,24 @@ from Cython.Build import cythonize
 from jinja2 import Environment, FileSystemLoader
 from setuptools import Extension, find_packages, setup
 
+
+EXAMPLES_PACKAGE = "gprMax._examples"
+EXAMPLES_SOURCE = Path("examples")
+
+
+def packaged_example_files():
+    """Return example resources, excluding local interpreter artefacts."""
+
+    return [
+        path.relative_to(EXAMPLES_SOURCE).as_posix()
+        for path in EXAMPLES_SOURCE.rglob("*")
+        if path.is_file()
+        and "__pycache__" not in path.parts
+        and path.suffix not in {".pyc", ".pyo"}
+        and path.name != "__init__.py"
+    ]
+
+
 # Check Python version
 MIN_PYTHON_VERSION = (3, 7)
 if sys.version_info[:2] < MIN_PYTHON_VERSION:
@@ -307,7 +325,9 @@ else:
             "mpi-fractals": ["mpi4py", "mpi4py-fft"],
         },
         ext_modules=extensions,
-        packages=find_packages(),
+        packages=find_packages(exclude=("examples", "examples.*")) + [EXAMPLES_PACKAGE],
+        package_dir={EXAMPLES_PACKAGE: str(EXAMPLES_SOURCE)},
+        package_data={EXAMPLES_PACKAGE: packaged_example_files()},
         include_package_data=True,
         include_dirs=[np.get_include()],
         zip_safe=False,

--- a/tests/utilities/test_examples_resources.py
+++ b/tests/utilities/test_examples_resources.py
@@ -1,0 +1,63 @@
+"""Tests for installed, version-matched example resources."""
+
+import pytest
+
+from gprMax import examples
+from gprMax._version import __version__
+
+
+@pytest.mark.unit
+def test_example_categories_are_available():
+    categories = dict(examples.list_examples())
+
+    assert {"gpr", "antennas", "features", "jupyter-notebooks", "rcs"} <= categories.keys()
+    assert all(count > 0 for count in categories.values())
+
+
+@pytest.mark.unit
+def test_copy_examples_uses_versioned_default_and_preserves_layout(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    workspace = examples.copy_examples()
+
+    assert workspace == tmp_path / f"gprMax-examples-{__version__}"
+    assert (workspace / "examples" / "README.rst").is_file()
+    assert (workspace / "examples" / "gpr" / "basic" / "cylinder_Ascan_2D.in").is_file()
+    assert not list((workspace / "examples").rglob("__pycache__"))
+    assert not list((workspace / "examples").rglob("*.pyc"))
+
+
+@pytest.mark.unit
+def test_copy_examples_refuses_existing_tree_without_force(tmp_path):
+    destination = tmp_path / "workspace"
+    examples.copy_examples(destination)
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        examples.copy_examples(destination)
+
+
+@pytest.mark.unit
+def test_copy_examples_force_updates_files_and_preserves_unrelated_files(tmp_path):
+    destination = tmp_path / "workspace"
+    examples.copy_examples(destination)
+    marker = destination / "examples" / "local-notes.txt"
+    marker.write_text("keep", encoding="utf-8")
+    readme = destination / "examples" / "README.rst"
+    readme.write_text("stale", encoding="utf-8")
+
+    examples.copy_examples(destination, force=True)
+
+    assert marker.read_text(encoding="utf-8") == "keep"
+    assert readme.read_text(encoding="utf-8").startswith("==============")
+
+
+@pytest.mark.unit
+def test_examples_cli_lists_and_copies(tmp_path, capsys):
+    assert examples.main(["list"]) == 0
+    assert "Examples distributed with gprMax" in capsys.readouterr().out
+
+    destination = tmp_path / "copied"
+    assert examples.main(["copy", str(destination)]) == 0
+    output = capsys.readouterr().out
+    assert str(destination / "examples") in output
+    assert "python -m gprMax examples/gpr/basic/cylinder_Ascan_2D.in" in output


### PR DESCRIPTION
## Summary

- bundle the existing example tree as private package resources in binary wheels
- add python -m gprMax.examples list and copy commands
- copy examples into a writable, versioned workspace while preserving documented examples/... paths
- refuse accidental overwrites unless --force is supplied
- exclude local Python bytecode caches from distributions
- document the workflow for wheel and source installations

## Validation

- 3,708 unit tests passed; 5 expected environment skips
- 9 focused example-resource and optional-package tests passed
- Sphinx HTML documentation built with warnings treated as errors
- built and installed a wheel into an isolated target outside the repository
- listed and copied resources from that isolated installation
- successfully built the copied 2-D cylinder example with --geometry-only
- fresh build staging contained 54 example resources and no Python caches

## Scope note

Wheel inspection also showed that the existing packaging includes the manual testing archive and several large validation artefacts. That pre-existing wheel-size issue is intentionally left for the subsequent binary-wheel packaging PR.