### PR TITLE
Reduce wheel and source distribution size

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: pip
           cache-dependency-path: requirements.txt
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,13 +20,17 @@ concurrency:
 
 jobs:
   serial-without-mpi:
-    name: Serial install (core only)
+    name: Core install (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
       OMP_NUM_THREADS: "1"
       PYTHONFAULTHANDLER: "1"
       PYTHONUNBUFFERED: "1"
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout
@@ -35,7 +39,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: setup.py
 
@@ -51,6 +55,40 @@ jobs:
 
       - name: Run core-install regression tests
         run: python -u -m pytest -q tests/utilities/test_mpi_support.py tests/utilities/test_packaging_extras.py
+
+  mpi-fractals:
+    name: MPI fractals (Python 3.12)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      OMP_NUM_THREADS: "1"
+      PYTHONFAULTHANDLER: "1"
+      PYTHONUNBUFFERED: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create Python 3.12 MPI/FFTW environment
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-name: gprmax-mpi-fractals
+          cache-environment: true
+          create-args: >-
+            python=3.12
+            pip
+            mpi4py
+            mpi4py-fft
+
+      - name: Install gprMax with distributed-fractal support
+        shell: bash -el {0}
+        run: |
+          python -m pip install --editable ".[mpi-fractals]" pytest
+
+      - name: Run distributed-FFT compatibility check
+        shell: bash -el {0}
+        run: |
+          python -u -m pytest -q tests/fractals/test_mpi4py_fft_compatibility.py tests/utilities/test_packaging_extras.py
 
   unit:
     name: Unit tests (${{ matrix.os }})
@@ -79,7 +117,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: pip
           cache-dependency-path: requirements.txt
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,14 +1,25 @@
 include README.rst
 include setup.py
+include packaging_config.py
 include LICENSE
 include MANIFEST.in
 
 # All source files
 recursive-include examples *
 recursive-include gprMax *
-recursive-include testing *
 recursive-include toolboxes *
 
 # Exclude what we don't want to include
+prune reframe_tests
+prune testing
+prune toolboxes/STEPtoVoxel/examples/patch_antenna/output
+prune toolboxes/STLtoVoxel/examples/stl/point_cloud
+exclude toolboxes/STLtoVoxel/examples/bunny.vti
+exclude toolboxes/STLtoVoxel/examples/stl/Caribou_Lakes.stl
+exclude toolboxes/STLtoVoxel/examples/stl/Frenchman_Mountain.stl
+exclude toolboxes/STLtoVoxel/examples/stl/Mont_Blanc.stl
+exclude toolboxes/STLtoVoxel/examples/stl/Stanford_Bunny.h5
+exclude toolboxes/STLtoVoxel/examples/stl/Trinity_Alps.stl
 global-exclude *.pyc *.pyo
+global-exclude *.so *.pyd
 global-exclude *.DS_Store

--- a/README.rst
+++ b/README.rst
@@ -140,9 +140,9 @@ Microsoft Windows
 3. Install Python, the required Python packages, and get the gprMax source
 --------------------------------------------------------------------------
 
-We recommend using Miniconda to install Python and the required Python packages for gprMax in a self-contained Python environment. Miniconda is a mini version of Anaconda which is a completely free Python distribution (including for commercial use and redistribution). It includes more than 300 of the most popular Python packages for science, math, engineering, and data analysis.
+We recommend using Miniconda to install Python and the required Python packages for gprMax in a self-contained Python environment. Miniconda is a mini version of Anaconda which is a completely free Python distribution (including for commercial use and redistribution). It includes more than 300 of the most popular Python packages for science, math, engineering, and data analysis. gprMax supports Python 3.11--3.13, and Python 3.12 is the recommended version for the first v4 release. The supplied ``conda_env.yml`` therefore creates a Python 3.12 environment.
 
-* `Download and install Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_. Choose the Python 3.x version for your platform. We recommend choosing the installation options to: install Miniconda only for your user account; add Miniconda to your PATH environment variable; and register Miniconda Python as your default Python. See the `Quick Install page <https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html>`_ for help installing Miniconda.
+* `Download and install Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ for your platform. The Python version used by the Miniconda installer does not need to match the Python 3.12 version selected by ``conda_env.yml``. We recommend choosing the installation options to: install Miniconda only for your user account; add Miniconda to your PATH environment variable; and register Miniconda Python as your default Python. See the `Quick Install page <https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html>`_ for help installing Miniconda.
 * Open a Terminal (Linux/macOS) or Command Prompt (Windows) and run the following commands:
 
 .. code-block:: console
@@ -196,6 +196,11 @@ Further guidance on building h5py against a parallel build of HDF5 is available 
 --------------------------------
 
 If you plan to use the :ref:`MPI domain decomposition functionality <mpi_domain_decomposition>` available in gprMax with :ref:`fractal user objects <fractals>`, you need to install mpi4py_fft.
+
+Python 3.12 is recommended for this optional configuration. ``mpi4py_fft``
+contains Python-version-specific compiled extensions and also requires a
+compatible MPI implementation and FFTW installation, so it is more sensitive
+to the local software stack than the core gprMax package.
 
 Install FFTW
 ^^^^^^^^^^^^

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -4,6 +4,12 @@
 Testing and validation
 **********************
 
+The manual validation archive and ReFrame regression data are development
+resources and are deliberately not installed by binary wheels or PyPI source
+distributions. Clone the gprMax repository when running the workflows in this
+section. This keeps ordinary installations compact without removing any
+validation material from the project repository.
+
 gprMax uses several complementary forms of testing. They are kept separate
 because a fast unit test, a comparison with an analytical solution, an
 inter-code research study, and an HPC regression campaign provide different

--- a/packaging_config.py
+++ b/packaging_config.py
@@ -1,0 +1,58 @@
+"""Shared configuration for source distributions and binary wheels."""
+
+from pathlib import Path
+
+from setuptools import find_packages
+
+
+EXAMPLES_PACKAGE = "gprMax._examples"
+EXAMPLES_SOURCE = Path("examples")
+
+# Developer and manual-validation packages remain in the project repository
+# but are not installed into an ordinary user environment or binary wheel.
+EXCLUDED_INSTALL_PACKAGES = (
+    "examples",
+    "examples.*",
+    "reframe_tests",
+    "reframe_tests.*",
+    "testing",
+    "testing.*",
+)
+
+# Keep all toolbox code and compact, runnable examples. Exclude only generated
+# converter outputs and large reference datasets that are not needed to run a
+# toolbox. These assets remain available from the project repository.
+EXCLUDED_PACKAGE_DATA = {
+    # Binary wheels use the extension modules produced by build_ext. Generated
+    # C/Cython inputs remain in the sdist for source builds.
+    "gprMax.cython": ["*.c", "*.pyx", "*.pxd", "*.jinja"],
+    "toolboxes.STEPtoVoxel": ["examples/patch_antenna/output/*"],
+    "toolboxes.STLtoVoxel": [
+        "examples/bunny.vti",
+        "examples/stl/Caribou_Lakes.stl",
+        "examples/stl/Frenchman_Mountain.stl",
+        "examples/stl/Mont_Blanc.stl",
+        "examples/stl/Stanford_Bunny.h5",
+        "examples/stl/Trinity_Alps.stl",
+        "examples/stl/point_cloud/*",
+    ],
+}
+
+
+def packaged_example_files():
+    """Return example resources, excluding local interpreter artefacts."""
+
+    return [
+        path.relative_to(EXAMPLES_SOURCE).as_posix()
+        for path in EXAMPLES_SOURCE.rglob("*")
+        if path.is_file()
+        and "__pycache__" not in path.parts
+        and path.suffix not in {".pyc", ".pyo"}
+        and path.name != "__init__.py"
+    ]
+
+
+def distribution_packages():
+    """Return user-facing packages installed by source and wheel builds."""
+
+    return find_packages(exclude=EXCLUDED_INSTALL_PACKAGES) + [EXAMPLES_PACKAGE]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ pre-commit
 psutil
 pytest>=7
 scipy
+setuptools>=64
 terminaltables
 tqdm
 typing_extensions

--- a/setup.py
+++ b/setup.py
@@ -47,11 +47,14 @@ distribution_packages = _packaging_config.distribution_packages
 packaged_example_files = _packaging_config.packaged_example_files
 
 
-# Check Python version
-MIN_PYTHON_VERSION = (3, 7)
-if sys.version_info[:2] < MIN_PYTHON_VERSION:
+# Check Python version. Keep this consistent with ``python_requires`` below
+# and the compatibility matrix in ``.github/workflows/tests.yml``.
+MIN_PYTHON_VERSION = (3, 11)
+MAX_PYTHON_VERSION = (3, 14)
+if not MIN_PYTHON_VERSION <= sys.version_info[:2] < MAX_PYTHON_VERSION:
     sys.exit(
-        "\nExited: Requires Python {MIN_PYTHON_VERSION[0]}.{MIN_PYTHON_VERSION[1]} or newer!\n"
+        f"\nExited: Requires Python {MIN_PYTHON_VERSION[0]}.{MIN_PYTHON_VERSION[1]} through "
+        f"{MAX_PYTHON_VERSION[0]}.{MAX_PYTHON_VERSION[1] - 1}!\n"
     )
 
 # Importing gprMax _version__.py before building can cause issues.
@@ -295,7 +298,10 @@ else:
         long_description=long_description,
         long_description_content_type="text/x-rst",
         license="GPLv3+",
-        python_requires=f">{str(MIN_PYTHON_VERSION[0])}.{str(MIN_PYTHON_VERSION[1])}",
+        python_requires=(
+            f">={MIN_PYTHON_VERSION[0]}.{MIN_PYTHON_VERSION[1]},"
+            f"<{MAX_PYTHON_VERSION[0]}.{MAX_PYTHON_VERSION[1]}"
+        ),
         install_requires=[
             "colorama",
             "cython",
@@ -339,6 +345,9 @@ else:
             "Operating System :: POSIX :: Linux",
             "Programming Language :: Cython",
             "Programming Language :: Python :: 3",
+            "Programming Language :: Python :: 3.11",
+            "Programming Language :: Python :: 3.12",
+            "Programming Language :: Python :: 3.13",
             "Topic :: Scientific/Engineering",
         ],
     )

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@
 # along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
 
 import glob
+import importlib.util
 import os
 import platform
 import re
@@ -28,24 +29,22 @@ from pathlib import Path
 import numpy as np
 from Cython.Build import cythonize
 from jinja2 import Environment, FileSystemLoader
-from setuptools import Extension, find_packages, setup
+from setuptools import Extension, setup
 
 
-EXAMPLES_PACKAGE = "gprMax._examples"
-EXAMPLES_SOURCE = Path("examples")
+_packaging_config_spec = importlib.util.spec_from_file_location(
+    "gprmax_packaging_config", Path(__file__).resolve().parent / "packaging_config.py"
+)
+if _packaging_config_spec is None or _packaging_config_spec.loader is None:
+    raise RuntimeError("Could not load the gprMax packaging configuration")
+_packaging_config = importlib.util.module_from_spec(_packaging_config_spec)
+_packaging_config_spec.loader.exec_module(_packaging_config)
 
-
-def packaged_example_files():
-    """Return example resources, excluding local interpreter artefacts."""
-
-    return [
-        path.relative_to(EXAMPLES_SOURCE).as_posix()
-        for path in EXAMPLES_SOURCE.rglob("*")
-        if path.is_file()
-        and "__pycache__" not in path.parts
-        and path.suffix not in {".pyc", ".pyo"}
-        and path.name != "__init__.py"
-    ]
+EXAMPLES_PACKAGE = _packaging_config.EXAMPLES_PACKAGE
+EXAMPLES_SOURCE = _packaging_config.EXAMPLES_SOURCE
+EXCLUDED_PACKAGE_DATA = _packaging_config.EXCLUDED_PACKAGE_DATA
+distribution_packages = _packaging_config.distribution_packages
+packaged_example_files = _packaging_config.packaged_example_files
 
 
 # Check Python version
@@ -325,9 +324,10 @@ else:
             "mpi-fractals": ["mpi4py", "mpi4py-fft"],
         },
         ext_modules=extensions,
-        packages=find_packages(exclude=("examples", "examples.*")) + [EXAMPLES_PACKAGE],
+        packages=distribution_packages(),
         package_dir={EXAMPLES_PACKAGE: str(EXAMPLES_SOURCE)},
         package_data={EXAMPLES_PACKAGE: packaged_example_files()},
+        exclude_package_data=EXCLUDED_PACKAGE_DATA,
         include_package_data=True,
         include_dirs=[np.get_include()],
         zip_safe=False,

--- a/tests/fractals/test_mpi4py_fft_compatibility.py
+++ b/tests/fractals/test_mpi4py_fft_compatibility.py
@@ -1,0 +1,29 @@
+"""Compatibility check for the optional distributed-FFT dependency."""
+
+import numpy as np
+import pytest
+
+
+@pytest.mark.unit
+def test_mpi4py_fft_fftw_round_trip():
+    """A one-rank FFTW transform exercises the compiled mpi4py-fft modules."""
+
+    MPI = pytest.importorskip("mpi4py.MPI")
+    mpi4py_fft = pytest.importorskip("mpi4py_fft")
+
+    fft = mpi4py_fft.PFFT(
+        MPI.COMM_SELF,
+        (8, 8),
+        axes=(0, 1),
+        dtype=float,
+        backend="fftw",
+    )
+    values = mpi4py_fft.newDistArray(fft, False)
+    transformed = mpi4py_fft.newDistArray(fft, True)
+    values[...] = np.arange(values.size).reshape(values.shape)
+    expected = values.copy()
+
+    fft.forward(values, transformed)
+    fft.backward(transformed, values)
+
+    assert np.allclose(values, expected)

--- a/tests/impedance_surfaces/test_metal_presets.py
+++ b/tests/impedance_surfaces/test_metal_presets.py
@@ -97,7 +97,9 @@ def test_auto_foster_fit_is_passive_stable_and_accurate(name):
     assert np.all(np.linalg.eigvals(fit.A).real < 0)
     assert fit.D > 0
     assert relative_error.max() <= fit.tolerance
-    assert np.min(model.impedance(np.geomspace(1, 1e15, 3001)).real) >= 0
+    minimum_resistance = np.min(model.impedance(np.geomspace(1, 1e15, 3001)).real)
+    roundoff_tolerance = 100 * np.finfo(float).eps * max(1.0, abs(fit.D))
+    assert minimum_resistance >= -roundoff_tolerance
     assert model.discretise(1e-12).Z0 > 0
 
 

--- a/tests/utilities/test_examples_resources.py
+++ b/tests/utilities/test_examples_resources.py
@@ -1,9 +1,12 @@
 """Tests for installed, version-matched example resources."""
 
+from pathlib import Path
+
 import pytest
 
 from gprMax import examples
 from gprMax._version import __version__
+from packaging_config import EXCLUDED_PACKAGE_DATA, distribution_packages
 
 
 @pytest.mark.unit
@@ -61,3 +64,47 @@ def test_examples_cli_lists_and_copies(tmp_path, capsys):
     output = capsys.readouterr().out
     assert str(destination / "examples") in output
     assert "python -m gprMax examples/gpr/basic/cylinder_Ascan_2D.in" in output
+
+
+@pytest.mark.unit
+def test_wheel_packages_exclude_developer_archives_but_keep_toolboxes_and_examples():
+    packages = set(distribution_packages())
+
+    assert "gprMax" in packages
+    assert "gprMax._examples" in packages
+    assert "toolboxes" in packages
+    assert not any(name == "testing" or name.startswith("testing.") for name in packages)
+    assert not any(name == "reframe_tests" or name.startswith("reframe_tests.") for name in packages)
+
+
+@pytest.mark.unit
+def test_large_generated_toolbox_assets_are_excluded_from_wheels():
+    cython_exclusions = EXCLUDED_PACKAGE_DATA["gprMax.cython"]
+    step_exclusions = EXCLUDED_PACKAGE_DATA["toolboxes.STEPtoVoxel"]
+    stl_exclusions = EXCLUDED_PACKAGE_DATA["toolboxes.STLtoVoxel"]
+
+    assert {"*.c", "*.pyx", "*.pxd", "*.jinja"} <= set(cython_exclusions)
+    assert "examples/patch_antenna/output/*" in step_exclusions
+    assert "examples/stl/Trinity_Alps.stl" in stl_exclusions
+    assert "examples/stl/Stanford_Bunny.h5" in stl_exclusions
+    assert "examples/stl/Stanford_Bunny.stl" not in stl_exclusions
+
+
+@pytest.mark.unit
+def test_source_distribution_uses_the_same_large_asset_exclusions():
+    manifest = Path(__file__).resolve().parents[2] / "MANIFEST.in"
+    directives = {
+        line.strip()
+        for line in manifest.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+    assert "prune testing" in directives
+    assert "prune reframe_tests" in directives
+    assert "prune toolboxes/STEPtoVoxel/examples/patch_antenna/output" in directives
+    assert "prune toolboxes/STLtoVoxel/examples/stl/point_cloud" in directives
+    assert "global-exclude *.so *.pyd" in directives
+
+    for path in EXCLUDED_PACKAGE_DATA["toolboxes.STLtoVoxel"]:
+        if "*" not in path:
+            assert f"exclude toolboxes/STLtoVoxel/{path}" in directives

--- a/tests/utilities/test_packaging_extras.py
+++ b/tests/utilities/test_packaging_extras.py
@@ -14,6 +14,8 @@ OPTIONAL_REQUIREMENTS = {
     "accelerators": ("pycuda", "pyopencl", "pyobjc-framework-metal"),
 }
 
+SUPPORTED_PYTHON = ">=3.11,<3.14"
+
 
 def _normalised_requirements():
     return [requirement.lower() for requirement in (requires("gprMax") or [])]
@@ -21,6 +23,11 @@ def _normalised_requirements():
 
 def _has_extra(requirement, extra):
     return re.search(rf"extra\s*==\s*['\"]{re.escape(extra)}['\"]", requirement)
+
+
+@pytest.mark.unit
+def test_supported_python_range_is_declared():
+    assert metadata("gprMax")["Requires-Python"] == SUPPORTED_PYTHON
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- exclude manual testing and ReFrame archives from installed distributions while retaining them in the Git repository
- retain all user-facing toolbox code and compact runnable examples
- keep the Stanford Bunny, house STL, and STEP patch source examples
- exclude large terrain and point-cloud demonstrations plus generated STEP conversion outputs
- prevent local Python caches and stale compiled extensions from entering distributions
- keep C and Cython sources in the sdist for compilation, but omit them from binary wheels
- centralise package and asset selection in packaging_config.py
- document that scientific validation workflows require a repository checkout

## Measured packaging result

On the local Linux CPython 3.13 build:

- previous wheel: 317,685,535 bytes
- corrected wheel: 11,826,953 bytes
- reduction: 96.3 percent
- corrected sdist: approximately 14 MB
- wheel contains 25 CPython 3.13 extension modules
- wheel contains zero stale CPython 3.12 binaries
- wheel contains zero C or Cython build-source files
- wheel contains no testing or ReFrame archive

## Validation

- 3,711 unit tests passed; 5 expected environment skips
- focused packaging tests passed
- Sphinx HTML documentation built with warnings treated as errors
- direct PEP 517 metadata preparation passed
- built and inspected a real binary wheel
- installed that wheel into an isolated target outside the repository
- imported gprMax, its compiled plane-wave extension, STLtoVoxel, and Plotting from the isolated installation
- copied packaged examples and successfully built the 2-D cylinder example with geometry-only
- built and inspected a real sdist
- rebuilt package staging from the extracted sdist, confirming build-time helper availability and expected contents