### PR TITLE
Build portable binary wheels for supported platforms

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,6 +134,10 @@ jobs:
           python -m pip install openmpi==5.0.10
           mpiexec --version
 
+      - name: Install OpenMP runtime on macOS
+        if: runner.os == 'macOS'
+        run: brew install libomp
+
       - name: Install gprMax and test dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,96 @@
+name: Binary distributions
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - devel
+      - master
+    paths:
+      - ".github/workflows/wheels.yml"
+      - "build_config.py"
+      - "MANIFEST.in"
+      - "packaging_config.py"
+      - "pyproject.toml"
+      - "setup.py"
+      - "gprMax/**"
+      - "examples/**"
+      - "toolboxes/**"
+      - "tests/wheel_smoke.py"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wheels-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  wheels:
+    name: Wheels (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            runner: ubuntu-latest
+            arch: x86_64
+          - name: windows-amd64
+            runner: windows-latest
+            arch: AMD64
+          - name: macos-x86_64
+            runner: macos-15-intel
+            arch: x86_64
+          - name: macos-arm64
+            runner: macos-latest
+            arch: arm64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Build and test wheels
+        uses: pypa/cibuildwheel@v4.2.0
+        env:
+          CIBW_ARCHS: ${{ matrix.arch }}
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v7
+        with:
+          name: gprmax-wheels-${{ matrix.name }}
+          path: wheelhouse/*.whl
+          if-no-files-found: error
+
+  sdist:
+    name: Source distribution
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Build source distribution
+        run: pipx run build --sdist
+
+      - name: Check source distribution metadata
+        run: pipx run twine check dist/*.tar.gz
+
+      - name: Install and test source distribution
+        run: |
+          python -m venv /tmp/gprmax-sdist-test
+          /tmp/gprmax-sdist-test/bin/python -m pip install dist/*.tar.gz
+          MPLBACKEND=Agg OMP_NUM_THREADS=1 /tmp/gprmax-sdist-test/bin/python tests/wheel_smoke.py
+
+      - name: Upload source distribution
+        uses: actions/upload-artifact@v7
+        with:
+          name: gprmax-sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -10,6 +10,7 @@ on:
       - ".github/workflows/wheels.yml"
       - "build_config.py"
       - "MANIFEST.in"
+      - "packaging/**"
       - "packaging_config.py"
       - "pyproject.toml"
       - "setup.py"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include README.rst
 include setup.py
 include build_config.py
 include packaging_config.py
+include packaging/build_macos_libomp.sh
 include LICENSE
 include MANIFEST.in
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.rst
 include setup.py
+include build_config.py
 include packaging_config.py
 include LICENSE
 include MANIFEST.in

--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,40 @@ Package overview
 Installation
 ============
 
-The following steps provide guidance on how to install gprMax:
+Binary wheel installation (recommended)
+---------------------------------------
+
+For a released gprMax v4 package, the simplest installation is:
+
+.. code-block:: console
+
+    $ python -m pip install gprMax
+
+The binary wheels contain the compiled CPU extensions and do not require a C
+compiler, OpenMP development headers, Git, or a Conda environment on the
+user's machine. Python 3.11--3.13 is supported, with Python 3.12 recommended.
+Release wheels are built for 64-bit Linux and Windows, and for both Intel and
+Apple Silicon macOS. A virtual environment, including one created by Conda or
+``venv``, is still recommended to isolate dependencies.
+
+Optional features use the same extras as source installations, for example:
+
+.. code-block:: console
+
+    $ python -m pip install "gprMax[mpi]"
+    $ python -m pip install "gprMax[cuda]"
+    $ python -m pip install "gprMax[metal]"
+
+These extras install Python bindings only. MPI, CUDA, OpenCL, and Metal still
+require compatible system runtimes and hardware as described below and in
+the `accelerator documentation
+<https://docs.gprmax.com/en/latest/accelerators.html>`_.
+
+Installing from source
+----------------------
+
+Build from source when developing gprMax, modifying its Cython extensions, or
+using a platform for which no wheel is published. The source-build steps are:
 
 1. Install a C compiler which supports OpenMP
 2. [Optional] Install MPI
@@ -101,11 +134,17 @@ Linux
 macOS
 ^^^^^
 
-* Xcode (the IDE for macOS) comes with the LLVM (clang) compiler, but it does not currently support OpenMP, so you must install `gcc <https://gcc.gnu.org>`_. That said, it is still useful to have Xcode (with command line tools) installed. It can be downloaded from the App Store. Once Xcode is installed, download and install the `Homebrew package manager <http://brew.sh>`_ and then to install gcc, run:
+* Install the Xcode command-line tools, which provide Apple Clang, and install
+  the OpenMP runtime using `Homebrew <https://brew.sh>`_:
 
 .. code-block:: console
 
-    $ brew install gcc
+    $ xcode-select --install
+    $ brew install libomp
+
+  gprMax detects ``libomp`` from Homebrew, the active Python environment, or
+  ``GPRMAX_LIBOMP_PREFIX``. The previous Homebrew GCC requirement is no longer
+  necessary.
 
 Microsoft Windows
 ^^^^^^^^^^^^^^^^^
@@ -167,7 +206,9 @@ If you are using Arch Linux (https://www.archlinux.org/) you may need to also in
 4. [Optional] Build h5py against Parallel HDF5
 ----------------------------------------------
 
-If you plan to use the :ref:`MPI domain decomposition functionality <mpi_domain_decomposition>` available in gprMax, h5py must be built with MPI support.
+If you plan to use the `MPI domain decomposition functionality
+<https://docs.gprmax.com/en/latest/accelerators.html#mpi-domain-decomposition>`_
+available in gprMax, h5py must be built with MPI support.
 
 Install with conda
 ^^^^^^^^^^^^^^^^^^
@@ -195,7 +236,9 @@ Further guidance on building h5py against a parallel build of HDF5 is available 
 5. [Optional] Install mpi4py_fft
 --------------------------------
 
-If you plan to use the :ref:`MPI domain decomposition functionality <mpi_domain_decomposition>` available in gprMax with :ref:`fractal user objects <fractals>`, you need to install mpi4py_fft.
+If you plan to use the `MPI domain decomposition functionality
+<https://docs.gprmax.com/en/latest/accelerators.html#mpi-domain-decomposition>`_
+with fractal user objects, you need to install mpi4py_fft.
 
 Python 3.12 is recommended for this optional configuration. ``mpi4py_fft``
 contains Python-version-specific compiled extensions and also requires a
@@ -262,6 +305,20 @@ Once you have installed the aforementioned tools follow these steps to build and
 
     (gprMax)$ pip install -e gprMax
 
+Release and ordinary source builds use portable instruction sets. Developers
+making a private build for the current host can opt into machine-specific
+optimisation on Linux or macOS:
+
+.. code-block:: console
+
+    (gprMax)$ GPRMAX_BUILD_NATIVE=1 pip install -e gprMax
+
+Do not redistribute a native build: it may contain instructions unavailable
+on another processor. Published binary wheels never enable this option. Two
+extension modules are compiled concurrently by default; constrained systems
+can set ``GPRMAX_BUILD_JOBS=1``, while release builders may select a larger
+positive value.
+
 For MPI domain decomposition or task farming, install the MPI extra instead:
 
 .. code-block:: console
@@ -295,7 +352,8 @@ requests every accelerator binding applicable to the current operating
 system. It is not the default because package installers cannot detect whether
 a compatible device, driver, CUDA toolkit, or OpenCL runtime is present, and
 building an unavailable binding can prevent installation. The backend-specific
-system software described in :ref:`accelerators` is still required.
+system software described in the `accelerator documentation
+<https://docs.gprmax.com/en/latest/accelerators.html>`_ is still required.
 
 **You are now ready to proceed to running gprMax.**
 

--- a/build_config.py
+++ b/build_config.py
@@ -1,0 +1,156 @@
+"""Portable compiler configuration shared by source and wheel builds."""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Optional
+
+
+@dataclass(frozen=True)
+class CompilerConfiguration:
+    """Arguments required to compile and link the Cython extensions."""
+
+    compile_args: tuple[str, ...]
+    linker_args: tuple[str, ...]
+    libraries: tuple[str, ...] = ()
+    include_dirs: tuple[str, ...] = ()
+    library_dirs: tuple[str, ...] = ()
+
+
+def _enabled(value: Optional[str]) -> bool:
+    return value is not None and value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def build_jobs(*, environ: Mapping[str, str] = os.environ) -> int:
+    """Return a conservative number of parallel extension-build jobs."""
+
+    configured = environ.get("GPRMAX_BUILD_JOBS")
+    if configured is None:
+        return min(2, os.cpu_count() or 1)
+    try:
+        jobs = int(configured)
+    except ValueError as exc:
+        raise ValueError("GPRMAX_BUILD_JOBS must be a positive integer") from exc
+    if jobs < 1:
+        raise ValueError("GPRMAX_BUILD_JOBS must be a positive integer")
+    return jobs
+
+
+def _native_flag(platform_name: str, machine: str) -> Optional[str]:
+    """Return an explicit opt-in host-CPU optimisation flag."""
+
+    if platform_name == "linux":
+        return "-march=native"
+    if platform_name == "darwin":
+        return "-mcpu=native" if machine.lower() in {"arm64", "aarch64"} else "-march=native"
+    return None
+
+
+def _valid_libomp_prefix(prefix: Path) -> bool:
+    return (prefix / "include" / "omp.h").is_file() and (prefix / "lib" / "libomp.dylib").is_file()
+
+
+def find_libomp_prefix(
+    *,
+    environ: Mapping[str, str] = os.environ,
+    python_prefix: Path = Path(sys.prefix),
+) -> Optional[Path]:
+    """Locate a macOS ``libomp`` installation without assuming one package manager."""
+
+    candidates: list[Path] = []
+    configured = environ.get("GPRMAX_LIBOMP_PREFIX")
+    if configured:
+        candidates.append(Path(configured).expanduser())
+
+    candidates.append(python_prefix)
+
+    # Prefer an explicit setting or the active Python environment. In
+    # particular, do not require Homebrew to be runnable when either of these
+    # already provides a complete libomp installation.
+    for candidate in candidates:
+        candidate = candidate.resolve()
+        if _valid_libomp_prefix(candidate):
+            return candidate
+
+    candidates = []
+    brew = shutil.which("brew")
+    if brew is not None:
+        result = subprocess.run(
+            [brew, "--prefix", "libomp"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            candidates.append(Path(result.stdout.strip()))
+
+    candidates.extend((Path("/opt/homebrew/opt/libomp"), Path("/usr/local/opt/libomp")))
+
+    for candidate in candidates:
+        candidate = candidate.resolve()
+        if _valid_libomp_prefix(candidate):
+            return candidate
+    return None
+
+
+def compiler_configuration(
+    *,
+    platform_name: str = sys.platform,
+    machine: str = platform.machine(),
+    environ: Mapping[str, str] = os.environ,
+    libomp_prefix: Optional[Path] = None,
+) -> CompilerConfiguration:
+    """Return portable OpenMP build flags for the requested platform.
+
+    Host-specific instruction selection is deliberately disabled by default so
+    binary wheels run on machines other than the build host. Developers making
+    private source builds may opt in with ``GPRMAX_BUILD_NATIVE=1``.
+    """
+
+    native = _enabled(environ.get("GPRMAX_BUILD_NATIVE"))
+
+    if platform_name == "win32":
+        if native:
+            raise ValueError("GPRMAX_BUILD_NATIVE is not supported by the MSVC build")
+        return CompilerConfiguration(compile_args=("/O2", "/openmp", "/w"), linker_args=())
+
+    if platform_name == "linux":
+        compile_args = ["-O3", "-w", "-fopenmp"]
+        if native:
+            compile_args.append("-march=native")
+        return CompilerConfiguration(
+            compile_args=tuple(compile_args),
+            linker_args=("-fopenmp",),
+        )
+
+    if platform_name == "darwin":
+        prefix = libomp_prefix or find_libomp_prefix(environ=environ)
+        if prefix is None or not _valid_libomp_prefix(Path(prefix)):
+            raise RuntimeError(
+                "Cannot find libomp on macOS. Install it with 'brew install libomp' or set "
+                "GPRMAX_LIBOMP_PREFIX to a prefix containing include/omp.h and lib/libomp.dylib."
+            )
+
+        prefix = Path(prefix).resolve()
+        compile_args = ["-O3", "-w", "-Xpreprocessor", "-fopenmp"]
+        if native:
+            native_flag = _native_flag(platform_name, machine)
+            if native_flag is not None:
+                compile_args.append(native_flag)
+
+        lib_dir = prefix / "lib"
+        return CompilerConfiguration(
+            compile_args=tuple(compile_args),
+            linker_args=(f"-Wl,-rpath,{lib_dir}",),
+            libraries=("omp",),
+            include_dirs=(str(prefix / "include"),),
+            library_dirs=(str(lib_dir),),
+        )
+
+    raise RuntimeError(f"Unsupported platform for compiling gprMax extensions: {platform_name}")

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -130,6 +130,34 @@ checking is enabled, so misspelled or unregistered markers fail collection.
 New tests should also pass the repository's Black, isort, and pre-commit
 checks.
 
+Binary distribution tests
+=========================
+
+The ``Binary distributions`` GitHub Actions workflow builds CPython
+3.11--3.13 wheels for Linux x86-64, Windows AMD64, macOS x86-64, and macOS
+ARM64. It also builds the source distribution. This is deliberately different
+from testing an editable source checkout: each repaired wheel is installed in
+an isolated environment before any test runs.
+
+``tests/wheel_smoke.py`` then:
+
+* imports every Cython extension, detecting missing OpenMP or other shared
+  libraries;
+* verifies that build-only C/Cython sources were not installed;
+* lists and copies the version-matched packaged examples; and
+* runs a compact CPU model using the installed wheel.
+
+The workflow uses ``auditwheel``, ``delvewheel``, and ``delocate`` through
+``cibuildwheel`` to repair platform wheels and bundle permitted shared-library
+dependencies. ``twine check`` validates every wheel and source archive. Pull
+requests changing packaging, compiled code, toolboxes, or packaged examples
+trigger the workflow; it may also be run manually. The resulting archives are
+retained as workflow artifacts but are not automatically published to PyPI.
+
+Portable release builds do not use ``-march=native``. Developers may request
+a private host-optimised Linux or macOS source build with
+``GPRMAX_BUILD_NATIVE=1``; such a build is not suitable for redistribution.
+
 Analytical validation
 =====================
 

--- a/packaging/build_macos_libomp.sh
+++ b/packaging/build_macos_libomp.sh
@@ -5,17 +5,25 @@ set -euo pipefail
 # raise the minimum version required by a repaired wheel. Build the standalone
 # LLVM OpenMP runtime under cibuildwheel's deployment target instead.
 readonly LLVM_VERSION="21.1.8"
-readonly ARCHIVE="openmp-${LLVM_VERSION}.src.tar.xz"
-readonly SHA256="856b023748b41ac7b2c83fd8e9f765ff48a4df2fe6777d2811ef7c7ed8f2f977"
-readonly URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/${ARCHIVE}"
+readonly RELEASE_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}"
+readonly OPENMP_ARCHIVE="openmp-${LLVM_VERSION}.src.tar.xz"
+readonly OPENMP_SHA256="856b023748b41ac7b2c83fd8e9f765ff48a4df2fe6777d2811ef7c7ed8f2f977"
+readonly CMAKE_ARCHIVE="cmake-${LLVM_VERSION}.src.tar.xz"
+readonly CMAKE_SHA256="85735f20fd8c81ecb0a09abb0c267018475420e93b65050cc5b7634eab744de9"
 readonly PREFIX="${GPRMAX_LIBOMP_PREFIX:-/tmp/gprmax-libomp}"
 
 workdir="$(mktemp -d "${TMPDIR:-/tmp}/gprmax-libomp.XXXXXX")"
 trap 'rm -rf "${workdir}"' EXIT
 
-curl --fail --location --retry 5 --output "${workdir}/${ARCHIVE}" "${URL}"
-printf '%s  %s\n' "${SHA256}" "${workdir}/${ARCHIVE}" | shasum -a 256 --check
-tar -xf "${workdir}/${ARCHIVE}" -C "${workdir}"
+curl --fail --location --retry 5 --output "${workdir}/${OPENMP_ARCHIVE}" \
+    "${RELEASE_URL}/${OPENMP_ARCHIVE}"
+curl --fail --location --retry 5 --output "${workdir}/${CMAKE_ARCHIVE}" \
+    "${RELEASE_URL}/${CMAKE_ARCHIVE}"
+printf '%s  %s\n' "${OPENMP_SHA256}" "${workdir}/${OPENMP_ARCHIVE}" | shasum -a 256 --check
+printf '%s  %s\n' "${CMAKE_SHA256}" "${workdir}/${CMAKE_ARCHIVE}" | shasum -a 256 --check
+tar -xf "${workdir}/${OPENMP_ARCHIVE}" -C "${workdir}"
+tar -xf "${workdir}/${CMAKE_ARCHIVE}" -C "${workdir}"
+mv "${workdir}/cmake-${LLVM_VERSION}.src" "${workdir}/cmake"
 
 # The repaired wheel redistributes libomp, so ship the complete upstream
 # licence alongside the bundled library.

--- a/packaging/build_macos_libomp.sh
+++ b/packaging/build_macos_libomp.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Homebrew bottles are built for the host macOS release and can therefore
+# raise the minimum version required by a repaired wheel. Build the standalone
+# LLVM OpenMP runtime under cibuildwheel's deployment target instead.
+readonly LLVM_VERSION="21.1.8"
+readonly ARCHIVE="openmp-${LLVM_VERSION}.src.tar.xz"
+readonly SHA256="856b023748b41ac7b2c83fd8e9f765ff48a4df2fe6777d2811ef7c7ed8f2f977"
+readonly URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/${ARCHIVE}"
+readonly PREFIX="${GPRMAX_LIBOMP_PREFIX:-/tmp/gprmax-libomp}"
+
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/gprmax-libomp.XXXXXX")"
+trap 'rm -rf "${workdir}"' EXIT
+
+curl --fail --location --retry 5 --output "${workdir}/${ARCHIVE}" "${URL}"
+printf '%s  %s\n' "${SHA256}" "${workdir}/${ARCHIVE}" | shasum -a 256 --check
+tar -xf "${workdir}/${ARCHIVE}" -C "${workdir}"
+
+# The repaired wheel redistributes libomp, so ship the complete upstream
+# licence alongside the bundled library.
+mkdir -p gprMax/licenses
+cp "${workdir}/openmp-${LLVM_VERSION}.src/LICENSE.TXT" \
+    gprMax/licenses/LLVM-OpenMP-LICENSE.txt
+
+cmake \
+    -S "${workdir}/openmp-${LLVM_VERSION}.src" \
+    -B "${workdir}/build" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -DCMAKE_OSX_ARCHITECTURES="$(uname -m)" \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:?}" \
+    -DLIBOMP_ENABLE_SHARED=ON \
+    -DLIBOMP_ENABLE_STATIC=OFF \
+    -DLIBOMP_FORTRAN_MODULES=OFF \
+    -DLIBOMP_OMPT_SUPPORT=OFF
+cmake --build "${workdir}/build" --parallel 2
+cmake --install "${workdir}/build"
+
+test -f "${PREFIX}/include/omp.h"
+test -f "${PREFIX}/lib/libomp.dylib"

--- a/packaging_config.py
+++ b/packaging_config.py
@@ -25,6 +25,7 @@ EXCLUDED_INSTALL_PACKAGES = (
 EXCLUDED_PACKAGE_DATA = {
     # Binary wheels use the extension modules produced by build_ext. Generated
     # C/Cython inputs remain in the sdist for source builds.
+    "gprMax": ["config.pxd", "*.pxd"],
     "gprMax.cython": ["*.c", "*.pyx", "*.pxd", "*.jinja"],
     "toolboxes.STEPtoVoxel": ["examples/patch_antenna/output/*"],
     "toolboxes.STLtoVoxel": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,16 @@ markers = [
     "gpu: requires execution on a real GPU device",
     "slow: normally takes more than 10 seconds on a development machine",
 ]
+
+[tool.cibuildwheel]
+build = ["cp311-*", "cp312-*", "cp313-*"]
+skip = ["*-musllinux_*", "*-win32"]
+build-verbosity = 1
+test-command = "python {project}/tests/wheel_smoke.py"
+test-environment = { MPLBACKEND = "Agg", OMP_NUM_THREADS = "1", PYTHONFAULTHANDLER = "1" }
+audit-requires = ["twine"]
+audit-command = "twine check {wheel}"
+
+[tool.cibuildwheel.macos]
+before-all = "brew install libomp"
+environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,5 +29,5 @@ audit-requires = ["twine"]
 audit-command = "twine check {wheel}"
 
 [tool.cibuildwheel.macos]
-before-all = "brew install libomp"
-environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
+before-all = "bash packaging/build_macos_libomp.sh"
+environment = { MACOSX_DEPLOYMENT_TARGET = "11.0", GPRMAX_LIBOMP_PREFIX = "/tmp/gprmax-libomp" }

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,8 @@
 import glob
 import importlib.util
 import os
-import platform
 import re
 import shutil
-import subprocess
 import sys
 from pathlib import Path
 
@@ -31,6 +29,16 @@ from Cython.Build import cythonize
 from jinja2 import Environment, FileSystemLoader
 from setuptools import Extension, setup
 
+_build_config_spec = importlib.util.spec_from_file_location(
+    "gprmax_build_config", Path(__file__).resolve().parent / "build_config.py"
+)
+if _build_config_spec is None or _build_config_spec.loader is None:
+    raise RuntimeError("Could not load the gprMax compiler configuration")
+_build_config = importlib.util.module_from_spec(_build_config_spec)
+sys.modules[_build_config_spec.name] = _build_config
+_build_config_spec.loader.exec_module(_build_config)
+compiler_configuration = _build_config.compiler_configuration
+build_jobs = _build_config.build_jobs
 
 _packaging_config_spec = importlib.util.spec_from_file_location(
     "gprmax_packaging_config", Path(__file__).resolve().parent / "packaging_config.py"
@@ -193,67 +201,8 @@ if "cleanall" in sys.argv:
     sys.argv[1] = "clean"  # this is what distutils understands
 
 else:
-    # Compiler options - Windows
-    if sys.platform == "win32":
-        # No static linking as no static version of OpenMP library;
-        # /w disables warnings
-        compile_args = ["/O2", "/openmp", "/w"]
-        linker_args = []
-        libraries = []
-
-    elif sys.platform == "darwin":
-        # Check for Intel or Apple M series CPU
-        cpuID = (
-            subprocess.check_output(
-                "sysctl -n machdep.cpu.brand_string",
-                shell=True,
-                stderr=subprocess.STDOUT,
-            )
-            .decode("utf-8")
-            .strip()
-        )
-        cpuID = " ".join(cpuID.split())
-        if "Apple" in cpuID:
-            gccbasepath = "/opt/homebrew/bin/"
-        else:
-            gccbasepath = "/usr/local/bin/"
-        gccpath = glob.glob(gccbasepath + "gcc-[0-9][0-9]")
-        if gccpath:
-            # Use newest gcc found
-            os.environ["CC"] = gccpath[-1].split(os.sep)[-1]
-            if "Apple" in cpuID:
-                rpath = "/opt/homebrew/opt/gcc/lib/gcc/" + gccpath[-1].split(os.sep)[-1][-1] + "/"
-        else:
-            raise (
-                f"Cannot find gcc in {gccbasepath}. gprMax requires gcc "
-                + "to be installed - easily done through the Homebrew package "
-                + "manager (http://brew.sh). Note: gcc with OpenMP support "
-                + "is required."
-            )
-
-        # Set minimum supported macOS deployment target to installed macOS version
-        MIN_MACOS_VERSION = platform.mac_ver()[0]
-        try:
-            os.environ["MACOSX_DEPLOYMENT_TARGET"]
-            del os.environ["MACOSX_DEPLOYMENT_TARGET"]
-        except:
-            pass
-        os.environ["MIN_SUPPORTED_MACOSX_DEPLOYMENT_TARGET"] = MIN_MACOS_VERSION
-        # Sometimes worth testing with '-fstrict-aliasing', '-fno-common'
-        compile_args = [
-            "-O3",
-            "-w",
-            "-fopenmp",
-            "-march=native",
-            f"-mmacosx-version-min={MIN_MACOS_VERSION}",
-        ]
-        linker_args = ["-fopenmp", f"-mmacosx-version-min={MIN_MACOS_VERSION}"]
-        libraries = ["gomp"]
-
-    elif sys.platform == "linux":
-        compile_args = ["-O3", "-w", "-fopenmp", "-march=native"]
-        linker_args = ["-fopenmp"]
-        libraries = []
+    compiler = compiler_configuration()
+    parallel_build_jobs = build_jobs()
 
     # Build list of all the extensions - Cython source files
     extensions = []
@@ -263,10 +212,11 @@ else:
             tmp[0].replace(os.sep, "."),
             [tmp[0] + tmp[1]],
             language="c",
-            include_dirs=[np.get_include()],
-            extra_compile_args=compile_args,
-            extra_link_args=linker_args,
-            libraries=libraries,
+            include_dirs=[np.get_include(), *compiler.include_dirs],
+            library_dirs=list(compiler.library_dirs),
+            extra_compile_args=list(compiler.compile_args),
+            extra_link_args=list(compiler.linker_args),
+            libraries=list(compiler.libraries),
         )
         extensions.append(extension)
 
@@ -280,7 +230,7 @@ else:
             "embedsignature": True,
             "language_level": 3,
         },
-        nthreads=None,
+        nthreads=parallel_build_jobs,
         annotate=False,
     )
 
@@ -336,6 +286,7 @@ else:
         exclude_package_data=EXCLUDED_PACKAGE_DATA,
         include_package_data=True,
         include_dirs=[np.get_include()],
+        options={"build_ext": {"parallel": parallel_build_jobs}},
         zip_safe=False,
         classifiers=[
             "Environment :: Console",

--- a/tests/utilities/test_build_config.py
+++ b/tests/utilities/test_build_config.py
@@ -1,0 +1,128 @@
+"""Tests for portable extension compiler settings."""
+
+from pathlib import Path
+
+import pytest
+
+from build_config import build_jobs, compiler_configuration, find_libomp_prefix
+
+
+def _fake_libomp(prefix: Path) -> Path:
+    (prefix / "include").mkdir(parents=True)
+    (prefix / "lib").mkdir(parents=True)
+    (prefix / "include" / "omp.h").touch()
+    (prefix / "lib" / "libomp.dylib").touch()
+    return prefix
+
+
+@pytest.mark.unit
+def test_build_jobs_default_is_conservative(monkeypatch):
+    monkeypatch.setattr("build_config.os.cpu_count", lambda: 64)
+
+    assert build_jobs(environ={}) == 2
+
+
+@pytest.mark.unit
+def test_build_jobs_accepts_positive_override():
+    assert build_jobs(environ={"GPRMAX_BUILD_JOBS": "4"}) == 4
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", ["0", "-1", "many"])
+def test_build_jobs_rejects_invalid_override(value):
+    with pytest.raises(ValueError, match="positive integer"):
+        build_jobs(environ={"GPRMAX_BUILD_JOBS": value})
+
+
+@pytest.mark.unit
+def test_linux_release_flags_are_portable():
+    config = compiler_configuration(platform_name="linux", environ={})
+
+    assert config.compile_args == ("-O3", "-w", "-fopenmp")
+    assert config.linker_args == ("-fopenmp",)
+    assert "-march=native" not in config.compile_args
+
+
+@pytest.mark.unit
+def test_linux_native_optimisation_requires_explicit_opt_in():
+    config = compiler_configuration(
+        platform_name="linux",
+        environ={"GPRMAX_BUILD_NATIVE": "yes"},
+    )
+
+    assert config.compile_args[-1] == "-march=native"
+
+
+@pytest.mark.unit
+def test_windows_uses_msvc_openmp_without_host_specific_flags():
+    config = compiler_configuration(platform_name="win32", environ={})
+
+    assert config.compile_args == ("/O2", "/openmp", "/w")
+    assert config.linker_args == ()
+
+
+@pytest.mark.unit
+def test_windows_rejects_unsupported_native_build_request():
+    with pytest.raises(ValueError, match="not supported"):
+        compiler_configuration(
+            platform_name="win32",
+            environ={"GPRMAX_BUILD_NATIVE": "1"},
+        )
+
+
+@pytest.mark.unit
+def test_macos_uses_clang_and_libomp(tmp_path):
+    prefix = _fake_libomp(tmp_path / "libomp")
+    config = compiler_configuration(
+        platform_name="darwin",
+        machine="arm64",
+        environ={},
+        libomp_prefix=prefix,
+    )
+
+    assert config.compile_args == ("-O3", "-w", "-Xpreprocessor", "-fopenmp")
+    assert config.libraries == ("omp",)
+    assert config.include_dirs == (str(prefix / "include"),)
+    assert config.library_dirs == (str(prefix / "lib"),)
+    assert config.linker_args == (f"-Wl,-rpath,{prefix / 'lib'}",)
+    assert not any("macosx-version-min" in arg for arg in config.compile_args + config.linker_args)
+
+
+@pytest.mark.unit
+def test_macos_native_arm_build_is_explicit(tmp_path):
+    prefix = _fake_libomp(tmp_path / "libomp")
+    config = compiler_configuration(
+        platform_name="darwin",
+        machine="arm64",
+        environ={"GPRMAX_BUILD_NATIVE": "true"},
+        libomp_prefix=prefix,
+    )
+
+    assert config.compile_args[-1] == "-mcpu=native"
+
+
+@pytest.mark.unit
+def test_macos_reports_actionable_missing_libomp_error(tmp_path):
+    with pytest.raises(RuntimeError, match="brew install libomp"):
+        compiler_configuration(
+            platform_name="darwin",
+            environ={},
+            libomp_prefix=tmp_path / "missing",
+        )
+
+
+@pytest.mark.unit
+def test_explicit_libomp_prefix_takes_priority(tmp_path, monkeypatch):
+    configured = _fake_libomp(tmp_path / "configured")
+    monkeypatch.setattr(
+        "build_config.shutil.which",
+        lambda executable: pytest.fail(f"unexpected lookup for {executable}"),
+    )
+
+    assert (
+        find_libomp_prefix(
+            environ={"GPRMAX_LIBOMP_PREFIX": str(configured)},
+            python_prefix=tmp_path / "python",
+        )
+        == configured.resolve()
+    )

--- a/tests/utilities/test_examples_resources.py
+++ b/tests/utilities/test_examples_resources.py
@@ -74,15 +74,19 @@ def test_wheel_packages_exclude_developer_archives_but_keep_toolboxes_and_exampl
     assert "gprMax._examples" in packages
     assert "toolboxes" in packages
     assert not any(name == "testing" or name.startswith("testing.") for name in packages)
-    assert not any(name == "reframe_tests" or name.startswith("reframe_tests.") for name in packages)
+    assert not any(
+        name == "reframe_tests" or name.startswith("reframe_tests.") for name in packages
+    )
 
 
 @pytest.mark.unit
 def test_large_generated_toolbox_assets_are_excluded_from_wheels():
+    package_exclusions = EXCLUDED_PACKAGE_DATA["gprMax"]
     cython_exclusions = EXCLUDED_PACKAGE_DATA["gprMax.cython"]
     step_exclusions = EXCLUDED_PACKAGE_DATA["toolboxes.STEPtoVoxel"]
     stl_exclusions = EXCLUDED_PACKAGE_DATA["toolboxes.STLtoVoxel"]
 
+    assert {"config.pxd", "*.pxd"} <= set(package_exclusions)
     assert {"*.c", "*.pyx", "*.pxd", "*.jinja"} <= set(cython_exclusions)
     assert "examples/patch_antenna/output/*" in step_exclusions
     assert "examples/stl/Trinity_Alps.stl" in stl_exclusions

--- a/tests/wheel_smoke.py
+++ b/tests/wheel_smoke.py
@@ -1,0 +1,101 @@
+"""Smoke test executed from an installed binary wheel, outside the source tree."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.machinery
+import os
+import tempfile
+from pathlib import Path
+
+os.environ.setdefault("MPLCONFIGDIR", tempfile.mkdtemp(prefix="gprmax-matplotlib-"))
+
+import gprMax
+from gprMax.examples import copy_examples, list_examples
+
+CYTHON_MODULES = (
+    "eigenmode_dft",
+    "eigenmode_source",
+    "fields_updates_dispersive",
+    "fields_updates_hsg",
+    "fields_updates_normal",
+    "fractals_generate",
+    "geometry_outputs",
+    "geometry_primitives",
+    "impedance_surface",
+    "network_port",
+    "ntff",
+    "plane_wave",
+    "pml_build",
+    "pml_updates_electric_HORIPML",
+    "pml_updates_electric_MRIPML",
+    "pml_updates_magnetic_HORIPML",
+    "pml_updates_magnetic_MRIPML",
+    "sar_averaging",
+    "snapshots",
+    "symmetry_boundaries",
+    "symmetry_boundaries_dispersive",
+    "symmetry_boundaries_dispersive_complex",
+    "virtual_waveguide",
+    "yee_cell_build",
+    "yee_cell_setget_rigid",
+)
+
+
+def _assert_compiled_extensions_load() -> None:
+    extension_suffixes = tuple(importlib.machinery.EXTENSION_SUFFIXES)
+    for name in CYTHON_MODULES:
+        module = importlib.import_module(f"gprMax.cython.{name}")
+        assert module.__file__ is not None
+        assert module.__file__.endswith(extension_suffixes), module.__file__
+
+
+def _assert_only_wheel_payload_is_installed() -> None:
+    package = Path(gprMax.__file__).resolve().parent
+    cython_dir = package / "cython"
+    assert not list(cython_dir.glob("*.pyx"))
+    assert not list(cython_dir.glob("*.c"))
+    assert not list(package.rglob("*.pxd"))
+
+
+def _assert_examples_are_available(workspace: Path) -> None:
+    categories = dict(list_examples())
+    assert categories.get("gpr", 0) > 0
+    assert categories.get("antennas", 0) > 0
+
+    copied = copy_examples(workspace)
+    assert (copied / "examples" / "gpr" / "basic" / "cylinder_Ascan_2D.in").is_file()
+
+
+def _run_tiny_cpu_model(output: Path) -> None:
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=(0.001, 0.001, 0.001)))
+    scene.add(gprMax.Domain(p1=(0.01, 0.01, 0.01)))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.TimeWindow(iterations=300))
+    scene.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
+    scene.add(
+        gprMax.HertzianDipole(p1=(0.005, 0.005, 0.005), polarisation="z", waveform_id="pulse")
+    )
+    scene.add(gprMax.Rx(p1=(0.006, 0.005, 0.005), outputs=["Ez"]))
+
+    gprMax.run(
+        scenes=[scene],
+        outputfile=str(output),
+        hide_progress_bars=True,
+        log_level=30,
+    )
+    assert output.with_suffix(".h5").is_file()
+
+
+def main() -> None:
+    _assert_compiled_extensions_load()
+    _assert_only_wheel_payload_is_installed()
+    with tempfile.TemporaryDirectory(prefix="gprmax-wheel-") as directory:
+        root = Path(directory)
+        _assert_examples_are_available(root / "workspace")
+        _run_tiny_cpu_model(root / "smoke")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- replace host-specific compiler flags with a portable, tested build configuration
- build CPython 3.11-3.13 wheels for Linux x86-64, Windows AMD64, Intel macOS, and Apple Silicon macOS
- repair platform wheels with auditwheel, delvewheel, or delocate and test every installed archive
- build a deployment-target-compatible LLVM OpenMP runtime for macOS wheels and include its complete upstream licence
- bundle version-matched examples while excluding Cython build inputs and developer validation archives
- document wheel, source, optional accelerator, MPI, and macOS Clang/libomp installation paths

## Verification

- all 13 pull-request checks pass
- CPU regression tests pass
- core installation tests pass on Python 3.11, 3.12, and 3.13
- MPI/FFTW compatibility tests pass
- unit tests pass on Linux, Windows, and macOS
- source distribution passes Twine validation, isolated installation, extension imports, example-resource checks, and a CPU model
- CPython 3.11-3.13 wheels pass on Linux x86-64, Windows AMD64, Intel macOS, and Apple Silicon macOS
- every repaired wheel passes Twine, imports all 25 Cython extensions, contains no C/Cython build inputs, copies packaged examples, and runs a CPU model from an isolated installation
- 6,031 local non-GPU/non-slow tests and 26 focused packaging/compiler tests passed
- Sphinx HTML build passes with warnings treated as errors

The workflow uploads build artifacts only; it does not publish to PyPI.