### PR TITLE
Harden Metal and OpenCL update interfaces

### DIFF
--- a/gprMax/solvers.py
+++ b/gprMax/solvers.py
@@ -42,8 +42,12 @@ class Solver:
         """
         Args:
             updates: Updates contains methods to run FDTD algorithm.
-            hsg: boolean to use sub-gridding.
         """
+
+        if not isinstance(updates, Updates):
+            raise TypeError(
+                f"updates must implement the Updates interface, got {type(updates).__name__}"
+            )
 
         self.updates = updates
         self.solvetime = 0

--- a/gprMax/updates/metal_updates.py
+++ b/gprMax/updates/metal_updates.py
@@ -41,6 +41,7 @@ from gprMax.eigenmode_device import (
     prepare_device_eigenmode_source,
     reanchor_device_eigenmode_monitor,
 )
+from gprMax.grid.metal_grid import MetalGrid
 from gprMax.network_ports import dtoh_rational_network_outputs, htod_rational_network_arrays
 from gprMax.ntff.device import MetalCombinedKSIRCollector
 from gprMax.receivers import dtoh_rx_array, htod_rx_arrays, requested_current_outputs
@@ -61,21 +62,22 @@ from gprMax.sources import (
     htod_transmission_line_arrays,
 )
 from gprMax.updates.metal_plane_waves import MetalPlaneWaveController
+from gprMax.updates.updates import Updates
 from gprMax.utilities.utilities import round32
 
 logger = logging.getLogger(__name__)
 
 
-class MetalUpdates:
+class MetalUpdates(Updates[MetalGrid]):
     """Defines update functions for Apple Metal-based solver."""
 
-    def __init__(self, G, shared=None):
+    def __init__(self, G: MetalGrid, shared=None):
         """
         Args:
-            G: OpenCLGrid class describing a grid in a model.
+            G: MetalGrid class describing a grid in a model.
         """
 
-        self.grid = G
+        super().__init__(G)
 
         self.metal = import_module("Metal")
         self.opts = self.metal.MTLCompileOptions.new()

--- a/gprMax/updates/opencl_updates.py
+++ b/gprMax/updates/opencl_updates.py
@@ -16,6 +16,7 @@
 # along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
 import logging
+import os
 from importlib import import_module
 
 import numpy as np
@@ -68,6 +69,18 @@ from gprMax.updates.updates import Updates
 logger = logging.getLogger(__name__)
 
 
+def _configure_pyopencl_cache_failure_policy() -> None:
+    """Give PyOpenCL's cache fallback a non-fatal default.
+
+    PyOpenCL 2026.1.2 indexes this environment variable directly when its
+    compiler cache fails. If the variable is absent, the fallback itself
+    raises ``KeyError`` instead of rebuilding from source. Preserve an
+    explicit user policy, but make an absent policy non-fatal.
+    """
+
+    os.environ.setdefault("PYOPENCL_CACHE_FAILURE_FATAL", "")
+
+
 class OpenCLUpdates(Updates[OpenCLGrid]):
     """Defines update functions for OpenCL-based solver."""
 
@@ -79,6 +92,7 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
         super().__init__(G)
 
         # Import pyopencl module
+        _configure_pyopencl_cache_failure_policy()
         self.cl = import_module("pyopencl")
         self.elwiseknl = getattr(import_module("pyopencl.elementwise"), "ElementwiseKernel")
 

--- a/tests/updates/test_metal_dispersive_warning.py
+++ b/tests/updates/test_metal_dispersive_warning.py
@@ -40,13 +40,14 @@ import pytest
 
 import gprMax.solvers as solvers_mod
 from gprMax import config, gprMax
+from gprMax.updates.cpu_updates import CPUUpdates
 
 
 class _FakeMetalGrid:
     pass
 
 
-class _FakeMetalUpdates:
+class _FakeMetalUpdates(CPUUpdates):
     def __init__(self, grid):
         self.grid = grid
 

--- a/tests/updates/test_opencl_current_output_dispatch.py
+++ b/tests/updates/test_opencl_current_output_dispatch.py
@@ -26,6 +26,20 @@ import gprMax.updates.opencl_updates as opencl_updates
 from gprMax.updates.opencl_updates import OpenCLUpdates
 
 
+def test_opencl_cache_failure_policy_defaults_to_nonfatal(monkeypatch):
+    """An unwritable/broken PyOpenCL cache must fall back to source builds."""
+
+    monkeypatch.delenv("PYOPENCL_CACHE_FAILURE_FATAL", raising=False)
+    opencl_updates._configure_pyopencl_cache_failure_policy()
+    assert opencl_updates.os.environ["PYOPENCL_CACHE_FAILURE_FATAL"] == ""
+
+
+def test_opencl_cache_failure_policy_preserves_user_choice(monkeypatch):
+    monkeypatch.setenv("PYOPENCL_CACHE_FAILURE_FATAL", "1")
+    opencl_updates._configure_pyopencl_cache_failure_policy()
+    assert opencl_updates.os.environ["PYOPENCL_CACHE_FAILURE_FATAL"] == "1"
+
+
 def _set_config(monkeypatch):
     monkeypatch.setattr(
         config,

--- a/tests/updates/test_solver.py
+++ b/tests/updates/test_solver.py
@@ -19,7 +19,7 @@
 
 This file holds the **running order of an FDTD timestep**, and it holds it
 nowhere else. There is no "advance one step" method on ``CPUUpdates``; the
-sequence exists only as eleven consecutive lines inside ``Solver.solve``.
+sequence exists only inside ``Solver.solve``.
 
 That matters because the Yee scheme leapfrogs. Electric and magnetic fields
 are staggered half a timestep apart and each is computed from the curl of the
@@ -54,6 +54,7 @@ CPU_ITERATION_ORDER = [
     "store_outputs",
     "store_snapshots",
     "observe_ntff_electric",
+    "observe_sar_electric",
     "update_magnetic",
     "update_magnetic_pml",
     "update_magnetic_sources",
@@ -69,6 +70,8 @@ CPU_ITERATION_ORDER = [
     "update_plane_waves_electric",
     "update_symmetry_boundaries_electric_b",
     "update_electric_b",
+    "update_impedance_surfaces",
+    "update_network_terminals",
 ]
 
 # Called once each, outside the loop.
@@ -125,6 +128,9 @@ class RecordingUpdates(CPUUpdates):
     def observe_ntff_electric(self, iteration):
         self._record("observe_ntff_electric")
 
+    def observe_sar_electric(self, iteration):
+        self._record("observe_sar_electric")
+
     def update_eigenmode_sources_magnetic(self, iteration):
         self._record("update_eigenmode_sources_magnetic")
 
@@ -146,6 +152,12 @@ class RecordingUpdates(CPUUpdates):
     def update_electric_b(self):
         self._record("update_electric_b")
 
+    def update_impedance_surfaces(self):
+        self._record("update_impedance_surfaces")
+
+    def update_network_terminals(self, iteration):
+        self._record("update_network_terminals")
+
     def time_start(self):
         self._record("time_start")
 
@@ -163,8 +175,8 @@ class RecordingUpdates(CPUUpdates):
 class MinimalRecordingUpdates(Updates):
     """A conforming backend that is *not* a ``CPUUpdates``.
 
-    Used to show which steps are CPU-only: the two plane-wave calls are
-    skipped entirely for a backend the ``isinstance`` guard does not match.
+    It records the common mandatory sequence and selected optional hooks,
+    while leaving plane-wave and eigenmode hooks as inherited no-ops.
     """
 
     def __init__(self):
@@ -201,6 +213,9 @@ class MinimalRecordingUpdates(Updates):
     def observe_ntff_electric(self, iteration):
         self._record("observe_ntff_electric")
 
+    def observe_sar_electric(self, iteration):
+        self._record("observe_sar_electric")
+
     def observe_ntff_magnetic(self, iteration):
         self._record("observe_ntff_magnetic")
 
@@ -212,6 +227,12 @@ class MinimalRecordingUpdates(Updates):
 
     def update_electric_b(self):
         self._record("update_electric_b")
+
+    def update_impedance_surfaces(self):
+        self._record("update_impedance_surfaces")
+
+    def update_network_terminals(self, iteration):
+        self._record("update_network_terminals")
 
     def time_start(self):
         self._record("time_start")
@@ -237,7 +258,7 @@ def recording_updates():
 
 
 class TestSolverConstruction:
-    """``Solver(updates)`` — three attributes, no logic."""
+    """``Solver(updates)`` — validate and retain a conforming backend."""
 
     def test_stores_the_updates_object(self, recording_updates):
         assert Solver(recording_updates).updates is recording_updates
@@ -260,9 +281,15 @@ class TestSolverConstruction:
         Solver(recording_updates)
         assert recording_updates.calls == []
 
+    def test_rejects_an_object_that_bypasses_the_updates_contract(self):
+        """Fail during setup rather than at the first missing timestep hook."""
+
+        with pytest.raises(TypeError, match="Updates interface"):
+            Solver(SimpleNamespace())
+
 
 class TestIterationOrder:
-    """The eleven beats, in order. The heart of this file."""
+    """The complete timestep sequence, in order. The heart of this file."""
 
     def test_one_iteration_produces_the_canonical_sequence(self, recording_updates):
         """The full per-iteration order for a CPU run.
@@ -322,16 +349,21 @@ class TestIterationOrder:
 
         assert calls.index(field) < calls.index(pml) < calls.index(sources)
 
-    def test_electric_b_is_the_last_step_of_the_iteration(self, recording_updates):
-        """The dispersive closing half runs after everything else.
+    def test_electric_b_precedes_sparse_electric_edge_corrections(self, recording_updates):
+        """The dispersive closing half runs before sparse edge corrections.
 
         It needs both the old and the new electric field, so it cannot run
-        until the PML and the sources have finished with E.
+        until the PML and the sources have finished with E. Impedance and
+        network-terminal corrections then act on the completed bulk update.
         """
         Solver(recording_updates).solve(range(1))
 
         body = [c for c in recording_updates.calls if c not in PROLOGUE + EPILOGUE]
-        assert body[-1] == "update_electric_b"
+        assert body[-3:] == [
+            "update_electric_b",
+            "update_impedance_surfaces",
+            "update_network_terminals",
+        ]
 
     def test_electric_b_follows_the_electric_sources(self, recording_updates):
         Solver(recording_updates).solve(range(1))
@@ -346,11 +378,11 @@ class TestIterationOrder:
         assert calls.index("update_magnetic_sources") < calls.index("update_plane_waves_magnetic")
         assert calls.index("update_electric_sources") < calls.index("update_plane_waves_electric")
 
-    def test_there_are_eighteen_steps_in_an_iteration(self, recording_updates):
+    def test_there_are_twenty_one_steps_in_an_iteration(self, recording_updates):
         Solver(recording_updates).solve(range(1))
 
         body = [c for c in recording_updates.calls if c not in PROLOGUE + EPILOGUE]
-        assert len(body) == 18
+        assert len(body) == 21
 
 
 class TestLoopBracketing:
@@ -428,7 +460,7 @@ class TestIterationCount:
         Solver(recording_updates).solve(iter([0, 1, 2]))
 
         body = [c for c in recording_updates.calls if c not in PROLOGUE + EPILOGUE]
-        assert len(body) == 3 * 18
+        assert len(body) == 3 * len(CPU_ITERATION_ORDER)
 
     def test_iteration_values_are_passed_to_the_steps(self):
         """Whatever the iterator yields reaches the iteration-taking steps."""
@@ -443,15 +475,11 @@ class TestIterationCount:
         assert seen == [3, 9, 27]
 
 
-class TestBackendSpecificSteps:
-    """Which steps a backend gets depends on its type.
+class TestOptionalAndBackendSpecificSteps:
+    """Optional hooks may be inherited as no-ops or overridden by a backend."""
 
-    ``Solver.solve`` guards four of its calls with ``isinstance``, because
-    the methods are not on the ``Updates`` base class.
-    """
-
-    def test_a_non_cpu_backend_skips_the_plane_wave_steps(self):
-        """The two plane-wave calls are ``CPUUpdates``-only."""
+    def test_inherited_plane_wave_hooks_are_noops(self):
+        """The calls occur, but a backend may intentionally do no work."""
         updates = MinimalRecordingUpdates()
 
         Solver(updates).solve(range(1))
@@ -459,19 +487,22 @@ class TestBackendSpecificSteps:
         assert "update_plane_waves_electric" not in updates.calls
         assert "update_plane_waves_magnetic" not in updates.calls
 
-    def test_a_non_cpu_backend_still_runs_the_shared_steps(self):
-        """Everything on the base class still happens, in the same order.
-        CPU-only steps (plane-waves, eigenmode) are excluded."""
+    def test_a_minimal_backend_still_runs_the_recorded_shared_steps(self):
+        """Recorded hooks retain their order around inherited no-ops."""
         updates = MinimalRecordingUpdates()
 
         Solver(updates).solve(range(1))
 
-        cpu_only = {"update_plane_waves", "update_eigenmode_sources", "observe_eigenmode_ports"}
+        inherited_noops = {
+            "update_plane_waves",
+            "update_eigenmode_sources",
+            "observe_eigenmode_ports",
+        }
         body = [c for c in updates.calls if c not in PROLOGUE + EPILOGUE]
         assert body == [
             step
             for step in CPU_ITERATION_ORDER
-            if not any(step.startswith(prefix) for prefix in cpu_only)
+            if not any(step.startswith(prefix) for prefix in inherited_noops)
         ]
 
     def test_a_non_cpu_backend_is_still_bracketed(self):
@@ -505,12 +536,8 @@ class TestBackendSpecificSteps:
         assert "cleanup" not in updates.calls
         assert updates.calls[-1] == "calculate_solve_time"
 
-    def test_the_cpu_guard_matches_subclasses(self, recording_updates):
-        """``isinstance`` here, not exact type — unlike ``create_solver``.
-
-        ``RecordingUpdates`` subclasses ``CPUUpdates`` and does get the
-        plane-wave steps, which is what makes it a faithful stand-in.
-        """
+    def test_a_cpu_subclass_uses_overridden_plane_wave_hooks(self, recording_updates):
+        """Overrides remain active through a ``CPUUpdates`` subclass."""
         assert isinstance(recording_updates, CPUUpdates)
         assert type(recording_updates) is not CPUUpdates
 
@@ -564,9 +591,9 @@ class TestCreateSolver:
         constructing ``CPUUpdates`` any other way leaves those attributes
         missing.
         """
-        updates_config.model_config.materials["dispersivedtype"] = (
-            updates_config.sim_config.dtypes["float_or_double"]
-        )
+        updates_config.model_config.materials["dispersivedtype"] = updates_config.sim_config.dtypes[
+            "float_or_double"
+        ]
 
         solver = create_solver(make_model(FDTDGrid(), maxpoles=2))
 

--- a/tests/updates/test_updates_base.py
+++ b/tests/updates/test_updates_base.py
@@ -18,9 +18,10 @@
 """The ``Updates`` abstract base class — ``gprMax/updates/updates.py``.
 
 ``Updates`` is the contract every solver backend implements. It carries no
-logic at all: eleven ``@abstractmethod`` declarations, two concrete no-ops,
-and an ``__init__`` that stores the grid. There is nothing to compute, so
-every test here is about the *shape* of the contract.
+numerical logic: eleven ``@abstractmethod`` declarations, concrete no-op
+hooks for optional features, and an ``__init__`` that stores the grid. There
+is nothing to compute, so every test here is about the *shape* of the
+contract.
 
 That is worth testing precisely because the class exists to make a mistake
 impossible. If a new abstract method is added upstream and one backend does
@@ -35,6 +36,7 @@ per method would pass unchanged if a twelfth were added, which is precisely
 the event worth catching.
 """
 
+import importlib
 import inspect
 from abc import ABC
 
@@ -63,8 +65,34 @@ ABSTRACT_METHODS = frozenset(
 )
 
 # Methods with a real (empty) body on the base class, inherited by any
-# backend that does not care to override them.
-CONCRETE_METHODS = frozenset({"finalise", "cleanup"})
+# backend that does not care to override them. Lifecycle hooks are kept
+# separate because they take no iteration argument.
+LIFECYCLE_HOOKS = frozenset({"finalise", "cleanup"})
+OPTIONAL_TIMESTEP_HOOKS = frozenset(
+    {
+        "observe_eigenmode_ports",
+        "observe_ntff_electric",
+        "observe_ntff_magnetic",
+        "observe_sar_electric",
+        "update_eigenmode_sources_electric",
+        "update_eigenmode_sources_magnetic",
+        "update_impedance_surfaces",
+        "update_network_terminals",
+        "update_plane_waves_electric",
+        "update_plane_waves_magnetic",
+        "update_symmetry_boundaries_electric",
+        "update_symmetry_boundaries_electric_b",
+    }
+)
+CONCRETE_METHODS = LIFECYCLE_HOOKS | OPTIONAL_TIMESTEP_HOOKS
+
+SOLVER_BACKENDS = (
+    ("gprMax.updates.cpu_updates", "CPUUpdates"),
+    ("gprMax.updates.cuda_updates", "CUDAUpdates"),
+    ("gprMax.updates.opencl_updates", "OpenCLUpdates"),
+    ("gprMax.updates.metal_updates", "MetalUpdates"),
+    ("gprMax.subgrids.updates", "SubgridUpdates"),
+)
 
 
 class MinimalUpdates(Updates):
@@ -167,7 +195,7 @@ class TestAbstractContract:
 
 
 class TestConcreteMethods:
-    """``finalise`` and ``cleanup`` — the two hooks with a default."""
+    """Optional timestep and lifecycle hooks have safe defaults."""
 
     @pytest.mark.parametrize("name", sorted(CONCRETE_METHODS))
     def test_hook_is_not_abstract(self, name):
@@ -176,15 +204,26 @@ class TestConcreteMethods:
 
     @pytest.mark.parametrize("name", sorted(CONCRETE_METHODS))
     def test_hook_returns_none(self, name):
-        """Both are no-ops on the base class."""
+        """Every default hook is a no-op on the base class."""
         updates = MinimalUpdates(FDTDGrid())
-        assert getattr(updates, name)() is None
+        signature = inspect.signature(getattr(Updates, name))
+        args = [0] * (len(signature.parameters) - 1)
+        assert getattr(updates, name)(*args) is None
 
-    @pytest.mark.parametrize("name", sorted(CONCRETE_METHODS))
-    def test_hook_takes_no_arguments_beyond_self(self, name):
+    @pytest.mark.parametrize("name", sorted(LIFECYCLE_HOOKS))
+    def test_lifecycle_hook_takes_no_arguments_beyond_self(self, name):
         """``Solver.solve`` calls both with no arguments."""
         sig = inspect.signature(getattr(Updates, name))
         assert list(sig.parameters) == ["self"]
+
+    @pytest.mark.parametrize("name", sorted(OPTIONAL_TIMESTEP_HOOKS))
+    def test_optional_timestep_hook_has_supported_signature(self, name):
+        """Optional hooks take either no value or the current iteration."""
+
+        assert list(inspect.signature(getattr(Updates, name)).parameters) in (
+            ["self"],
+            ["self", "iteration"],
+        )
 
     def test_cpu_updates_reimplements_both_hooks_identically(self):
         """``CPUUpdates`` re-declares both as byte-identical no-ops.
@@ -193,7 +232,7 @@ class TestConcreteMethods:
         harmless, but they are dead code, and anyone adding behaviour to the
         base-class hooks would find it silently ignored on the CPU path.
         """
-        for name in CONCRETE_METHODS:
+        for name in LIFECYCLE_HOOKS:
             assert name in CPUUpdates.__dict__
             assert getattr(CPUUpdates, name) is not getattr(Updates, name)
 
@@ -273,6 +312,28 @@ class TestBackendConformance:
         """No abstract methods remain, so it is instantiable."""
         assert not CPUUpdates.__abstractmethods__
 
+    @pytest.mark.parametrize("module_name,class_name", SOLVER_BACKENDS)
+    def test_every_local_solver_backend_implements_the_contract(self, module_name, class_name):
+        """Backend classes can neither bypass the ABC nor remain abstract.
+
+        Importing these modules does not initialise accelerator hardware; the
+        platform libraries are loaded only when an update object is built.
+        """
+
+        backend = getattr(importlib.import_module(module_name), class_name)
+        assert issubclass(backend, Updates)
+        assert not backend.__abstractmethods__
+
+    @pytest.mark.parametrize("module_name,class_name", SOLVER_BACKENDS)
+    def test_backend_overrides_preserve_contract_signatures(self, module_name, class_name):
+        """An override must accept the arguments used by ``Solver.solve``."""
+
+        backend = getattr(importlib.import_module(module_name), class_name)
+        for name in ABSTRACT_METHODS | CONCRETE_METHODS:
+            expected = list(inspect.signature(getattr(Updates, name)).parameters)
+            actual = list(inspect.signature(getattr(backend, name)).parameters)
+            assert actual == expected, f"{class_name}.{name}{actual} != Updates.{name}{expected}"
+
     def test_cpu_updates_can_be_constructed(self):
         assert isinstance(CPUUpdates(FDTDGrid()), Updates)
 
@@ -290,24 +351,24 @@ class TestBackendConformance:
         assert "set_dispersive_updates" in CPUUpdates.__dict__
         assert "set_dispersive_updates" not in vars(Updates)
 
-    def test_metal_updates_does_not_implement_the_contract(self):
-        """``MetalUpdates`` is not an ``Updates`` subclass at all.
+    def test_metal_updates_implements_the_contract(self):
+        """Metal inherits optional hooks as well as the required interface.
 
-        It is a plain class that assigns ``self.grid = G`` by hand. Because
-        ``Solver.__init__`` is annotated ``updates: Updates`` and
-        ``create_solver`` hands it a ``MetalUpdates``, the Metal path violates
-        the solver's own type contract — and the ABC cannot catch it, because
-        nothing ever inherited from the ABC.
-
-        Written up in ``notes/bugs/metal-updates-not-an-updates-subclass.md``.
-        The import is guarded because the module imports ``Metal`` lazily but
-        may still fail to import on a non-Apple platform.
+        This prevents a newly added optional timestep hook from failing only
+        on Metal with ``AttributeError``. Platform-specific libraries are
+        imported lazily, so class conformance can be checked without Apple
+        hardware.
         """
         metal_updates = pytest.importorskip(
             "gprMax.updates.metal_updates",
             reason="metal_updates imports platform-specific machinery",
         )
-        assert not issubclass(metal_updates.MetalUpdates, Updates)
+        assert issubclass(metal_updates.MetalUpdates, Updates)
+        assert not metal_updates.MetalUpdates.__abstractmethods__
+        assert (
+            metal_updates.MetalUpdates.update_impedance_surfaces
+            is Updates.update_impedance_surfaces
+        )
 
 
 pytestmark = pytest.mark.unit


### PR DESCRIPTION
## Summary

- make MetalUpdates inherit the common Updates interface so optional solver hooks are always available
- reject non-conforming update backends when Solver is constructed
- expand backend conformance and timestep-order tests across CPU, CUDA, OpenCL, Metal, and subgrid backends
- add a non-fatal default for the PyOpenCL compiler-cache fallback while preserving an explicit user policy
- correct stale solver-test descriptions and Metal type documentation

## Motivation

Metal models failed at the first timestep because Solver unconditionally calls update_impedance_surfaces, while MetalUpdates previously bypassed the Updates base class and therefore did not inherit its optional no-op hook. The strengthened contract checks prevent the same class of omission from escaping to platform-specific runtime testing.

A real Intel OpenCL run also exposed a PyOpenCL 2026.1.2 cache-fallback KeyError when PYOPENCL_CACHE_FAILURE_FATAL was absent. The compatibility default allows PyOpenCL to rebuild from source after a cache failure.

## Validation

- 156 focused interface and dispatch tests passed
- 400 update tests passed, 6 skipped, 33 deselected
- 6,267 tests passed in the broad non-GPU/non-slow suite; the only three failures were MPI subprocess launches blocked by the local sandbox socket policy
- Intel OpenCL transmission-line CPU parity test passed
- Intel OpenCL equivalent-current time-domain NTFF CPU parity test passed
- Black, isort, and git diff whitespace checks passed

Metal hardware is not available on this Linux server, so the Metal regression is covered through class-contract, signature, dispatch, and solver-order tests; the originally reported model should also be rerun on Apple Metal.