### PR TITLE
Fix geometry-object material index validation

### DIFF
--- a/gprMax/input_cmds_geometry.py
+++ b/gprMax/input_cmds_geometry.py
@@ -48,6 +48,24 @@ from gprMax.utilities import round_value
 from gprMax.utilities import get_terminal_width
 
 
+def _check_geometry_material_indices(command, matfile, materialcmds, *arrays):
+    """Check that geometry arrays only reference imported material indices."""
+
+    maxindex = -1
+    for array in arrays:
+        if array.size:
+            maxindex = max(maxindex, int(np.amax(array)))
+
+    maxmaterialindex = len(materialcmds) - 1
+    if maxindex > maxmaterialindex:
+        message = (
+            "'" + command + "'"
+            + ' found material index {} in the geometry objects file greater than the maximum index for the specified materials ({}) in materials file {}. '
+            + 'The materials file must contain a #material command for every material index referenced by the geometry arrays; files written by #geometry_objects_write commonly include pec and free_space.'
+        )
+        raise CmdInputError(message.format(maxindex, maxmaterialindex, matfile))
+
+
 def process_geometrycmds(geometry, G):
     """
     This function checks the validity of command parameters, creates instances
@@ -124,8 +142,7 @@ def process_geometrycmds(geometry, G):
                 data = data.astype('int16')
 
             # Check that there are no values in the data greater than the maximum index for the specified materials
-            if np.amax(data) > len(materials) - 1:
-                raise CmdInputError("'" + ' '.join(tmp) + "'" + ' found data value(s) ({}) in the geometry objects file greater than the maximum index for the specified materials ({})'.format(np.amax(data), len(materials) - 1))
+            _check_geometry_material_indices(' '.join(tmp), matfile, materials, data)
 
             # Look to see if rigid and ID arrays are present (these should be
             # present if the original geometry objects were written from gprMax)
@@ -133,6 +150,7 @@ def process_geometrycmds(geometry, G):
                 rigidE = f['/rigidE'][:]
                 rigidH = f['/rigidH'][:]
                 ID = f['/ID'][:]
+                _check_geometry_material_indices(' '.join(tmp), matfile, materials, ID)
                 G.solid[xs:xs + data.shape[0], ys:ys + data.shape[1], zs:zs + data.shape[2]] = data + numexistmaterials
                 G.rigidE[:, xs:xs + rigidE.shape[1], ys:ys + rigidE.shape[2], zs:zs + rigidE.shape[3]] = rigidE
                 G.rigidH[:, xs:xs + rigidH.shape[1], ys:ys + rigidH.shape[2], zs:zs + rigidH.shape[3]] = rigidH

--- a/gprMax/input_cmds_geometry.py
+++ b/gprMax/input_cmds_geometry.py
@@ -56,7 +56,11 @@ def _check_geometry_material_indices(command, matfile, materialcmds, *arrays):
         if array.size:
             maxindex = max(maxindex, int(np.amax(array)))
 
-    maxmaterialindex = len(materialcmds) - 1
+    # ``materialcmds`` contains all commands imported from the materials file,
+    # including dispersion commands. Only #material commands declare entries
+    # in the file-local material index used by the geometry arrays.
+    nmaterials = sum(cmd.lstrip().startswith('#material:') for cmd in materialcmds)
+    maxmaterialindex = nmaterials - 1
     if maxindex > maxmaterialindex:
         message = (
             "'" + command + "'"

--- a/tests/test_geometry_objects_read.py
+++ b/tests/test_geometry_objects_read.py
@@ -1,0 +1,62 @@
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+import h5py
+import numpy as np
+
+from gprMax.exceptions import CmdInputError
+from gprMax.input_cmds_geometry import process_geometrycmds
+from gprMax.materials import Material
+
+
+def builtin_materials():
+    pec = Material(0, 'pec')
+    pec.se = float('inf')
+    pec.type = 'builtin'
+    pec.averagable = False
+    free_space = Material(1, 'free_space')
+    free_space.type = 'builtin'
+    return [pec, free_space]
+
+
+class GeometryObjectsReadTest(unittest.TestCase):
+
+    def test_generated_geometry_reports_missing_material_indices(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            geofile = os.path.join(tmpdir, 'geometry.h5')
+            matfile = os.path.join(tmpdir, 'materials.txt')
+
+            with h5py.File(geofile, 'w') as f:
+                f.attrs['dx_dy_dz'] = (1.0, 1.0, 1.0)
+                f['/data'] = np.zeros((1, 1, 1), dtype=np.int16)
+                f['/rigidE'] = np.zeros((6, 1, 1, 1), dtype=np.int8)
+                f['/rigidH'] = np.zeros((6, 1, 1, 1), dtype=np.int8)
+                f['/ID'] = np.ones((6, 1, 1, 1), dtype=np.uint32)
+
+            with open(matfile, 'w') as f:
+                f.write('#material: 1 inf 1 0 pec\n')
+
+            grid = SimpleNamespace(
+                dx=1.0,
+                dy=1.0,
+                dz=1.0,
+                inputdirectory=tmpdir,
+                materials=builtin_materials(),
+                progressbars=True,
+                messages=False,
+                solid=np.zeros((1, 1, 1), dtype=np.int16),
+                rigidE=np.zeros((6, 1, 1, 1), dtype=np.int8),
+                rigidH=np.zeros((6, 1, 1, 1), dtype=np.int8),
+                ID=np.zeros((6, 1, 1, 1), dtype=np.uint32),
+            )
+
+            command = '#geometry_objects_read: 0 0 0 geometry.h5 materials.txt'
+
+            with self.assertRaisesRegex(CmdInputError, 'materials file'):
+                process_geometrycmds([command], grid)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_geometry_objects_read.py
+++ b/tests/test_geometry_objects_read.py
@@ -7,6 +7,7 @@ import h5py
 import numpy as np
 
 from gprMax.exceptions import CmdInputError
+from gprMax.input_cmds_geometry import _check_geometry_material_indices
 from gprMax.input_cmds_geometry import process_geometrycmds
 from gprMax.materials import Material
 
@@ -22,6 +23,21 @@ def builtin_materials():
 
 
 class GeometryObjectsReadTest(unittest.TestCase):
+
+    def test_dispersion_commands_do_not_count_as_materials(self):
+        materialcmds = [
+            '#material: 2 0 1 0 soil\n',
+            '#add_dispersion_debye: 1 1 1e-9 soil\n',
+        ]
+        ID = np.ones((6, 1, 1, 1), dtype=np.uint32)
+
+        with self.assertRaisesRegex(CmdInputError, 'materials file'):
+            _check_geometry_material_indices(
+                '#geometry_objects_read: 0 0 0 geometry.h5 materials.txt',
+                'materials.txt',
+                materialcmds,
+                ID,
+            )
 
     def test_generated_geometry_reports_missing_material_indices(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- preserve and build on the original validation work from #678
- validate material indices in both `/data` and `/ID` geometry arrays
- count only `#material:` declarations when determining the valid file-local index range
- prevent dispersion directives from masking a missing material
- report a clear input error before invalid material IDs reach the solver

This is a focused v3 maintenance fix before the `master` branch is archived following the gprMax v4 release.

## Validation

- `python -m unittest -v tests.test_geometry_objects_read`
- 2 tests passed
- Python compilation and `git diff --check` passed

Supersedes #678.