### PR TITLE
Improve CLI handling for missing input files

### DIFF
--- a/gprMax/gprMax.py
+++ b/gprMax/gprMax.py
@@ -16,6 +16,7 @@
 # along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
 import argparse
+from pathlib import Path
 
 import gprMax.config as config
 
@@ -125,6 +126,15 @@ help_msg = {
         " file."
     ),
 }
+
+
+def _existing_input_file(value: str) -> Path:
+    """Return an input path or raise an argparse-friendly error."""
+
+    path = Path(value).expanduser()
+    if not path.is_file():
+        raise argparse.ArgumentTypeError(f"input file does not exist: {value}")
+    return path
 
 
 def run(
@@ -261,7 +271,7 @@ def cli():
     parser = argparse.ArgumentParser(
         prog="gprMax", formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
-    parser.add_argument("inputfile", help=help_msg["inputfile"])
+    parser.add_argument("inputfile", type=_existing_input_file, help=help_msg["inputfile"])
     parser.add_argument("-outputfile", "-o", help=help_msg["outputfile"])
     parser.add_argument("-n", default=args_defaults["n"], type=int, help=help_msg["n"])
     parser.add_argument("-i", type=int, help=help_msg["i"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
+#
+# This file is part of the gprMax source code base.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""Command-line interface regression tests."""
+
+import sys
+
+import pytest
+
+from gprMax.gprMax import _existing_input_file, cli
+
+
+@pytest.mark.unit
+def test_existing_input_file_is_returned_as_a_path(tmp_path):
+    inputfile = tmp_path / "model.in"
+    inputfile.write_text("#title: model\n", encoding="utf-8")
+
+    assert _existing_input_file(str(inputfile)) == inputfile
+
+
+@pytest.mark.unit
+def test_missing_input_file_is_reported_without_traceback(monkeypatch, capsys, tmp_path):
+    missing = tmp_path / "missing.in"
+    monkeypatch.setattr(sys, "argv", ["gprMax", str(missing)])
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli()
+
+    assert excinfo.value.code == 2
+    error = capsys.readouterr().err
+    assert f"input file does not exist: {missing}" in error
+    assert "Traceback" not in error


### PR DESCRIPTION
## Summary

Validate the positional CLI input path during argument parsing so a missing file produces a concise argparse error rather than a Python traceback during study preflight.

This is a current-devel replacement for #624. The original contributor is credited as a co-author.

## Tests

- Missing input exits with status 2 and no traceback
- Existing input is returned as a Path
- Existing model-range regression tests remain passing

Result: 8 passed.