### PR TITLE
Add OpenCL wall-clock timing fallback

### DIFF
--- a/gprMax/updates/opencl_updates.py
+++ b/gprMax/updates/opencl_updates.py
@@ -18,6 +18,7 @@
 import logging
 import os
 from importlib import import_module
+from time import perf_counter
 
 import numpy as np
 from jinja2 import Environment, PackageLoader
@@ -2258,6 +2259,7 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
         """Starts event timers used to calculate solving time for model."""
         self.event_marker1 = self.cl.enqueue_marker(self.queue)
         self.event_marker1.wait()
+        self._time_wall_start = perf_counter()
 
     def calculate_memory_used(self, iteration):
         """Calculates memory used on last iteration.
@@ -2275,7 +2277,10 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
         """Calculates solving time for model."""
         event_marker2 = self.cl.enqueue_marker(self.queue)
         event_marker2.wait()
-        return (event_marker2.profile.end - self.event_marker1.profile.start) * 1e-9
+        elapsed = (event_marker2.profile.end - self.event_marker1.profile.start) * 1e-9
+        if elapsed <= 0:
+            return perf_counter() - self._time_wall_start
+        return elapsed
 
     def finalise(self):
         """Copies data from compute device back to CPU to save to file(s)."""

--- a/tests/updates/test_opencl_timing.py
+++ b/tests/updates/test_opencl_timing.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
+#
+# This file is part of the gprMax source code base.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""OpenCL solver timing regression tests."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gprMax.updates import opencl_updates
+from gprMax.updates.opencl_updates import OpenCLUpdates
+
+
+class _Marker:
+    def __init__(self, *, start=0, end=0):
+        self.profile = SimpleNamespace(start=start, end=end)
+        self.waited = False
+
+    def wait(self):
+        self.waited = True
+
+
+class _OpenCL:
+    def __init__(self, markers):
+        self.markers = iter(markers)
+
+    def enqueue_marker(self, queue):
+        return next(self.markers)
+
+
+def _updates(markers):
+    updates = object.__new__(OpenCLUpdates)
+    updates.cl = _OpenCL(markers)
+    updates.queue = object()
+    return updates
+
+
+@pytest.mark.unit
+def test_opencl_solve_time_uses_device_profile(monkeypatch):
+    first = _Marker(start=100)
+    second = _Marker(end=1_500_000_100)
+    updates = _updates([first, second])
+    monkeypatch.setattr(opencl_updates, "perf_counter", lambda: 10.0)
+
+    updates.time_start()
+
+    assert updates.calculate_solve_time() == pytest.approx(1.5)
+    assert first.waited
+    assert second.waited
+
+
+@pytest.mark.unit
+def test_opencl_solve_time_falls_back_when_device_profile_is_zero(monkeypatch):
+    first = _Marker()
+    second = _Marker()
+    updates = _updates([first, second])
+    wall_times = iter((10.0, 12.5))
+    monkeypatch.setattr(opencl_updates, "perf_counter", lambda: next(wall_times))
+
+    updates.time_start()
+
+    assert updates.calculate_solve_time() == pytest.approx(2.5)
+    assert first.waited
+    assert second.waited


### PR DESCRIPTION
## Summary

Retain OpenCL event profiling when the device returns valid timestamps, but fall back to monotonic wall-clock timing when an Apple-style ICD reports a zero or negative elapsed time.

The fallback begins after the initial marker has completed and ends after the final marker completes, so it covers the solve interval without including the initial queue-drain wait. This changes timing reporting only; it does not affect simulation physics.

This is a current-devel replacement for #671 and addresses the residual reporting behaviour discussed in #382. The original contributor is credited as a co-author.

## Tests

- Valid device profiling remains authoritative
- Zero device timestamps use the wall-clock fallback
- Existing OpenCL dispatch tests remain passing

Result: 6 passed; 14 hardware-only tests skipped because OpenCL/CUDA hardware and packages are unavailable locally.