### PR TITLE
Fix accelerator indexing, installation docs, and benchmarks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -206,6 +206,7 @@ Optional features use the same extras as source installations, for example:
 
     $ python -m pip install "gprMax[mpi]"
     $ python -m pip install "gprMax[cuda]"
+    $ python -m pip install "gprMax[opencl]"
     $ python -m pip install "gprMax[metal]"
 
 These extras install Python bindings only. MPI, CUDA, OpenCL, and Metal still
@@ -446,9 +447,16 @@ Accelerator bindings are also optional and can be installed independently:
 
 .. code-block:: console
 
-    (gprMax)$ pip install -e "gprMax[cuda]"       # NVIDIA CUDA; Linux/Windows
-    (gprMax)$ pip install -e "gprMax[opencl]"     # OpenCL
-    (gprMax)$ pip install -e "gprMax[metal]"      # Apple Metal; macOS
+    (gprMax)$ python -m pip install -e "gprMax[cuda]"       # NVIDIA CUDA; Linux/Windows
+    (gprMax)$ python -m pip install -e "gprMax[opencl]"     # OpenCL
+    (gprMax)$ python -m pip install -e "gprMax[metal]"      # Apple Metal; macOS
+
+The ``gprMax[...]`` target is used here because these source-installation
+steps are run from the directory above the gprMax checkout. If the current
+directory is instead the top level of the checkout, use the equivalent
+``.[...]`` target, for example
+``python -m pip install -e ".[metal]"``. The accelerator documentation uses
+this latter form.
 
 Several extras can be requested together, for example
 ``gprMax[cuda,opencl]``. The ``gprMax[accelerators]`` convenience extra

--- a/docs/source/accelerators.rst
+++ b/docs/source/accelerators.rst
@@ -17,9 +17,24 @@ Additionally, the Message Passing Interface (MPI) can be utilised to implement a
 
 Some of these accelerators and frameworks require additional software to be installed. The guidance below explains how to do that and gives examples of usage.
 
+.. _accelerator-bindings-installation:
+
+Installing optional accelerator bindings
+========================================
+
 The CPU/OpenMP solver is part of the core installation. The Python bindings
-for the other accelerators are optional package extras and can be installed
-independently from the top-level gprMax source directory:
+for the other accelerators are optional package extras. For a released gprMax
+package installed from the Python Package Index (PyPI), install the binding for
+the required backend with one of the following commands:
+
+.. code-block:: console
+
+    $ python -m pip install "gprMax[cuda]"       # Linux/Windows
+    $ python -m pip install "gprMax[opencl]"
+    $ python -m pip install "gprMax[metal]"      # macOS
+
+For an editable source installation, run the corresponding command from the
+top-level directory of the gprMax checkout:
 
 .. code-block:: console
 
@@ -27,10 +42,15 @@ independently from the top-level gprMax source directory:
     (gprMax)$ python -m pip install -e ".[opencl]"
     (gprMax)$ python -m pip install -e ".[metal]"      # macOS
 
-Extras can be combined, for example ``.[cuda,opencl]``. The
-``.[accelerators]`` convenience extra requests all accelerator bindings that
-apply to the current operating system. A core installation remains fully
-usable with the CPU solver when none of these extras is installed.
+The different targets are intentional: ``gprMax[...]`` names the released
+distribution, whereas ``.[...]`` refers to the checkout in the current
+directory and ``-e`` makes that source installation editable. Extras can be
+combined in either form, for example ``gprMax[cuda,opencl]`` or
+``.[cuda,opencl]``. The ``accelerators`` convenience extra, selected as either
+``gprMax[accelerators]`` or ``.[accelerators]``, requests all accelerator
+bindings that apply to the current operating system. A core installation
+remains fully usable with the CPU solver when none of these extras is
+installed.
 
 .. warning::
 
@@ -213,16 +233,11 @@ The following steps provide guidance on how to install the extra components to a
    user path environment variable, for example
    ``C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\vX.X\bin`` on Windows
    or the toolkit's ``bin`` directory on Linux.
-3. Install the CUDA extra. Open a Terminal (Linux) or Command Prompt
-   (Windows), navigate into the top-level gprMax directory, activate the
-   gprMax environment if necessary, and run:
-
-   .. code-block:: console
-
-       (gprMax)$ python -m pip install -e ".[cuda]"
-
-   This installs ``pycuda``. Modern macOS releases do not support NVIDIA CUDA,
-   so the dependency is guarded by a platform marker.
+3. Install the CUDA extra using the command for the relevant installation type
+   under :ref:`Installing optional accelerator bindings
+   <accelerator-bindings-installation>`. This installs ``pycuda``. Modern
+   macOS releases do not support NVIDIA CUDA, so the dependency is guarded by
+   a platform marker.
 
 Example
 -------
@@ -250,15 +265,10 @@ Software required
 The following steps provide guidance on how to install the extra components to allow gprMax to use OpenCL:
 
 1. Install a vendor OpenCL implementation/ICD for the intended CPU or GPU.
-2. Open a Terminal (Linux/macOS) or Command Prompt (Windows), navigate into the
-   top-level gprMax directory, activate the gprMax environment if necessary,
-   and install the OpenCL extra:
-
-   .. code-block:: console
-
-       (gprMax)$ python -m pip install -e ".[opencl]"
-
-   This installs ``pyopencl``; it does not install the vendor OpenCL runtime.
+2. Install the OpenCL extra using the command for the relevant installation
+   type under :ref:`Installing optional accelerator bindings
+   <accelerator-bindings-installation>`. This installs ``pyopencl``; it does
+   not install the vendor OpenCL runtime.
 
 Example
 -------
@@ -296,14 +306,10 @@ Software required
 
 The following Python package is required to use Apple Metal acceleration:
 
-1. Open a Terminal on macOS, navigate into the top-level gprMax directory,
-   activate the gprMax environment if necessary, and install the Metal extra:
-
-   .. code-block:: console
-
-       (gprMax)$ python -m pip install -e ".[metal]"
-
-   This installs ``pyobjc-framework-Metal`` only on macOS.
+1. Install the Metal extra using the command for the relevant installation
+   type under :ref:`Installing optional accelerator bindings
+   <accelerator-bindings-installation>`. This installs
+   ``pyobjc-framework-Metal`` only on macOS.
 
 .. note::
 

--- a/gprMax/cuda_opencl/knl_common_base.tmpl
+++ b/gprMax/cuda_opencl/knl_common_base.tmpl
@@ -8,14 +8,14 @@
 #define IDX2D_SRCINFO(m, n) (m)*{{NY_SRCINFO}}+(n)
 #define IDX2D_SRCWAVES(m, n) (m)*({{NY_SRCWAVES}})+(n)
 
-#define IDX3D_FIELDS(i, j, k) (i)*({{NY_FIELDS}})*({{NZ_FIELDS}})+(j)*({{NZ_FIELDS}})+(k)
-#define IDX3D_RXS(i, j, k) (i)*({{NY_RXS}})*({{NZ_RXS}})+(j)*({{NZ_RXS}})+(k)
+#define IDX3D_FIELDS(i, j, k) ((size_t)(i)*(size_t)({{NY_FIELDS}})*(size_t)({{NZ_FIELDS}})+(size_t)(j)*(size_t)({{NZ_FIELDS}})+(size_t)(k))
+#define IDX3D_RXS(i, j, k) ((size_t)(i)*(size_t)({{NY_RXS}})*(size_t)({{NZ_RXS}})+(size_t)(j)*(size_t)({{NZ_RXS}})+(size_t)(k))
 
-#define IDX4D_ID(p, i, j, k) (p)*({{NX_ID}})*({{NY_ID}})*({{NZ_ID}})+(i)*({{NY_ID}})*({{NZ_ID}})+(j)*({{NZ_ID}})+(k)
-#define IDX4D_SNAPS(p, i, j, k) (p)*({{NX_SNAPS}})*({{NY_SNAPS}})*({{NZ_SNAPS}})+(i)*({{NY_SNAPS}})*({{NZ_SNAPS}})+(j)*({{NZ_SNAPS}})+(k)
-#define IDX4D_T(p, i, j, k) (p)*({{NX_T}})*({{NY_T}})*({{NZ_T}})+(i)*({{NY_T}})*({{NZ_T}})+(j)*({{NZ_T}})+(k)
-#define IDX4D_PHI1(p, i, j, k) (p)*(NX_PHI1)*(NY_PHI1)*(NZ_PHI1)+(i)*(NY_PHI1)*(NZ_PHI1)+(j)*(NZ_PHI1)+(k)
-#define IDX4D_PHI2(p, i, j, k) (p)*(NX_PHI2)*(NY_PHI2)*(NZ_PHI2)+(i)*(NY_PHI2)*(NZ_PHI2)+(j)*(NZ_PHI2)+(k)
+#define IDX4D_ID(p, i, j, k) ((size_t)(p)*(size_t)({{NX_ID}})*(size_t)({{NY_ID}})*(size_t)({{NZ_ID}})+(size_t)(i)*(size_t)({{NY_ID}})*(size_t)({{NZ_ID}})+(size_t)(j)*(size_t)({{NZ_ID}})+(size_t)(k))
+#define IDX4D_SNAPS(p, i, j, k) ((size_t)(p)*(size_t)({{NX_SNAPS}})*(size_t)({{NY_SNAPS}})*(size_t)({{NZ_SNAPS}})+(size_t)(i)*(size_t)({{NY_SNAPS}})*(size_t)({{NZ_SNAPS}})+(size_t)(j)*(size_t)({{NZ_SNAPS}})+(size_t)(k))
+#define IDX4D_T(p, i, j, k) ((size_t)(p)*(size_t)({{NX_T}})*(size_t)({{NY_T}})*(size_t)({{NZ_T}})+(size_t)(i)*(size_t)({{NY_T}})*(size_t)({{NZ_T}})+(size_t)(j)*(size_t)({{NZ_T}})+(size_t)(k))
+#define IDX4D_PHI1(p, i, j, k) ((size_t)(p)*(size_t)(NX_PHI1)*(size_t)(NY_PHI1)*(size_t)(NZ_PHI1)+(size_t)(i)*(size_t)(NY_PHI1)*(size_t)(NZ_PHI1)+(size_t)(j)*(size_t)(NZ_PHI1)+(size_t)(k))
+#define IDX4D_PHI2(p, i, j, k) ((size_t)(p)*(size_t)(NX_PHI2)*(size_t)(NY_PHI2)*(size_t)(NZ_PHI2)+(size_t)(i)*(size_t)(NY_PHI2)*(size_t)(NZ_PHI2)+(size_t)(j)*(size_t)(NZ_PHI2)+(size_t)(k))
 
 
 // Material coefficients (read-only) stored in constant memory of compute device

--- a/gprMax/cuda_opencl/knl_fields_updates.py
+++ b/gprMax/cuda_opencl/knl_fields_updates.py
@@ -72,16 +72,18 @@ update_electric = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for 3D field arrays
-    int yz_fields = i % ($NY_FIELDS * $NZ_FIELDS);
-    int x = i / ($NY_FIELDS * $NZ_FIELDS);
-    int y = yz_fields / $NZ_FIELDS;
-    int z = yz_fields % $NZ_FIELDS;
+    size_t field_plane = (size_t)$NY_FIELDS * (size_t)$NZ_FIELDS;
+    size_t yz_fields = (size_t)i % field_plane;
+    int x = (int)((size_t)i / field_plane);
+    int y = (int)(yz_fields / (size_t)$NZ_FIELDS);
+    int z = (int)(yz_fields % (size_t)$NZ_FIELDS);
 
     // Convert the linear index to subscripts for 4D material ID array
-    int yz_ID = (i % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID);
-    int x_ID = (i % ($NX_ID * $NY_ID * $NZ_ID)) / ($NY_ID * $NZ_ID);
-    int y_ID = yz_ID / $NZ_ID;
-    int z_ID = yz_ID % $NZ_ID;
+    size_t ID_plane = (size_t)$NY_ID * (size_t)$NZ_ID;
+    size_t ID_offset = (size_t)i % ((size_t)$NX_ID * ID_plane);
+    int x_ID = (int)(ID_offset / ID_plane);
+    int y_ID = (int)((ID_offset % ID_plane) / (size_t)$NZ_ID);
+    int z_ID = (int)((ID_offset % ID_plane) % (size_t)$NZ_ID);
 
     // Ex component
     if ((NY != 1 || NZ != 1) && x >= 0 && x < NX && y > 0 && y < NY && z > 0 && z < NZ) {
@@ -165,16 +167,18 @@ update_magnetic = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for 3D field arrays
-    int yz_fields = i % ($NY_FIELDS * $NZ_FIELDS);
-    int x = i / ($NY_FIELDS * $NZ_FIELDS);
-    int y = yz_fields / $NZ_FIELDS;
-    int z = yz_fields % $NZ_FIELDS;
+    size_t field_plane = (size_t)$NY_FIELDS * (size_t)$NZ_FIELDS;
+    size_t yz_fields = (size_t)i % field_plane;
+    int x = (int)((size_t)i / field_plane);
+    int y = (int)(yz_fields / (size_t)$NZ_FIELDS);
+    int z = (int)(yz_fields % (size_t)$NZ_FIELDS);
 
     // Convert the linear index to subscripts for 4D material ID array
-    int yz_ID = (i % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID);
-    int x_ID = (i % ($NX_ID * $NY_ID * $NZ_ID)) / ($NY_ID * $NZ_ID);
-    int y_ID = yz_ID / $NZ_ID;
-    int z_ID = yz_ID % $NZ_ID;
+    size_t ID_plane = (size_t)$NY_ID * (size_t)$NZ_ID;
+    size_t ID_offset = (size_t)i % ((size_t)$NX_ID * ID_plane);
+    int x_ID = (int)(ID_offset / ID_plane);
+    int y_ID = (int)((ID_offset % ID_plane) / (size_t)$NZ_ID);
+    int z_ID = (int)((ID_offset % ID_plane) % (size_t)$NZ_ID);
 
     // Hx component. Include both own-axis domain walls; PMC symmetry uses
     // the lower-wall value, while the ordinary outer-wall result remains
@@ -280,22 +284,25 @@ update_electric_dispersive_A = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for 3D field arrays
-    int yz_fields = i % ($NY_FIELDS * $NZ_FIELDS);
-    int x = i / ($NY_FIELDS * $NZ_FIELDS);
-    int y = yz_fields / $NZ_FIELDS;
-    int z = yz_fields % $NZ_FIELDS;
+    size_t field_plane = (size_t)$NY_FIELDS * (size_t)$NZ_FIELDS;
+    size_t yz_fields = (size_t)i % field_plane;
+    int x = (int)((size_t)i / field_plane);
+    int y = (int)(yz_fields / (size_t)$NZ_FIELDS);
+    int z = (int)(yz_fields % (size_t)$NZ_FIELDS);
 
     // Convert the linear index to subscripts for 4D material ID array
-    int yz_ID = (i % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID);
-    int x_ID = (i % ($NX_ID * $NY_ID * $NZ_ID)) / ($NY_ID * $NZ_ID);
-    int y_ID = yz_ID / $NZ_ID;
-    int z_ID = yz_ID % $NZ_ID;
+    size_t ID_plane = (size_t)$NY_ID * (size_t)$NZ_ID;
+    size_t ID_offset = (size_t)i % ((size_t)$NX_ID * ID_plane);
+    int x_ID = (int)(ID_offset / ID_plane);
+    int y_ID = (int)((ID_offset % ID_plane) / (size_t)$NZ_ID);
+    int z_ID = (int)((ID_offset % ID_plane) % (size_t)$NZ_ID);
 
     // Convert the linear index to subscripts for 4D dispersive array
-    int yz_T = (i % ($NX_T * $NY_T * $NZ_T)) % ($NY_T * $NZ_T);
-    int x_T = (i % ($NX_T * $NY_T * $NZ_T)) / ($NY_T * $NZ_T);
-    int y_T = yz_T / $NZ_T;
-    int z_T = yz_T % $NZ_T;
+    size_t T_plane = (size_t)$NY_T * (size_t)$NZ_T;
+    size_t T_offset = (size_t)i % ((size_t)$NX_T * T_plane);
+    int x_T = (int)(T_offset / T_plane);
+    int y_T = (int)((T_offset % T_plane) / (size_t)$NZ_T);
+    int z_T = (int)((T_offset % T_plane) % (size_t)$NZ_T);
 
     // Ex component
     if ((NY != 1 || NZ != 1) && x >= 0 && x < NX && y > 0 && y < NY && z > 0 && z < NZ) {
@@ -414,22 +421,25 @@ update_electric_dispersive_B = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for 3D field arrays
-    int yz_fields = i % ($NY_FIELDS * $NZ_FIELDS);
-    int x = i / ($NY_FIELDS * $NZ_FIELDS);
-    int y = yz_fields / $NZ_FIELDS;
-    int z = yz_fields % $NZ_FIELDS;
+    size_t field_plane = (size_t)$NY_FIELDS * (size_t)$NZ_FIELDS;
+    size_t yz_fields = (size_t)i % field_plane;
+    int x = (int)((size_t)i / field_plane);
+    int y = (int)(yz_fields / (size_t)$NZ_FIELDS);
+    int z = (int)(yz_fields % (size_t)$NZ_FIELDS);
 
     // Convert the linear index to subscripts for 4D material ID array
-    int yz_ID = (i % ($NX_ID * $NY_ID * $NZ_ID)) % ($NY_ID * $NZ_ID);
-    int x_ID = (i % ($NX_ID * $NY_ID * $NZ_ID)) / ($NY_ID * $NZ_ID);
-    int y_ID = yz_ID / $NZ_ID;
-    int z_ID = yz_ID % $NZ_ID;
+    size_t ID_plane = (size_t)$NY_ID * (size_t)$NZ_ID;
+    size_t ID_offset = (size_t)i % ((size_t)$NX_ID * ID_plane);
+    int x_ID = (int)(ID_offset / ID_plane);
+    int y_ID = (int)((ID_offset % ID_plane) / (size_t)$NZ_ID);
+    int z_ID = (int)((ID_offset % ID_plane) % (size_t)$NZ_ID);
 
     // Convert the linear index to subscripts for 4D dispersive array
-    int yz_T = (i % ($NX_T * $NY_T * $NZ_T)) % ($NY_T * $NZ_T);
-    int x_T = (i % ($NX_T * $NY_T * $NZ_T)) / ($NY_T * $NZ_T);
-    int y_T = yz_T / $NZ_T;
-    int z_T = yz_T % $NZ_T;
+    size_t T_plane = (size_t)$NY_T * (size_t)$NZ_T;
+    size_t T_offset = (size_t)i % ((size_t)$NX_T * T_plane);
+    int x_T = (int)(T_offset / T_plane);
+    int y_T = (int)((T_offset % T_plane) / (size_t)$NZ_T);
+    int z_T = (int)((T_offset % T_plane) % (size_t)$NZ_T);
 
     // Ex component
     if ((NY != 1 || NZ != 1) && x >= 0 && x < NX && y > 0 && y < NY && z > 0 && z < NZ) {

--- a/gprMax/cuda_opencl/knl_symmetry_boundaries.py
+++ b/gprMax/cuda_opencl/knl_symmetry_boundaries.py
@@ -70,15 +70,17 @@ kernel void update_electric_pmc(
     // plus the doubled ghost contribution from each adjoining PMC plane.
     $CUDA_IDX
 
-    int x = i / ($NY_FIELDS * $NZ_FIELDS);
-    int y = (i % ($NY_FIELDS * $NZ_FIELDS)) / $NZ_FIELDS;
-    int z = (i % ($NY_FIELDS * $NZ_FIELDS)) % $NZ_FIELDS;
+    size_t field_plane = (size_t)$NY_FIELDS * (size_t)$NZ_FIELDS;
+    size_t yz_fields = (size_t)i % field_plane;
+    int x = (int)((size_t)i / field_plane);
+    int y = (int)(yz_fields / (size_t)$NZ_FIELDS);
+    int z = (int)(yz_fields % (size_t)$NZ_FIELDS);
 
-    int x_ID = (i % ($NX_ID * $NY_ID * $NZ_ID)) / ($NY_ID * $NZ_ID);
-    int y_ID = ((i % ($NX_ID * $NY_ID * $NZ_ID)) %
-        ($NY_ID * $NZ_ID)) / $NZ_ID;
-    int z_ID = ((i % ($NX_ID * $NY_ID * $NZ_ID)) %
-        ($NY_ID * $NZ_ID)) % $NZ_ID;
+    size_t ID_plane = (size_t)$NY_ID * (size_t)$NZ_ID;
+    size_t ID_offset = (size_t)i % ((size_t)$NX_ID * ID_plane);
+    int x_ID = (int)(ID_offset / ID_plane);
+    int y_ID = (int)((ID_offset % ID_plane) / (size_t)$NZ_ID);
+    int z_ID = (int)((ID_offset % ID_plane) % (size_t)$NZ_ID);
 
     int ex_on_pmc = (y == 0 && PMC_Y0) || (y == NY && PMC_YMAX)
         || (z == 0 && PMC_Z0) || (z == NZ && PMC_ZMAX);
@@ -296,14 +298,16 @@ kernel void update_electric_pmc_dispersive_b(
     "func": Template(
         r"""
     $CUDA_IDX
-    int x = i / ($NY_FIELDS * $NZ_FIELDS);
-    int y = (i % ($NY_FIELDS * $NZ_FIELDS)) / $NZ_FIELDS;
-    int z = (i % ($NY_FIELDS * $NZ_FIELDS)) % $NZ_FIELDS;
-    int x_ID = (i % ($NX_ID * $NY_ID * $NZ_ID)) / ($NY_ID * $NZ_ID);
-    int y_ID = ((i % ($NX_ID * $NY_ID * $NZ_ID)) %
-        ($NY_ID * $NZ_ID)) / $NZ_ID;
-    int z_ID = ((i % ($NX_ID * $NY_ID * $NZ_ID)) %
-        ($NY_ID * $NZ_ID)) % $NZ_ID;
+    size_t field_plane = (size_t)$NY_FIELDS * (size_t)$NZ_FIELDS;
+    size_t yz_fields = (size_t)i % field_plane;
+    int x = (int)((size_t)i / field_plane);
+    int y = (int)(yz_fields / (size_t)$NZ_FIELDS);
+    int z = (int)(yz_fields % (size_t)$NZ_FIELDS);
+    size_t ID_plane = (size_t)$NY_ID * (size_t)$NZ_ID;
+    size_t ID_offset = (size_t)i % ((size_t)$NX_ID * ID_plane);
+    int x_ID = (int)(ID_offset / ID_plane);
+    int y_ID = (int)((ID_offset % ID_plane) / (size_t)$NZ_ID);
+    int z_ID = (int)((ID_offset % ID_plane) % (size_t)$NZ_ID);
 
     int ex_on_pmc = (y == 0 && PMC_Y0) || (y == NY && PMC_YMAX)
         || (z == 0 && PMC_Z0) || (z == NZ && PMC_ZMAX);

--- a/gprMax/updates/cuda_updates.py
+++ b/gprMax/updates/cuda_updates.py
@@ -69,6 +69,11 @@ from gprMax.utilities.utilities import round32
 
 logger = logging.getLogger(__name__)
 
+CUDA_THREAD_INDEX = (
+    "size_t i = (size_t)blockIdx.x * (size_t)blockDim.x + "
+    "(size_t)threadIdx.x;"
+)
+
 
 class CUDAUpdates(Updates[CUDAGrid]):
     """Defines update functions for GPU-based (CUDA) solver."""
@@ -104,7 +109,7 @@ class CUDAUpdates(Updates[CUDAGrid]):
         # Substitutions in function bodies
         self.subs_func = {
             "REAL": config.sim_config.dtypes["C_float_or_double"],
-            "CUDA_IDX": "int i = blockIdx.x * blockDim.x + threadIdx.x;",
+            "CUDA_IDX": CUDA_THREAD_INDEX,
             "TFSF_IDX": "int t = blockIdx.x * blockDim.x + threadIdx.x;",
             "METAL_DFT_PARAMETERS": "",
             "NX_FIELDS": self.grid.nx + 1,

--- a/tests/updates/test_gpu_large_grid_indexing.py
+++ b/tests/updates/test_gpu_large_grid_indexing.py
@@ -1,0 +1,109 @@
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
+#
+# This file is part of the gprMax source code base.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
+
+"""Source-generation regressions for accelerator grids above 2^31 entries."""
+
+import pytest
+from jinja2 import Environment, PackageLoader
+
+from gprMax.cuda_opencl import knl_fields_updates, knl_symmetry_boundaries
+from gprMax.updates.cuda_updates import CUDA_THREAD_INDEX
+
+
+def _render_common(backend):
+    env = Environment(loader=PackageLoader("gprMax", "cuda_opencl"))
+    return env.get_template(f"knl_common_{backend}.tmpl").render(
+        REAL="float",
+        DRUDELORENTZ=False,
+        NY_FIELDS=50_001,
+        NZ_FIELDS=50_003,
+        NY_RXS=50_005,
+        NZ_RXS=50_007,
+        NX_ID=6,
+        NY_ID=50_009,
+        NZ_ID=50_021,
+        NX_SNAPS=6,
+        NY_SNAPS=50_023,
+        NZ_SNAPS=50_029,
+        NX_T=6,
+        NY_T=50_033,
+        NZ_T=50_047,
+    )
+
+
+def test_cuda_global_thread_index_uses_pointer_sized_arithmetic():
+    assert CUDA_THREAD_INDEX.startswith("size_t i =")
+    assert "(size_t)blockIdx.x" in CUDA_THREAD_INDEX
+    assert "(size_t)blockDim.x" in CUDA_THREAD_INDEX
+    assert "(size_t)threadIdx.x" in CUDA_THREAD_INDEX
+
+
+@pytest.mark.parametrize("backend", ["cuda", "opencl", "metal"])
+@pytest.mark.parametrize(
+    "macro",
+    [
+        "IDX3D_FIELDS",
+        "IDX3D_RXS",
+        "IDX4D_ID",
+        "IDX4D_SNAPS",
+        "IDX4D_T",
+        "IDX4D_PHI1",
+        "IDX4D_PHI2",
+    ],
+)
+def test_flattened_accelerator_indices_use_pointer_sized_arithmetic(
+    backend, macro
+):
+    source = _render_common(backend)
+    definition = next(
+        line for line in source.splitlines() if line.startswith(f"#define {macro}(")
+    )
+
+    assert "(size_t)" in definition
+
+
+@pytest.mark.parametrize(
+    "kernel",
+    [
+        knl_fields_updates.update_electric,
+        knl_fields_updates.update_magnetic,
+        knl_fields_updates.update_electric_dispersive_A,
+        knl_fields_updates.update_electric_dispersive_B,
+        knl_symmetry_boundaries.update_electric_pmc,
+        knl_symmetry_boundaries.update_electric_pmc_dispersive_b,
+    ],
+)
+def test_field_coordinate_products_use_pointer_sized_arithmetic(kernel):
+    source = kernel["func"].template
+
+    assert "size_t field_plane" in source
+    assert "size_t ID_plane" in source
+    assert "size_t ID_offset" in source
+
+
+@pytest.mark.parametrize(
+    "kernel",
+    [
+        knl_fields_updates.update_electric_dispersive_A,
+        knl_fields_updates.update_electric_dispersive_B,
+    ],
+)
+def test_dispersive_coordinate_products_use_pointer_sized_arithmetic(kernel):
+    source = kernel["func"].template
+
+    assert "size_t T_plane" in source
+    assert "size_t T_offset" in source


### PR DESCRIPTION
## Summary

- prevent signed 32-bit overflow in the CUDA global thread index for domains above 2^31 field entries
- use pointer-sized arithmetic for flattened 3D/4D accelerator array offsets and for field, material-ID, and dispersive coordinate products
- extend the correction to the PMC symmetry kernels added since the original proposal
- add hardware-independent source-generation regressions for CUDA, OpenCL, and Metal
- distinguish released-package accelerator installs (`gprMax[...]`) from editable source installs (`.[...]`)
- add the omitted OpenCL installation example and centralise the CUDA, OpenCL, and Metal binding instructions
- make every module in `testing/benchmarking` import-safe and runnable through a portable command-line interface
- replace the Metal benchmark's hard-coded developer path and subprocess parsing with the current gprMax Python API, JSON output, and optional plotting
- remove legacy `# Authors:` header bylines and align the affected University copyright headers with the 2026 source-file convention

## Context

This carries forward the valid large-grid part of #517 by @JustHereForWork, which reported failures for CUDA simulations using more than approximately 65 GB on an A100 80 GB GPU. The receiver finalisation bug included in that PR has already been fixed independently on `devel`, so it is intentionally excluded here.

The implementation is rebased on current `devel` and uses `size_t` consistently for address calculations. Coordinate values remain 32-bit after the flattened offset has been decomposed because individual axis lengths are still represented by the existing 32-bit kernel arguments.

The documentation update also resolves the inconsistency between the README installation page and the accelerator guide. PyPI commands now name the `gprMax` distribution, while source commands use `-e ".[extra]"` from the checkout root; the README retains its equivalent `-e "gprMax[extra]"` form where its workflow explicitly runs from the parent directory.

The benchmark audit found that `bench_simple` executed its full 72-case matrix on import, while `benchmark_metal` changed into a developer-specific absolute path and depended on parsing historical CLI output. Both now have testable builders and command-line entry points. The benchmarking guide documents reduced smoke-test commands as well as the full runs.

## Validation

- 64 targeted kernel-generation, dispersive, symmetry, and snapshot tests passed
- 27 Metal-specific unit/dispatch tests passed
- 2 end-to-end Metal-versus-double-precision-CPU plane-wave parity cases passed on Apple GPU hardware, including a dispersive case
- 5 packaging-extra tests passed
- 18 benchmark configuration, plotting, numerical-oracle, and execution tests passed
- reduced end-to-end runs completed for all five benchmark modules; the Metal benchmark executed both CPU and Apple Metal backends on an M1 Max
- `git diff --check` passed

CUDA hardware is not available on the development Mac, so the large A100 case could not be reproduced locally. The regression tests verify that all relevant generated address expressions use pointer-sized arithmetic, and the Metal hardware runs confirm that the shared-template change compiles and preserves numerical parity.
