### PR TITLE
Repair benchmark utilities and standardise source headers

### DIFF
--- a/docs/source/benchmarking.rst
+++ b/docs/source/benchmarking.rst
@@ -9,11 +9,21 @@ This section provides information and results from performance benchmarking of g
 How to benchmark?
 =================
 
-The following simple models (found in the ``testing/benchmarking`` sub-package) can be used to benchmark gprMax on your own system. The models feature different domain sizes (from 100^3 to 800^3 cells) and contain a simple Hertzian dipole source in free space:
+The ``bench_simple`` module in the ``testing/benchmarking`` sub-package can be
+used to benchmark gprMax on your own system. Its default matrix covers domain
+sizes from 100^3 to 800^3 cells and several OpenMP thread counts, with a simple
+Hertzian dipole source in free space. Run it from the repository root:
 
-.. literalinclude:: ../../testing/benchmarking/bench_simple.py
-    :language: python
-    :linenos:
+.. code-block:: none
+
+    (gprMax)$ python -m testing.benchmarking.bench_simple
+
+Domain sizes, thread counts, discretisation, time window, and output path can
+be selected from the command line. Use a reduced matrix for a quick smoke test:
+
+.. code-block:: none
+
+    (gprMax)$ python -m testing.benchmarking.bench_simple --domains 0.024 --threads 1 --time-window 1e-11 --output /tmp/bench_simple
 
 The performance metric used to measure the throughput of the solver is:
 
@@ -77,20 +87,15 @@ Apple Metal GPU Benchmarking
 
 For macOS users with Apple Silicon (M-series) based GPUs, a dedicated Metal benchmarking script is available in the ``testing/benchmarking`` sub-package:
 
-.. literalinclude:: ../../testing/benchmarking/benchmark_metal.py
-    :language: python
-    :linenos:
-    :lines: 1-30
-
 This script provides comprehensive benchmarking capabilities specifically designed for the Apple Metal backend:
 
 Features
 --------
 
-* **Automated domain size testing**: Tests multiple domain sizes from 50×50×50 to 200×200×200 cells
+* **Automated domain size testing**: Tests multiple domain sizes from 50×50×50 to 400×400×400 cells by default
 * **CPU vs Metal comparison**: Runs identical simulations on both CPU and Metal backends for direct performance comparison
 * **Performance visualization**: Generates plots showing throughput (Mcells/s) and speedup ratios
-* **Data export**: Saves results in multiple formats (JSON, NumPy) for further analysis
+* **Data export**: Saves the configuration, individual timings, throughput, and speedup results as JSON
 * **Validation integration**: Can be combined with PML validation testing
 
 Usage
@@ -100,15 +105,21 @@ To run the Metal benchmarking suite:
 
 .. code-block:: none
 
-    (gprMax)$ cd testing/benchmarking
-    (gprMax)$ python benchmark_metal.py
+    (gprMax)$ python -m testing.benchmarking.benchmark_metal
+
+For a quick functional test before a full benchmark, reduce the domain,
+iterations, repeats, and warmups:
+
+.. code-block:: none
+
+    (gprMax)$ python -m testing.benchmarking.benchmark_metal --sizes 24 --iterations 4 --repeats 1 --warmups 0 --no-plot --output /tmp/metal_benchmark.json
 
 The script will automatically:
 
-1. Create benchmark input files for different domain sizes
+1. Build identical Python-API scenes for different domain sizes
 2. Run simulations using both CPU and Metal backends
 3. Calculate performance metrics using the standard formula above
-4. Generate comparison plots and save results
+4. Save JSON results and, unless ``--no-plot`` is specified, generate a comparison plot
 
 Visualization Tools
 ===================

--- a/testing/analytical_solutions.py
+++ b/testing/analytical_solutions.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
-# This file is part of gprMax.
+# This file is part of the gprMax source code base.
 #
 # gprMax is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -9,11 +9,11 @@
 #
 # gprMax is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
 from scipy.constants import c

--- a/testing/analytical_solutions.py
+++ b/testing/analytical_solutions.py
@@ -1,6 +1,4 @@
-# Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
-#                          and Nathan Mannall
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
 # This file is part of gprMax.
 #

--- a/testing/benchmarking/__init__.py
+++ b/testing/benchmarking/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
+#
+# This file is part of the gprMax source code base.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.

--- a/testing/benchmarking/bench_simple.py
+++ b/testing/benchmarking/bench_simple.py
@@ -1,52 +1,115 @@
-"""A series of models with different domain sizes used for benchmarking.
-The domain is free space with a simple source (Hertzian Dipole) and
-receiver at the centre.
-"""
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
+#
+# This file is part of the gprMax source code base.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
+"""Run a simple free-space CPU benchmark over domain and thread matrices."""
+
+import argparse
 import itertools
 from pathlib import Path
 
 import gprMax
 
-# File path for output
-fn = Path(__file__)
 
-# Cube side lengths (in cells) for different domains
-domains = [0.10, 0.15, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80]
+DEFAULT_DOMAINS = (0.10, 0.15, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80)
+DEFAULT_THREADS = (1, 2, 4, 8, 16, 32, 64, 128)
 
-# Number of OpenMP threads to benchmark each domain size
-ompthreads = [1, 2, 4, 8, 16, 32, 64, 128]
 
-scenes = []
+def _positive_int(value):
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be a positive integer")
+    return parsed
 
-# Discretisation
-dl = 0.001
 
-for d, threads in itertools.product(domains, ompthreads):
-    # Domain
-    x = d
-    y = x
-    z = x
+def _positive_float(value):
+    parsed = float(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
 
-    scene = gprMax.Scene()
 
-    title = gprMax.Title(name=fn.with_suffix("").name)
-    domain = gprMax.Domain(p1=(x, y, z))
-    dxdydz = gprMax.Discretisation(p1=(dl, dl, dl))
-    time_window = gprMax.TimeWindow(time=3e-9)
-    wv = gprMax.Waveform(wave_type="gaussiandotnorm", amp=1, freq=900e6, id="MySource")
-    src = gprMax.HertzianDipole(p1=(x / 2, y / 2, z / 2), polarisation="x", waveform_id="MySource")
+def build_scenes(domains, threads, cell_size=0.001, time_window=3e-9):
+    """Build the requested Cartesian product of benchmark scenes."""
 
-    omp = gprMax.OMPThreads(n=threads)
+    scenes = []
+    title = Path(__file__).stem
+    for extent, thread_count in itertools.product(domains, threads):
+        scene = gprMax.Scene()
+        scene.add(gprMax.Title(name=title))
+        scene.add(gprMax.Domain(p1=(extent,) * 3))
+        scene.add(gprMax.Discretisation(p1=(cell_size,) * 3))
+        scene.add(gprMax.TimeWindow(time=time_window))
+        scene.add(
+            gprMax.Waveform(
+                wave_type="gaussiandotnorm",
+                amp=1,
+                freq=900e6,
+                id="MySource",
+            )
+        )
+        scene.add(
+            gprMax.HertzianDipole(
+                p1=(extent / 2,) * 3,
+                polarisation="x",
+                waveform_id="MySource",
+            )
+        )
+        scene.add(gprMax.OMPThreads(n=thread_count))
+        scenes.append(scene)
+    return scenes
 
-    scene.add(title)
-    scene.add(domain)
-    scene.add(dxdydz)
-    scene.add(time_window)
-    scene.add(wv)
-    scene.add(src)
-    scene.add(omp)
-    scenes.append(scene)
 
-# Run model
-gprMax.run(scenes=scenes, n=len(scenes), geometry_only=False, outputfile=fn, gpu=None)
+def _parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--domains",
+        nargs="+",
+        type=_positive_float,
+        default=DEFAULT_DOMAINS,
+        help="cube side lengths in metres",
+    )
+    parser.add_argument(
+        "--threads",
+        nargs="+",
+        type=_positive_int,
+        default=DEFAULT_THREADS,
+        help="OpenMP thread counts",
+    )
+    parser.add_argument("--cell-size", type=_positive_float, default=0.001)
+    parser.add_argument("--time-window", type=_positive_float, default=3e-9)
+    parser.add_argument("--output", type=Path, default=Path(__file__))
+    return parser
+
+
+def main():
+    args = _parser().parse_args()
+    scenes = build_scenes(
+        args.domains,
+        args.threads,
+        cell_size=args.cell_size,
+        time_window=args.time_window,
+    )
+    gprMax.run(
+        scenes=scenes,
+        n=len(scenes),
+        geometry_only=False,
+        outputfile=args.output,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/benchmarking/benchmark_impedance_box.py
+++ b/testing/benchmarking/benchmark_impedance_box.py
@@ -1,3 +1,20 @@
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
+#
+# This file is part of the gprMax source code base.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
+
 """Benchmark the CPU cost of local surface-impedance pole updates.
 
 The benchmark includes an ordinary-grid baseline, a zero-pole resistive

--- a/testing/benchmarking/benchmark_layered_ntff.py
+++ b/testing/benchmarking/benchmark_layered_ntff.py
@@ -6,6 +6,14 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
 """Benchmark the Cython planar-layered NTFF sum against its NumPy oracle.
 

--- a/testing/benchmarking/benchmark_layered_ntff.py
+++ b/testing/benchmarking/benchmark_layered_ntff.py
@@ -1,6 +1,6 @@
-# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
-# This file is part of gprMax.
+# This file is part of the gprMax source code base.
 #
 # gprMax is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/testing/benchmarking/benchmark_metal.py
+++ b/testing/benchmarking/benchmark_metal.py
@@ -1,235 +1,258 @@
-#!/usr/bin/env python3
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
+#
+# This file is part of the gprMax source code base.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
+
+"""Benchmark Apple Metal and CPU throughput on identical gprMax scenes.
+
+Run from the repository root, for example::
+
+    python -m testing.benchmarking.benchmark_metal --sizes 50 100 150
 """
-Apple Metal GPU Benchmarking Script for gprMax
-Measures performance across different domain sizes and compares with CPU.
-"""
 
-import os
-import subprocess
-import re
-import numpy as np
-import matplotlib.pyplot as plt
+from __future__ import annotations
 
+import argparse
+import json
+import logging
+import statistics
+import tempfile
+from pathlib import Path
+from time import perf_counter
 
-def create_benchmark_input(size, name):
-    """Create a benchmark input file with specified domain size."""
-    content = f"""#title: Metal GPU Benchmark - {size}x{size}x{size} domain
-#domain: {size*0.001:.3f} {size*0.001:.3f} {size*0.001:.3f}
-#dx_dy_dz: 0.001 0.001 0.001
-#time_window: 3e-09
-#pml_cells: 0
+import gprMax
 
-#material: 6 0 1 0 half_space
-
-#waveform: ricker 1 1.5e9 my_ricker
-#hertzian_dipole: x {size*0.001/2:.3f} {size*0.001/2:.3f} {size*0.001/2:.3f} my_ricker
-#rx: {size*0.001/2:.3f} {size*0.001/2:.3f} {size*0.001/2:.3f}
-
-#box: 0 0 0 {size*0.001:.3f} {size*0.001/2:.3f} {size*0.001:.3f} half_space
-"""
-    
-    with open(f"testing/benchmarking/{name}.in", "w") as f:
-        f.write(content)
-    return f"testing/benchmarking/{name}.in"
+DEFAULT_SIZES = (50, 75, 100, 125, 150, 175, 200, 250, 300, 400)
 
 
-def run_benchmark(input_file, backend_flag="", output_suffix=""):
-    """Run a single benchmark and extract performance metrics."""
-    cmd = ["python", "-m", "gprMax", input_file]
-    if backend_flag:
-        cmd.append(backend_flag)
-    if output_suffix:
-        cmd.extend(["-o", f"benchmark_{output_suffix}"])
-    
-    print(f"Running: {' '.join(cmd)}")
-    
-    try:
-        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-        
-        # Extract timing information from output
-        lines = result.stdout.split('\n')
-        
-        # Find execution time
-        exec_time = None
-        iterations = None
-        
-        for line in lines:
-            if "iterations)" in line and "secs" in line:
-                # Extract iterations from pattern like "1559 iterations)"
-                match = re.search(r'(\d+) iterations\)', line)
-                if match:
-                    iterations = int(match.group(1))
-            
-            if "=== Simulation completed in" in line:
-                # Extract time from pattern like "=== Simulation completed in 4.6083 seconds ==="
-                match = re.search(r'completed in ([\d\.]+) seconds', line)
-                if match:
-                    exec_time = float(match.group(1))
-        
-        # Extract domain information from the input file
-        with open(input_file, 'r') as f:
-            content = f.read()
-            
-        # Extract domain size from #domain line
-        domain_match = re.search(r'#domain: ([\d\.]+) ([\d\.]+) ([\d\.]+)', content)
-        if domain_match:
-            dx_size = float(domain_match.group(1))
-            dy_size = float(domain_match.group(2)) 
-            dz_size = float(domain_match.group(3))
-            
-        # Extract cell size
-        cell_match = re.search(r'#dx_dy_dz: ([\d\.]+) ([\d\.]+) ([\d\.]+)', content)
-        if cell_match:
-            dx = float(cell_match.group(1))
-            dy = float(cell_match.group(2))
-            dz = float(cell_match.group(3))
-            
-            # Calculate number of cells
-            nx = int(dx_size / dx)
-            ny = int(dy_size / dy) 
-            nz = int(dz_size / dz)
-        
-        if exec_time and iterations and nx and ny and nz:
-            # Calculate performance using the formula: P = (NX × NY × NZ × NT) / (T × 1×10⁶)
-            total_cells = nx * ny * nz * iterations
-            performance = total_cells / (exec_time * 1e6)
-            
-            return {
-                'nx': nx, 'ny': ny, 'nz': nz, 'nt': iterations,
-                'exec_time': exec_time, 'performance': performance,
-                'total_cells': total_cells
-            }
-        else:
-            print(f"Failed to extract metrics from output")
-            return None
-            
-    except subprocess.CalledProcessError as e:
-        print(f"Benchmark failed: {e}")
-        print(f"STDERR: {e.stderr}")
-        return None
+def _positive_int(value):
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be a positive integer")
+    return parsed
+
+
+def _nonnegative_int(value):
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("value must be a non-negative integer")
+    return parsed
+
+
+def _positive_float(value):
+    parsed = float(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def build_scene(size, *, cell_size, iterations, threads):
+    """Build one two-material cube used by both benchmark backends."""
+
+    extent = size * cell_size
+    centre = (extent / 2,) * 3
+    scene = gprMax.Scene()
+    scene.add(gprMax.Title(name=f"Metal benchmark {size}x{size}x{size}"))
+    scene.add(gprMax.Domain(p1=(extent,) * 3))
+    scene.add(gprMax.Discretisation(p1=(cell_size,) * 3))
+    scene.add(gprMax.TimeWindow(iterations=iterations))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.OMPThreads(n=threads))
+    scene.add(gprMax.Material(er=6, se=0, mr=1, sm=0, id="half_space"))
+    scene.add(
+        gprMax.Waveform(
+            wave_type="ricker",
+            amp=1,
+            freq=1.5e9,
+            id="my_ricker",
+        )
+    )
+    scene.add(
+        gprMax.HertzianDipole(
+            p1=centre,
+            polarisation="x",
+            waveform_id="my_ricker",
+        )
+    )
+    scene.add(gprMax.Rx(p1=centre, outputs=["Ex"]))
+    scene.add(
+        gprMax.Box(
+            p1=(0, 0, 0),
+            p2=(extent, extent / 2, extent),
+            material_id="half_space",
+        )
+    )
+    return scene
+
+
+def _solver_options(backend, device):
+    if backend == "metal":
+        return {"metal": [device], "gpu_precision": "single"}
+    return {"cpu_precision": "single"}
+
+
+def _run_once(args, output_directory, size, backend, repeat):
+    outputfile = output_directory / f"{backend}_{size}_{repeat}"
+    started = perf_counter()
+    gprMax.run(
+        scenes=[
+            build_scene(
+                size,
+                cell_size=args.cell_size,
+                iterations=args.iterations,
+                threads=args.threads,
+            )
+        ],
+        n=1,
+        outputfile=outputfile,
+        hide_progress_bars=True,
+        log_level=logging.WARNING,
+        **_solver_options(backend, args.device),
+    )
+    return perf_counter() - started
+
+
+def _backend_result(size, iterations, times):
+    median_seconds = statistics.median(times)
+    return {
+        "run_seconds": times,
+        "median_seconds": median_seconds,
+        "performance_mcells_per_second": (
+            size**3 * iterations / (median_seconds * 1e6)
+        ),
+    }
+
+
+def run_benchmark(args):
+    """Execute the CPU/Metal matrix and return JSON-serialisable results."""
+
+    cases = []
+    with tempfile.TemporaryDirectory(prefix="gprmax_metal_benchmark_") as temporary:
+        output_directory = Path(temporary)
+        for size in args.sizes:
+            for warmup in range(args.warmups):
+                _run_once(args, output_directory, size, "cpu", f"warmup_{warmup}")
+                _run_once(args, output_directory, size, "metal", f"warmup_{warmup}")
+
+            times = {"cpu": [], "metal": []}
+            for repeat in range(args.repeats):
+                backends = ("cpu", "metal") if repeat % 2 == 0 else ("metal", "cpu")
+                for backend in backends:
+                    times[backend].append(
+                        _run_once(args, output_directory, size, backend, repeat)
+                    )
+
+            cpu = _backend_result(size, args.iterations, times["cpu"])
+            metal = _backend_result(size, args.iterations, times["metal"])
+            cases.append(
+                {
+                    "size": size,
+                    "cells": size**3,
+                    "cpu": cpu,
+                    "metal": metal,
+                    "speedup": (
+                        metal["performance_mcells_per_second"]
+                        / cpu["performance_mcells_per_second"]
+                    ),
+                }
+            )
+
+    return {
+        "configuration": {
+            "sizes": list(args.sizes),
+            "cell_size": args.cell_size,
+            "iterations": args.iterations,
+            "threads": args.threads,
+            "metal_device": args.device,
+            "repeats": args.repeats,
+            "warmups": args.warmups,
+            "precision": "single",
+        },
+        "cases": cases,
+    }
+
+
+def create_performance_plot(results, path, *, show=False):
+    """Write throughput and speedup plots for a benchmark result."""
+
+    import matplotlib.pyplot as plt
+
+    cases = results["cases"]
+    sizes = [case["size"] for case in cases]
+    cpu = [case["cpu"]["performance_mcells_per_second"] for case in cases]
+    metal = [case["metal"]["performance_mcells_per_second"] for case in cases]
+    speedups = [case["speedup"] for case in cases]
+
+    figure, (throughput_axis, speedup_axis) = plt.subplots(1, 2, figsize=(15, 6))
+    throughput_axis.plot(sizes, metal, "ro-", label="Apple Metal")
+    throughput_axis.plot(sizes, cpu, "bo-", label="CPU (OpenMP)")
+    throughput_axis.set_xlabel("Domain size [cells per side]")
+    throughput_axis.set_ylabel("Performance [Mcells/s]")
+    throughput_axis.set_title("gprMax throughput")
+    throughput_axis.legend()
+    throughput_axis.grid(True, alpha=0.3)
+
+    speedup_axis.plot(sizes, speedups, "go-")
+    speedup_axis.axhline(1.0, color="red", linestyle="--", alpha=0.7)
+    speedup_axis.set_xlabel("Domain size [cells per side]")
+    speedup_axis.set_ylabel("Metal/CPU speedup")
+    speedup_axis.set_title("Apple Metal speedup")
+    speedup_axis.grid(True, alpha=0.3)
+
+    figure.tight_layout()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    figure.savefig(path, dpi=300, bbox_inches="tight")
+    if show:
+        plt.show()
+    plt.close(figure)
+
+
+def _parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sizes", nargs="+", type=_positive_int, default=DEFAULT_SIZES)
+    parser.add_argument("--cell-size", type=_positive_float, default=0.001)
+    parser.add_argument("--iterations", type=_positive_int, default=1500)
+    parser.add_argument("--threads", type=_positive_int, default=8)
+    parser.add_argument("--device", type=_nonnegative_int, default=0)
+    parser.add_argument("--repeats", type=_positive_int, default=3)
+    parser.add_argument("--warmups", type=_nonnegative_int, default=1)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("metal_benchmark_results.json"),
+    )
+    parser.add_argument(
+        "--plot",
+        type=Path,
+        default=Path("metal_benchmark_results.png"),
+    )
+    parser.add_argument("--no-plot", action="store_true")
+    parser.add_argument("--show", action="store_true")
+    return parser
 
 
 def main():
-    """Main benchmarking function."""
-    print("🚀 Apple Metal GPU Benchmarking Suite for gprMax")
-    print("=" * 60)
-    
-    # Change to gprMax directory
-    os.chdir("/Users/cwarren/Desktop/gprMax")
-    
-    # Define domain sizes to test (cells per side for cubic domains)
-    domain_sizes = [50, 75, 100, 125, 150, 175, 200, 250, 300, 400]  # Start smaller for Apple Silicon
-    
-    # Storage for results
-    metal_results = []
-    cpu_results = []
-    
-    print(f"Testing domain sizes: {domain_sizes} cells per side")
-    
-    for size in domain_sizes:
-        print(f"\n📊 Testing {size}×{size}×{size} domain...")
-        
-        # Create benchmark input file
-        input_file = create_benchmark_input(size, f"benchmark_{size}")
-        
-        # Test Metal backend
-        print(f"🔥 Testing Metal backend...")
-        metal_result = run_benchmark(input_file, "-metal", f"metal_{size}")
-        if metal_result:
-            metal_result['size'] = size
-            metal_results.append(metal_result)
-            print(f"   Metal: {metal_result['performance']:.1f} Mcells/s")
-        
-        # Test CPU backend
-        print(f"🖥️ Testing CPU backend...")
-        cpu_result = run_benchmark(input_file, "", f"cpu_{size}")
-        if cpu_result:
-            cpu_result['size'] = size
-            cpu_results.append(cpu_result)
-            print(f"   CPU:   {cpu_result['performance']:.1f} Mcells/s")
-            
-        # Calculate speedup if both succeeded
-        if metal_result and cpu_result:
-            speedup = metal_result['performance'] / cpu_result['performance']
-            print(f"   Speedup: {speedup:.2f}×")
-    
-    # Create performance comparison plot
-    if metal_results and cpu_results:
-        create_performance_plot(metal_results, cpu_results)
-        
-    # Print summary
-    print_summary(metal_results, cpu_results)
-
-
-def create_performance_plot(metal_results, cpu_results):
-    """Create a performance comparison plot."""
-    metal_sizes = [r['size'] for r in metal_results]
-    metal_perf = [r['performance'] for r in metal_results]
-    cpu_sizes = [r['size'] for r in cpu_results]
-    cpu_perf = [r['performance'] for r in cpu_results]
-    
-    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(15, 6))
-    
-    # Performance comparison
-    ax1.plot(metal_sizes, metal_perf, 'ro-', label='Apple Metal', linewidth=2, markersize=8)
-    ax1.plot(cpu_sizes, cpu_perf, 'bo-', label='CPU (OpenMP)', linewidth=2, markersize=8)
-    ax1.set_xlabel('Domain Size [cells per side]')
-    ax1.set_ylabel('Performance [Mcells/s]')
-    ax1.set_title('gprMax Performance: Metal vs CPU')
-    ax1.legend()
-    ax1.grid(True, alpha=0.3)
-    
-    # Speedup plot
-    common_sizes = sorted(set(metal_sizes) & set(cpu_sizes))
-    speedups = []
-    for size in common_sizes:
-        metal_perf_val = next(r['performance'] for r in metal_results if r['size'] == size)
-        cpu_perf_val = next(r['performance'] for r in cpu_results if r['size'] == size)
-        speedups.append(metal_perf_val / cpu_perf_val)
-    
-    ax2.plot(common_sizes, speedups, 'go-', linewidth=2, markersize=8)
-    ax2.axhline(y=1.0, color='r', linestyle='--', alpha=0.7, label='No speedup')
-    ax2.set_xlabel('Domain Size [cells per side]')
-    ax2.set_ylabel('Speedup (Metal/CPU)')
-    ax2.set_title('Metal GPU Speedup over CPU')
-    ax2.legend()
-    ax2.grid(True, alpha=0.3)
-    
-    plt.tight_layout()
-    plt.savefig('metal_benchmark_results.png', dpi=300, bbox_inches='tight')
-    print(f"\n📈 Performance plot saved as: metal_benchmark_results.png")
-    plt.show()
-
-
-def print_summary(metal_results, cpu_results):
-    """Print benchmark summary."""
-    print(f"\n{'='*80}")
-    print("🎯 BENCHMARK SUMMARY")
-    print('='*80)
-    print(f"{'Size':<8} {'Metal [Mcells/s]':<15} {'CPU [Mcells/s]':<15} {'Speedup':<10} {'Exec Time (M)':<12} {'Exec Time (C)':<12}")
-    print('-'*80)
-    
-    for metal_r in metal_results:
-        size = metal_r['size']
-        cpu_r = next((r for r in cpu_results if r['size'] == size), None)
-        
-        if cpu_r:
-            speedup = metal_r['performance'] / cpu_r['performance']
-            print(f"{size:<8} {metal_r['performance']:<15.1f} {cpu_r['performance']:<15.1f} "
-                  f"{speedup:<10.2f} {metal_r['exec_time']:<12.2f} {cpu_r['exec_time']:<12.2f}")
-        else:
-            print(f"{size:<8} {metal_r['performance']:<15.1f} {'N/A':<15} {'N/A':<10} "
-                  f"{metal_r['exec_time']:<12.2f} {'N/A':<12}")
-    
-    if metal_results and cpu_results:
-        avg_speedup = np.mean([metal_r['performance'] / next(cpu_r['performance'] for cpu_r in cpu_results if cpu_r['size'] == metal_r['size']) 
-                              for metal_r in metal_results if any(cpu_r['size'] == metal_r['size'] for cpu_r in cpu_results)])
-        print(f"\n🚀 Average Speedup: {avg_speedup:.2f}×")
-        
-        max_metal_perf = max(r['performance'] for r in metal_results)
-        max_cpu_perf = max(r['performance'] for r in cpu_results)
-        print(f"🔥 Peak Metal Performance: {max_metal_perf:.1f} Mcells/s")
-        print(f"🖥️  Peak CPU Performance: {max_cpu_perf:.1f} Mcells/s")
+    args = _parser().parse_args()
+    results = run_benchmark(args)
+    payload = json.dumps(results, indent=2)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(payload + "\n", encoding="utf-8")
+    if not args.no_plot:
+        create_performance_plot(results, args.plot, show=args.show)
+    print(payload)
+    print(f"Results written to {args.output}")
 
 
 if __name__ == "__main__":

--- a/testing/benchmarking/benchmark_ntff.py
+++ b/testing/benchmarking/benchmark_ntff.py
@@ -1,6 +1,6 @@
-# Copyright (C) 2026: The University of Edinburgh, United Kingdom
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
-# This file is part of gprMax.
+# This file is part of the gprMax source code base.
 #
 # gprMax is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,7 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
 """Benchmark the incremental wall-clock cost of KSIR frequency collection.
 

--- a/testing/benchmarking/benchmark_ntff.py
+++ b/testing/benchmarking/benchmark_ntff.py
@@ -1,6 +1,4 @@
 # Copyright (C) 2026: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley,
-#                          and Nathan Mannall
 #
 # This file is part of gprMax.
 #

--- a/testing/diff_output_files.py
+++ b/testing/diff_output_files.py
@@ -1,6 +1,4 @@
-# Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
-#                          and Nathan Mannall
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
 # This file is part of gprMax.
 #

--- a/testing/diff_output_files.py
+++ b/testing/diff_output_files.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
-# This file is part of gprMax.
+# This file is part of the gprMax source code base.
 #
 # gprMax is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -9,11 +9,11 @@
 #
 # gprMax is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
 import logging
 from pathlib import Path

--- a/testing/models_pmls/pml_3D_pec_plate/plot_pml_comparison.py
+++ b/testing/models_pmls/pml_3D_pec_plate/plot_pml_comparison.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
-# This file is part of gprMax.
+# This file is part of the gprMax source code base.
 #
 # gprMax is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -9,11 +9,11 @@
 #
 # gprMax is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
 import itertools
 import logging

--- a/testing/models_pmls/pml_3D_pec_plate/plot_pml_comparison.py
+++ b/testing/models_pmls/pml_3D_pec_plate/plot_pml_comparison.py
@@ -1,5 +1,4 @@
-# Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, and John Hartley
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
 # This file is part of gprMax.
 #

--- a/testing/models_pmls/pml_basic/plot_pml_comparison.py
+++ b/testing/models_pmls/pml_basic/plot_pml_comparison.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
-# This file is part of gprMax.
+# This file is part of the gprMax source code base.
 #
 # gprMax is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -9,11 +9,11 @@
 #
 # gprMax is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
 import itertools
 import logging

--- a/testing/models_pmls/pml_basic/plot_pml_comparison.py
+++ b/testing/models_pmls/pml_basic/plot_pml_comparison.py
@@ -1,5 +1,4 @@
-# Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, and John Hartley
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
 # This file is part of gprMax.
 #

--- a/testing/test_experimental.py
+++ b/testing/test_experimental.py
@@ -1,6 +1,4 @@
-# Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
-#                          and Nathan Mannall
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
 # This file is part of gprMax.
 #

--- a/testing/test_experimental.py
+++ b/testing/test_experimental.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
-# This file is part of gprMax.
+# This file is part of the gprMax source code base.
 #
 # gprMax is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -9,11 +9,11 @@
 #
 # gprMax is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
 import argparse
 import logging

--- a/testing/test_models.py
+++ b/testing/test_models.py
@@ -1,6 +1,4 @@
-# Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, John Hartley, 
-#                          and Nathan Mannall
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
 # This file is part of gprMax.
 #

--- a/testing/test_models.py
+++ b/testing/test_models.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
-# This file is part of gprMax.
+# This file is part of the gprMax source code base.
 #
 # gprMax is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -9,11 +9,11 @@
 #
 # gprMax is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
 import logging
 import sys

--- a/tests/test_benchmarking_scripts.py
+++ b/tests/test_benchmarking_scripts.py
@@ -24,6 +24,45 @@ from types import SimpleNamespace
 from testing.benchmarking import bench_simple, benchmark_layered_ntff
 from testing.benchmarking import benchmark_metal as metal_benchmark
 
+STANDARD_PREAMBLE = """# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
+#
+# This file is part of the gprMax source code base.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
+"""
+
+STANDARD_HEADER_PATHS = (
+    "testing/analytical_solutions.py",
+    "testing/benchmarking/__init__.py",
+    "testing/benchmarking/bench_simple.py",
+    "testing/benchmarking/benchmark_impedance_box.py",
+    "testing/benchmarking/benchmark_layered_ntff.py",
+    "testing/benchmarking/benchmark_metal.py",
+    "testing/benchmarking/benchmark_ntff.py",
+    "testing/diff_output_files.py",
+    "testing/models_pmls/pml_3D_pec_plate/plot_pml_comparison.py",
+    "testing/models_pmls/pml_basic/plot_pml_comparison.py",
+    "testing/test_experimental.py",
+    "testing/test_models.py",
+    "toolboxes/Plotting/plot_Ascan.py",
+    "toolboxes/Plotting/plot_Bscan.py",
+    "toolboxes/Plotting/plot_source_wave.py",
+    "toolboxes/Utilities/Paraview/gprMax.py",
+    "toolboxes/Utilities/get_host_spec.py",
+    "toolboxes/Utilities/outputfiles_merge.py",
+)
+
 
 def test_simple_benchmark_builds_the_requested_matrix_without_running():
     scenes = bench_simple.build_scenes(
@@ -128,3 +167,11 @@ def test_python_source_headers_do_not_contain_legacy_author_bylines():
                 offenders.append(f"{path.relative_to(root)}:{line_number}")
 
     assert offenders == []
+
+
+def test_changed_source_headers_use_the_standard_project_preamble():
+    root = Path(__file__).parents[1]
+
+    for relative_path in STANDARD_HEADER_PATHS:
+        source = (root / relative_path).read_text(encoding="utf-8")
+        assert source.startswith(STANDARD_PREAMBLE), relative_path

--- a/tests/test_benchmarking_scripts.py
+++ b/tests/test_benchmarking_scripts.py
@@ -1,0 +1,130 @@
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
+#
+# This file is part of the gprMax source code base.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
+
+"""Configuration and smoke tests for the standalone benchmark modules."""
+
+import itertools
+from pathlib import Path
+from types import SimpleNamespace
+
+from testing.benchmarking import bench_simple, benchmark_layered_ntff
+from testing.benchmarking import benchmark_metal as metal_benchmark
+
+
+def test_simple_benchmark_builds_the_requested_matrix_without_running():
+    scenes = bench_simple.build_scenes(
+        domains=(0.024, 0.030),
+        threads=(1, 2),
+        cell_size=0.001,
+        time_window=1e-11,
+    )
+
+    assert len(scenes) == 4
+    assert all(scene.single_use_objects for scene in scenes)
+    assert all(scene.grid_objects for scene in scenes)
+
+
+def test_metal_benchmark_uses_current_python_api_backend_options():
+    assert metal_benchmark._solver_options("cpu", 3) == {
+        "cpu_precision": "single"
+    }
+    assert metal_benchmark._solver_options("metal", 3) == {
+        "metal": [3],
+        "gpu_precision": "single",
+    }
+
+
+def test_metal_benchmark_runs_cpu_and_metal_for_each_case(monkeypatch):
+    calls = []
+    ticks = itertools.cycle((0.0, 1.0))
+    monkeypatch.setattr(metal_benchmark, "perf_counter", lambda: next(ticks))
+    monkeypatch.setattr(
+        metal_benchmark.gprMax,
+        "run",
+        lambda **kwargs: calls.append(kwargs),
+    )
+    args = SimpleNamespace(
+        sizes=(24,),
+        cell_size=0.001,
+        iterations=4,
+        threads=1,
+        device=0,
+        repeats=2,
+        warmups=1,
+    )
+
+    results = metal_benchmark.run_benchmark(args)
+
+    assert len(calls) == 6
+    assert sum("metal" in call for call in calls) == 3
+    assert sum("cpu_precision" in call for call in calls) == 3
+    assert results["cases"][0]["cpu"]["median_seconds"] == 1
+    assert results["cases"][0]["metal"]["median_seconds"] == 1
+    assert results["cases"][0]["speedup"] == 1
+
+
+def test_metal_benchmark_plot_is_written(tmp_path):
+    backend = {
+        "run_seconds": [1.0],
+        "median_seconds": 1.0,
+        "performance_mcells_per_second": 2.0,
+    }
+    results = {
+        "cases": [
+            {
+                "size": 24,
+                "cpu": backend,
+                "metal": {**backend, "performance_mcells_per_second": 4.0},
+                "speedup": 2.0,
+            }
+        ]
+    }
+    output = tmp_path / "benchmark.png"
+
+    metal_benchmark.create_performance_plot(results, output)
+
+    assert output.stat().st_size > 0
+
+
+def test_layered_ntff_benchmark_matches_numpy_oracle():
+    args = SimpleNamespace(
+        frequencies=2,
+        directions=5,
+        patches=4,
+        threads=1,
+        seed=22,
+    )
+
+    result = benchmark_layered_ntff.run_benchmark(args)
+
+    assert result["maximum_electric_difference"] < 1e-12
+    assert result["maximum_magnetic_difference"] < 1e-12
+
+
+def test_python_source_headers_do_not_contain_legacy_author_bylines():
+    root = Path(__file__).parents[1]
+    offenders = []
+    for path in root.rglob("*.py"):
+        if any(part in {".git", "__pycache__", "build", "dist"} for part in path.parts):
+            continue
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            if line.lstrip("# ").lower().startswith("authors:"):
+                offenders.append(f"{path.relative_to(root)}:{line_number}")
+
+    assert offenders == []

--- a/toolboxes/Plotting/plot_Ascan.py
+++ b/toolboxes/Plotting/plot_Ascan.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
-# This file is part of gprMax.
+# This file is part of the gprMax source code base.
 #
 # gprMax is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -9,11 +9,11 @@
 #
 # gprMax is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
 import argparse
 from pathlib import Path

--- a/toolboxes/Plotting/plot_Ascan.py
+++ b/toolboxes/Plotting/plot_Ascan.py
@@ -1,5 +1,4 @@
-# Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, and John Hartley
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
 # This file is part of gprMax.
 #

--- a/toolboxes/Plotting/plot_Bscan.py
+++ b/toolboxes/Plotting/plot_Bscan.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
-# This file is part of gprMax.
+# This file is part of the gprMax source code base.
 #
 # gprMax is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -9,11 +9,11 @@
 #
 # gprMax is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
 import argparse
 from pathlib import Path

--- a/toolboxes/Plotting/plot_Bscan.py
+++ b/toolboxes/Plotting/plot_Bscan.py
@@ -1,5 +1,4 @@
-# Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, and John Hartley
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
 # This file is part of gprMax.
 #

--- a/toolboxes/Plotting/plot_source_wave.py
+++ b/toolboxes/Plotting/plot_source_wave.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
-# This file is part of gprMax.
+# This file is part of the gprMax source code base.
 #
 # gprMax is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -9,11 +9,11 @@
 #
 # gprMax is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
 import argparse
 import logging

--- a/toolboxes/Plotting/plot_source_wave.py
+++ b/toolboxes/Plotting/plot_source_wave.py
@@ -1,5 +1,4 @@
-# Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, and John Hartley
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
 # This file is part of gprMax.
 #

--- a/toolboxes/Utilities/Paraview/gprMax.py
+++ b/toolboxes/Utilities/Paraview/gprMax.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
-# This file is part of gprMax.
+# This file is part of the gprMax source code base.
 #
 # gprMax is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -9,11 +9,11 @@
 #
 # gprMax is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
 from paraview.servermanager import Proxy, SourceProxy
 from paraview.simple import (

--- a/toolboxes/Utilities/Paraview/gprMax.py
+++ b/toolboxes/Utilities/Paraview/gprMax.py
@@ -1,5 +1,4 @@
-# Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, and John Hartley
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
 # This file is part of gprMax.
 #

--- a/toolboxes/Utilities/get_host_spec.py
+++ b/toolboxes/Utilities/get_host_spec.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
-# This file is part of gprMax.
+# This file is part of the gprMax source code base.
 #
 # gprMax is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,7 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with gprMax. If not, see <http://www.gnu.org/licenses/>.
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
 import logging
 

--- a/toolboxes/Utilities/get_host_spec.py
+++ b/toolboxes/Utilities/get_host_spec.py
@@ -1,5 +1,4 @@
-# Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, and John Hartley
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
 # This file is part of gprMax.
 #

--- a/toolboxes/Utilities/outputfiles_merge.py
+++ b/toolboxes/Utilities/outputfiles_merge.py
@@ -1,5 +1,4 @@
-# Copyright (C) 2015-2025: The University of Edinburgh, United Kingdom
-#                 Authors: Craig Warren, Antonis Giannopoulos, and John Hartley
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
 # This file is part of gprMax.
 #

--- a/toolboxes/Utilities/outputfiles_merge.py
+++ b/toolboxes/Utilities/outputfiles_merge.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
 #
-# This file is part of gprMax.
+# This file is part of the gprMax source code base.
 #
 # gprMax is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -9,11 +9,11 @@
 #
 # gprMax is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with gprMax.  If not, see <http://www.gnu.org/licenses/>.
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
 import argparse
 import glob


### PR DESCRIPTION
## Summary

- make `testing.benchmarking.bench_simple` import-safe and configurable from the command line instead of executing its 72-case default matrix on import
- replace `benchmark_metal`'s developer-specific absolute path, temporary input files, subprocess invocation, and historical output parsing with the current gprMax Python API
- add configurable Metal benchmark sizes, iterations, repeats, warmups, JSON output, and optional throughput/speedup plotting
- document full and reduced smoke-test commands in the benchmarking guide
- give all benchmark modules the standard project source header
- remove every legacy `# Authors:` header byline found in Python sources and apply the complete current 2015-2026 University/GPL preamble verbatim to every affected file; Sphinx project-author metadata and licence wording are intentionally unchanged
- add regression coverage for benchmark construction, backend selection, CPU/Metal matrix execution, plot generation, layered-NTFF numerical parity, and source headers

## Context

This is a follow-up to #820, which was merged while this benchmark audit was in progress. No benchmark changes were included in that merged PR.

The existing Metal benchmark could not run outside one developer's checkout because it changed into `/Users/cwarren/Desktop/gprMax`, and it launched a bare `python` subprocess. The new implementation runs identical scenes directly through `gprMax.run`, uses the selected Python environment, and stores complete machine-readable timing results.

## Validation

- all five benchmark modules compile and return successful `--help` output
- 19 targeted benchmark and exact-header tests passed, including the existing production NTFF benchmark execution test
- reduced end-to-end CPU runs completed for `bench_simple`, `benchmark_impedance_box`, `benchmark_layered_ntff`, and `benchmark_ntff`
- a reduced `benchmark_metal` run completed the same 24^3, four-iteration model on both the CPU and an Apple M1 Max Metal GPU and wrote valid JSON metrics
- the layered-NTFF smoke run matched its NumPy oracle to approximately 5.2e-18 electric and 1.9e-20 magnetic maximum absolute difference
- benchmark plot generation produced a non-empty PNG
- `git diff --check` passed
