### PR TITLE
Fix release-readiness issues and accelerator indexing

### DIFF
--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -2423,6 +2423,13 @@ to the subgrid object. With ``autotranslate=True`` these objects can use main
 grid coordinates. Subgridding currently uses the double-precision CPU solver;
 CUDA, OpenCL, and Metal subgrid execution are not part of this release.
 
+.. note::
+
+    The HSG formulation fixes ``pml_separation`` at ``ratio // 2 + 2``. The
+    constructor retains the argument for API compatibility, but any supplied
+    value is intentionally ignored. Changing this separation is experimental
+    and requires modifying the formulation in the source code.
+
 .. code-block:: python
 
     subgrid = gprMax.SubGridHSG(

--- a/gprMax/cuda_opencl/knl_magnetic_frill_source.py
+++ b/gprMax/cuda_opencl/knl_magnetic_frill_source.py
@@ -93,19 +93,20 @@ update_magnetic_frill_source = {
     $CUDA_IDX
 
     if (i < NFRILL) {
+        size_t frill = (size_t)i;
         $REAL current_bulk = ($REAL)0;
-        int nterms = frill_term_counts[i];
+        int nterms = frill_term_counts[frill];
 
         for (int term = 0; term < nterms; term++) {
-            int term_index = i * $MAX_FRILLTERMS + term;
-            int info_index = term_index * $NY_FRILLTERMINFO;
-            int param_index = term_index * $NY_FRILLTERMPARAMS;
+            size_t term_index = frill * (size_t)$MAX_FRILLTERMS + (size_t)term;
+            size_t info_index = term_index * (size_t)$NY_FRILLTERMINFO;
+            size_t param_index = term_index * (size_t)$NY_FRILLTERMPARAMS;
             int component = frill_term_info[info_index + 0];
             int x = frill_term_info[info_index + 1];
             int y = frill_term_info[info_index + 2];
             int z = frill_term_info[info_index + 3];
             $REAL weight = frill_term_params[param_index + 0];
-            int field_index = IDX3D_FIELDS(x,y,z);
+            size_t field_index = IDX3D_FIELDS(x,y,z);
 
             if (component == 0) {
                 current_bulk += weight * Hx[field_index];
@@ -118,14 +119,14 @@ update_magnetic_frill_source = {
             }
         }
 
-        int source_index = i * $NY_FRILLPARAMS;
-        int output_index = i * $NY_FRILLOUT + iteration;
+        size_t source_index = frill * (size_t)$NY_FRILLPARAMS;
+        size_t output_index = frill * (size_t)$NY_FRILLOUT + (size_t)iteration;
         $REAL Z0 = frill_params[source_index + 0];
         $REAL G = frill_params[source_index + 1];
         $REAL theta = frill_params[source_index + 2];
-        $REAL previous_current = frill_state[i];
+        $REAL previous_current = frill_state[frill];
         $REAL Vinc_value = ($REAL)0.5
-            * frill_waveform[i * $NY_FRILLWAVES + iteration];
+            * frill_waveform[frill * (size_t)$NY_FRILLWAVES + (size_t)iteration];
         $REAL zeta = G * Z0;
 
         // Hyun's time-average terminal equation is implicit because this
@@ -146,15 +147,15 @@ update_magnetic_frill_source = {
         Vtotal[output_index] = V_ab;
 
         for (int term = 0; term < nterms; term++) {
-            int term_index = i * $MAX_FRILLTERMS + term;
-            int info_index = term_index * $NY_FRILLTERMINFO;
-            int param_index = term_index * $NY_FRILLTERMPARAMS;
+            size_t term_index = frill * (size_t)$MAX_FRILLTERMS + (size_t)term;
+            size_t info_index = term_index * (size_t)$NY_FRILLTERMINFO;
+            size_t param_index = term_index * (size_t)$NY_FRILLTERMPARAMS;
             int component = frill_term_info[info_index + 0];
             int x = frill_term_info[info_index + 1];
             int y = frill_term_info[info_index + 2];
             int z = frill_term_info[info_index + 3];
             $REAL source_gain = frill_term_params[param_index + 1];
-            int field_index = IDX3D_FIELDS(x,y,z);
+            size_t field_index = IDX3D_FIELDS(x,y,z);
 
             if (component == 0) {
                 Hx[field_index] += source_gain * V_ab;
@@ -169,7 +170,7 @@ update_magnetic_frill_source = {
 
         // This state remains active after the requested waveform interval;
         // the waveform becomes zero but the passive Z0 terminal persists.
-        frill_state[i] = current_new;
+        frill_state[frill] = current_new;
     }
 """
     ),

--- a/gprMax/cuda_opencl/knl_pml_updates_electric_HORIPML.py
+++ b/gprMax/cuda_opencl/knl_pml_updates_electric_HORIPML.py
@@ -326,20 +326,24 @@ order1_xminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA01, RB0, RE0, RF0, dHy, dHz;
     $REAL dx = d;
@@ -410,20 +414,24 @@ order2_xminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA0, RB0, RE0, RF0, RA1, RB1, RE1, RF1, RA01, dHy, dHz;
     $REAL dx = d;
@@ -510,20 +518,24 @@ order1_xplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA01, RB0, RE0, RF0, dHy, dHz;
     $REAL dx = d;
@@ -594,20 +606,24 @@ order2_xplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA0, RB0, RE0, RF0, RA1, RB1, RE1, RF1, RA01, dHy, dHz;
     $REAL dx = d;
@@ -693,20 +709,24 @@ order1_yminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA01, RB0, RE0, RF0, dHx, dHz;
     $REAL dy = d;
@@ -777,20 +797,24 @@ order2_yminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA0, RB0, RE0, RF0, RA1, RB1, RE1, RF1, RA01, dHx, dHz;
     $REAL dy = d;
@@ -877,20 +901,24 @@ order1_yplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA01, RB0, RE0, RF0, dHx, dHz;
     $REAL dy = d;
@@ -961,20 +989,24 @@ order2_yplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA0, RB0, RE0, RF0, RA1, RB1, RE1, RF1, RA01, dHx, dHz;
     $REAL dy = d;
@@ -1061,20 +1093,24 @@ order1_zminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA01, RB0, RE0, RF0, dHx, dHy;
     $REAL dz = d;
@@ -1145,20 +1181,24 @@ order2_zminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA0, RB0, RE0, RF0, RA1, RB1, RE1, RF1, RA01, dHx, dHy;
     $REAL dz = d;
@@ -1245,20 +1285,24 @@ order1_zplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA01, RB0, RE0, RF0, dHx, dHy;
     $REAL dz = d;
@@ -1329,20 +1373,24 @@ order2_zplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA0, RB0, RE0, RF0, RA1, RB1, RE1, RF1, RA01, dHx, dHy;
     $REAL dz = d;

--- a/gprMax/cuda_opencl/knl_pml_updates_electric_MRIPML.py
+++ b/gprMax/cuda_opencl/knl_pml_updates_electric_MRIPML.py
@@ -327,20 +327,24 @@ order1_xminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, dHy, dHz;
     $REAL dx = d;
@@ -417,20 +421,24 @@ order2_xminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, RB1, RC1, RE1, RF1, Psi1, Psi2, dHy, dHz;
     $REAL dx = d;
@@ -517,20 +525,24 @@ order1_xplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, dHy, dHz;
     $REAL dx = d;
@@ -607,20 +619,24 @@ order2_xplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, RB1, RC1, RE1, RF1, Psi1, Psi2, dHy, dHz;
     $REAL dx = d;
@@ -707,20 +723,24 @@ order1_yminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, dHx, dHz;
     $REAL dy = d;
@@ -797,20 +817,24 @@ order2_yminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, RB1, RC1, RE1, RF1, Psi1, Psi2, dHx, dHz;
     $REAL dy = d;
@@ -897,20 +921,24 @@ order1_yplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, dHx, dHz;
     $REAL dy = d;
@@ -987,20 +1015,24 @@ order2_yplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, RB1, RC1, RE1, RF1, Psi1, Psi2, dHx, dHz;
     $REAL dy = d;
@@ -1087,20 +1119,24 @@ order1_zminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, dHx, dHy;
     $REAL dz = d;
@@ -1177,20 +1213,24 @@ order2_zminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, RB1, RC1, RE1, RF1, Psi1, Psi2, dHx, dHy;
     $REAL dz = d;
@@ -1277,20 +1317,24 @@ order1_zplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, dHx, dHy;
     $REAL dz = d;
@@ -1367,20 +1411,24 @@ order2_zplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, RB1, RC1, RE1, RF1, Psi1, Psi2, dHx, dHy;
     $REAL dz = d;

--- a/gprMax/cuda_opencl/knl_pml_updates_magnetic_HORIPML.py
+++ b/gprMax/cuda_opencl/knl_pml_updates_magnetic_HORIPML.py
@@ -326,20 +326,24 @@ order1_xminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA01, RB0, RE0, RF0, dEy, dEz;
     $REAL dx = d;
@@ -410,20 +414,24 @@ order2_xminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA0, RB0, RE0, RF0, RA1, RB1, RE1, RF1, RA01, dEy, dEz;
     $REAL dx = d;
@@ -510,20 +518,24 @@ order1_xplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA01, RB0, RE0, RF0, dEy, dEz;
     $REAL dx = d;
@@ -594,20 +606,24 @@ order2_xplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA0, RB0, RE0, RF0, RA1, RB1, RE1, RF1, RA01, dEy, dEz;
     $REAL dx = d;
@@ -694,20 +710,24 @@ order1_yminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA01, RB0, RE0, RF0, dEx, dEz;
     $REAL dy = d;
@@ -778,20 +798,24 @@ order2_yminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA0, RB0, RE0, RF0, RA1, RB1, RE1, RF1, RA01, dEx, dEz;
     $REAL dy = d;
@@ -877,20 +901,24 @@ order1_yplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA01, RB0, RE0, RF0, dEx, dEz;
     $REAL dy = d;
@@ -961,20 +989,24 @@ order2_yplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA0, RB0, RE0, RF0, RA1, RB1, RE1, RF1, RA01, dEx, dEz;
     $REAL dy = d;
@@ -1059,20 +1091,24 @@ order1_zminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA01, RB0, RE0, RF0, dEx, dEy;
     $REAL dz = d;
@@ -1143,20 +1179,24 @@ order2_zminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA0, RB0, RE0, RF0, RA1, RB1, RE1, RF1, RA01, dEx, dEy;
     $REAL dz = d;
@@ -1243,20 +1283,24 @@ order1_zplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA01, RB0, RE0, RF0, dEx, dEy;
     $REAL dz = d;
@@ -1327,20 +1371,24 @@ order2_zplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL RA0, RB0, RE0, RF0, RA1, RB1, RE1, RF1, RA01, dEx, dEy;
     $REAL dz = d;

--- a/gprMax/cuda_opencl/knl_pml_updates_magnetic_MRIPML.py
+++ b/gprMax/cuda_opencl/knl_pml_updates_magnetic_MRIPML.py
@@ -326,20 +326,24 @@ order1_xminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, dEy, dEz;
     $REAL dx = d;
@@ -416,20 +420,24 @@ order2_xminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, RB1, RC1, RE1, RF1, Psi1, Psi2, dEy, dEz;
     $REAL dx = d;
@@ -516,20 +524,24 @@ order1_xplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, dEy, dEz;
     $REAL dx = d;
@@ -606,20 +618,24 @@ order2_xplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, RB1, RC1, RE1, RF1, Psi1, Psi2, dEy, dEz;
     $REAL dx = d;
@@ -706,20 +722,24 @@ order1_yminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, dEx, dEz;
     $REAL dy = d;
@@ -796,20 +816,24 @@ order2_yminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, RB1, RC1, RE1, RF1, Psi1, Psi2, dEx, dEz;
     $REAL dy = d;
@@ -896,20 +920,24 @@ order1_yplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, dEx, dEz;
     $REAL dy = d;
@@ -986,20 +1014,24 @@ order2_yplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, RB1, RC1, RE1, RF1, Psi1, Psi2, dEx, dEz;
     $REAL dy = d;
@@ -1086,20 +1118,24 @@ order1_zminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, dEx, dEy;
     $REAL dz = d;
@@ -1176,20 +1212,24 @@ order2_zminus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, RB1, RC1, RE1, RF1, Psi1, Psi2, dEx, dEy;
     $REAL dz = d;
@@ -1276,20 +1316,24 @@ order1_zplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, dEx, dEy;
     $REAL dz = d;
@@ -1366,20 +1410,24 @@ order2_zplus = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for PML PHI1 (4D) arrays
-    int p1 = i / (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int rem1 = i % (NX_PHI1 * NY_PHI1 * NZ_PHI1);
-    int i1 = rem1 / (NY_PHI1 * NZ_PHI1);
-    int jk1 = rem1 % (NY_PHI1 * NZ_PHI1);
-    int j1 = jk1 / NZ_PHI1;
-    int k1 = jk1 % NZ_PHI1;
+    size_t phi1_plane = (size_t)NY_PHI1 * (size_t)NZ_PHI1;
+    size_t phi1_volume = (size_t)NX_PHI1 * phi1_plane;
+    size_t rem1 = (size_t)i % phi1_volume;
+    int p1 = (int)((size_t)i / phi1_volume);
+    int i1 = (int)(rem1 / phi1_plane);
+    size_t jk1 = rem1 % phi1_plane;
+    int j1 = (int)(jk1 / (size_t)NZ_PHI1);
+    int k1 = (int)(jk1 % (size_t)NZ_PHI1);
 
     // Convert the linear index to subscripts for PML PHI2 (4D) arrays
-    int p2 = i / (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int rem2 = i % (NX_PHI2 * NY_PHI2 * NZ_PHI2);
-    int i2 = rem2 / (NY_PHI2 * NZ_PHI2);
-    int jk2 = rem2 % (NY_PHI2 * NZ_PHI2);
-    int j2 = jk2 / NZ_PHI2;
-    int k2 = jk2 % NZ_PHI2;
+    size_t phi2_plane = (size_t)NY_PHI2 * (size_t)NZ_PHI2;
+    size_t phi2_volume = (size_t)NX_PHI2 * phi2_plane;
+    size_t rem2 = (size_t)i % phi2_volume;
+    int p2 = (int)((size_t)i / phi2_volume);
+    int i2 = (int)(rem2 / phi2_plane);
+    size_t jk2 = rem2 % phi2_plane;
+    int j2 = (int)(jk2 / (size_t)NZ_PHI2);
+    int k2 = (int)(jk2 % (size_t)NZ_PHI2);
 
     $REAL IRA, IRA1, RB0, RC0, RE0, RF0, RB1, RC1, RE1, RF1, Psi1, Psi2, dEx, dEy;
     $REAL dz = d;

--- a/gprMax/cuda_opencl/knl_rational_network.py
+++ b/gprMax/cuda_opencl/knl_rational_network.py
@@ -118,25 +118,28 @@ update_rational_network = {
     $CUDA_IDX
 
     if (i < NTERMINALS) {
-        int x = info[i * $NY_RNINFO + 0];
-        int y = info[i * $NY_RNINFO + 1];
-        int z = info[i * $NY_RNINFO + 2];
-        int polarisation = info[i * $NY_RNINFO + 3];
-        int pole_offset = info[i * $NY_RNINFO + 4];
-        int pole_count = info[i * $NY_RNINFO + 5];
+        size_t terminal = (size_t)i;
+        size_t info_offset = terminal * (size_t)$NY_RNINFO;
+        size_t params_offset = terminal * (size_t)$NY_RNPARAMS;
+        int x = info[info_offset + 0];
+        int y = info[info_offset + 1];
+        int z = info[info_offset + 2];
+        int polarisation = info[info_offset + 3];
+        int pole_offset = info[info_offset + 4];
+        int pole_count = info[info_offset + 5];
 
-        $REAL dl = params[i * $NY_RNPARAMS + 0];
-        $REAL area = params[i * $NY_RNPARAMS + 1];
-        $REAL source_coefficient = params[i * $NY_RNPARAMS + 2];
-        $REAL denominator = params[i * $NY_RNPARAMS + 3];
-        $REAL alpha = params[i * $NY_RNPARAMS + 4];
-        $REAL conductance = params[i * $NY_RNPARAMS + 5];
-        $REAL capacitance = params[i * $NY_RNPARAMS + 6];
+        $REAL dl = params[params_offset + 0];
+        $REAL area = params[params_offset + 1];
+        $REAL source_coefficient = params[params_offset + 2];
+        $REAL denominator = params[params_offset + 3];
+        $REAL alpha = params[params_offset + 4];
+        $REAL conductance = params[params_offset + 5];
+        $REAL capacitance = params[params_offset + 6];
 
-        int whole_offset = i * $NY_RNWAVEWHOLE;
-        int half_offset = i * $NY_RNWAVEHALF;
-        int voltage_offset = i * $NY_RNVOLTAGE;
-        int current_offset = i * $NY_RNCURRENT;
+        size_t whole_offset = terminal * (size_t)$NY_RNWAVEWHOLE;
+        size_t half_offset = terminal * (size_t)$NY_RNWAVEHALF;
+        size_t voltage_offset = terminal * (size_t)$NY_RNVOLTAGE;
+        size_t current_offset = terminal * (size_t)$NY_RNCURRENT;
         $REAL voltage_old = voltage[voltage_offset + iteration];
         $REAL generator_old = waveform_whole[whole_offset + iteration];
         $REAL generator_new = waveform_whole[whole_offset + iteration + 1];
@@ -157,7 +160,7 @@ update_rational_network = {
             history += half_real;
         }
 
-        int field_index = IDX3D_FIELDS(x,y,z);
+        size_t field_index = IDX3D_FIELDS(x,y,z);
         $REAL electric;
         if (polarisation == 0) {
             electric = (Ex[field_index] + source_coefficient * history / area) / denominator;

--- a/gprMax/cuda_opencl/knl_snapshots.py
+++ b/gprMax/cuda_opencl/knl_snapshots.py
@@ -144,11 +144,13 @@ store_snapshot = {
     $CUDA_IDX
 
     // Convert the linear index to subscripts for 4D SNAPS array
-    int rem_snaps = i % ($NX_SNAPS * $NY_SNAPS * $NZ_SNAPS);
-    int x = rem_snaps / ($NY_SNAPS * $NZ_SNAPS);
-    int yz_snaps = rem_snaps % ($NY_SNAPS * $NZ_SNAPS);
-    int y = yz_snaps / $NZ_SNAPS;
-    int z = yz_snaps % $NZ_SNAPS;
+    size_t snapshot_plane = (size_t)$NY_SNAPS * (size_t)$NZ_SNAPS;
+    size_t snapshot_volume = (size_t)$NX_SNAPS * snapshot_plane;
+    size_t rem_snaps = (size_t)i % snapshot_volume;
+    int x = (int)(rem_snaps / snapshot_plane);
+    size_t yz_snaps = rem_snaps % snapshot_plane;
+    int y = (int)(yz_snaps / (size_t)$NZ_SNAPS);
+    int z = (int)(yz_snaps % (size_t)$NZ_SNAPS);
 
     // Subscripts for field arrays
     int xx, yy, zz;

--- a/gprMax/cuda_opencl/knl_symmetry_boundaries.py
+++ b/gprMax/cuda_opencl/knl_symmetry_boundaries.py
@@ -230,7 +230,7 @@ _DISPERSION_SNIPPET = Template(
     """
         $REAL phi = ($REAL)0;
         for (int pole = 0; pole < MAXPOLES; pole++) {
-            int state = IDX4D_T(pole,x,y,z);
+            size_t state = IDX4D_T(pole,x,y,z);
             phi += GPRMAX_CREAL(GPRMAX_CMUL(
                 updatecoeffsdispersive[IDX2D_MATDISP(material,pole*3)],
                 $T[state]));
@@ -315,7 +315,7 @@ kernel void update_electric_pmc_dispersive_b(
             && ex_on_pmc) {
         int material = ID[IDX4D_ID(0,x_ID,y_ID,z_ID)];
         for (int pole = 0; pole < MAXPOLES; pole++) {
-            int state = IDX4D_T(pole,x,y,z);
+            size_t state = IDX4D_T(pole,x,y,z);
             Tx[state] = GPRMAX_CSUB(Tx[state], GPRMAX_CRMUL(
                 updatecoeffsdispersive[IDX2D_MATDISP(material,2+pole*3)],
                 Ex[IDX3D_FIELDS(x,y,z)]));
@@ -327,7 +327,7 @@ kernel void update_electric_pmc_dispersive_b(
             && ey_on_pmc) {
         int material = ID[IDX4D_ID(1,x_ID,y_ID,z_ID)];
         for (int pole = 0; pole < MAXPOLES; pole++) {
-            int state = IDX4D_T(pole,x,y,z);
+            size_t state = IDX4D_T(pole,x,y,z);
             Ty[state] = GPRMAX_CSUB(Ty[state], GPRMAX_CRMUL(
                 updatecoeffsdispersive[IDX2D_MATDISP(material,2+pole*3)],
                 Ey[IDX3D_FIELDS(x,y,z)]));
@@ -339,7 +339,7 @@ kernel void update_electric_pmc_dispersive_b(
             && ez_on_pmc) {
         int material = ID[IDX4D_ID(2,x_ID,y_ID,z_ID)];
         for (int pole = 0; pole < MAXPOLES; pole++) {
-            int state = IDX4D_T(pole,x,y,z);
+            size_t state = IDX4D_T(pole,x,y,z);
             Tz[state] = GPRMAX_CSUB(Tz[state], GPRMAX_CRMUL(
                 updatecoeffsdispersive[IDX2D_MATDISP(material,2+pole*3)],
                 Ez[IDX3D_FIELDS(x,y,z)]));

--- a/gprMax/hash_cmds_file.py
+++ b/gprMax/hash_cmds_file.py
@@ -342,7 +342,9 @@ def check_cmd_names(processedlines, checkessential=True):
     countessentialcmds = 0
     lindex = 0
     while lindex < len(processedlines):
-        cmd = processedlines[lindex].split(":")
+        # The first colon separates the command name from its parameters.
+        # Preserve any later colons in paths, URLs, titles, or identifiers.
+        cmd = processedlines[lindex].split(":", maxsplit=1)
 
         # Check the command name and parameters were both found
         if len(cmd) < 2:
@@ -387,7 +389,7 @@ def check_cmd_names(processedlines, checkessential=True):
         # Assign command parameters as values to dictionary keys
         if cmdname in singlecmds:
             if singlecmds[cmdname] is None:
-                singlecmds[cmdname] = cmd[1].strip(" \t\n")
+                singlecmds[cmdname] = cmdparams.strip(" \t\n")
             else:
                 logger.exception(
                     "You can only have a single instance of " + cmdname + " in your model"
@@ -395,7 +397,7 @@ def check_cmd_names(processedlines, checkessential=True):
                 raise SyntaxError
 
         elif cmdname in multiplecmds:
-            multiplecmds[cmdname].append(cmd[1].strip(" \t\n"))
+            multiplecmds[cmdname].append(cmdparams.strip(" \t\n"))
 
         elif cmdname in geometrycmds:
             geometry.append(processedlines[lindex].strip(" \t\n"))

--- a/gprMax/model.py
+++ b/gprMax/model.py
@@ -113,7 +113,7 @@ class Model:
 
     @property
     def dy(self) -> float:
-        return self.G.dl[0]
+        return self.G.dl[1]
 
     @dy.setter
     def dy(self, value: float):
@@ -121,7 +121,7 @@ class Model:
 
     @property
     def dz(self) -> float:
-        return self.G.dl[0]
+        return self.G.dl[2]
 
     @dz.setter
     def dz(self, value: float):

--- a/gprMax/subgrids/user_objects.py
+++ b/gprMax/subgrids/user_objects.py
@@ -174,8 +174,11 @@ class SubGridHSG(SubGridBase):
         id: string identifier for the sub-grid.
         is_os_sep: int for the number of main grid cells between the Inner
                     Surface and the Outer Surface. Defaults to 3.
-        pml_separation: int for the number of sub-grid cells between the Outer
-                        Surface and the PML. Defaults to ratio // 2 + 2
+        pml_separation: retained for API compatibility, but the HSG formulation
+                        fixes the number of sub-grid cells between the Outer
+                        Surface and the PML at ``ratio // 2 + 2``. Any supplied
+                        value is therefore ignored. Using a different value is
+                        experimental and requires changing the formulation.
         subgrid_pml_thickness: int for the thickness of the PML on each of the
                                 6 sides of the sub-grid. Defaults to 6.
         interpolation: string for the degree of the interpolation scheme used
@@ -206,6 +209,8 @@ class SubGridHSG(SubGridBase):
         filter=True,
         **kwargs,
     ):
+        # The HSG formulation fixes this separation. Keep the public argument
+        # for API compatibility, but deliberately do not use a supplied value.
         pml_separation = ratio // 2 + 2
 
         # Copy over the optional parameters

--- a/gprMax/utilities/host_info.py
+++ b/gprMax/utilities/host_info.py
@@ -507,18 +507,16 @@ def detect_cuda_gpus():
 
         drv.init()
 
-        # Check and list any CUDA-Enabled GPUs
-        deviceIDsavail = []
-        if drv.Device.count() == 0:
+        # The CUDA driver already applies CUDA_VISIBLE_DEVICES before reporting
+        # the device count and renumbers the visible devices to local ordinals
+        # 0..count-1. Parsing the environment variable here would incorrectly
+        # pass physical indices (or GPU/MIG UUIDs) back to drv.Device.
+        device_count = drv.Device.count()
+        if device_count == 0:
             logger.warning("No NVIDIA CUDA-Enabled GPUs detected!\n" + cuda_reqs)
-        elif "CUDA_VISIBLE_DEVICES" in os.environ:
-            deviceIDsavail = os.environ.get("CUDA_VISIBLE_DEVICES")
-            deviceIDsavail = [int(s) for s in deviceIDsavail.split(",")]
-        else:
-            deviceIDsavail = range(drv.Device.count())
 
         # Gather information about detected GPUs
-        for ID in deviceIDsavail:
+        for ID in range(device_count):
             gpus[ID] = drv.Device(ID)
 
     else:

--- a/tests/grid/test_model.py
+++ b/tests/grid/test_model.py
@@ -18,13 +18,8 @@
 """Tests for ``gprMax.model.Model``.
 
 ``Model`` is a thin owner of exactly one ``FDTDGrid``: almost every attribute
-is a property forwarding to ``self.G``. That makes it cheap to test and makes
-a forwarding slip invisible in normal use.
-
-The ``dy`` / ``dz`` *getters* are defective — they read ``dl[0]`` — so no
-assertion here reads them back. The setters are correct and are pinned, which
-is what makes the getter defect demonstrable without asserting broken
-behaviour. Write-up: ``notes/bugs/model-dy-dz-getters.md``.
+is a property forwarding to ``self.G``. That makes it cheap to test, but also
+makes an axis-forwarding slip easy to miss unless anisotropic spacing is used.
 
 ``Model.__init__`` calls ``set_omp_threads``, which reads host CPU information
 that has nothing to do with the class under test, so it is patched out here.
@@ -133,13 +128,13 @@ class TestCells:
 
 
 class TestDiscretisationForwarding:
-    def test_dx_getter_reads_the_x_spacing(self, model):
+    @pytest.mark.parametrize("axis,name", [(0, "dx"), (1, "dy"), (2, "dz")])
+    def test_getters_read_the_correct_axis(self, model, axis, name):
         model.G.dl = np.array(DL_ANISO)
-        assert model.dx == DL_ANISO[0]
+        assert getattr(model, name) == DL_ANISO[axis]
 
     @pytest.mark.parametrize("axis,name", [(0, "dx"), (1, "dy"), (2, "dz")])
     def test_setters_write_the_correct_axis(self, model, axis, name):
-        """All three *setters* are correct — only the getters are not."""
         setattr(model, name, 0.009)
         assert model.G.dl[axis] == 0.009
 

--- a/tests/hash_cmds/test_hash_cmds_file.py
+++ b/tests/hash_cmds/test_hash_cmds_file.py
@@ -187,6 +187,16 @@ class TestCheckCmdNames:
         assert all(v == [] for v in multi.values())
         assert geometry == []
 
+    def test_colons_in_single_command_parameters_are_preserved(self):
+        lines = self._essentials() + ["#title: survey: line 1\n"]
+        single, _, _ = check_cmd_names(lines)
+        assert single["#title"] == "survey: line 1"
+
+    def test_windows_drive_colon_is_not_treated_as_another_separator(self):
+        lines = self._essentials() + ["#output_dir: C:\\gprmax\\results\n"]
+        single, _, _ = check_cmd_names(lines)
+        assert single["#output_dir"] == "C:\\gprmax\\results"
+
     def test_multi_cmd_appended_to_multi_dict(self):
         lines = self._essentials() + [
             "#waveform: gaussian 1.0 1e9 wf1\n",

--- a/tests/subgrids/test_subgrid_commands.py
+++ b/tests/subgrids/test_subgrid_commands.py
@@ -24,9 +24,9 @@ command into a wired-up ``SubGridHSG`` grid registered on the model.
 The size helpers are pure arithmetic on ``ratio`` and are asserted against
 hand-computed numbers rather than against the code's own derivation.
 
-Note the ``pml_separation`` argument is discarded by ``SubGridHSG.__init__``
-(see ``notes/bugs/subgrid-pml-separation-override.md``), so nothing here
-passes one and expects it to survive.
+The HSG formulation fixes ``pml_separation`` at ``ratio // 2 + 2``. The public
+argument is retained for compatibility but is intentionally ignored; changing
+the separation is an unsupported experimental modification to the formulation.
 """
 
 from types import SimpleNamespace
@@ -143,6 +143,10 @@ class TestKwargPassThrough:
         cmd = command()
         assert cmd.kwargs["p1"] == (0.010, 0.010, 0.010)
         assert cmd.kwargs["p2"] == (0.016, 0.016, 0.016)
+
+    def test_pml_separation_is_fixed_by_the_formulation(self, command):
+        cmd = command(ratio=5, pml_separation=99)
+        assert cmd.kwargs["pml_separation"] == 5 // 2 + 2
 
     def test_defaults_are_applied(self):
         cmd = SubGridHSG(p1=(0, 0, 0), p2=(1, 1, 1))

--- a/tests/test_magnetic_frill_device.py
+++ b/tests/test_magnetic_frill_device.py
@@ -163,5 +163,7 @@ def test_magnetic_frill_template_substitutions_are_complete(backend):
     assert "$" not in arguments
     assert "$" not in body
     assert "first_active" not in body
-    assert "frill_state[i] = current_new" in body
+    assert "size_t frill = (size_t)i" in body
+    assert "frill_state[frill] = current_new" in body
+    assert "frill_state[i]" not in body
     assert "source_gain * V_ab" in body

--- a/tests/updates/test_gpu_large_grid_indexing.py
+++ b/tests/updates/test_gpu_large_grid_indexing.py
@@ -17,10 +17,22 @@
 
 """Source-generation regressions for accelerator grids above 2^31 entries."""
 
+from string import Template
+
 import pytest
 from jinja2 import Environment, PackageLoader
 
-from gprMax.cuda_opencl import knl_fields_updates, knl_symmetry_boundaries
+from gprMax.cuda_opencl import (
+    knl_fields_updates,
+    knl_magnetic_frill_source,
+    knl_pml_updates_electric_HORIPML,
+    knl_pml_updates_electric_MRIPML,
+    knl_pml_updates_magnetic_HORIPML,
+    knl_pml_updates_magnetic_MRIPML,
+    knl_rational_network,
+    knl_snapshots,
+    knl_symmetry_boundaries,
+)
 from gprMax.updates.cuda_updates import CUDA_THREAD_INDEX
 
 
@@ -107,3 +119,56 @@ def test_dispersive_coordinate_products_use_pointer_sized_arithmetic(kernel):
 
     assert "size_t T_plane" in source
     assert "size_t T_offset" in source
+
+
+def test_sparse_source_field_offsets_remain_pointer_sized():
+    rational = knl_rational_network.update_rational_network["func"].template
+    frill = knl_magnetic_frill_source.update_magnetic_frill_source["func"].template
+
+    assert rational.count("size_t field_index = IDX3D_FIELDS") == 1
+    assert frill.count("size_t field_index = IDX3D_FIELDS") == 2
+    assert "int field_index = IDX3D_FIELDS" not in rational + frill
+
+
+def test_dispersive_symmetry_state_offsets_remain_pointer_sized():
+    phase_a = knl_symmetry_boundaries._DISPERSION_SNIPPET.template
+    phase_b = knl_symmetry_boundaries.update_electric_pmc_dispersive_b["func"].template
+
+    assert phase_a.count("size_t state = IDX4D_T") == 1
+    assert phase_b.count("size_t state = IDX4D_T") == 3
+    assert "int state = IDX4D_T" not in phase_a + phase_b
+
+
+def test_snapshot_coordinate_products_use_pointer_sized_arithmetic():
+    source = knl_snapshots.store_snapshot["func"].template
+
+    assert "size_t snapshot_plane" in source
+    assert "size_t snapshot_volume" in source
+    assert "size_t rem_snaps" in source
+    assert "$NX_SNAPS * $NY_SNAPS * $NZ_SNAPS" not in source
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        knl_pml_updates_electric_HORIPML,
+        knl_pml_updates_electric_MRIPML,
+        knl_pml_updates_magnetic_HORIPML,
+        knl_pml_updates_magnetic_MRIPML,
+    ],
+)
+def test_pml_coordinate_products_use_pointer_sized_arithmetic(module):
+    sources = [
+        value["func"].template
+        for value in vars(module).values()
+        if isinstance(value, dict) and isinstance(value.get("func"), Template)
+    ]
+
+    assert len(sources) == 12
+    for source in sources:
+        assert "size_t phi1_plane" in source
+        assert "size_t phi1_volume" in source
+        assert "size_t phi2_plane" in source
+        assert "size_t phi2_volume" in source
+        assert "NX_PHI1 * NY_PHI1 * NZ_PHI1" not in source
+        assert "NX_PHI2 * NY_PHI2 * NZ_PHI2" not in source

--- a/tests/utilities/test_device_detection.py
+++ b/tests/utilities/test_device_detection.py
@@ -254,21 +254,24 @@ class TestDetectCudaGpus:
 
         assert detect_cuda_gpus() == {}
 
-    def test_the_visible_devices_variable_restricts_the_list(self, cuda, monkeypatch):
-        """Schedulers set ``CUDA_VISIBLE_DEVICES``; gprMax must honour it.
-
-        Ignoring it on a shared node would mean grabbing another job's GPU.
-        """
-        cuda(count=4)
+    def test_driver_visible_devices_use_local_ordinals(self, cuda, monkeypatch):
+        """The CUDA driver applies the scheduler mask and renumbers devices."""
+        cuda(count=2)
         monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1,2")
 
-        assert sorted(detect_cuda_gpus()) == [1, 2]
+        assert sorted(detect_cuda_gpus()) == [0, 1]
 
-    def test_a_single_visible_device_is_parsed(self, cuda, monkeypatch):
-        cuda(count=4)
+    def test_a_single_visible_device_is_local_device_zero(self, cuda, monkeypatch):
+        cuda(count=1)
         monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3")
 
-        assert sorted(detect_cuda_gpus()) == [3]
+        assert sorted(detect_cuda_gpus()) == [0]
+
+    def test_a_uuid_visibility_mask_is_left_for_the_driver(self, cuda, monkeypatch):
+        cuda(count=1)
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-deadbeef-1234")
+
+        assert sorted(detect_cuda_gpus()) == [0]
 
     def test_the_visible_devices_variable_is_ignored_when_there_are_none(
         self, cuda, monkeypatch, caplog


### PR DESCRIPTION
## Summary

- use CUDA driver-visible local ordinals instead of reparsing `CUDA_VISIBLE_DEVICES`, including UUID and MIG-compatible masks
- preserve colons inside hash-command parameters while retaining the first colon as the command separator
- complete pointer-sized indexing in PML, snapshot, rational-network, magnetic-frill, and dispersive symmetry accelerator kernels
- correct the `Model.dy` and `Model.dz` getters for anisotropic grids
- document and test that HSG `pml_separation = ratio // 2 + 2` is fixed by the formulation and intentionally ignores the compatibility argument

## Validation

- 205 focused regression tests passed
- 1,291 broader update/PML/output tests passed (47 skipped, 49 deselected; non-MPI selection)
- 137 Metal-specific tests passed
- real Apple Metal/CPU parity passed for the basic model, snapshots, magnetic frills, series-RLC rational networks, Debye/Lorentz PMC symmetry, and second-order HORIPML/MRIPML on all six faces
- `python -m compileall -q gprMax tests` passed
- `git diff --check` passed

Sphinx and Ruff were not available in the local environment, so those optional checks were not run.