### PR TITLE
Optimise virtual-waveguide accelerator clearing and indexing

### DIFF
--- a/gprMax/cuda_opencl/knl_virtual_waveguide.py
+++ b/gprMax/cuda_opencl/knl_virtual_waveguide.py
@@ -20,7 +20,7 @@
 from string import Template
 
 
-def _args(name, backend, *, electric):
+def _args(name, backend, *, electric, field_kind="H"):
     prefix = {"cuda": "__global__ void", "opencl": "", "metal": "kernel void"}[backend]
     integer = "device const int&" if backend == "metal" else "int"
     real_const = {
@@ -64,7 +64,11 @@ def _args(name, backend, *, electric):
             "aux_Hz",
         )
     else:
-        names = ("main_Hx", "main_Hy", "main_Hz", "aux_Hx", "aux_Hy", "aux_Hz")
+        names = tuple(
+            f"{owner}_{field_kind}{axis}"
+            for owner in ("main", "aux")
+            for axis in "xyz"
+        )
     values.extend(f"{real} {value}" for value in names)
     suffix = ", uint i [[thread_position_in_grid]]" if backend == "metal" else ""
     if backend == "opencl":
@@ -88,7 +92,7 @@ couple_magnetic = {
         int aperture = direction_sign < 0 ? 0 :
             (normal_axis == 0 ? aux_nx : (normal_axis == 1 ? aux_ny : aux_nz));
         int aux_index;
-        int main_index;
+        size_t main_index;
         if (u < nu && v < nv) {
             if (normal_axis == 0) {
                 aux_index = aperture * (aux_ny + 1) * (aux_nz + 1) + u * (aux_nz + 1) + v;
@@ -120,37 +124,41 @@ clear_rear_magnetic = {
         """
     $CUDA_IDX
     if (i < NPOINTS) {
-        int x = i / ($NY_FIELDS * $NZ_FIELDS);
-        int remainder = i - x * $NY_FIELDS * $NZ_FIELDS;
-        int y = remainder / $NZ_FIELDS;
-        int z = remainder - y * $NZ_FIELDS;
-        bool rear, tangent_plane;
+        int nu = u1 - u0;
+        int nv = v1 - v0;
+        size_t uv_plane = (size_t)(nu + 1) * (size_t)(nv + 1);
+        int normal_offset = (int)((size_t)i / uv_plane);
+        size_t uv = (size_t)i % uv_plane;
+        int u = (int)(uv / (size_t)(nv + 1));
+        int v = (int)(uv % (size_t)(nv + 1));
+        int normal_cells = normal_axis == 0 ? $NX_FIELDS - 1 :
+            (normal_axis == 1 ? $NY_FIELDS - 1 : $NZ_FIELDS - 1);
+        int normal = (direction_sign < 0 ? plane_index : 0) + normal_offset;
+        int x = normal_axis == 0 ? normal : u0 + u;
+        int y = normal_axis == 1 ? normal : (normal_axis == 0 ? u0 + u : v0 + v);
+        int z = normal_axis == 2 ? normal : v0 + v;
+        size_t main_index = IDX3D_FIELDS(x,y,z);
+
+        bool clear_normal = u < nu && v < nv &&
+            (direction_sign > 0 || normal > plane_index);
+        bool clear_tangential = direction_sign > 0 || normal < normal_cells;
+        bool clear_u = clear_tangential && u <= nu && v < nv;
+        bool clear_v = clear_tangential && u < nu && v <= nv;
+
         if (normal_axis == 0) {
-            rear = direction_sign < 0 ? x >= plane_index : x < plane_index;
-            tangent_plane = direction_sign < 0 ? x < $NX_FIELDS - 1 : true;
-            if (rear) {
-                if ((direction_sign > 0 || x > plane_index) && y >= u0 && y < u1 && z >= v0 && z < v1) main_Hx[i] = 0;
-                if (tangent_plane && y >= u0 && y <= u1 && z >= v0 && z < v1) main_Hy[i] = 0;
-                if (tangent_plane && y >= u0 && y < u1 && z >= v0 && z <= v1) main_Hz[i] = 0;
-            }
+            if (clear_normal) main_Hx[main_index] = 0;
+            if (clear_u) main_Hy[main_index] = 0;
+            if (clear_v) main_Hz[main_index] = 0;
         }
         else if (normal_axis == 1) {
-            rear = direction_sign < 0 ? y >= plane_index : y < plane_index;
-            tangent_plane = direction_sign < 0 ? y < $NY_FIELDS - 1 : true;
-            if (rear) {
-                if ((direction_sign > 0 || y > plane_index) && x >= u0 && x < u1 && z >= v0 && z < v1) main_Hy[i] = 0;
-                if (tangent_plane && x >= u0 && x <= u1 && z >= v0 && z < v1) main_Hx[i] = 0;
-                if (tangent_plane && x >= u0 && x < u1 && z >= v0 && z <= v1) main_Hz[i] = 0;
-            }
+            if (clear_normal) main_Hy[main_index] = 0;
+            if (clear_u) main_Hx[main_index] = 0;
+            if (clear_v) main_Hz[main_index] = 0;
         }
         else {
-            rear = direction_sign < 0 ? z >= plane_index : z < plane_index;
-            tangent_plane = direction_sign < 0 ? z < $NZ_FIELDS - 1 : true;
-            if (rear) {
-                if ((direction_sign > 0 || z > plane_index) && x >= u0 && x < u1 && y >= v0 && y < v1) main_Hz[i] = 0;
-                if (tangent_plane && x >= u0 && x <= u1 && y >= v0 && y < v1) main_Hx[i] = 0;
-                if (tangent_plane && x >= u0 && x < u1 && y >= v0 && y <= v1) main_Hy[i] = 0;
-            }
+            if (clear_normal) main_Hz[main_index] = 0;
+            if (clear_u) main_Hx[main_index] = 0;
+            if (clear_v) main_Hy[main_index] = 0;
         }
     }
 """
@@ -174,7 +182,8 @@ couple_electric = {
         int aperture = direction_sign < 0 ? 0 :
             (normal_axis == 0 ? aux_nx : (normal_axis == 1 ? aux_ny : aux_nz));
         int inside = direction_sign < 0 ? 0 : aperture - 1;
-        int aidx = 0, midx = 0, material;
+        int aidx = 0, material;
+        size_t midx = 0;
         $REAL cross_field;
 
         if (normal_axis == 0) {
@@ -259,17 +268,61 @@ couple_electric = {
 
 
 clear_rear_electric = {
-    "args_cuda": _args("clear_virtual_waveguide_rear_electric", "cuda", electric=False),
-    "args_opencl": _args("clear_virtual_waveguide_rear_electric", "opencl", electric=False),
-    "args_metal": _args("clear_virtual_waveguide_rear_electric", "metal", electric=False),
+    "args_cuda": _args(
+        "clear_virtual_waveguide_rear_electric",
+        "cuda",
+        electric=False,
+        field_kind="E",
+    ),
+    "args_opencl": _args(
+        "clear_virtual_waveguide_rear_electric",
+        "opencl",
+        electric=False,
+        field_kind="E",
+    ),
+    "args_metal": _args(
+        "clear_virtual_waveguide_rear_electric",
+        "metal",
+        electric=False,
+        field_kind="E",
+    ),
     "func": Template(
         """
     $CUDA_IDX
-    if(i<NPOINTS){
-        int x=i/($NY_FIELDS*$NZ_FIELDS);int r=i-x*$NY_FIELDS*$NZ_FIELDS;int y=r/$NZ_FIELDS;int z=r-y*$NZ_FIELDS;bool rear;
-        if(normal_axis==0){rear=direction_sign<0?x>plane_index:x<plane_index;if(rear){if((direction_sign<0||x<plane_index-1)&&y>=u0&&y<=u1&&z>=v0&&z<=v1)main_Hx[i]=0;if(y>=u0&&y<u1&&z>=v0&&z<=v1)main_Hy[i]=0;if(y>=u0&&y<=u1&&z>=v0&&z<v1)main_Hz[i]=0;}}
-        else if(normal_axis==1){rear=direction_sign<0?y>plane_index:y<plane_index;if(rear){if((direction_sign<0||y<plane_index-1)&&x>=u0&&x<=u1&&z>=v0&&z<=v1)main_Hy[i]=0;if(x>=u0&&x<u1&&z>=v0&&z<=v1)main_Hx[i]=0;if(x>=u0&&x<=u1&&z>=v0&&z<v1)main_Hz[i]=0;}}
-        else{rear=direction_sign<0?z>plane_index:z<plane_index;if(rear){if((direction_sign<0||z<plane_index-1)&&x>=u0&&x<=u1&&y>=v0&&y<=v1)main_Hz[i]=0;if(x>=u0&&x<u1&&y>=v0&&y<=v1)main_Hx[i]=0;if(x>=u0&&x<=u1&&y>=v0&&y<v1)main_Hy[i]=0;}}
+    if (i < NPOINTS) {
+        int nu = u1 - u0;
+        int nv = v1 - v0;
+        size_t uv_plane = (size_t)(nu + 1) * (size_t)(nv + 1);
+        int normal_offset = (int)((size_t)i / uv_plane);
+        size_t uv = (size_t)i % uv_plane;
+        int u = (int)(uv / (size_t)(nv + 1));
+        int v = (int)(uv % (size_t)(nv + 1));
+        int normal = (direction_sign < 0 ? plane_index + 1 : 0) + normal_offset;
+        int x = normal_axis == 0 ? normal : u0 + u;
+        int y = normal_axis == 1 ? normal : (normal_axis == 0 ? u0 + u : v0 + v);
+        int z = normal_axis == 2 ? normal : v0 + v;
+        size_t main_index = IDX3D_FIELDS(x,y,z);
+
+        bool clear_normal = u <= nu && v <= nv &&
+            (direction_sign < 0 || normal < plane_index - 1);
+        bool clear_u = u < nu && v <= nv;
+        bool clear_v = u <= nu && v < nv;
+
+        if (normal_axis == 0) {
+            if (clear_normal) main_Ex[main_index] = 0;
+            if (clear_u) main_Ey[main_index] = 0;
+            if (clear_v) main_Ez[main_index] = 0;
+        }
+        else if (normal_axis == 1) {
+            if (clear_normal) main_Ey[main_index] = 0;
+            if (clear_u) main_Ex[main_index] = 0;
+            if (clear_v) main_Ez[main_index] = 0;
+        }
+        else {
+            if (clear_normal) main_Ez[main_index] = 0;
+            if (clear_u) main_Ex[main_index] = 0;
+            if (clear_v) main_Ey[main_index] = 0;
+        }
     }
 """
     ),

--- a/gprMax/updates/cuda_updates.py
+++ b/gprMax/updates/cuda_updates.py
@@ -1622,11 +1622,11 @@ class CUDAUpdates(Updates[CUDAGrid]):
             *main_h,
             *aux_h,
         )
-        nmain = self.grid.Ex.size
+        nrear = guide._rear_clear_points(magnetic=True)
         self._virtual_launch(
             self.clear_virtual_magnetic_dev,
-            nmain,
-            *self._virtual_scalars(guide, nmain),
+            nrear,
+            *self._virtual_scalars(guide, nrear),
             *main_h,
             *aux_h,
         )
@@ -1669,11 +1669,11 @@ class CUDAUpdates(Updates[CUDAGrid]):
             *main_fields,
             *aux_fields,
         )
-        nmain = self.grid.Ex.size
+        nrear = guide._rear_clear_points(magnetic=False)
         self._virtual_launch(
             self.clear_virtual_electric_dev,
-            nmain,
-            *self._virtual_scalars(guide, nmain),
+            nrear,
+            *self._virtual_scalars(guide, nrear),
             *(field.gpudata for field in (self.grid.Ex_dev, self.grid.Ey_dev, self.grid.Ez_dev)),
             *(
                 field.gpudata

--- a/gprMax/updates/metal_updates.py
+++ b/gprMax/updates/metal_updates.py
@@ -1054,12 +1054,12 @@ class MetalUpdates(Updates[MetalGrid]):
             (*main_h, *aux_h),
             nface,
         )
-        nmain = self.grid.Ex.size
+        nrear = guide._rear_clear_points(magnetic=True)
         self._dispatch_1d(
             self.pso_virtual_clear_magnetic,
-            self._virtual_scalars(guide, nmain),
+            self._virtual_scalars(guide, nrear),
             (*main_h, *aux_h),
-            nmain,
+            nrear,
         )
 
     def _update_virtual_waveguide_electric(self, guide, iteration):
@@ -1096,10 +1096,10 @@ class MetalUpdates(Updates[MetalGrid]):
             ),
             nface,
         )
-        nmain = self.grid.Ex.size
+        nrear = guide._rear_clear_points(magnetic=False)
         self._dispatch_1d(
             self.pso_virtual_clear_electric,
-            self._virtual_scalars(guide, nmain),
+            self._virtual_scalars(guide, nrear),
             (
                 self.grid.Ex_dev,
                 self.grid.Ey_dev,
@@ -1108,7 +1108,7 @@ class MetalUpdates(Updates[MetalGrid]):
                 guide.aux_grid.Ey_dev,
                 guide.aux_grid.Ez_dev,
             ),
-            nmain,
+            nrear,
         )
 
     def update_magnetic(self):

--- a/gprMax/updates/opencl_updates.py
+++ b/gprMax/updates/opencl_updates.py
@@ -1970,11 +1970,11 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
             *main_h,
             *aux_h,
         )
-        nmain = self.grid.Ex.size
+        nrear = guide._rear_clear_points(magnetic=True)
         self._virtual_launch(
             self.clear_virtual_magnetic_dev,
-            nmain,
-            *self._virtual_scalars(guide, nmain),
+            nrear,
+            *self._virtual_scalars(guide, nrear),
             *main_h,
             *aux_h,
         )
@@ -2011,11 +2011,11 @@ class OpenCLUpdates(Updates[OpenCLGrid]):
             *main_fields,
             *aux_fields,
         )
-        nmain = self.grid.Ex.size
+        nrear = guide._rear_clear_points(magnetic=False)
         self._virtual_launch(
             self.clear_virtual_electric_dev,
-            nmain,
-            *self._virtual_scalars(guide, nmain),
+            nrear,
+            *self._virtual_scalars(guide, nrear),
             self.grid.Ex_dev,
             self.grid.Ey_dev,
             self.grid.Ez_dev,

--- a/gprMax/virtual_waveguide.py
+++ b/gprMax/virtual_waveguide.py
@@ -102,7 +102,7 @@ class VirtualWaveguide:
                 f"clearance + 3 cells ({minimum_length} cells for this request)."
             )
         domain_size = np.asarray(
-            getattr(self.main_grid, "global_size", self.main_grid.size), dtype=np.int32
+            getattr(self.main_grid, "global_size", self.main_grid.size), dtype=object
         )
         normal_cells = int(domain_size[self.normal_axis])
         if not 1 <= self.plane_index < normal_cells:
@@ -113,10 +113,15 @@ class VirtualWaveguide:
                 "along each transverse axis."
             )
         int32_max = np.iinfo(np.int32).max
-        main_points = int(np.prod(np.asarray(domain_size, dtype=object) + 1))
         auxiliary_size = [self.nu, self.nv, self.spec.length_cells]
         auxiliary_points = int(np.prod(np.asarray(auxiliary_size, dtype=object) + 1))
-        if max(main_points, auxiliary_points, (self.nu + 1) * (self.nv + 1)) > int32_max:
+        device_counts = (
+            auxiliary_points,
+            (self.nu + 1) * (self.nv + 1),
+            self._rear_clear_points(magnetic=True),
+            self._rear_clear_points(magnetic=False),
+        )
+        if config.sim_config.general["solver"] != "cpu" and max(device_counts) > int32_max:
             raise ValueError("Virtual-waveguide device indexing exceeds the signed 32-bit range.")
 
         if self.mpi:
@@ -145,6 +150,23 @@ class VirtualWaveguide:
                 "Virtual-waveguide aperture coupling does not yet support "
                 "dispersive guide materials; found " + ", ".join(dispersive) + "."
             )
+
+    def _rear_clear_points(self, *, magnetic):
+        """Return the compact accelerator dispatch size for the detached rear.
+
+        The rear occupies only the aperture cross-section extruded from the
+        split plane to the relevant main-domain boundary. Magnetic Yee
+        components on the far normal boundary require one additional plane;
+        the component-specific bounds remain in the device kernel.
+        """
+
+        domain_size = getattr(self.main_grid, "global_size", self.main_grid.size)
+        normal_cells = int(domain_size[self.normal_axis])
+        if self.direction_sign < 0:
+            normal_points = normal_cells - self.plane_index + int(magnetic)
+        else:
+            normal_points = self.plane_index
+        return normal_points * (self.nu + 1) * (self.nv + 1)
 
     def _adjacent_solids(self):
         if self.mpi:

--- a/tests/fdfd_eigenmode_solver/test_virtual_waveguide_device.py
+++ b/tests/fdfd_eigenmode_solver/test_virtual_waveguide_device.py
@@ -17,7 +17,9 @@
 
 """Device-kernel and full-solve parity for virtual eigenmode waveguides."""
 
+import inspect
 from pathlib import Path
+from types import SimpleNamespace
 
 import h5py
 import numpy as np
@@ -25,8 +27,30 @@ import pytest
 from numpy.testing import assert_allclose
 
 import gprMax
+import gprMax.config as config
 from gprMax.cuda_opencl import knl_eigenmode, knl_virtual_waveguide
+from gprMax.updates.cuda_updates import CUDAUpdates
+from gprMax.updates.metal_updates import MetalUpdates
+from gprMax.updates.opencl_updates import OpenCLUpdates
+from gprMax.virtual_waveguide import VirtualWaveguide as RuntimeVirtualWaveguide
 from tests.test_virtual_waveguide_integration import _uniform_waveguide_scene
+
+try:
+    import Metal
+
+    HAS_METAL = Metal.MTLCreateSystemDefaultDevice() is not None
+except Exception:
+    HAS_METAL = False
+
+
+def _device_options(request, backend):
+    if backend == "cuda":
+        return {"gpu": [request.getfixturevalue("gpu_device")]}, "double"
+    if backend == "opencl":
+        return {"opencl": [request.getfixturevalue("opencl_device")]}, "double"
+    if not HAS_METAL:
+        pytest.skip("No Apple Metal device/PyObjC available")
+    return {"metal": True}, "single"
 
 
 @pytest.mark.parametrize("backend", ["cuda", "opencl", "metal"])
@@ -55,6 +79,118 @@ def test_eigenmode_device_templates_have_complete_substitutions(backend):
         body = specification["func"].substitute(substitutions)
         assert "$" not in arguments
         assert "$" not in body
+
+
+@pytest.mark.parametrize("magnetic", [False, True])
+@pytest.mark.parametrize("direction_sign", [-1, 1])
+@pytest.mark.parametrize("normal_axis", range(3))
+def test_rear_clear_dispatch_covers_only_the_aperture_prism(
+    normal_axis, direction_sign, magnetic
+):
+    size = np.array([101, 82, 73])
+    guide = RuntimeVirtualWaveguide.__new__(RuntimeVirtualWaveguide)
+    guide.main_grid = SimpleNamespace(size=size)
+    guide.normal_axis = normal_axis
+    guide.direction_sign = direction_sign
+    guide.plane_index = 29 if direction_sign > 0 else int(size[normal_axis]) - 23
+    guide.nu = 7
+    guide.nv = 5
+
+    if direction_sign < 0:
+        normal_points = (
+            int(size[normal_axis]) - guide.plane_index + int(magnetic)
+        )
+    else:
+        normal_points = guide.plane_index
+    expected = normal_points * (guide.nu + 1) * (guide.nv + 1)
+
+    assert guide._rear_clear_points(magnetic=magnetic) == expected
+    assert expected < int(np.prod(size + 1))
+
+
+def _validation_guide(size, nu, nv):
+    guide = RuntimeVirtualWaveguide.__new__(RuntimeVirtualWaveguide)
+    guide.main_grid = SimpleNamespace(
+        size=np.asarray(size),
+        materials=[SimpleNamespace(numID=0, ID="free_space", poles=0)],
+    )
+    guide.port = SimpleNamespace(invariant_axis=None)
+    guide.spec = SimpleNamespace(
+        length_cells=6,
+        pml_cells=2,
+        source_clearance_cells=1,
+    )
+    guide.normal_axis = 2
+    guide.direction_sign = 1
+    guide.plane_index = 1
+    guide.nu = nu
+    guide.nv = nv
+    guide.mpi = False
+    guide._adjacent_component_ids = lambda: (np.zeros(1), np.zeros(1))
+    guide._adjacent_solids = lambda: (np.zeros(1), np.zeros(1))
+    guide._component_cross_section = lambda: np.zeros(1, dtype=np.uint32)
+    return guide
+
+
+def test_device_validation_allows_wide_main_field_addresses(monkeypatch):
+    monkeypatch.setattr(config, "sim_config", SimpleNamespace(general={"solver": "metal"}))
+    monkeypatch.setattr(config, "get_model_config", lambda: SimpleNamespace(mode="3D"))
+    guide = _validation_guide(size=(50_000, 50_000, 2), nu=4, nv=5)
+
+    assert int(np.prod(np.asarray(guide.main_grid.size, dtype=object) + 1)) > np.iinfo(
+        np.int32
+    ).max
+    guide._validate()
+
+
+def test_device_validation_still_rejects_oversized_compact_dispatch(monkeypatch):
+    monkeypatch.setattr(config, "sim_config", SimpleNamespace(general={"solver": "metal"}))
+    monkeypatch.setattr(config, "get_model_config", lambda: SimpleNamespace(mode="3D"))
+    guide = _validation_guide(size=(60_000, 60_000, 2), nu=50_000, nv=50_000)
+
+    with pytest.raises(ValueError, match="device indexing exceeds"):
+        guide._validate()
+
+
+@pytest.mark.parametrize(
+    "specification,field_kind",
+    [
+        (knl_virtual_waveguide.clear_rear_magnetic, "H"),
+        (knl_virtual_waveguide.clear_rear_electric, "E"),
+    ],
+)
+def test_rear_clear_kernels_use_compact_coordinates_and_wide_main_addresses(
+    specification, field_kind
+):
+    body = specification["func"].template
+
+    assert "size_t uv_plane" in body
+    assert "size_t main_index = IDX3D_FIELDS" in body
+    assert "$NY_FIELDS * $NZ_FIELDS" not in body
+    assert f"main_{field_kind}x[i]" not in body
+    for backend in ("cuda", "opencl", "metal"):
+        arguments = specification[f"args_{backend}"].template
+        assert f"main_{field_kind}x" in arguments
+
+
+def test_aperture_coupling_keeps_main_grid_offsets_pointer_sized():
+    magnetic = knl_virtual_waveguide.couple_magnetic["func"].template
+    electric = knl_virtual_waveguide.couple_electric["func"].template
+
+    assert "size_t main_index" in magnetic
+    assert "int main_index" not in magnetic
+    assert "size_t midx" in electric
+    assert "int aidx = 0, midx" not in electric
+
+
+@pytest.mark.parametrize("updates", [CUDAUpdates, OpenCLUpdates, MetalUpdates])
+def test_accelerator_rear_clear_dispatch_does_not_use_the_main_field_size(updates):
+    magnetic = inspect.getsource(updates._update_virtual_waveguide_magnetic)
+    electric = inspect.getsource(updates._update_virtual_waveguide_electric)
+
+    assert "_rear_clear_points(magnetic=True)" in magnetic
+    assert "_rear_clear_points(magnetic=False)" in electric
+    assert "self.grid.Ex.size" not in magnetic + electric
 
 
 def _port_results(path, port_number=1):
@@ -124,12 +260,9 @@ def _direct_eigenmode_source_scene():
 @pytest.mark.gpu
 @pytest.mark.parametrize("normal_axis", range(3))
 @pytest.mark.parametrize("direction", ["-", "+"])
-@pytest.mark.parametrize("backend", ["cuda", "opencl"])
+@pytest.mark.parametrize("backend", ["cuda", "opencl", "metal"])
 def test_device_virtual_waveguide_matches_cpu(tmp_path, request, backend, normal_axis, direction):
-    if backend == "cuda":
-        device_options = {"gpu": [request.getfixturevalue("gpu_device")]}
-    else:
-        device_options = {"opencl": [request.getfixturevalue("opencl_device")]}
+    device_options, device_precision = _device_options(request, backend)
 
     suffix = f"{'xyz'[normal_axis]}{'minus' if direction == '-' else 'plus'}"
     cpu_path = tmp_path / f"cpu_virtual_{suffix}"
@@ -144,7 +277,7 @@ def test_device_virtual_waveguide_matches_cpu(tmp_path, request, backend, normal
     gprMax.run(
         scenes=[_uniform_waveguide_scene(normal_axis, direction)],
         outputfile=device_path,
-        gpu_precision="double",
+        gpu_precision=device_precision,
         hide_progress_bars=True,
         log_level=30,
         **device_options,
@@ -166,12 +299,9 @@ def test_device_virtual_waveguide_matches_cpu(tmp_path, request, backend, normal
 
 @pytest.mark.integration
 @pytest.mark.gpu
-@pytest.mark.parametrize("backend", ["cuda", "opencl"])
+@pytest.mark.parametrize("backend", ["cuda", "opencl", "metal"])
 def test_device_virtual_waveguide_broadband_matches_cpu(tmp_path, request, backend):
-    if backend == "cuda":
-        device_options = {"gpu": [request.getfixturevalue("gpu_device")]}
-    else:
-        device_options = {"opencl": [request.getfixturevalue("opencl_device")]}
+    device_options, device_precision = _device_options(request, backend)
 
     cpu_path = tmp_path / "cpu_virtual_broadband"
     device_path = tmp_path / f"{backend}_virtual_broadband"
@@ -185,7 +315,7 @@ def test_device_virtual_waveguide_broadband_matches_cpu(tmp_path, request, backe
     gprMax.run(
         scenes=[_broadband_virtual_waveguide_scene()],
         outputfile=device_path,
-        gpu_precision="double",
+        gpu_precision=device_precision,
         hide_progress_bars=True,
         log_level=30,
         **device_options,
@@ -201,12 +331,9 @@ def test_device_virtual_waveguide_broadband_matches_cpu(tmp_path, request, backe
 
 @pytest.mark.integration
 @pytest.mark.gpu
-@pytest.mark.parametrize("backend", ["cuda", "opencl"])
+@pytest.mark.parametrize("backend", ["cuda", "opencl", "metal"])
 def test_device_passive_virtual_waveguide_matches_cpu(tmp_path, request, backend):
-    if backend == "cuda":
-        device_options = {"gpu": [request.getfixturevalue("gpu_device")]}
-    else:
-        device_options = {"opencl": [request.getfixturevalue("opencl_device")]}
+    device_options, device_precision = _device_options(request, backend)
 
     cpu_path = tmp_path / "cpu_virtual_passive"
     device_path = tmp_path / f"{backend}_virtual_passive"
@@ -223,7 +350,7 @@ def test_device_passive_virtual_waveguide_matches_cpu(tmp_path, request, backend
     gprMax.run(
         scenes=[_active_and_passive_virtual_waveguide_scene()],
         outputfile=device_path,
-        gpu_precision="double",
+        gpu_precision=device_precision,
         **device_options,
         **run_options,
     )
@@ -239,12 +366,9 @@ def test_device_passive_virtual_waveguide_matches_cpu(tmp_path, request, backend
 
 @pytest.mark.integration
 @pytest.mark.gpu
-@pytest.mark.parametrize("backend", ["cuda", "opencl"])
+@pytest.mark.parametrize("backend", ["cuda", "opencl", "metal"])
 def test_device_direct_eigenmode_source_matches_cpu(tmp_path, request, backend):
-    if backend == "cuda":
-        device_options = {"gpu": [request.getfixturevalue("gpu_device")]}
-    else:
-        device_options = {"opencl": [request.getfixturevalue("opencl_device")]}
+    device_options, device_precision = _device_options(request, backend)
 
     cpu_path = tmp_path / "cpu_direct_eigenmode"
     device_path = tmp_path / f"{backend}_direct_eigenmode"
@@ -258,7 +382,7 @@ def test_device_direct_eigenmode_source_matches_cpu(tmp_path, request, backend):
     gprMax.run(
         scenes=[_direct_eigenmode_source_scene()],
         outputfile=device_path,
-        gpu_precision="double",
+        gpu_precision=device_precision,
         **device_options,
         **run_options,
     )


### PR DESCRIPTION
## Summary

- dispatch accelerator rear-field clearing over only the detached aperture prism rather than the full main-grid field array
- preserve the CPU Yee-staggered electric and magnetic clearing bounds for all axes and propagation directions
- use pointer-sized flattened addresses for main-grid coupling and clearing while retaining 32-bit compact guide coordinates and dispatch counts
- remove the obsolete signed-32-bit restriction on total main-grid points, while continuing to reject genuinely oversized compact device operations
- add Metal to the permanent virtual-waveguide CPU-parity tests

## Validation

- real Metal integration suite: `9 passed` (all three axes, both directions, broadband excitation, active/passive ports, and direct eigenmode source)
- all 18 incident/outgoing/S comparisons across the six axis/direction cases matched CPU exactly
- two-mode Metal comparison matched CPU exactly for `incident`, `outgoing`, and `active_S`
- CPU virtual-waveguide integration suite: `2 passed`
- focused virtual-waveguide tests: `51 passed`
- wider non-MPI update regression suite: `444 passed, 6 skipped`
- kernel-template substitution, large flattened-address acceptance, compact-dispatch overflow rejection, compilation, and whitespace checks passed

CUDA and OpenCL runtime packages are not available on the test machine. Their generated templates and host dispatch paths are covered, and they share the kernel body exercised by Metal; their hardware-dependent parity cases remain in the test suite for accelerator CI.
