### PR TITLE
Fix geometry build validation and reporting

### DIFF
--- a/gprMax/cython/geometry_primitives.pyx
+++ b/gprMax/cython/geometry_primitives.pyx
@@ -504,7 +504,7 @@ cpdef void build_voxel(
             ID[5, i, j, k + 1] = numIDz
 
 
-cpdef void build_triangle(
+cpdef Py_ssize_t build_triangle(
     double x1,
     double y1,
     double z1,
@@ -552,7 +552,7 @@ cpdef void build_triangle(
         solid, rigidE, rigidH, ID: memoryviews to access solid, rigid and ID arrays.
     """
 
-    cdef Py_ssize_t i, j, k
+    cdef Py_ssize_t i, j, k, occupied = 0
     cdef int i1, i2, j1, j2, levelcells, thicknesscells
     cdef int u1, v1, u2, v2, u3, v3
     cdef long long bu, bv, cu, cv, qu2, qv2
@@ -614,7 +614,7 @@ cpdef void build_triangle(
     cu, cv = u3 - u1, v3 - v1
     denominator = bu * cv - bv * cu
     if denominator == 0:
-        return
+        return 0
 
     for i in range(i1, i2):
         for j in range(j1, j2):
@@ -650,6 +650,7 @@ cpdef void build_triangle(
                     elif normal == 'z':
                         build_face_xy(i, j, levelcells, numIDx, numIDy,
                                       rigidE, rigidH, ID)
+                    occupied += 1
                 else:
                     for k in range(levelcells, levelcells + thicknesscells):
                         if normal == 'x':
@@ -673,9 +674,12 @@ cpdef void build_triangle(
                             if tag_itemsize:
                                 set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1],
                                                  solid.shape[2], i, j, k, tag_id)
+                        occupied += 1
+
+    return occupied
 
 
-cpdef void build_cylindrical_sector(
+cpdef Py_ssize_t build_cylindrical_sector(
     double ctr1,
     double ctr2,
     double level,
@@ -727,7 +731,7 @@ cpdef void build_cylindrical_sector(
         solid, rigidE, rigidH, ID: memoryviews to access solid, rigid and ID arrays.
     """
 
-    cdef Py_ssize_t x, y, z
+    cdef Py_ssize_t x, y, z, occupied = 0
     cdef int x1, x2, y1, y2, z1, z2, thicknesscells, ctr1cell, ctr2cell
     cdef int radiuscells1, radiuscells2
     cdef double rel1, rel2
@@ -771,6 +775,7 @@ cpdef void build_cylindrical_sector(
                     if thicknesscells == 0:
                         build_face_yz(levelcells, y, z, numIDy, numIDz,
                                       rigidE, rigidH, ID)
+                        occupied += 1
                     else:
                         for x in range(levelcells, levelcells + thicknesscells):
                             build_voxel(x, y, z, numID, numIDx, numIDy, numIDz,
@@ -779,6 +784,7 @@ cpdef void build_cylindrical_sector(
                             if tag_itemsize:
                                 set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1],
                                                  solid.shape[2], x, y, z, tag_id)
+                            occupied += 1
 
     elif normal == 'y':
         # Angles are defined from zero degrees on the positive x-axis going
@@ -807,6 +813,7 @@ cpdef void build_cylindrical_sector(
                     if thicknesscells == 0:
                         build_face_xz(x, levelcells, z, numIDx, numIDz,
                                       rigidE, rigidH, ID)
+                        occupied += 1
                     else:
                         for y in range(levelcells, levelcells + thicknesscells):
                             build_voxel(x, y, z, numID, numIDx, numIDy, numIDz,
@@ -815,6 +822,7 @@ cpdef void build_cylindrical_sector(
                             if tag_itemsize:
                                 set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1],
                                                  solid.shape[2], x, y, z, tag_id)
+                            occupied += 1
 
     elif normal == 'z':
         # Angles are defined from zero degrees on the positive x-axis going
@@ -843,6 +851,7 @@ cpdef void build_cylindrical_sector(
                     if thicknesscells == 0:
                         build_face_xy(x, y, levelcells, numIDx, numIDy,
                                       rigidE, rigidH, ID)
+                        occupied += 1
                     else:
                         for z in range(levelcells, levelcells + thicknesscells):
                             build_voxel(x, y, z, numID, numIDx, numIDy, numIDz,
@@ -851,9 +860,12 @@ cpdef void build_cylindrical_sector(
                             if tag_itemsize:
                                 set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1],
                                                  solid.shape[2], x, y, z, tag_id)
+                            occupied += 1
+
+    return occupied
 
 
-cpdef void build_box(
+cpdef Py_ssize_t build_box(
     int xs,
     int xf,
     int ys,
@@ -975,8 +987,10 @@ cpdef void build_box(
                         set_rigid_Hz(i, j, k, rigidH)
                         ID[5, i, j, k] = numIDz
 
+    return <Py_ssize_t>(xf - xs) * (yf - ys) * (zf - zs)
 
-cpdef void build_cylinder(
+
+cpdef Py_ssize_t build_cylinder(
     double x1,
     double y1,
     double z1,
@@ -1018,7 +1032,7 @@ cpdef void build_cylinder(
         solid, rigidE, rigidH, ID: memoryviews to access solid, rigid and ID arrays.
     """
 
-    cdef Py_ssize_t i, j, k
+    cdef Py_ssize_t i, j, k, occupied = 0
     cdef int xs, xf, ys, yf, zs, zf
     cdef int ix1, iy1, iz1, ix2, iy2, iz2
     cdef int rx, ry, rz
@@ -1042,7 +1056,7 @@ cpdef void build_cylinder(
     ax, ay, az = (ix2 - ix1) * dx, (iy2 - iy1) * dy, (iz2 - iz1) * dz
     axis2 = ax * ax + ay * ay + az * az
     if axis2 == 0:
-        return
+        return 0
 
     rx, ry, rz = <int>ceil(r / dx), <int>ceil(r / dy), <int>ceil(r / dz)
     xs, xf = max(0, min(ix1, ix2) - rx - 1), min(solid.shape[0], max(ix1, ix2) + rx + 1)
@@ -1065,9 +1079,12 @@ cpdef void build_cylinder(
                         if tag_itemsize:
                             set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1],
                                              solid.shape[2], i, j, k, tag_id)
+                        occupied += 1
+
+    return occupied
 
 
-cpdef void build_cone(
+cpdef Py_ssize_t build_cone(
     double x1,
     double y1,
     double z1,
@@ -1111,7 +1128,7 @@ cpdef void build_cone(
         solid, rigidE, rigidH, ID: memoryviews to access solid, rigid and ID arrays.
     """
 
-    cdef Py_ssize_t i, j, k
+    cdef Py_ssize_t i, j, k, occupied = 0
     cdef int xs, xf, ys, yf, zs, zf
     cdef int ix1, iy1, iz1, ix2, iy2, iz2
     cdef int rx, ry, rz
@@ -1135,7 +1152,7 @@ cpdef void build_cone(
     ax, ay, az = (ix2 - ix1) * dx, (iy2 - iy1) * dy, (iz2 - iz1) * dz
     axis2 = ax * ax + ay * ay + az * az
     if axis2 == 0:
-        return
+        return 0
 
     Rmax = max(r1, r2)
     rx, ry, rz = <int>ceil(Rmax / dx), <int>ceil(Rmax / dy), <int>ceil(Rmax / dz)
@@ -1159,9 +1176,12 @@ cpdef void build_cone(
                         if tag_itemsize:
                             set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1],
                                              solid.shape[2], i, j, k, tag_id)
+                        occupied += 1
+
+    return occupied
 
 
-cpdef void build_sphere(
+cpdef Py_ssize_t build_sphere(
     int xc,
     int yc,
     int zc,
@@ -1199,7 +1219,7 @@ cpdef void build_sphere(
         solid, rigidE, rigidH, ID: memoryviews to access solid, rigid and ID arrays.
     """
 
-    cdef Py_ssize_t i, j, k
+    cdef Py_ssize_t i, j, k, occupied = 0
     cdef int xs, xf, ys, yf, zs, zf, rx, ry, rz
     cdef double qx, qy, qz
     cdef int tag_itemsize = 0
@@ -1246,9 +1266,12 @@ cpdef void build_sphere(
                     if tag_itemsize:
                         set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1],
                                          solid.shape[2], i, j, k, tag_id)
+                    occupied += 1
+
+    return occupied
 
 
-cpdef void build_ellipsoid(
+cpdef Py_ssize_t build_ellipsoid(
     int xc,
     int yc,
     int zc,
@@ -1290,7 +1313,7 @@ cpdef void build_ellipsoid(
         solid, rigidE, rigidH, ID: memoryviews to access solid, rigid and ID arrays.
     """
 
-    cdef Py_ssize_t i, j, k
+    cdef Py_ssize_t i, j, k, occupied = 0
     cdef int xs, xf, ys, yf, zs, zf, rxcells, rycells, rzcells
     cdef double qx, qy, qz
     cdef int tag_itemsize = 0
@@ -1337,6 +1360,9 @@ cpdef void build_ellipsoid(
                     if tag_itemsize:
                         set_geometry_tag(tag_bytes, tag_itemsize, solid.shape[1],
                                          solid.shape[2], i, j, k, tag_id)
+                    occupied += 1
+
+    return occupied
 
 
 cpdef void build_voxels_from_array(

--- a/gprMax/model.py
+++ b/gprMax/model.py
@@ -49,6 +49,23 @@ from gprMax.utilities.utilities import get_terminal_width
 logger = logging.getLogger(__name__)
 
 
+def _process_memory_bytes(process):
+    """Return the best available host-memory estimate for a process.
+
+    USS is preferred, but querying it can be denied by the operating system
+    even after a model has solved successfully. RSS is a portable fallback;
+    if both queries fail, reporting memory must not fail the simulation.
+    """
+
+    try:
+        return process.memory_full_info().uss
+    except (psutil.Error, AttributeError, OSError, NotImplementedError):
+        try:
+            return process.memory_info().rss
+        except (psutil.Error, AttributeError, OSError, NotImplementedError):
+            return None
+
+
 class Model:
     """Builds and runs (solves) a model."""
 
@@ -857,10 +874,11 @@ class Model:
         elif config.sim_config.general["solver"] == "opencl":
             mem_str = f" host + unknown for device"
 
-        logger.info(
-            f"Memory used (estimated): "
-            + f"~{humanize.naturalsize(self.p.memory_full_info().uss)}{mem_str}"
+        host_memory = _process_memory_bytes(self.p)
+        host_memory_str = (
+            f"~{humanize.naturalsize(host_memory)}" if host_memory is not None else "unknown"
         )
+        logger.info(f"Memory used (estimated): {host_memory_str}{mem_str}")
         logger.info(
             f"Time taken: "
             + f"{humanize.precisedelta(datetime.timedelta(seconds=solver.solvetime), format='%0.4f')}\n"

--- a/gprMax/scene.py
+++ b/gprMax/scene.py
@@ -30,6 +30,9 @@ from gprMax.user_objects.cmds_geometry.add_grass import AddGrass
 from gprMax.user_objects.cmds_geometry.add_surface_roughness import AddSurfaceRoughness
 from gprMax.user_objects.cmds_geometry.add_surface_water import AddSurfaceWater
 from gprMax.user_objects.cmds_geometry.fractal_box import FractalBox
+from gprMax.user_objects.cmds_geometry.cmds_geometry import (
+    validate_distributed_geometry_rasterisation,
+)
 from gprMax.user_objects.cmds_singleuse import Discretisation, Domain, TimeWindow
 from gprMax.user_objects.user_objects import (
     GeometryUserObject,
@@ -302,6 +305,8 @@ class Scene:
         # Initialise geometry arrays for main and subgrids
         for grid in [model.G] + model.subgrids:
             grid.initialise_geometry_arrays()
+            if getattr(grid, "is_distributed", False) is True:
+                grid.geometry_rasterisation_records = []
 
         # Process the main grid geometry commands
         self.process_geometry_objects(self.geometry_objects, model.G)
@@ -309,3 +314,5 @@ class Scene:
 
         # Process all the commands for subgrids
         self.process_subgrid_objects(model)
+
+        validate_distributed_geometry_rasterisation(model.G)

--- a/gprMax/user_objects/cmds_geometry/box.py
+++ b/gprMax/user_objects/cmds_geometry/box.py
@@ -29,6 +29,7 @@ from .cmds_geometry import (
     check_averaging,
     geometry_tag_args,
     resolve_geometry_materials,
+    validate_geometry_rasterisation,
 )
 
 logger = logging.getLogger(__name__)
@@ -91,11 +92,18 @@ class Box(GeometryUserObject):
         # Exit early if none of the box is in this grid as there is
         # nothing else to do.
         if not grid_contains_box:
+            if getattr(grid, "is_distributed", False) is True:
+                validate_geometry_rasterisation(grid, 0, geometry=self.params_str())
             return
 
         # Find nearest point on grid without translation
         p5 = uip.round_to_grid_static_point(p1)
         p6 = uip.round_to_grid_static_point(p2)
+        if np.any(p6 <= p5):
+            raise ValueError(
+                f"{self.params_str()} must have positive cell extent on every axis "
+                "after spatial discretisation"
+            )
         xs, ys, zs = p3
         xf, yf, zf = p4
 
@@ -105,13 +113,6 @@ class Box(GeometryUserObject):
             geometry=self.params_str(),
             directional="material_id" not in self.kwargs,
         )
-        uses_surface_impedance = hasattr(materials[0], "surface_impedance_id")
-        if uses_surface_impedance and any(stop <= start for start, stop in zip(p3, p4)):
-            raise ValueError(
-                f"{self.params_str()} surface impedance requires positive cell extent "
-                "on every axis"
-            )
-
         # Isotropic case
         if len(materials) == 1:
             averaging = materials[0].averagable and averagebox
@@ -145,7 +146,7 @@ class Box(GeometryUserObject):
                 grid.materials.append(m)
 
         tag_data, tag_id = geometry_tag_args(grid, self.kwargs.get("tag"))
-        build_box(
+        occupied = build_box(
             xs,
             xf,
             ys,
@@ -167,6 +168,7 @@ class Box(GeometryUserObject):
             tag_data,
             tag_id,
         )
+        validate_geometry_rasterisation(grid, occupied, geometry=self.params_str())
 
         dielectricsmoothing = "on" if averaging else "off"
 

--- a/gprMax/user_objects/cmds_geometry/cmds_geometry.py
+++ b/gprMax/user_objects/cmds_geometry/cmds_geometry.py
@@ -68,6 +68,7 @@ def resolve_geometry_materials(
     geometry,
     cell_volume=True,
     directional=False,
+    directional_count=3,
 ):
     """Resolve bulk or surface-impedance IDs for a geometry object only."""
 
@@ -107,6 +108,14 @@ def resolve_geometry_materials(
             "material_id; directional material_ids are unsupported"
         )
 
+    expected_count = directional_count if directional else 1
+    if len(requested) != expected_count:
+        argument = "material_ids" if directional else "material_id"
+        raise ValueError(
+            f"{geometry} {argument} requires exactly {expected_count} material "
+            f"identifier{'s' if expected_count != 1 else ''}; got {len(requested)}"
+        )
+
     materials = [
         create_impedance_marker_material(grid, value.ID) if kind == "surface" else value
         for kind, value in resolved
@@ -135,18 +144,83 @@ def check_averaging(averaging):
     """Check and set material averaging value.
 
     Args:
-        averaging: string for input value from hash command - should be 'y'
-                    or 'n'.
+        averaging: boolean API value or a case-insensitive ``'y'``/``'n'``
+            string from a hash command.
 
     Returns:
         averaging: boolean for geometry object material averaging.
     """
 
-    if averaging.lower() == "y":
-        averaging = True
-    elif averaging.lower() == "n":
-        averaging = False
-    else:
-        logger.exception("Averaging should be either y or n")
+    if isinstance(averaging, (bool, np.bool_)):
+        return bool(averaging)
 
-    return averaging
+    if isinstance(averaging, str):
+        value = averaging.strip().lower()
+        if value == "y":
+            return True
+        if value == "n":
+            return False
+
+    message = f"Averaging should be 'y', 'n', True, or False; got {averaging!r}"
+    logger.error(message)
+    raise ValueError(message)
+
+
+def validate_geometry_rasterisation(grid, count, *, geometry):
+    """Reject geometry that does not select any Yee cells or faces.
+
+    Curved objects can have valid continuous dimensions but still disappear
+    when their cell-centre inclusion test is applied. Distributed grids build
+    each local portion independently, so combine the local counts before
+    deciding whether the complete object is empty.
+    """
+
+    count = int(count)
+    if getattr(grid, "is_distributed", False) is True:
+        # Defer the collective until every geometry object has been processed.
+        # This avoids deadlocking ranks that legitimately return early because
+        # a particular object does not overlap their local partition.
+        records = getattr(grid, "geometry_rasterisation_records", None)
+        if records is None:
+            records = []
+            grid.geometry_rasterisation_records = records
+        records.append((count, geometry))
+        return count
+
+    if count == 0:
+        raise ValueError(
+            f"{geometry} does not occupy any Yee cells or faces after spatial "
+            "discretisation; increase its dimensions or adjust its position"
+        )
+
+    return count
+
+
+def validate_distributed_geometry_rasterisation(grid):
+    """Validate the accumulated local geometry counts on an MPI grid."""
+
+    if getattr(grid, "is_distributed", False) is not True:
+        return
+
+    records = getattr(grid, "geometry_rasterisation_records", [])
+    lengths = grid.comm.allgather(len(records))
+    if len(set(lengths)) != 1:
+        raise RuntimeError(
+            "MPI ranks recorded different numbers of geometry objects during rasterisation"
+        )
+    if not records:
+        return
+
+    local_counts = np.asarray([count for count, _ in records], dtype=np.int64)
+    global_counts = np.empty_like(local_counts)
+    grid.comm.Allreduce(local_counts, global_counts)
+    empty = [
+        geometry
+        for (_, geometry), count in zip(records, global_counts)
+        if int(count) == 0
+    ]
+    if empty:
+        raise ValueError(
+            f"{empty[0]} does not occupy any Yee cells or faces after spatial "
+            "discretisation; increase its dimensions or adjust its position"
+        )

--- a/gprMax/user_objects/cmds_geometry/cone.py
+++ b/gprMax/user_objects/cmds_geometry/cone.py
@@ -27,6 +27,7 @@ from gprMax.user_objects.cmds_geometry.cmds_geometry import (
     check_averaging,
     geometry_tag_args,
     resolve_geometry_materials,
+    validate_geometry_rasterisation,
 )
 from gprMax.user_objects.user_objects import GeometryUserObject
 
@@ -170,7 +171,7 @@ class Cone(GeometryUserObject):
                 grid.materials.append(m)
 
         tag_data, tag_id = geometry_tag_args(grid, self.kwargs.get("tag"))
-        build_cone(
+        occupied = build_cone(
             x1,
             y1,
             z1,
@@ -197,6 +198,7 @@ class Cone(GeometryUserObject):
             tag_data,
             tag_id,
         )
+        validate_geometry_rasterisation(grid, occupied, geometry=self.params_str())
 
         dielectricsmoothing = "on" if averaging else "off"
         logger.info(

--- a/gprMax/user_objects/cmds_geometry/cylinder.py
+++ b/gprMax/user_objects/cmds_geometry/cylinder.py
@@ -26,6 +26,7 @@ from gprMax.user_objects.cmds_geometry.cmds_geometry import (
     check_averaging,
     geometry_tag_args,
     resolve_geometry_materials,
+    validate_geometry_rasterisation,
 )
 from gprMax.user_objects.user_objects import GeometryUserObject
 
@@ -143,7 +144,7 @@ class Cylinder(GeometryUserObject):
                 grid.materials.append(m)
 
         tag_data, tag_id = geometry_tag_args(grid, self.kwargs.get("tag"))
-        build_cylinder(
+        occupied = build_cylinder(
             x1,
             y1,
             z1,
@@ -169,6 +170,7 @@ class Cylinder(GeometryUserObject):
             tag_data,
             tag_id,
         )
+        validate_geometry_rasterisation(grid, occupied, geometry=self.params_str())
 
         dielectricsmoothing = "on" if averaging else "off"
         logger.info(

--- a/gprMax/user_objects/cmds_geometry/cylindrical_sector.py
+++ b/gprMax/user_objects/cmds_geometry/cylindrical_sector.py
@@ -27,6 +27,7 @@ from gprMax.user_objects.cmds_geometry.cmds_geometry import (
     check_averaging,
     geometry_tag_args,
     resolve_geometry_materials,
+    validate_geometry_rasterisation,
 )
 from gprMax.user_objects.user_objects import GeometryUserObject
 
@@ -149,6 +150,8 @@ class CylindricalSector(GeometryUserObject):
         # Exit early if none of the cylindrical sector is in this grid
         # as there is nothing else to do.
         if not sector_within_grid:
+            if getattr(grid, "is_distributed", False) is True:
+                validate_geometry_rasterisation(grid, 0, geometry=self.params_str())
             return
 
         # Check averaging
@@ -237,8 +240,9 @@ class CylindricalSector(GeometryUserObject):
 
             # Uniaxial anisotropic case
             elif len(materials) == 3:
-                # numID requires a value but it will not be used
-                numID = None
+                # The typed volumetric ID is unused for a surface sector, but
+                # the Python/Cython boundary still requires a valid integer.
+                numID = materials[0].numID
                 numIDx = materials[0].numID
                 numIDy = materials[1].numID
                 numIDz = materials[2].numID
@@ -250,7 +254,7 @@ class CylindricalSector(GeometryUserObject):
         if tag is not None and thickness <= 0:
             raise ValueError(f"{self.params_str()} a cell-centred tag requires a volumetric sector")
         tag_data, tag_id = geometry_tag_args(grid, tag)
-        build_cylindrical_sector(
+        occupied = build_cylindrical_sector(
             ctr1,
             ctr2,
             level,
@@ -277,6 +281,7 @@ class CylindricalSector(GeometryUserObject):
             tag_data,
             tag_id,
         )
+        validate_geometry_rasterisation(grid, occupied, geometry=self.params_str())
 
         if thickness > 0:
             dielectricsmoothing = "on" if averaging else "off"

--- a/gprMax/user_objects/cmds_geometry/ellipsoid.py
+++ b/gprMax/user_objects/cmds_geometry/ellipsoid.py
@@ -26,6 +26,7 @@ from gprMax.user_objects.cmds_geometry.cmds_geometry import (
     check_averaging,
     geometry_tag_args,
     resolve_geometry_materials,
+    validate_geometry_rasterisation,
 )
 from gprMax.user_objects.user_objects import GeometryUserObject
 
@@ -138,7 +139,7 @@ class Ellipsoid(GeometryUserObject):
                 grid.materials.append(m)
 
         tag_data, tag_id = geometry_tag_args(grid, self.kwargs.get("tag"))
-        build_ellipsoid(
+        occupied = build_ellipsoid(
             xc,
             yc,
             zc,
@@ -163,6 +164,7 @@ class Ellipsoid(GeometryUserObject):
             tag_data,
             tag_id,
         )
+        validate_geometry_rasterisation(grid, occupied, geometry=self.params_str())
 
         dielectricsmoothing = "on" if averaging else "off"
         logger.info(

--- a/gprMax/user_objects/cmds_geometry/plate.py
+++ b/gprMax/user_objects/cmds_geometry/plate.py
@@ -22,7 +22,7 @@ from gprMax.cython.geometry_primitives import build_face_xy, build_face_xz, buil
 from gprMax.grid.fdtd_grid import FDTDGrid
 from gprMax.user_objects.user_objects import GeometryUserObject
 
-from .cmds_geometry import resolve_geometry_materials
+from .cmds_geometry import resolve_geometry_materials, validate_geometry_rasterisation
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,9 @@ class Plate(GeometryUserObject):
         p2: list of the upper right (x,y,z) coordinates of the plate.
         material_id: string for the material identifier that must correspond
                         to material that has already been defined.
-        material_ids: list of material identifiers in the x, y, z directions.
+        material_ids: two material identifiers for the plate's tangential
+            directions: y/z for a yz-plane plate, x/z for an xz-plane plate,
+            or x/y for an xy-plane plate.
     """
 
     @property
@@ -91,6 +93,8 @@ class Plate(GeometryUserObject):
         # Exit early if none of the plate is in this grid as there is
         # nothing else to do.
         if not plate_within_grid:
+            if getattr(grid, "is_distributed", False) is True:
+                validate_geometry_rasterisation(grid, 0, geometry=self.params_str())
             return
 
         xs, ys, zs = p1
@@ -122,7 +126,10 @@ class Plate(GeometryUserObject):
             geometry=self.params_str(),
             cell_volume=False,
             directional="material_id" not in self.kwargs,
+            directional_count=2,
         )
+
+        occupied = 0
 
         # yz-plane plate
         if xs == xf:
@@ -138,6 +145,7 @@ class Plate(GeometryUserObject):
             for j in range(ys, yf):
                 for k in range(zs, zf):
                     build_face_yz(xs, j, k, numIDy, numIDz, grid.rigidE, grid.rigidH, grid.ID)
+                    occupied += 1
 
         # xz-plane plate
         elif ys == yf:
@@ -153,6 +161,7 @@ class Plate(GeometryUserObject):
             for i in range(xs, xf):
                 for k in range(zs, zf):
                     build_face_xz(i, ys, k, numIDx, numIDz, grid.rigidE, grid.rigidH, grid.ID)
+                    occupied += 1
 
         # xy-plane plate
         elif zs == zf:
@@ -168,6 +177,9 @@ class Plate(GeometryUserObject):
             for i in range(xs, xf):
                 for j in range(ys, yf):
                     build_face_xy(i, j, zs, numIDx, numIDy, grid.rigidE, grid.rigidH, grid.ID)
+                    occupied += 1
+
+        validate_geometry_rasterisation(grid, occupied, geometry=self.params_str())
 
         logger.info(
             f"{self.grid_name(grid)}Plate from {p3[0]:g}m, {p3[1]:g}m, "

--- a/gprMax/user_objects/cmds_geometry/sphere.py
+++ b/gprMax/user_objects/cmds_geometry/sphere.py
@@ -26,6 +26,7 @@ from gprMax.user_objects.cmds_geometry.cmds_geometry import (
     check_averaging,
     geometry_tag_args,
     resolve_geometry_materials,
+    validate_geometry_rasterisation,
 )
 from gprMax.user_objects.user_objects import GeometryUserObject
 
@@ -130,7 +131,7 @@ class Sphere(GeometryUserObject):
                 grid.materials.append(m)
 
         tag_data, tag_id = geometry_tag_args(grid, self.kwargs.get("tag"))
-        build_sphere(
+        occupied = build_sphere(
             xc,
             yc,
             zc,
@@ -153,6 +154,7 @@ class Sphere(GeometryUserObject):
             tag_data,
             tag_id,
         )
+        validate_geometry_rasterisation(grid, occupied, geometry=self.params_str())
 
         dielectricsmoothing = "on" if averaging else "off"
         logger.info(

--- a/gprMax/user_objects/cmds_geometry/triangle.py
+++ b/gprMax/user_objects/cmds_geometry/triangle.py
@@ -29,6 +29,7 @@ from .cmds_geometry import (
     check_averaging,
     geometry_tag_args,
     resolve_geometry_materials,
+    validate_geometry_rasterisation,
 )
 
 logger = logging.getLogger(__name__)
@@ -142,6 +143,8 @@ class Triangle(GeometryUserObject):
         # Exit early if none of the triangle is in this grid as there is
         # nothing else to do.
         if not triangle_within_grid:
+            if getattr(grid, "is_distributed", False) is True:
+                validate_geometry_rasterisation(grid, 0, geometry=self.params_str())
             return
 
         # Update start bound of the triangle
@@ -220,7 +223,7 @@ class Triangle(GeometryUserObject):
         if tag is not None and thickness <= 0:
             raise ValueError(f"{self.params_str()} a cell-centred tag requires a volumetric prism")
         tag_data, tag_id = geometry_tag_args(grid, tag)
-        build_triangle(
+        occupied = build_triangle(
             x1,
             y1,
             z1,
@@ -250,6 +253,7 @@ class Triangle(GeometryUserObject):
             tag_data,
             tag_id,
         )
+        validate_geometry_rasterisation(grid, occupied, geometry=self.params_str())
 
         p4 = uip.round_to_grid_static_point(up1)
         p5 = uip.round_to_grid_static_point(up2)

--- a/tests/cmds_geometry/test_anisotropic_commands.py
+++ b/tests/cmds_geometry/test_anisotropic_commands.py
@@ -191,3 +191,63 @@ def test_missing_anisotropic_material_error_names_only_missing_id(monkeypatch, t
             outputfile=tmp_path / "missing_material",
             hide_progress_bars=True,
         )
+
+
+@pytest.mark.parametrize(
+    "geometry,expected_count",
+    (
+        (
+            gprMax.Box(
+                p1=(0.008, 0.008, 0.008),
+                p2=(0.016, 0.016, 0.016),
+                material_ids=MATERIAL_IDS[:2],
+            ),
+            3,
+        ),
+        (
+            gprMax.Plate(
+                p1=(0.008, 0.008, 0.012),
+                p2=(0.016, 0.016, 0.012),
+                material_ids=MATERIAL_IDS,
+            ),
+            2,
+        ),
+    ),
+)
+def test_invalid_directional_material_count_is_reported(geometry, expected_count, tmp_path):
+    scene = _base_scene()
+    scene.add(geometry)
+
+    with pytest.raises(ValueError, match=rf"requires exactly {expected_count}"):
+        gprMax.run(
+            scenes=[scene],
+            n=1,
+            geometry_only=True,
+            outputfile=tmp_path / f"count_{expected_count}",
+            hide_progress_bars=True,
+        )
+
+
+def test_anisotropic_surface_sector_accepts_typed_material_id(tmp_path):
+    scene = _base_scene()
+    scene.add(
+        gprMax.CylindricalSector(
+            normal="z",
+            ctr1=0.014,
+            ctr2=0.014,
+            extent1=0.012,
+            extent2=0.012,
+            r=0.004,
+            start=0,
+            end=90,
+            material_ids=MATERIAL_IDS,
+        )
+    )
+
+    gprMax.run(
+        scenes=[scene],
+        n=1,
+        geometry_only=True,
+        outputfile=tmp_path / "anisotropic_surface_sector",
+        hide_progress_bars=True,
+    )

--- a/tests/cmds_geometry/test_degenerate_primitives.py
+++ b/tests/cmds_geometry/test_degenerate_primitives.py
@@ -149,6 +149,82 @@ def _scene():
             ),
             "finite",
         ),
+        (
+            "flat_box",
+            gprMax.Box(
+                p1=(0.005, 0.005, 0.005),
+                p2=(0.005, 0.010, 0.010),
+                material_id="pec",
+            ),
+            "positive cell extent",
+        ),
+        (
+            "underresolved_sphere",
+            gprMax.Sphere(
+                p1=(0.010, 0.010, 0.010),
+                r=0.0004,
+                material_id="pec",
+            ),
+            "does not occupy any Yee cells or faces",
+        ),
+        (
+            "underresolved_ellipsoid",
+            gprMax.Ellipsoid(
+                p1=(0.010, 0.010, 0.010),
+                xr=0.0004,
+                yr=0.0004,
+                zr=0.0004,
+                material_id="pec",
+            ),
+            "does not occupy any Yee cells or faces",
+        ),
+        (
+            "underresolved_cylinder",
+            gprMax.Cylinder(
+                p1=(0.008, 0.010, 0.010),
+                p2=(0.012, 0.010, 0.010),
+                r=0.0004,
+                material_id="pec",
+            ),
+            "does not occupy any Yee cells or faces",
+        ),
+        (
+            "underresolved_cone",
+            gprMax.Cone(
+                p1=(0.008, 0.010, 0.010),
+                p2=(0.012, 0.010, 0.010),
+                r1=0.0004,
+                r2=0.0004,
+                material_id="pec",
+            ),
+            "does not occupy any Yee cells or faces",
+        ),
+        (
+            "underresolved_sector",
+            gprMax.CylindricalSector(
+                normal="z",
+                ctr1=0.010,
+                ctr2=0.010,
+                extent1=0.008,
+                extent2=0.012,
+                r=0.0004,
+                start=0,
+                end=90,
+                material_id="pec",
+            ),
+            "does not occupy any Yee cells or faces",
+        ),
+        (
+            "underresolved_triangle",
+            gprMax.Triangle(
+                p1=(0.005, 0.005, 0.010),
+                p2=(0.006, 0.005, 0.010),
+                p3=(0.005, 0.006, 0.010),
+                thickness=0.001,
+                material_id="pec",
+            ),
+            "does not occupy any Yee cells or faces",
+        ),
     ],
 )
 def test_degenerate_geometry_is_rejected(name, geometry, error, tmp_path):

--- a/tests/geometry_primitives/test_cmds_geometry_helpers.py
+++ b/tests/geometry_primitives/test_cmds_geometry_helpers.py
@@ -18,12 +18,20 @@
 """Unit tests for the shared helpers in
 ``gprMax/user_objects/cmds_geometry/cmds_geometry.py``.
 
-``check_averaging`` converts the hash-command averaging flag.
+``check_averaging`` converts the hash-command averaging flag, while the
+rasterisation helpers combine per-rank object occupancy.
 """
 
+from types import SimpleNamespace
+
+import numpy as np
 import pytest
 
-from gprMax.user_objects.cmds_geometry.cmds_geometry import check_averaging
+from gprMax.user_objects.cmds_geometry.cmds_geometry import (
+    check_averaging,
+    validate_distributed_geometry_rasterisation,
+    validate_geometry_rasterisation,
+)
 
 
 class TestCheckAveraging:
@@ -34,6 +42,40 @@ class TestCheckAveraging:
     @pytest.mark.parametrize("value", ["n", "N"])
     def test_no_maps_to_false(self, value):
         assert check_averaging(value) is False
+
+    @pytest.mark.parametrize("value", [True, False, np.bool_(True), np.bool_(False)])
+    def test_boolean_values_are_accepted(self, value):
+        assert check_averaging(value) is bool(value)
+
+    @pytest.mark.parametrize("value", ["yes", "", 1, None])
+    def test_invalid_values_are_rejected(self, value):
+        with pytest.raises(ValueError, match="Averaging should be"):
+            check_averaging(value)
+
+
+class _SingleRankComm:
+    def allgather(self, value):
+        return [value]
+
+    def Allreduce(self, send, receive):
+        receive[:] = send
+
+
+class TestGeometryRasterisationReporting:
+    def test_distributed_counts_are_deferred_then_validated(self):
+        grid = SimpleNamespace(is_distributed=True, comm=_SingleRankComm())
+
+        validate_geometry_rasterisation(grid, 2, geometry="#sphere")
+        validate_distributed_geometry_rasterisation(grid)
+
+        assert grid.geometry_rasterisation_records == [(2, "#sphere")]
+
+    def test_distributed_empty_object_is_rejected(self):
+        grid = SimpleNamespace(is_distributed=True, comm=_SingleRankComm())
+        validate_geometry_rasterisation(grid, 0, geometry="#sphere")
+
+        with pytest.raises(ValueError, match="does not occupy any Yee cells or faces"):
+            validate_distributed_geometry_rasterisation(grid)
 
 
 pytestmark = pytest.mark.unit

--- a/tests/test_model_memory_reporting.py
+++ b/tests/test_model_memory_reporting.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
+#
+# This file is part of the gprMax source code base.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
+
+"""Regression tests for best-effort process-memory reporting."""
+
+from types import SimpleNamespace
+
+import psutil
+import pytest
+
+from gprMax.model import _process_memory_bytes
+
+
+class _USSAccessDenied:
+    def memory_full_info(self):
+        raise psutil.AccessDenied(pid=123)
+
+    def memory_info(self):
+        return SimpleNamespace(rss=456)
+
+
+class _AllAccessDenied(_USSAccessDenied):
+    def memory_info(self):
+        raise psutil.AccessDenied(pid=123)
+
+
+def test_process_memory_falls_back_to_rss_when_uss_is_denied():
+    assert _process_memory_bytes(_USSAccessDenied()) == 456
+
+
+def test_process_memory_is_optional_when_all_queries_are_denied():
+    assert _process_memory_bytes(_AllAccessDenied()) is None
+
+
+pytestmark = pytest.mark.unit


### PR DESCRIPTION
## Summary

- reject boxes with zero discretised volume and curved/prismatic objects that rasterise to no Yee cells or faces
- return occupancy counts from geometry rasterisers and aggregate them safely across MPI partitions
- fix anisotropic zero-thickness cylindrical sectors passing an invalid volumetric material ID into Cython
- validate directional material cardinality explicitly, including the two tangential materials used by plates
- accept boolean or y/n averaging values and reject invalid values clearly
- make post-solve memory reporting fall back from USS to RSS, then to unknown, without failing a successful run

The geometry inclusion predicates and resulting material/field arrays are unchanged for valid objects.

## Testing

- Cython geometry extensions rebuilt successfully
- focused regressions: 48 passed
- object, geometry primitive, hash-command, and material validation sweep: 455 passed, 1 skipped (CUDA unavailable)
- wider production-related sweep: 582 passed, 1 skipped, 30 MPI tests deselected
- full non-MPI audit reached 6,272 passed and exposed one mocked early-return compatibility failure; that control-flow issue was fixed and the failed test plus affected suites were rerun successfully

Real MPI execution was not available locally because mpi4py is not installed. The deferred per-rank occupancy aggregation has unit coverage and should also be included in the existing CUDA/MPI server handoff.