### PR TITLE
Fix STL toolbox dependency for PyPI installs

### DIFF
--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -145,6 +145,8 @@ an isolated environment before any test runs.
   libraries;
 * verifies that build-only C/Cython sources were not installed;
 * lists and copies the version-matched packaged examples; and
+* imports ``numpy-stl`` and performs an STL voxelisation using the packaged
+  ``STLtoVoxel`` example;
 * runs a compact CPU model using the installed wheel.
 
 The workflow uses ``auditwheel``, ``delvewheel``, and ``delocate`` through

--- a/setup.py
+++ b/setup.py
@@ -259,6 +259,7 @@ else:
             "jinja2",
             "matplotlib",
             "numpy",
+            "numpy-stl",
             "Pillow",
             "psutil",
             "scipy",

--- a/tests/wheel_smoke.py
+++ b/tests/wheel_smoke.py
@@ -29,6 +29,7 @@ os.environ.setdefault("MPLCONFIGDIR", tempfile.mkdtemp(prefix="gprmax-matplotlib
 
 import gprMax
 from gprMax.examples import copy_examples, list_examples
+from toolboxes.STLtoVoxel.convert import convert_file
 
 CYTHON_MODULES = (
     "eigenmode_dft",
@@ -94,6 +95,19 @@ def _assert_matlab_utilities_are_available() -> None:
     assert (matlab / "plot_Bscan.m").is_file()
 
 
+def _assert_stl_toolbox_is_available() -> None:
+    """Exercise the STL dependency from an installed distribution."""
+
+    toolboxes = Path(importlib.import_module("toolboxes").__file__).resolve().parent
+    source = toolboxes / "STLtoVoxel" / "examples" / "stl" / "Stanford_Bunny.stl"
+    assert source.is_file()
+
+    volume = convert_file(source, (0.004, 0.004, 0.004), parallel=False)
+    assert volume.ndim == 3
+    assert volume.size > 0
+    assert (volume >= 0).any()
+
+
 def _run_tiny_cpu_model(output: Path) -> None:
     scene = gprMax.Scene()
     scene.add(gprMax.Discretisation(p1=(0.001, 0.001, 0.001)))
@@ -120,6 +134,7 @@ def main() -> None:
     with tempfile.TemporaryDirectory(prefix="gprmax-wheel-") as directory:
         root = Path(directory)
         _assert_examples_are_available(root / "workspace")
+        _assert_stl_toolbox_is_available()
         _run_tiny_cpu_model(root / "smoke")
 
 

--- a/toolboxes/GeometryImport/README.rst
+++ b/toolboxes/GeometryImport/README.rst
@@ -17,13 +17,24 @@ geometry.
 Dependencies
 ------------
 
-The recommended conda environment installs the format readers. The individual
-dependencies are:
+These format readers are optional and are not installed by
+``pip install gprMax``. Install only the readers required by the input formats
+you use:
 
 * ``nibabel`` for NIfTI;
 * ``pynrrd`` for NRRD and 3D Slicer segmentation NRRD;
 * ``SimpleITK`` for MetaImage;
 * ``meshio`` and ``pyvista``/VTK for Gmsh and VTK-family meshes.
+
+For example, a PyPI installation can be extended with all supported readers
+using:
+
+.. code-block:: console
+
+    python -m pip install nibabel pynrrd SimpleITK meshio pyvista
+
+The repository's recommended ``conda_env.yml`` development environment
+already includes these readers.
 
 They are imported only when the corresponding converter is used and add no
 runtime work to the FDTD solver.

--- a/toolboxes/STLtoVoxel/README.rst
+++ b/toolboxes/STLtoVoxel/README.rst
@@ -25,6 +25,13 @@ Package contents
 * ``convert.py``, ``perimeter.py``, ``slice.py`` are modules adapted from the `stl-to-voxel <https://github.com/cpederkoff/stl-to-voxel>`_ Python library by Christian Pederkoff.
 * ``license.md`` is the license for the `stl-to-voxel <https://github.com/cpederkoff/stl-to-voxel>`_ Python library by Christian Pederkoff.
 
+Installation
+============
+
+``STLtoVoxel`` and its ``numpy-stl`` dependency are installed automatically
+with gprMax. No separate toolbox installation is required when gprMax is
+installed from PyPI or from source.
+
 How to use the package
 ======================
 


### PR DESCRIPTION
## Summary
- install numpy-stl with the standard gprMax package so STLtoVoxel works after a normal PyPI install
- clarify which toolbox dependencies are included and which GeometryImport readers remain optional
- exercise STL voxelisation in the installed-wheel smoke test

## Validation
- 327 toolbox tests passed, 1 skipped (MATLAB unavailable)
- 14 focused STL and packaging tests passed
- built and installed a macOS ARM64 wheel outside the source tree
- confirmed wheel metadata contains Requires-Dist: numpy-stl
- installed-wheel smoke test passed, including STL voxelisation and a tiny CPU simulation