### PR TITLE
Fix receiver identity, hard-source timing and execution/processing regressions

### DIFF
--- a/docs/source/accelerators.rst
+++ b/docs/source/accelerators.rst
@@ -215,6 +215,15 @@ For example, in figure :numref:`fractal_domain_decomposition_figure`, surface ro
 Task farm
 ---------
 
+A failed task does not discard the other jobs: the batch finishes, successful
+outputs remain available, and workers are joined before a ``TaskfarmError``
+is raised on **every MPI rank**. An uncaught failed batch therefore reports a
+nonzero launcher exit status. Python API callers that handle the error must
+catch it on all ranks; the communicator remains usable. The exception's
+``failures`` mapping identifies failed zero-based job indices. Complete
+``results`` are retained on the master; workers receive failure records with
+``None`` placeholders for successful results.
+
 By default, the MPI task farm functionality is turned off. It can be used with the ``--taskfarm`` command line option, which specifies the total number of MPI tasks, i.e. master + workers, for the MPI task farm. This option is most usefully combined with ``-n`` to allow individual models to be farmed out using an MPI task farm, e.g. to create a B-scan with 60 traces and use MPI to farm out each trace:
 
 .. code-block:: console

--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -20,6 +20,16 @@ The Python API in gprMax allows users to access gprMax functions directly from P
 
 The syntax of the API is generally more verbose than the input file (hash) command syntax. However, for input file commands where there are an undefined number of parameters, such as adding dispersive properties, the user may find the API more manageable.
 
+Source/receiver positions and output bounds containing ``inf`` are resolved
+against each grid when it is built. The declaration retains its symbolic
+coordinates, so reusing it with a different grid spacing or domain does not
+freeze the first build's resolved position.
+
+``str(user_object)`` is a readable, hash-style diagnostic, not a general
+API-to-input-file exporter. In particular, omitted optional fields do not
+always round-trip through the positional hash grammar. Use the documented
+hash syntax when writing an input file.
+
 .. note::
 
     In prior versions of gprMax (<4) the input file could be scripted using Python inserted between two commands (`#python:` and `#end_python:`). This feature is now deprecated and will be removed entirely in later versions. Users are encouraged to move to the new Python API. Antenna models can still be inserted between `#python:` and `#end_python:` commands but will need to make a small change to their input file. An example of this is provided in `examples/gpr/antennas/gssi_1500/antenna_like_GSSI_1500_fs.in`. Alternatively a switch to the Python API can be made using the adjacent `examples/gpr/antennas/gssi_1500/antenna_like_GSSI_1500_fs.py` example.
@@ -1296,11 +1306,24 @@ The callable can also be a closure, which is a convenient way to generate a fami
 
 Exactly one of ``user_func`` and ``user_values`` must be supplied. When
 ``user_values`` is used without ``user_time``, gprMax associates the samples
-with its simulation time vector. ``kind`` and ``fill_value`` are passed to
-``scipy.interpolate.interp1d`` and apply only to sampled waveforms. User-defined
+with exactly ``iterations`` times, ``arange(iterations) * dt``. The number of
+values must match; supply an explicit, strictly increasing ``user_time`` for
+another sampling grid. Sampled waveforms default to linear interpolation
+inside the supplied time axis and **zero outside it**. ``kind`` and
+``fill_value`` override those defaults (including explicit ``'extrapolate'``)
+and apply only to sampled waveforms. Numeric fill values are honoured outside
+both ends of the time axis. Callables retain their own boundary behaviour.
+User-defined
 waveforms can drive local Hertzian or magnetic dipoles, voltage sources,
 transmission lines, and magnetic-frill sources. The discrete-plane-wave
 formulation currently requires a built-in analytic waveform.
+
+Hard voltage sources evaluate only whole-step samples, including the initial
+electric field at time zero. Resistive voltage sources and Hertzian dipoles
+use their existing half-step current samples; a final half-step outside a
+sampled waveform's time axis uses the selected fill value. Zero waveform
+amplitude does not remove an active hard-source clamp: its start/stop window
+still controls whether the electric edge is prescribed.
 
 Eigenmode band, ports, excitation, and virtual guides
 ------------------------------------------------------

--- a/docs/source/input_api.rst
+++ b/docs/source/input_api.rst
@@ -148,6 +148,12 @@ Output Directory
 ----------------
 .. autoclass:: gprMax.user_objects.cmds_singleuse.OutputDir
 
+Relative ``OutputDir(dir=...)`` paths are resolved against the working directory
+when the Scene is built. This differs from hash ``#output_dir`` paths, which are
+relative to the top-level input file. The resolved directory is retained during
+``geometry_fixed=True`` repetition, with distinct numbered model and snapshot
+paths.
+
 Magnetic Averaging
 ------------------
 .. autoclass:: gprMax.user_objects.cmds_singleuse.MagneticAveraging
@@ -201,6 +207,12 @@ The available source overrides are ``active``, ``position``,
 study determines the run count automatically; pass ``i=N`` to restart at the
 one-based case number ``N``. For a text input model the equivalent
 ``#study`` command reads the same information from CSV.
+
+Study ``start``/``stop`` overrides must be finite. ``active`` and ``record``
+accept Python or NumPy boolean scalars; strings, numeric flags and boolean
+arrays are rejected rather than interpreted by truthiness. These checks also
+apply before reusing a study in another run. ``record=False`` remains
+unsupported and is rejected for both boolean types.
 
 For a complete acquisition that users can edit in a spreadsheet, see the
 :ref:`CSV B-scan example <bscan_csv_study>`. A Python model can use that same
@@ -1044,6 +1056,11 @@ Fractal Box
 -----------
 .. autoclass:: gprMax.user_objects.cmds_geometry.fractal_box.FractalBox
 
+Fractal definitions can be reused for a geometry preview followed by a solve,
+or in multiple rebuilt Scenes. Each fresh grid gets its own fractal volume and
+material-bin mapping. Supply a seed for reproducible geometry. With
+``geometry_fixed=True``, the already-built geometry is retained instead.
+
 .. note::
 
     * We are not aware of a formulation of Perfectly Matched Layer (PML) absorbing boundary that can specifically handle distributions of material properties (such as those created by fractals) throughout the thickness of the PML, i.e. this is a required area of research. Our PML formulations can work to an extent depending on your modelling scenario and requirements. You may need to increase the thickness of the PML and/or consider tuning the parameters of the PML (:ref:`pml-tuning`) to improve performance for your specific model.
@@ -1492,6 +1509,13 @@ resistance creates a hard source and therefore requires a separate
 The waveform amplitude is the generator voltage in volts. See
 :ref:`#voltage_source <voltage_source>` for the one-cell source equation and
 the definition of the automatic port spectra.
+
+A hard source also prescribes the initial electric field before sample zero
+is stored. Subsequent prescriptions use the new electric time level
+:math:`(n+1)\Delta t`. ``start`` and ``stop`` are inclusive at these physical
+times. A zero waveform still clamps the edge while active; ``start=0`` and
+:math:`0<\mathtt{stop}<\Delta t` apply only the initial impulse and then release
+the edge. In a subgrid, use its local :math:`\Delta t`.
 
 Hertzian Dipole Source
 ----------------------
@@ -2564,6 +2588,11 @@ A subgrid is added to the main scene, but its materials and geometry are added
 to the subgrid object. With ``autotranslate=True`` these objects can use main
 grid coordinates. Refining subgrids use the double-precision CPU solver.
 CUDA, OpenCL, and Metal subgrid execution are not part of this release.
+
+Pass ``subgrid=True`` even for a geometry-only preview; a Scene containing
+subgrids without that flag is rejected before model construction. Every subgrid
+must have a nonempty ``id`` unique within its Scene. IDs cannot contain path
+separators or NUL, or be ``.`` or ``..``, because they identify HDF5 groups.
 
 ``ratio=1`` selects an **equal-resolution embedded region**. This is exposed
 through ``SubGridHSG`` to avoid a second, overlapping object API, but it does

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -1475,7 +1475,15 @@ The amplitude values will be interpolated using either the aforementioned user s
     #excitation_file: file1 [str1 str2]
 
 * ``file1`` can be the name of the file containing the specified waveform in the same directory as the input file, or ``file`` can be the full path to the file containing the specified waveform (allowing you to specify any location).
-* ``str1`` and ``str2`` are an optional parameter pair that allow values for ``kind`` and ``fill_value`` to be passed to the interpolation function (`scipy.interpolate.interp1d <https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html>`_). If they are not given the default values for the function will be used.
+* ``str1`` and ``str2`` are an optional parameter pair that allow values for ``kind`` and ``fill_value`` to be passed to the interpolation function (`scipy.interpolate.interp1d <https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html>`_). If omitted, gprMax uses linear interpolation and zero outside the supplied time axis. A numeric fill value applies at both ends; extrapolation occurs only when explicitly requested with ``linear extrapolate`` (or another interpolation kind).
+
+Without a time column, the time axis is exactly ``arange(iterations) * dt``.
+Electric-current sources (resistive voltage sources and Hertzian dipoles)
+retain their half-step sampling and can request a sample past the final
+supplied whole-step value; the selected fill policy applies there. Magnetic
+dipoles retain their whole-step sampling.
+A zero-resistance voltage source evaluates only its required whole-step
+electric-field samples. These rules do not change source start/stop gating.
 
 For example, to specify the file ``my_waves.txt``, which contains two custom waveform shapes, use: ``#excitation_file: my_waves.txt``. The contents of the file ``my_waves.txt`` would take the form:
 

--- a/docs/source/input_hash_cmds.rst
+++ b/docs/source/input_hash_cmds.rst
@@ -191,6 +191,23 @@ Allows you to include commands from a file. It will insert the commands from the
 
 ``file1`` can be the name of the file containing the commands in the same directory as the input file, or ``file`` can be the full path to the file containing the commands (allowing you to specify any location).
 
+Includes may be nested. Each relative include path is resolved against the
+directory of the file containing that command, not the process working
+directory. Commands retain their inclusion order. Repeated includes are allowed,
+but cycles and nesting beyond 100 files are rejected. Python blocks inside
+included files are not supported; keep legacy Python blocks in the top-level
+input file or use the Python API.
+
+Study and array-codebook preflight use the same include traversal and path
+rules as model parsing. ``#study`` and ``#array_codebook`` must be literal
+commands in the top-level input or an included file, not printed by a
+``#python`` block: they determine the run before Python preprocessing occurs.
+Their CSV/JSON paths remain relative to the top-level input file.
+
+Older development versions searched the working directory first and could
+silently ignore nested includes. Models relying on that search order should use
+an absolute path or a path relative to the containing file.
+
 
 #time_step_stability_factor:
 ----------------------------
@@ -279,6 +296,12 @@ Allows you to control the directory where output file(s) will be stored.  The sy
     #output_dir: str1
 
 where ``str1`` can be either the absolute path to the directory for the output file(s) or a path relative to the directory of the input files. The default value is the same as the directory of the input files.
+
+Relative paths are based on the **top-level** input file, including when this
+command is declared in an included file. The directory is preserved across
+``--geometry-fixed`` runs; each model still receives its own numbered filename
+and snapshot directory. Python API ``OutputDir`` paths remain relative to the
+process working directory.
 
 
 #omp_threads:
@@ -1639,6 +1662,21 @@ Allows you to introduce a voltage source at an electric field location. It can b
   to 50 Ohms. A finite-resistance source uses ``f4`` and must not supply
   ``f7``.
 * ``str1`` is the identifier of the waveform that should be used with the source.
+
+For a zero-resistance source, the initial electric field is prescribed at
+:math:`t=0` before receiver/snapshot sampling or the first magnetic update.
+After each electric update the source prescribes :math:`E^{n+1}` using the
+waveform at :math:`(n+1)\Delta t`. Its start/stop interval is inclusive and
+tested at this physical electric-field time, including the initial sample.
+Other source types retain their own staggered update times.
+
+An ``impulse`` waveform is nonzero for one sampled time step, but a hard
+source continues to clamp its edge to zero while it remains active. To
+prescribe only the initial impulse and then release the edge, use
+``f5=0`` and :math:`0<f6<\Delta t` (the source's local time step, if inside
+a subgrid). ``f6=\Delta t`` includes a second, zero-valued prescription.
+This initialisation occurs once per run, including geometry reuse, on CPU,
+CUDA, OpenCL, Metal, MPI CPU grids, and supported CPU subgrids.
 
 Every 3-D voltage source automatically stores its terminal voltage and
 frequency-domain ``S11``, ``Zin``, and ``Yin``. No separate receiver-port

--- a/docs/source/output.rst
+++ b/docs/source/output.rst
@@ -31,6 +31,9 @@ The output file has the following HDF5 attributes at the root (``/``):
   source histories stored below local source groups.
 - ``ReceiverTimingSchemaVersion`` identifies the schema used for receiver
   dataset time offsets.
+- ``ReceiverOrderSchemaVersion=1`` identifies the public receiver ordering
+  contract. ``ReceiverOrder=construction`` means rank-independent construction
+  order; ``ReceiverLayout`` identifies the ordered receiver declarations.
 
 The output file contains HDF5 groups for sources (``srcs``), transmission lines
 (``tls``), magnetic frill sources (``frills``), receivers (``rxs``),
@@ -647,6 +650,94 @@ Within each individual ``rx`` group are the following attributes:
 * ``Position`` is the x, y, z position (in metres) of the receiver in the model.
 * ``GridPosition`` is the integer x, y, z position of the receiver on its
   owning grid.
+* ``BuildIndex`` is the zero-based public construction ordinal within this
+  grid. For ordinary solver output, ``rxN`` has ``BuildIndex=N-1``.
+* ``NameKind`` distinguishes a user label (``user``) from an automatically
+  generated coordinate label (``generated``).
+
+.. _receiver-numbering:
+
+Receiver numbering and cross-version processing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Public receivers are numbered in construction order, independently of their
+names and the MPI partition. Receiver arrays follow their x/y/z traversal
+order (z varies fastest). Private port samplers do not consume public numbers.
+Each subgrid has its own numbering namespace. The solver's runtime receiver
+list and accelerator buffer pages are not reordered when writing a file.
+
+Construction order follows command build priorities: individual ``Rx``
+commands are built before ``RxArray`` commands. It is not a promise of literal
+input-line order across interleaved command types. The ordinal survives MPI
+migration and geometry reuse. ``ReceiverLayout`` is a SHA-256 digest of the
+ordered declarations (explicit label or null, sorted requested components,
+study ID). Coordinates are intentionally excluded so a declared acquisition
+can move between runs. This digest describes an acquisition layout, **not**
+a model UUID or proof that two arbitrary simulations are physically equivalent.
+Do not reorder anonymous declarations between runs and assume their ordinal
+identities remain the same. Prefer unique names for independently built models.
+
+Earlier v4 development outputs sorted receiver Names lexicographically;
+v3 used insertion order. Neither has the new ordering metadata. Consequently,
+the same ``/rxs/rx1`` path can refer to different receivers across versions.
+Existing files are not rewritten. Low-level serial writers given receiver
+objects without build ordinals report ``ReceiverOrder=runtime`` and do not
+claim stable construction identities. Distributed output requires ordinals.
+
+The current Python merge, SEG-Y/SEG-2/DT1 collection and Marimo stacking tools
+anchor the selected receiver in the first file, then match its identity in
+later files. Unique ``StudyID`` takes precedence, followed by unique ``Name``;
+matching construction layout/index also supports generated or duplicate names.
+For generated names in the same layout, the ordinal takes precedence over
+coordinates embedded in the name, which may change during a scan. Ambiguous
+matches fail (Marimo skips the trace with a warning). Legacy single-receiver
+files without labels remain supported; unlabeled or duplicate-labeled legacy
+multi-receiver files require explicit, verified per-file selections rather
+than an inferred mapping. Positions may move and are kept with their samples.
+
+Merging retains the first file's paths and identity metadata. Each receiver's
+``trace_metadata/rxs/rxN/InputReceiverPath`` and ``Name`` datasets retain its
+per-input mapping alongside the existing per-trace positions. Derived
+ImpulseResponse files retain selected receivers' original paths/indices;
+these subsets can contain gaps, so readers should enumerate actual groups
+and sort numeric suffixes rather than construct paths from ``1..nrx``.
+
+Use name-based selections when migrating saved scripts:
+
+.. code-block:: python
+
+    from toolboxes.SFCW.processing import load_receiver
+    trace = load_receiver("run.h5", "name:surface", "Ez")
+
+    from toolboxes.Utilities.outputfiles_merge import get_output_data
+    data, dt = get_output_data("merged.h5", 1, "Ez", receiver_name="surface")
+
+SFCW/FMCW ``--receiver`` and ImpulseResponse receiver selections also accept
+``name:surface`` or ``study:identifier``. ImpulseResponse CLI syntax appends
+the component, for example ``--receiver name:surface:Ez``. Export utilities
+and Python B-scan plotting accept ``--trace-group name:surface``. Export
+``--receiver N`` selects N in the **first** input file. The shared Python
+``receiver_identity`` utility also offers per-grid ``build:N`` selection.
+
+FMCW automatically identity-matches an omitted background/incident receiver.
+An explicitly supplied background/incident receiver is an intentional
+per-file override, allowing reference measurements at a different point.
+AntennaPatterns still uses its own zero-padded radius/angle Names to order bins;
+do not replace that consumer-side sort with public group order. Native ports
+and NTFF retain their separate ID-based namespaces.
+
+MATLAB ``plot_Ascan`` and ``plot_Bscan`` accept ``ReceiverName`` (and ``Grid``
+for a subgrid). ``gprmax_receiver_path(file, name, grid)`` resolves a unique Name
+for lower-level readers/converters. Numeric/path selections remain file-local.
+The interactive legacy converter accepts only a single receiver; use an
+explicitly selected modern reader/exporter for multi-receiver data.
+
+Upgrade processing tools together with the solver. Old installed tools and
+external scripts cannot infer this mapping from numeric paths alone. Review
+stored numeric selections against ``Name``/``StudyID`` and positions. Regression
+comparisons now match receiver identities, but strict whole-group/file HDF5
+comparisons will still report the new metadata: verify the signals and then
+deliberately update reference files, rather than regenerating them blindly.
 
 Within each individual ``rx`` group can be the following datasets:
 
@@ -666,6 +757,9 @@ represent :math:`E^n`. Magnetic fields and magnetic-loop currents have
 ``TimeSampleOffset=-\Delta t/2`` and represent :math:`H^{n-1/2}` at stored
 sample index :math:`n`. These explicit physical times are important when
 combining electric and magnetic quantities or deconvolving a source.
+Receivers are observed before each field update. Sample zero is the initial
+state: magnetic fields are zero, but an active zero-resistance voltage source
+can prescribe a nonzero electric field at its edge before this observation.
 
 Within each individual ``src`` group are the following attributes:
 
@@ -683,8 +777,13 @@ the update look-ahead sample removed. ``SampleInterval`` and
 ``WaveformEvaluationTimeOffset`` attribute separately records the time used
 to evaluate the waveform function for source sample :math:`n`. A
 resistive voltage source and Hertzian electric dipole, for example, use
-:math:`t_0=\Delta t/2`, while a hard voltage source is imposed on
-:math:`E^{n+1}` and uses :math:`t_0=\Delta t`. Transmission-line sources store
+:math:`t_0=\Delta t/2`. Hard voltage sources initialise :math:`E^0` and then
+prescribe :math:`E^{n+1}` at :math:`(n+1)\Delta t`; their two offsets are zero.
+Their history contains samples 0 through :math:`N-1`, including the initial
+prescription, but not the terminal :math:`E^N` update. Older hard-source files
+have physical offset :math:`\Delta t` and evaluation offset zero; readers
+must honour the stored metadata rather than assuming either convention.
+Transmission-line sources store
 their two staggered histories as ``samples_whole`` and ``samples_half``;
 ``samples`` is a non-duplicating HDF5 link to the whole-step generator-voltage
 reference.
@@ -977,6 +1076,17 @@ including every Debye, Lorentz, Drude, or inclusive pole,
 This reduces to :math:`G_\mathrm{bg}+j\widetilde{\omega}C_\mathrm{gap}`
 for a nondispersive conductive material. Hard voltage ports use their sampled
 Ampere-loop current and are not yet supported on dispersive source edges.
+
+Hard-source port histories retain all :math:`N` receiver samples, including
+the initial voltage. ``TimeSampleOffset=0`` and
+``CurrentTimeSampleOffset=-\Delta t/2`` locate the voltage and raw loop-current
+histories respectively; their Fourier transforms apply these separate offsets.
+Native frequencies are based on :math:`N\Delta t`. Older hard-port outputs
+dropped the first sample and used :math:`N-1` samples with offsets
+:math:`\Delta t` and :math:`\Delta t/2`. Finite-resistance ports are unchanged:
+they still use :math:`N-1` half-step-aligned samples. Always use the stored
+``time``, ``time_current``, and ``frequency`` datasets, not an assumed length
+or a frequency axis borrowed from a different port.
 
 Important attributes include:
 

--- a/gprMax/config.py
+++ b/gprMax/config.py
@@ -174,6 +174,7 @@ class ModelConfig:
         self.appendmodelnumber = (
             "" if study_case_count == 1 else str(model_num + 1)
         )  # Indexed from 1
+        self.output_dir_override = None
         self.set_output_file_path()
 
         # Numerical dispersion analysis parameters
@@ -241,6 +242,10 @@ class ModelConfig:
         self.magnetic_averaging_mode = reference.magnetic_averaging_mode
         self.dispersive_averaging = reference.dispersive_averaging
         self.materials = dict(reference.materials)
+        # Preserve the policy, not the first model's already-numbered path.
+        # This also keeps snapshot directories beside their own model output.
+        if reference.output_dir_override is not None:
+            self.set_output_file_path(reference.output_dir_override)
 
     def get_scene(self):
         return sim_config.get_scene(self.model_num)
@@ -277,8 +282,9 @@ class ModelConfig:
         """
 
         if outputdir is not None:
-            Path(outputdir).mkdir(parents=True, exist_ok=True)
-            self.output_file_path = Path(outputdir, sim_config.input_file_path.stem)
+            self.output_dir_override = Path(outputdir).resolve()
+            self.output_dir_override.mkdir(parents=True, exist_ok=True)
+            self.output_file_path = self.output_dir_override / sim_config.input_file_path.stem
         elif sim_config.args.outputfile is not None:
             self.output_file_path = Path(sim_config.args.outputfile)
             if self.output_file_path.suffix.lower() == ".h5":
@@ -324,6 +330,13 @@ class SimulationConfig:
 
         self.args = args
 
+        # Validate declarations before hardware discovery or any model build.
+        # A false flag must never silently select a main-grid-only solve for
+        # a Scene that also contains fine-grid sources, geometry or outputs.
+        for scene in getattr(args, "scenes", None) or ():
+            if isinstance(scene, Scene):
+                scene.validate_subgrids(enabled=bool(getattr(args, "subgrid", False)))
+
         self.geometry_fixed: bool = args.geometry_fixed
         self.study = getattr(args, "study", None)
         self.geometry_only: bool = args.geometry_only
@@ -349,6 +362,9 @@ class SimulationConfig:
         if _multiple_accelerators_requested(non_cpu_solvers):
             logger.error("You cannot use combinations of CUDA, OpenCl and Apple Metal solvers simultaneously.")
             raise ValueError
+
+        if getattr(args, "subgrid", False) and any(solver is not None for solver in non_cpu_solvers):
+            raise ValueError("Subgrids require the CPU solver; CUDA, OpenCL and Metal are unsupported.")
 
         if self.mpi and hasattr(self.args, "subgrid") and self.args.subgrid:
             logger.error("You cannot use subgrids with MPI.")
@@ -477,14 +493,6 @@ class SimulationConfig:
                         " requested single precision."
                     )
                 self.general["precision"] = "double"
-            if (self.general["subgrid"] and self.general["solver"] == "cuda") or (
-                self.general["subgrid"] and self.general["solver"] == "opencl") or (
-                self.general["subgrid"] and self.general["solver"] == "metal"
-            ):
-                logger.error(
-                    "You cannot currently use CUDA, OpenCL, or Metal based solvers with models that contain sub-grids."
-                )
-                raise ValueError
         else:
             self.general["subgrid"] = False
 

--- a/gprMax/contexts.py
+++ b/gprMax/contexts.py
@@ -357,27 +357,25 @@ class TaskfarmContext(Context):
         executor = self.TaskfarmExecutor(self._run_model, comm=self.comm)
 
         # Check GPU resources versus number of MPI tasks
+        resource_error = None
         if (
             executor.is_master()
             and config.sim_config.general["solver"] == "cuda"
             and executor.size - 1 > len(config.sim_config.devices["devs"])
         ):
-            logger.error(
+            resource_error = (
                 "Not enough GPU resources for number of "
                 "MPI tasks requested. Number of MPI tasks "
                 "should be equal to number of GPUs + 1."
             )
-            raise ValueError
+        resource_error = self.comm.bcast(resource_error, root=executor.master)
+        if resource_error is not None:
+            raise ValueError(resource_error)
 
         jobs = [{"i": i} for i in self.model_range]
-        # Send the workers to their work loop
-        executor.start()
-        try:
-            if executor.is_master():
-                results = executor.submit(jobs)
-        finally:
-            # Failed jobs must still release workers waiting for more work.
-            executor.join()
+        # Join workers before propagating a failed batch collectively. A
+        # master-only exception can be masked by zero-exit workers in Hydra.
+        results = executor.run_collective(jobs)
 
         if executor.is_master():
             self._end_simulation()

--- a/gprMax/cuda_opencl/knl_source_updates.py
+++ b/gprMax/cuda_opencl/knl_source_updates.py
@@ -317,7 +317,10 @@ update_voltage_source = {
             int activity_offset = 4 * NVOLTSRC + 2 * source;
             int first_active = srcinfo1[activity_offset];
             int last_active = srcinfo1[activity_offset + 1];
-            int active = iteration >= first_active && iteration <= last_active;
+            // E(0) was prescribed on the host before upload. This overwrite
+            // lands on E(n+1); keep waveform tables on their physical lattice.
+            int hard_sample = iteration + 1;
+            int active = hard_sample >= first_active && hard_sample <= last_active;
 
             // 'x' polarised source
             if (polarisation == 0) {
@@ -328,7 +331,7 @@ update_voltage_source = {
                                                 srcwaveforms[IDX2D_SRCWAVES(source,iteration)] * area_inv;
                 }
                 else if (active) {
-                    Ex[IDX3D_FIELDS(x,y,z)] = -1 * srcwaveforms[IDX2D_SRCWAVES(source,iteration)] / dx;
+                    Ex[IDX3D_FIELDS(x,y,z)] = -1 * srcwaveforms[IDX2D_SRCWAVES(source,hard_sample)] / dx;
                 }
             }
 
@@ -341,7 +344,7 @@ update_voltage_source = {
                                                 srcwaveforms[IDX2D_SRCWAVES(source,iteration)] * area_inv;
                 }
                 else if (active) {
-                    Ey[IDX3D_FIELDS(x,y,z)] = -1 * srcwaveforms[IDX2D_SRCWAVES(source,iteration)] / dy;
+                    Ey[IDX3D_FIELDS(x,y,z)] = -1 * srcwaveforms[IDX2D_SRCWAVES(source,hard_sample)] / dy;
                 }
             }
 
@@ -354,7 +357,7 @@ update_voltage_source = {
                                                 srcwaveforms[IDX2D_SRCWAVES(source,iteration)] * area_inv;
                 }
                 else if (active) {
-                    Ez[IDX3D_FIELDS(x,y,z)] = -1 * srcwaveforms[IDX2D_SRCWAVES(source,iteration)] / dz;
+                    Ez[IDX3D_FIELDS(x,y,z)] = -1 * srcwaveforms[IDX2D_SRCWAVES(source,hard_sample)] / dz;
                 }
             }
         }

--- a/gprMax/fields_outputs.py
+++ b/gprMax/fields_outputs.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
+import hashlib
+import json
 import logging
 from pathlib import Path
 
@@ -31,6 +33,7 @@ logger = logging.getLogger(__name__)
 
 SOURCE_EXCITATION_SCHEMA_VERSION = 1
 RECEIVER_TIMING_SCHEMA_VERSION = 1
+RECEIVER_ORDER_SCHEMA_VERSION = 1
 SURFACE_IMPEDANCE_SCHEMA_VERSION = 3
 
 
@@ -66,8 +69,9 @@ def _write_source_excitation(group, source, grid):
     """Write the exact scalar excitation history consumed by a local source.
 
     The time offset refers to the physical Yee time of sample zero. Source
-    arrays contain one extra value for update look-ahead; only the values
-    consumed by the model's ``iterations`` updates are persisted.
+    arrays contain one extra value for update look-ahead. Persist N samples;
+    hard sources include the E(0) prescription and exclude the terminal E(N)
+    update, which lies beyond the stored receiver history.
     """
 
     source_type = type(source).__name__
@@ -86,7 +90,9 @@ def _write_source_excitation(group, source, grid):
     if source_type == "VoltageSource":
         if source.resistance == 0:
             samples = source.waveformvalues_wholedt[:iterations]
-            time_offset = dt
+            # Include the initial E(0) prescription; the terminal E(N)
+            # look-ahead update lies outside the receiver output history.
+            time_offset = 0.0
             evaluation_time_offset = 0.0
             quantity = "imposed_gap_voltage"
             lattice = "electric"
@@ -523,13 +529,37 @@ def write_hd5_data(basegrp, grid, is_subgrid=False):
     # solver's receiver order. Device transfer maps receiver pages by this
     # original order and internal port monitors are intentionally omitted from
     # the public /rxs namespace.
-    public_rxs.sort(key=lambda rx: rx.ID)
+    definitions = getattr(grid, "receiver_definitions", None)
+    if definitions and len(definitions) != len(public_rxs):
+        raise ValueError("Public receiver count differs from the registered declarations after gathering")
+    indices = [getattr(rx, "build_index", None) for rx in public_rxs]
+    if any(index is not None for index in indices):
+        if any(index is None for index in indices) or sorted(indices) != list(range(len(indices))):
+            raise ValueError("Public receiver build indices must be unique and contiguous after gathering")
+        public_rxs.sort(key=lambda rx: rx.build_index)
+        receiver_order = "construction"
+    else:
+        # Support serial callers supplying low-level receiver objects directly.
+        # Do not misrepresent their list order as a global construction identity.
+        if public_rxs and getattr(grid, "is_distributed", False):
+            raise ValueError("Distributed public receivers require global build indices")
+        receiver_order = "runtime"
+    basegrp.attrs["ReceiverOrderSchemaVersion"] = RECEIVER_ORDER_SCHEMA_VERSION
+    basegrp.attrs["ReceiverOrder"] = receiver_order
+    if receiver_order == "construction":
+        if definitions is not None and len(definitions) == len(public_rxs):
+            basegrp.attrs["ReceiverLayout"] = hashlib.sha256(
+                json.dumps(definitions, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+            ).hexdigest()
 
     # Create group, add positional data and write field component arrays for receivers
     for rxindex, rx in enumerate(public_rxs):
         grp = basegrp.create_group("rxs/rx" + str(rxindex + 1))
         if rx.ID:
             grp.attrs["Name"] = rx.ID
+        if receiver_order == "construction":
+            grp.attrs["BuildIndex"] = rx.build_index
+            grp.attrs["NameKind"] = rx.name_kind
         if getattr(rx, "study_id", None):
             grp.attrs["StudyID"] = rx.study_id
         grp.attrs["Position"] = _global_position(grid, rx.xcoord, rx.ycoord, rx.zcoord, is_subgrid)

--- a/gprMax/grid/fdtd_grid.py
+++ b/gprMax/grid/fdtd_grid.py
@@ -209,6 +209,9 @@ class FDTDGrid:
         self.virtual_waveguide_specs = {}
         self.virtual_waveguides = []
         self.rxs: List[Rx] = []
+        # Replicated on all MPI ranks, including declarations owned elsewhere.
+        # Separate from runtime pages and private, source-owned port samplers.
+        self.receiver_definitions = []
         self.port_monitors = []  # Source-bound S-parameter/impedance outputs
         self.sar_specs = []  # Deferred tagged-cell SAR output definitions
         self.radiometry_specs = []  # Deferred density-independent absorption outputs
@@ -357,7 +360,18 @@ class FDTDGrid:
         else:
             raise TypeError(f"Source of type '{type(source)}' is unknown to gprMax")
 
+    def register_receiver(self, name, outputs, study_id=None):
+        """Allocate a per-grid public ordinal BEFORE ownership filtering.
+
+        Positions deliberately do not participate: a declared receiver may
+        move between scan runs. Names remain labels, not ordering keys.
+        """
+        index = len(self.receiver_definitions)
+        self.receiver_definitions.append((name, sorted(outputs), study_id))
+        return index
+
     def add_receiver(self, receiver: Rx):
+        # Also used by MPI migration: never allocate/reassign an ordinal here.
         self.rxs.append(receiver)
 
     def build(self) -> None:

--- a/gprMax/hash_cmds_file.py
+++ b/gprMax/hash_cmds_file.py
@@ -16,7 +16,7 @@
 # along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
 import logging
-import sys
+from contextlib import redirect_stdout
 from io import StringIO
 from pathlib import Path
 
@@ -25,6 +25,7 @@ import gprMax.config as config
 from .hash_cmds_geometry import process_geometrycmds
 from .hash_cmds_multiuse import process_multicmds
 from .hash_cmds_singleuse import process_singlecmds
+from .hash_includes import expand_include_lines
 
 logger = logging.getLogger(__name__)
 
@@ -69,28 +70,18 @@ def process_python_include_code(inputfile, usernamespace):
             # String to hold Python code to be executed
             pythoncode = ""
             x += 1
-            while not inputlines[x].startswith("#end_python:"):
+            while x < len(inputlines) and not inputlines[x].startswith("#end_python:"):
                 # Add all code in current code block to string
                 pythoncode += inputlines[x] + "\n"
                 x += 1
-                if x == len(inputlines):
-                    logger.exception(
-                        "Cannot find the end of the Python code "
-                        + "block, i.e. missing #end_python: command."
-                    )
-                    raise SyntaxError
+            if x == len(inputlines):
+                raise SyntaxError("Cannot find the end of the Python code block: missing #end_python: command.")
             # Compile code for faster execution
             pythoncompiledcode = compile(pythoncode, "<string>", "exec")
-            # Redirect stdout to a text stream
-            sys.stdout = result = StringIO()
-            # Execute code block & make available only usernamespace
-            exec(pythoncompiledcode, usernamespace)
-            # String containing buffer of executed code
-            codeout = result.getvalue().split("\n")
-            result.close()
-
-            # Reset stdio
-            sys.stdout = sys.__stdout__
+            # Restore the caller's exact stream even if execution raises.
+            with StringIO() as result, redirect_stdout(result):
+                exec(pythoncompiledcode, usernamespace)
+                codeout = result.getvalue().split("\n")
 
             # Separate commands from any other generated output
             hashcmds = []
@@ -123,8 +114,10 @@ def process_python_include_code(inputfile, usernamespace):
 
 
 def process_include_files(hashcmds):
-    """Looks for and processes any include file commands and insert
-        the contents of the included file at that location.
+    """Expand includes recursively, relative to each containing input file.
+
+    Repeated includes are allowed; only cycles on the active inclusion path
+    are rejected. Python blocks in included files remain unsupported.
 
     Args:
         hashcmds: list of input commands.
@@ -134,40 +127,13 @@ def process_include_files(hashcmds):
                                 include file commands.
     """
 
-    processedincludecmds = []
-    x = 0
-    while x < len(hashcmds):
-        if hashcmds[x].startswith("#include_file:"):
-            includefile = hashcmds[x].split()
-
-            if len(includefile) != 2:
-                logger.exception("#include_file requires exactly one parameter")
-                raise ValueError
-
-            includefile = includefile[1]
-
-            # See if file exists at specified path and if not try input file directory
-            includefile = Path(includefile)
-            if not includefile.exists():
-                includefile = Path(config.sim_config.input_file_path.parent, includefile)
-
-            with open(includefile, "r") as f:
-                # Strip out any newline characters and comments that must begin with double hashes
-                includelines = [
-                    includeline.rstrip() + "\n"
-                    for includeline in f
-                    if (not includeline.startswith("##") and includeline.rstrip("\n"))
-                ]
-
-            # Add lines from include file
-            processedincludecmds.extend(includelines)
-
-        else:
-            processedincludecmds.append(hashcmds[x])
-
-        x += 1
-
-    return processedincludecmds
+    input_path = getattr(config.sim_config, "input_file_path", None)
+    input_path = Path(input_path).resolve() if input_path is not None else None
+    return expand_include_lines(
+        hashcmds,
+        input_path.parent if input_path is not None else Path.cwd(),
+        (input_path,) if input_path is not None else (),
+    )
 
 
 def write_processed_file(processedlines):
@@ -415,12 +381,13 @@ def check_cmd_names(processedlines, checkessential=True):
     return singlecmds, multiplecmds, geometry
 
 
-def get_user_objects(processedlines, checkessential=True):
+def get_user_objects(processedlines, checkessential=True, *, input_dir=None):
     """Make a list of all user objects.
 
     Args:
         processedlines: list of input commands after Python processing.
         checkessential: boolean to check for essential commands or not.
+        input_dir: optional top-level input directory for relative output paths.
 
     Returns:
         user_objs: list of all user objects.
@@ -430,7 +397,7 @@ def get_user_objects(processedlines, checkessential=True):
     parsed_commands = check_cmd_names(processedlines, checkessential=checkessential)
 
     # Process parameters for commands that can only occur once in the model
-    single_user_objs = process_singlecmds(parsed_commands[0])
+    single_user_objs = process_singlecmds(parsed_commands[0], input_dir=input_dir)
 
     # Process parameters for commands that can occur multiple times in
     # the model
@@ -474,7 +441,20 @@ def parse_hash_commands(scene):
         if config.sim_config.args.write_processed:
             write_processed_file(processedlines)
 
-        user_objs = get_user_objects(processedlines, checkessential=True)
+        expected_controls = getattr(config.sim_config.args, "_hash_preflight_controls", None)
+        actual_controls = tuple(
+            line.strip() for line in processedlines if line.startswith(("#study:", "#array_codebook:"))
+        )
+        if expected_controls is not None and actual_controls != expected_controls:
+            raise ValueError(
+                "#study and #array_codebook must be declared literally before preflight; "
+                "they cannot be generated by #python or changed during preprocessing."
+            )
+
+        user_objs = get_user_objects(
+            processedlines, checkessential=True,
+            input_dir=config.sim_config.input_file_path.resolve().parent,
+        )
         for user_obj in user_objs:
             scene.add(user_obj)
 

--- a/gprMax/hash_cmds_multiuse.py
+++ b/gprMax/hash_cmds_multiuse.py
@@ -103,6 +103,8 @@ def process_multicmds(multicmds):
         scene_objects: list that holds objects in scene.
     """
 
+    if multicmds.get("#include_file"):
+        raise ValueError("#include_file must be expanded by input-file preprocessing before command dispatch")
     scene_objects = []
 
     cmdname = "#waveform"

--- a/gprMax/hash_cmds_singleuse.py
+++ b/gprMax/hash_cmds_singleuse.py
@@ -16,6 +16,7 @@
 # along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
 import logging
+from pathlib import Path
 
 from .user_objects.cmds_singleuse import (
     DispersiveAveraging,
@@ -36,12 +37,14 @@ from .user_objects.cmds_singleuse import (
 logger = logging.getLogger(__name__)
 
 
-def process_singlecmds(singlecmds):
+def process_singlecmds(singlecmds, *, input_dir=None):
     """Checks the validity of command parameters and creates instances of
         classes of parameters.
 
     Args:
         singlecmds: dict of commands that can only occur once in the model.
+        input_dir: optional directory of the top-level input file, used to
+            resolve relative hash-command output directories.
 
     Returns:
         scene_objects: list that holds objects in scene.
@@ -57,7 +60,12 @@ def process_singlecmds(singlecmds):
 
     cmd = "#output_dir"
     if singlecmds[cmd] is not None:
-        output_dir = OutputDir(dir=singlecmds[cmd])
+        # Hash paths are relative to the top-level input, not the launch CWD.
+        # Resolve here so Python OutputDir keeps its existing CWD semantics.
+        directory = Path(singlecmds[cmd])
+        if input_dir is not None and not directory.is_absolute():
+            directory = Path(input_dir) / directory
+        output_dir = OutputDir(dir=str(directory))
         scene_objects.append(output_dir)
 
     # Number of threads for CPU-based (OpenMP) parallelised parts of code

--- a/gprMax/hash_includes.py
+++ b/gprMax/hash_includes.py
@@ -1,0 +1,63 @@
+"""Include traversal shared by model parsing and non-executing preflight.
+
+This module deliberately has no simulation/configuration dependencies: study
+preflight runs before a SimulationConfig exists.
+"""
+
+from pathlib import Path
+
+
+def expand_include_lines(lines, base_dir, stack=()):
+    """Expand each occurrence in order, relative to its containing file.
+
+    An active-path stack detects cycles without suppressing repeated includes.
+    Included Python blocks remain unsupported. Top-level Python is handled by
+    the caller (executed by parsing, skipped by preflight).
+    """
+    expanded = []
+    for line in lines:
+        if not line.startswith("#include_file:"):
+            expanded.append(line)
+            continue
+        tokens = line.split()
+        if len(tokens) != 2:
+            raise ValueError("#include_file requires exactly one parameter")
+        path = Path(tokens[1])
+        if not path.is_absolute():
+            path = Path(base_dir) / path
+        path = path.resolve()
+        if path in stack:
+            chain = " -> ".join(str(item) for item in (*stack, path))
+            raise ValueError(f"#include_file cycle detected: {chain}")
+        if len(stack) >= 100:
+            raise ValueError(f"#include_file nesting exceeds 100 files at {path}")
+        with path.open(encoding="utf-8") as handle:
+            included = [item.rstrip() + "\n" for item in handle if not item.startswith("##") and item.strip()]
+        if any(item.startswith(("#python:", "#end_python:")) for item in included):
+            raise SyntaxError(f"Python blocks in included files are unsupported: {path}")
+        expanded.extend(expand_include_lines(included, path.parent, (*stack, path)))
+    return expanded
+
+
+def static_hash_commands(inputfile):
+    """Read literal commands without executing top-level legacy Python.
+
+    Match the parser's column-zero command convention. Commands printed by
+    Python cannot participate in preflight; the parser still expands their
+    includes later using the same traversal.
+    """
+    if inputfile is None:
+        return []
+    path = Path(inputfile).expanduser().resolve()
+    commands = []
+    in_python = False
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("#python:"):
+            in_python = True
+        elif line.startswith("#end_python:"):
+            in_python = False
+        elif not in_python and line.startswith("#") and not line.startswith("##"):
+            commands.append(line.rstrip() + "\n")
+    if in_python:
+        raise SyntaxError("Cannot find the end of the Python code block: missing #end_python: command.")
+    return expand_include_lines(commands, path.parent, (path,))

--- a/gprMax/ports.py
+++ b/gprMax/ports.py
@@ -1508,7 +1508,9 @@ class VoltageSourcePortMonitor:
                 f"Voltage-source port {self.output_id!r} hard source has no terminal-current samples"
             )
 
-        nsamples = grid.iterations - 1
+        # Hard voltages include the prescribed E(0). Finite-resistance ports
+        # still pair adjacent E samples at half steps and need N-1 samples.
+        nsamples = grid.iterations if self.hard_source else grid.iterations - 1
         self.aligned_samples = nsamples
         full_frequency = np.fft.rfftfreq(nsamples, d=grid.dt)
         cells, limiting_material = minimum_wavelength_sampling(grid, full_frequency)
@@ -1711,22 +1713,21 @@ class VoltageSourcePortMonitor:
                 f"Voltage-source port {self.output_id!r} receiver history has the wrong length"
             )
 
-        # At receiver-storage index m, E is at m*dt and H is at
-        # (m-1/2)*dt. Drop the unexcited initial fields so each retained pair
-        # is exactly V^(n+1), I_loop^(n+1/2). Their separate transform offsets
-        # remove the half-step phase difference without the cosine attenuation
-        # introduced by time-domain averaging.
-        total_voltage = np.asarray(-self.dl * electric[1:], dtype=real_dtype)
-        loop_current = np.asarray(loop_half[1:], dtype=real_dtype)
+        # At storage index m, E is at m*dt and H is at (m-1/2)*dt. E(0)
+        # may contain the entire drive of a hard impulse, so retain it.
+        # Separate transform offsets preserve the half-step phase without
+        # the cosine attenuation introduced by time-domain averaging.
+        total_voltage = np.asarray(-self.dl * electric, dtype=real_dtype)
+        loop_current = np.asarray(loop_half, dtype=real_dtype)
         generator_voltage = total_voltage.copy()
-        self.hard_voltage_time_offset = float(grid.dt)
-        self.hard_current_time_offset = float(0.5 * grid.dt)
+        self.hard_voltage_time_offset = 0.0
+        self.hard_current_time_offset = float(-0.5 * grid.dt)
         time = np.asarray(
-            (np.arange(total_voltage.size, dtype=real_dtype) + 1) * grid.dt,
+            np.arange(total_voltage.size, dtype=real_dtype) * grid.dt,
             dtype=real_dtype,
         )
         self._hard_current_time = np.asarray(
-            (np.arange(loop_current.size, dtype=real_dtype) + 0.5) * grid.dt,
+            (np.arange(loop_current.size, dtype=real_dtype) - 0.5) * grid.dt,
             dtype=real_dtype,
         )
 

--- a/gprMax/scene.py
+++ b/gprMax/scene.py
@@ -26,6 +26,7 @@ from gprMax.materials import create_built_in_materials
 from gprMax.model import Model
 from gprMax.subgrids.grid import SubGridBaseGrid
 from gprMax.subgrids.user_objects import SubGridBase as SubGridUserBase
+from gprMax.subgrids.user_objects import validate_subgrid_id
 from gprMax.user_objects.cmds_geometry.add_grass import AddGrass
 from gprMax.user_objects.cmds_geometry.add_surface_roughness import AddSurfaceRoughness
 from gprMax.user_objects.cmds_geometry.add_surface_water import AddSurfaceWater
@@ -77,6 +78,18 @@ class Scene:
             self.output_objects.append(user_object)
         else:
             raise TypeError(f"Object of type '{type(user_object)}' is unknown to gprMax")
+
+    def validate_subgrids(self, *, enabled):
+        """Validate the Scene's execution requirement and output namespace."""
+        if self.subgrid_objects and not enabled:
+            raise ValueError("Scene contains subgrids; run with subgrid=True (CPU only).")
+        identifiers = set()
+        for subgrid in self.subgrid_objects:
+            identifier = subgrid.kwargs.get("id")
+            validate_subgrid_id(identifier)
+            if identifier in identifiers:
+                raise ValueError(f"Duplicate subgrid ID {identifier!r} in Scene")
+            identifiers.add(identifier)
 
     def build_model_objects(self, objects: Sequence[ModelUserObject], model: Model):
         """Builds objects in models.
@@ -288,6 +301,12 @@ class Scene:
         presents the user with UserObjects in order to build the internal
         Rx(), Cylinder() etc... objects.
         """
+
+        # Repeat the preflight for callers that construct models directly or
+        # mutate a Scene after SimulationConfig has been created.
+        from gprMax import config
+
+        self.validate_subgrids(enabled=config.sim_config.general.get("subgrid", False))
 
         # Create pre-defined (built-in) materials
         create_built_in_materials(model.G)

--- a/gprMax/solvers.py
+++ b/gprMax/solvers.py
@@ -19,6 +19,7 @@ import logging
 
 import gprMax.config as config
 from gprMax.model import Model
+from gprMax.sources import initialise_hard_source_fields
 
 from .grid.cuda_grid import CUDAGrid
 from .grid.fdtd_grid import FDTDGrid
@@ -153,6 +154,23 @@ def create_solver(model: Model) -> Solver:
         solver: Solver object.
     """
     grid = model.G
+    if getattr(model, "subgrids", ()) and not config.sim_config.general["subgrid"]:
+        raise ValueError("Model contains subgrids; run with subgrid=True (CPU only).")
+    # Model.build() has reset fields and applied source stepping/Study state.
+    # Do this once per run, before backend constructors upload the host fields
+    # or create the subgrid coupling state. Never advance additive sources here.
+    for source_grid in (grid, *getattr(model, "subgrids", ())):
+        prescribed = initialise_hard_source_fields(source_grid)
+        if getattr(source_grid, "is_distributed", False) is True:
+            from mpi4py import MPI
+
+            # Ranks without a local hard source still need their neighbours'
+            # E(0) before the first H update. Every rank participates in the
+            # decision and, if needed, the exchange; drain sends as well.
+            if source_grid.comm.allreduce(prescribed, op=MPI.LOR):
+                source_grid.halo_swap_electric()
+                source_grid.complete_halo_swaps()
+
     if config.sim_config.general["subgrid"]:
         updates = create_subgrid_updates(model)
         if updates.grid.maxpoles != 0:

--- a/gprMax/sources.py
+++ b/gprMax/sources.py
@@ -2910,17 +2910,22 @@ class VoltageSource(Source):
             G: FDTDGrid class describing a grid in a model.
         """
 
-        names = ("waveformvalues_halfdt", "waveformvalues_wholedt")
+        # A hard voltage prescribes E on whole steps; a resistive voltage
+        # injects J on half steps. Do not evaluate an unused lattice (notably
+        # the out-of-range final half step of a sampled hard excitation).
+        name = "waveformvalues_wholedt" if self.resistance == 0 else "waveformvalues_halfdt"
+        names = (name,)
+        self.waveformvalues_halfdt = None
+        self.waveformvalues_wholedt = None
         src_match = self._reuse_waveform_values(G, G.voltagesources, names)
 
         if not src_match:
             waveform = next(x for x in G.waveforms if x.ID == self.waveformID)
-            self.waveformvalues_halfdt = np.zeros(
+            values = np.zeros(
                 (G.iterations + 1), dtype=config.sim_config.dtypes["float_or_double"]
             )
-            self.waveformvalues_wholedt = np.zeros(
-                (G.iterations + 1), dtype=config.sim_config.dtypes["float_or_double"]
-            )
+            setattr(self, name, values)
+            offset = 0.0 if self.resistance == 0 else 0.5 * G.dt
 
             for iteration in range(G.iterations + 1):
                 time = G.dt * iteration
@@ -2928,10 +2933,7 @@ class VoltageSource(Source):
                     # Set the time of the waveform evaluation to account for any
                     # delay in the start
                     time -= self.start
-                    self.waveformvalues_halfdt[iteration] = waveform.calculate_value(
-                        time + 0.5 * G.dt, G.dt
-                    )
-                    self.waveformvalues_wholedt[iteration] = waveform.calculate_value(time, G.dt)
+                    values[iteration] = waveform.calculate_value(time + offset, G.dt)
 
         self._cache_waveform_values(G, names)
 

--- a/gprMax/sources.py
+++ b/gprMax/sources.py
@@ -2935,6 +2935,24 @@ class VoltageSource(Source):
 
         self._cache_waveform_values(G, names)
 
+    def impose_electric_field(self, sample, Ex, Ey, Ez, G):
+        """Prescribe a hard-source edge at physical electric time ``sample*dt``.
+
+        Used for E(0) initialisation and for E(n+1) after each electric update.
+        Activity is independent of amplitude: an active zero voltage clamps
+        the edge, whereas an inactive source releases it. Return whether the
+        edge was prescribed, including a zero-valued prescription.
+        """
+        if self.resistance != 0:
+            raise ValueError("Only a zero-resistance voltage source can prescribe E")
+        if not self.start <= sample * G.dt <= self.stop:
+            return False
+        field, dl = {"x": (Ex, G.dx), "y": (Ey, G.dy), "z": (Ez, G.dz)}[self.polarisation]
+        field[self.xcoord, self.ycoord, self.zcoord] = (
+            -self.waveformvalues_wholedt[sample] / dl
+        )
+        return True
+
     def update_electric(self, iteration, updatecoeffsE, ID, Ex, Ey, Ez, G):
         """Updates electric field values for a voltage source.
 
@@ -2948,6 +2966,10 @@ class VoltageSource(Source):
             G: FDTDGrid class describing a grid in a model.
         """
 
+        if self.resistance == 0:
+            self.impose_electric_field(iteration + 1, Ex, Ey, Ez, G)
+            return
+
         if iteration * G.dt >= self.start and iteration * G.dt <= self.stop:
             i = self.xcoord
             j = self.ycoord
@@ -2955,34 +2977,25 @@ class VoltageSource(Source):
             componentID = f"E{self.polarisation}"
 
             if self.polarisation == "x":
-                if self.resistance != 0:
-                    Ex[i, j, k] -= (
-                        updatecoeffsE[ID[G.IDlookup[componentID], i, j, k], 4]
-                        * self.waveformvalues_halfdt[iteration]
-                        * (1 / (self.resistance * G.dy * G.dz))
-                    )
-                else:
-                    Ex[i, j, k] = -1 * self.waveformvalues_wholedt[iteration] / G.dx
+                Ex[i, j, k] -= (
+                    updatecoeffsE[ID[G.IDlookup[componentID], i, j, k], 4]
+                    * self.waveformvalues_halfdt[iteration]
+                    * (1 / (self.resistance * G.dy * G.dz))
+                )
 
             elif self.polarisation == "y":
-                if self.resistance != 0:
-                    Ey[i, j, k] -= (
-                        updatecoeffsE[ID[G.IDlookup[componentID], i, j, k], 4]
-                        * self.waveformvalues_halfdt[iteration]
-                        * (1 / (self.resistance * G.dx * G.dz))
-                    )
-                else:
-                    Ey[i, j, k] = -1 * self.waveformvalues_wholedt[iteration] / G.dy
+                Ey[i, j, k] -= (
+                    updatecoeffsE[ID[G.IDlookup[componentID], i, j, k], 4]
+                    * self.waveformvalues_halfdt[iteration]
+                    * (1 / (self.resistance * G.dx * G.dz))
+                )
 
             elif self.polarisation == "z":
-                if self.resistance != 0:
-                    Ez[i, j, k] -= (
-                        updatecoeffsE[ID[G.IDlookup[componentID], i, j, k], 4]
-                        * self.waveformvalues_halfdt[iteration]
-                        * (1 / (self.resistance * G.dx * G.dy))
-                    )
-                else:
-                    Ez[i, j, k] = -1 * self.waveformvalues_wholedt[iteration] / G.dz
+                Ez[i, j, k] -= (
+                    updatecoeffsE[ID[G.IDlookup[componentID], i, j, k], 4]
+                    * self.waveformvalues_halfdt[iteration]
+                    * (1 / (self.resistance * G.dx * G.dy))
+                )
 
     def create_material(self, G):
         """Create a new material at the voltage source location that adds the
@@ -3176,6 +3189,21 @@ class MagneticDipole(Source):
                 )
 
 
+def initialise_hard_source_fields(G):
+    """Apply only active hard voltage sources to a run's initial host fields.
+
+    Call after field reset and per-case source setup, before device uploads
+    and the first field observation. Preserve declaration/list precedence
+    for coincident hard sources. No other source or material state advances.
+    Return whether any local edge was prescribed (even to zero).
+    """
+    prescribed = False
+    for source in getattr(G, "voltagesources", ()):
+        if source.resistance == 0:
+            prescribed |= source.impose_electric_field(0, G.Ex, G.Ey, G.Ez, G)
+    return prescribed
+
+
 def htod_src_arrays(sources, G, queue=None):
     """Initialise arrays on compute device for source coordinates/polarisation,
         other source information, and source waveform values.
@@ -3227,8 +3255,10 @@ def htod_src_arrays(sources, G, queue=None):
     if sources and sources[0].__class__.__name__ == "VoltageSource":
         # Keep the existing four-int coordinate stride and all float layouts.
         # The shared voltage kernel reads this compact tail using NVOLTSRC.
-        # Search exact host n*dt values, matching the CPU's inclusive predicate
-        # without device-precision rounding or a per-timestep activity buffer.
+        # Store physical waveform-sample indices, not solver-loop indices.
+        # The hard-source kernel tests sample n+1 against this interval; its
+        # sample 0 is imposed on the host before upload. Search exact host
+        # sample*dt values without device-precision rounding.
         iterations = range(G.iterations + 1)
         sample_time = lambda iteration: iteration * G.dt
         activity = np.asarray(

--- a/gprMax/studies.py
+++ b/gprMax/studies.py
@@ -145,9 +145,16 @@ class Study:
     def reset_runtime(self) -> None:
         """Clear bindings/state retained only for one call to :func:`gprMax.run`."""
 
+        self.validate_parameters()
         self._scene_bound = False
         self._runtime_baselines.clear()
         self._current_resolved_case = None
+
+    def validate_parameters(self) -> None:
+        """Normalise common API/CSV parameters before building any case."""
+        for case in self.cases:
+            for state in case.states:
+                state.parameters = _validated_state_parameters(state.parameters)
 
     @classmethod
     def from_csv(cls, type: str, path: Union[str, Path]) -> "Study":
@@ -246,6 +253,7 @@ class Study:
     def bind_scene(self, scene) -> None:
         """Assign stable IDs and resolve API object references before build."""
 
+        self.validate_parameters()
         if self._scene_bound:
             return
 
@@ -495,6 +503,7 @@ class Study:
     def _apply_state(self, grid, study_id: str, item, parameters: Mapping[str, Any]) -> dict[str, Any]:
         from gprMax.user_inputs import MainGridUserInput
 
+        parameters = _validated_state_parameters(parameters)
         applied: dict[str, Any] = {}
         if "position" in parameters:
             point = tuple(float(value) for value in parameters["position"])
@@ -533,7 +542,13 @@ class Study:
             item.start = float(parameters["start"])
         if "stop" in parameters:
             item.stop = float(parameters["stop"])
-        if item.start < 0 or item.stop <= item.start or item.stop > grid.timewindow:
+        if (
+            not math.isfinite(item.start)
+            or not math.isfinite(item.stop)
+            or item.start < 0
+            or item.stop <= item.start
+            or item.stop > grid.timewindow
+        ):
             raise ValueError(f"Study object '{study_id}' requires 0 <= start < stop <= the model time window.")
         scale = float(parameters.get("scale", 1.0))
         if not math.isfinite(scale):
@@ -618,6 +633,7 @@ class SourceStudy(Study):
     def bind_scene(self, scene) -> None:
         """Bind fixed main-grid terminal definitions and validate cases."""
 
+        self.validate_parameters()
         if self._scene_bound:
             return
 
@@ -853,6 +869,7 @@ class PlaneWaveStudy(Study):
     def bind_scene(self, scene) -> None:
         """Bind one main-grid DPW template and validate every case override."""
 
+        self.validate_parameters()
         if self._scene_bound:
             return
 
@@ -2338,6 +2355,7 @@ class EigenmodeStudy(Study):
     def bind_scene(self, scene) -> None:
         """Validate a complete, unambiguous modal-channel schedule."""
 
+        self.validate_parameters()
         if self._scene_bound:
             return
         from gprMax.user_objects.cmds_multiuse import EigenmodeExcitation, EigenmodePort
@@ -3138,8 +3156,17 @@ def preflight_study_args(args) -> Optional[Study]:
     if study is not None and not isinstance(study, Study):
         raise TypeError("The study API argument must be a Study instance.")
 
-    hash_spec = _find_hash_study(getattr(args, "inputfile", None))
-    hash_codebook = _find_hash_array_codebook(getattr(args, "inputfile", None))
+    from gprMax.hash_includes import static_hash_commands
+
+    inputfile = getattr(args, "inputfile", None)
+    commands = static_hash_commands(inputfile)
+    # The parser may subsequently execute top-level Python. Controls that size
+    # the run must not appear/change only then, after preflight has chosen it.
+    args._hash_preflight_controls = tuple(
+        line.strip() for line in commands if line.startswith(("#study:", "#array_codebook:"))
+    )
+    hash_spec = _find_hash_study(inputfile, commands=commands)
+    hash_codebook = _find_hash_array_codebook(inputfile, commands=commands)
     if study is not None and hash_spec is not None:
         raise ValueError("Specify a study through either the Python API or #study, not both.")
     if study is not None and hash_codebook is not None:
@@ -3183,101 +3210,66 @@ def preflight_study_args(args) -> Optional[Study]:
     return study
 
 
-def _find_hash_study(inputfile: Optional[Union[str, Path]]) -> Optional[tuple[str, Path]]:
+def _find_hash_study(inputfile: Optional[Union[str, Path]], *, commands=None) -> Optional[tuple[str, Path]]:
     if inputfile is None:
         return None
     main_path = Path(inputfile).expanduser().resolve()
     found: list[tuple[str, Path]] = []
-    visited: set[Path] = set()
+    if commands is None:
+        from gprMax.hash_includes import static_hash_commands
 
-    def scan(path: Path) -> None:
-        path = path.resolve()
-        if path in visited:
-            return
-        visited.add(path)
-        in_python = False
-        for line in path.read_text(encoding="utf-8").splitlines():
-            stripped = line.strip()
-            if not stripped or stripped.startswith("##"):
-                continue
-            if stripped.startswith("#python:"):
-                in_python = True
-                continue
-            if stripped.startswith("#end_python:"):
-                in_python = False
-                continue
-            if in_python:
-                # Preflight intentionally does not execute deprecated Python.
-                continue
-            if stripped.startswith("#include_file:"):
-                values = shlex.split(stripped.split(":", 1)[1])
-                if len(values) != 1:
-                    raise ValueError("#include_file requires exactly one parameter.")
-                include = Path(values[0]).expanduser()
-                if not include.exists():
-                    include = main_path.parent / include
-                scan(include)
-            elif stripped.startswith("#study:"):
-                values = shlex.split(stripped.split(":", 1)[1])
-                if len(values) != 2:
-                    raise ValueError("#study requires exactly two parameters: type and CSV path.")
-                csv_path = Path(values[1]).expanduser()
-                if not csv_path.is_absolute():
-                    csv_path = main_path.parent / csv_path
-                found.append((values[0].lower(), csv_path.resolve()))
-
-    scan(main_path)
+        commands = static_hash_commands(main_path)
+    for line in commands:
+        if line.startswith("#study:"):
+            values = shlex.split(line.split(":", 1)[1])
+            if len(values) != 2:
+                raise ValueError("#study requires exactly two parameters: type and CSV path.")
+            csv_path = Path(values[1]).expanduser()
+            if not csv_path.is_absolute():
+                csv_path = main_path.parent / csv_path
+            found.append((values[0].lower(), csv_path.resolve()))
     if len(found) > 1:
         raise ValueError("Only one #study command may be specified.")
     return found[0] if found else None
 
 
-def _find_hash_array_codebook(inputfile: Optional[Union[str, Path]]) -> Optional[Path]:
+def _find_hash_array_codebook(inputfile: Optional[Union[str, Path]], *, commands=None) -> Optional[Path]:
     if inputfile is None:
         return None
     main_path = Path(inputfile).expanduser().resolve()
     found: list[Path] = []
-    visited: set[Path] = set()
+    if commands is None:
+        from gprMax.hash_includes import static_hash_commands
 
-    def scan(path: Path) -> None:
-        path = path.resolve()
-        if path in visited:
-            return
-        visited.add(path)
-        in_python = False
-        for line in path.read_text(encoding="utf-8").splitlines():
-            stripped = line.strip()
-            if not stripped or stripped.startswith("##"):
-                continue
-            if stripped.startswith("#python:"):
-                in_python = True
-                continue
-            if stripped.startswith("#end_python:"):
-                in_python = False
-                continue
-            if in_python:
-                continue
-            if stripped.startswith("#include_file:"):
-                values = shlex.split(stripped.split(":", 1)[1])
-                if len(values) != 1:
-                    raise ValueError("#include_file requires exactly one parameter.")
-                include = Path(values[0]).expanduser()
-                if not include.is_absolute():
-                    include = main_path.parent / include
-                scan(include)
-            elif stripped.startswith("#array_codebook:"):
-                values = shlex.split(stripped.split(":", 1)[1])
-                if len(values) != 1:
-                    raise ValueError("#array_codebook requires exactly one JSON path.")
-                codebook = Path(values[0]).expanduser()
-                if not codebook.is_absolute():
-                    codebook = main_path.parent / codebook
-                found.append(codebook.resolve())
-
-    scan(main_path)
+        commands = static_hash_commands(main_path)
+    for line in commands:
+        if line.startswith("#array_codebook:"):
+            values = shlex.split(line.split(":", 1)[1])
+            if len(values) != 1:
+                raise ValueError("#array_codebook requires exactly one JSON path.")
+            codebook = Path(values[0]).expanduser()
+            if not codebook.is_absolute():
+                codebook = main_path.parent / codebook
+            found.append(codebook.resolve())
     if len(found) > 1:
         raise ValueError("Only one #array_codebook command may be specified.")
     return found[0] if found else None
+
+
+def _validated_state_parameters(parameters):
+    parameters = dict(parameters)
+    for name in ("active", "record"):
+        if name in parameters:
+            if not isinstance(parameters[name], (bool, np.bool_)):
+                raise ValueError(f"Study parameter '{name}' must be a boolean.")
+            parameters[name] = bool(parameters[name])
+    for name in ("start", "stop"):
+        if name in parameters:
+            value = float(parameters[name])
+            if not math.isfinite(value):
+                raise ValueError(f"Study parameter '{name}' must be finite.")
+            parameters[name] = value
+    return parameters
 
 
 def _is_source(item: Any) -> bool:

--- a/gprMax/subgrids/updates.py
+++ b/gprMax/subgrids/updates.py
@@ -44,6 +44,11 @@ def create_updates(model: Model):
             logger.exception(f"{str(sg)} is not a subgrid type")
             raise ValueError
 
+        # The main grid may now have a nonzero hard-source E(0). Seed the
+        # current electric precursor level before hsg_2 first reads it;
+        # the previous (pre-start) level remains zero. The next ordinary
+        # update_electric() then moves this E(0) into its history slot.
+        precursors.update_electric()
         sgu = SubgridUpdater(sg, precursors, model.G)
         updaters.append(sgu)
 

--- a/gprMax/subgrids/user_objects.py
+++ b/gprMax/subgrids/user_objects.py
@@ -37,6 +37,20 @@ from gprMax.user_objects.user_objects import (
 logger = logging.getLogger(__name__)
 
 
+def validate_subgrid_id(identifier):
+    """Require a stable, nonempty name for one HDF5 path component."""
+    if (
+        not isinstance(identifier, str)
+        or not identifier.strip()
+        or identifier in (".", "..")
+        or any(char in identifier for char in ("/", "\\", "\x00"))
+    ):
+        raise ValueError(
+            f"Subgrid ID {identifier!r} must be a nonempty string without path separators "
+            "or NUL, and cannot be '.' or '..'."
+        )
+
+
 class SubGridBase(ModelUserObject):
     """Allows UserObjectMulti and UserObjectGeometry to be nested in SubGrid
     type user objects.
@@ -102,6 +116,9 @@ class SubGridBase(ModelUserObject):
 
     def setup(self, sg: SubGridBaseGrid, model: Model):
         """ "Common setup to both all subgrid types."""
+        validate_subgrid_id(self.kwargs["id"])
+        if any(existing.name == self.kwargs["id"] for existing in model.subgrids):
+            raise ValueError(f"Duplicate subgrid ID {self.kwargs['id']!r} in model")
         p1 = self.kwargs["p1"]
         p2 = self.kwargs["p2"]
 
@@ -175,7 +192,8 @@ class SubGridHSG(SubGridBase):
                 directly, without temporal or spatial interpolation, filtering,
                 or a subgrid-boundary PML. This mode inherits the precision of
                 the main CPU grid.
-        id: string identifier for the sub-grid.
+        id: required nonempty string identifier, unique within the Scene.
+            Path separators, NUL, '.' and '..' are not allowed.
         is_os_sep: int for the number of main grid cells between the Inner
                     Surface and the Outer Surface. Defaults to 3.
         pml_separation: retained for API compatibility, but the HSG formulation

--- a/gprMax/taskfarm.py
+++ b/gprMax/taskfarm.py
@@ -252,9 +252,18 @@ class TaskfarmExecutor(object):
         down = [False] * len(self.workers)
         while True:
             for i, worker in enumerate(self.workers):
-                if self.comm.Iprobe(source=worker, tag=Tags.EXIT):
-                    self.comm.recv(source=worker, tag=Tags.EXIT)
-                    down[i] = True
+                if down[i]:
+                    continue
+                status = MPI.Status()
+                if self.comm.Iprobe(source=worker, tag=MPI.ANY_TAG, status=status):
+                    # Workers send READY before waiting for the next job or
+                    # EXIT. Drain it, and any in-flight DONE after a master
+                    # exception, before accepting the shutdown acknowledgement.
+                    # Do not leave unmatched messages at a collective/restart.
+                    self.comm.recv(source=worker, tag=status.tag)
+                    self.busy[i] = False
+                    if status.tag == Tags.EXIT:
+                        down[i] = True
             if all(down):
                 break
 
@@ -314,6 +323,45 @@ class TaskfarmExecutor(object):
 
         if any(isinstance(result, TaskFailure) for result in results):
             raise TaskfarmError(results)
+        return results
+
+    def run_collective(self, jobs):
+        """Run one batch and join workers, reporting failure on every rank.
+
+        Successful results are returned only on the master. After a failed
+        batch, the master's TaskfarmError retains all results; workers receive
+        the same indexed failure records, with None for successful job results.
+        No communicator abort is used: API callers can catch the exception on
+        all ranks. An uncaught failure therefore cannot leave zero-exit worker
+        ranks masking the master's failure in an MPI launcher's exit status.
+        """
+        results = None
+        failure = None
+        report = None
+        self.start()
+        try:
+            if self.is_master():
+                results = self.submit(jobs)
+        except BaseException as error:
+            failure = error
+            if isinstance(error, TaskfarmError):
+                report = (len(error.results), error.failures, None)
+            else:
+                report = (0, {}, f"{type(error).__name__}: {error}")
+        finally:
+            self.join()
+
+        report = self.comm.bcast(report, root=self.master)
+        if failure is not None:
+            raise failure
+        if report is not None:
+            count, failures, unexpected = report
+            if unexpected is not None:
+                raise RuntimeError(f"Task-farm master failed: {unexpected}")
+            failed_results = [None] * count
+            for index, record in failures.items():
+                failed_results[index] = record
+            raise TaskfarmError(failed_results)
         return results
 
     def __wait(self):

--- a/gprMax/user_objects/cmds_geometry/fractal_box.py
+++ b/gprMax/user_objects/cmds_geometry/fractal_box.py
@@ -213,7 +213,15 @@ class FractalBox(GeometryUserObject):
         )
 
     def build(self, grid: FDTDGrid):
-        if self.do_pre_build:
+        # The two passes belong to a grid build, not to this reusable API
+        # definition's lifetime. A preview, retry, backend change or another
+        # Scene may build the same definition against a fresh grid. Its volume
+        # and material-bin IDs must be registered on that grid before modifiers
+        # run; never rasterise a previous grid's volume during the prepass.
+        prepared_here = any(
+            volume is getattr(self, "volume", None) for volume in grid.fractalvolumes
+        )
+        if self.do_pre_build or not prepared_here:
             self.pre_build(grid)
             self.do_pre_build = False
         else:
@@ -798,10 +806,10 @@ class FractalBox(GeometryUserObject):
 
                 # fractalvolume/mask are only needed to build the voxel data
                 # above (already consumed into grid.solid/rigidE/rigidH/ID) -
-                # nothing later reads them again (generate_fractal_volume()
-                # never reruns for this box: build() only takes this branch
-                # once, and geometry_fixed reuse skips build() entirely on
-                # later runs). Freeing them here matters for multi-scene
+                # nothing later in this grid's solve reads them again. A
+                # fresh grid rebuild prepares a new volume; geometry_fixed
+                # reuse skips geometry construction entirely. Freeing them
+                # here matters for multi-scene
                 # sweeps, where the caller's own scenes list keeps every
                 # Scene - and therefore every FractalBox/FractalVolume -
                 # alive for the whole run; without this, a large fractal

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -3705,8 +3705,15 @@ class Rx(GridUserObject):
         self.point = uip.resolve_inf_point(self.point)
         point_within_grid, discretised_point = uip.check_src_rx_point(self.point, self.params_str())
 
+        build_index = grid.register_receiver(
+            self.id,
+            RxUser.defaultoutputs if self.outputs is None else self.outputs,
+            getattr(self, "_study_id", None),
+        )
         if point_within_grid:
             receiver = self._create_receiver(grid, discretised_point)
+            receiver.build_index = build_index
+            receiver.name_kind = "generated" if self.id is None else "user"
             grid.add_receiver(receiver)
 
             x, y, z = uip.round_to_grid_static_point(self.point)
@@ -3798,17 +3805,13 @@ class RxArray(GridUserObject):
                 f"{self.params_str()} the step size should not be less than the spatial discretisation."
             )
 
-        xs, ys, zs = uip.round_to_grid_static_point(self.lower_point)
-        xf, yf, zf = uip.round_to_grid_static_point(self.upper_point)
-        # Use discretised_dl (already corrected to a minimum of 1 cell on
-        # any axis given dl=0, a common "single row along this axis"
-        # pattern) rather than re-deriving from the raw self.dl, which
-        # still contains the uncorrected 0 - previously caused
-        # np.arange()'s internal division to divide by zero below.
-        # grid.dl is whichever grid this was built against (main grid or a
-        # subgrid, each with their own .dl - see SubGridBase.
-        # set_discretisation()), matching what round_to_grid_static_point()
-        # itself uses internally (self.grid.dl, where uip.grid is grid).
+        # Iterate in the user's coordinate frame, on this grid's lattice.
+        # The checked points above may already be translated to local MPI
+        # or subgrid indices; Rx.build() must apply that translation only once.
+        lower_indices = uip.discretise_static_point(self.lower_point)
+        upper_indices = uip.discretise_static_point(self.upper_point)
+        xs, ys, zs = lower_indices * grid.dl
+        xf, yf, zf = upper_indices * grid.dl
         dx, dy, dz = discretised_dl * grid.dl
 
         logger.info(
@@ -3818,10 +3821,17 @@ class RxArray(GridUserObject):
             f" {dx:g}m, {dy:g}m, {dz:g}m"
         )
 
-        for x in np.arange(xs, xf + grid.dx, dx):
-            for y in np.arange(ys, yf + grid.dy, dy):
-                for z in np.arange(zs, zf + grid.dz, dz):
-                    receiver = Rx((x, y, z))
+        # Integer ranges avoid floating-point stop overshoot, including on
+        # singleton axes. An upper bound not reached by a whole step is not
+        # exceeded; zero steps have already been replaced by one grid cell.
+        x_indices, y_indices, z_indices = (
+            range(int(start), int(stop) + 1, int(step))
+            for start, stop, step in zip(lower_indices, upper_indices, discretised_dl)
+        )
+        for x in x_indices:
+            for y in y_indices:
+                for z in z_indices:
+                    receiver = Rx((x * grid.dx, y * grid.dy, z * grid.dz))
                     receiver.build(grid)
 
 

--- a/gprMax/user_objects/cmds_multiuse.py
+++ b/gprMax/user_objects/cmds_multiuse.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gprMax. If not, see <https://www.gnu.org/licenses/>.
 
-import inspect
 import logging
 import math
 import operator
@@ -199,9 +198,9 @@ class ExcitationFile(GridUserObject):
         Args:
             filepath: Excitation file path.
             kind: Optional interpolation kind passed to
-                scipy.interpolate.interp1d. Default None.
+                scipy.interpolate.interp1d. None selects linear interpolation.
             fill_value: Optional float value or 'extrapolate' passed to
-                scipy.interpolate.interp1d. Default None.
+                scipy.interpolate.interp1d. None selects zero outside the time axis.
         """
         super().__init__(filepath=filepath, kind=kind, fill_value=fill_value)
         self.filepath = filepath
@@ -278,12 +277,15 @@ class ExcitationFile(GridUserObject):
                 )
 
             # Interpolate waveform values
-            if self.kind is None and self.fill_value is None:
-                w.userfunc = interpolate.interp1d(waveformtime, singlewaveformvalues)
-            else:
-                w.userfunc = interpolate.interp1d(
-                    waveformtime, singlewaveformvalues, kind=self.kind, fill_value=self.fill_value
-                )
+            # A sampled excitation is zero outside its supplied time axis,
+            # unless the user explicitly requests a different fill policy.
+            # Half-step current sources can sample beyond the final E sample.
+            w.userfunc = interpolate.interp1d(
+                waveformtime, singlewaveformvalues,
+                kind="linear" if self.kind is None else self.kind,
+                bounds_error=False,
+                fill_value=0.0 if self.fill_value is None else self.fill_value,
+            )
 
             logger.info(
                 self.grid_name(grid) + f"User waveform {w.ID} created using {timestr} and, if "
@@ -457,9 +459,6 @@ class Waveform(GridUserObject):
                     raise ValueError(
                         self.params_str() + " 'user_values' must contain only finite values."
                     )
-                fullargspec = inspect.getfullargspec(interpolate.interp1d)
-                kwargs = dict(zip(reversed(fullargspec.args), reversed(fullargspec.defaults)))
-
                 if "user_time" in self.kwargs:
                     try:
                         waveformtime = np.asarray(self.kwargs["user_time"], dtype=float)
@@ -468,7 +467,7 @@ class Waveform(GridUserObject):
                             self.params_str() + " 'user_time' must be a real numeric array."
                         ) from exc
                 else:
-                    waveformtime = np.arange(0, grid.timewindow + grid.dt, grid.dt)
+                    waveformtime = np.arange(grid.iterations, dtype=np.float64) * grid.dt
 
                 if waveformtime.ndim != 1 or waveformtime.size != uservalues.size:
                     raise ValueError(
@@ -481,13 +480,12 @@ class Waveform(GridUserObject):
                         "increasing values."
                     )
 
-                # Set args for interpolation if given by user
-                if "kind" in self.kwargs:
-                    kwargs["kind"] = self.kwargs["kind"]
-                if "fill_value" in self.kwargs:
-                    kwargs["fill_value"] = self.kwargs["fill_value"]
-
-                w.userfunc = interpolate.interp1d(waveformtime, uservalues, **kwargs)
+                w.userfunc = interpolate.interp1d(
+                    waveformtime, uservalues,
+                    kind="linear" if self.kwargs.get("kind") is None else self.kwargs["kind"],
+                    bounds_error=False,
+                    fill_value=0.0 if self.kwargs.get("fill_value") is None else self.kwargs["fill_value"],
+                )
 
                 logger.info(
                     self.grid_name(grid) + (f"Waveform {w.ID} that is user-defined created.")
@@ -869,13 +867,13 @@ class NetworkTerminal(GridUserObject):
             ) from exc
 
         uip = self._create_uip(grid)
-        self.point = uip.resolve_inf_point(self.point)
+        point = uip.resolve_inf_point(self.point)
         grid.networkterminal_specs[self.ID] = {
             "polarisation": self.polarisation,
             "network_id": self.network_id,
-            "point": tuple(float(value) for value in self.point),
+            "point": tuple(float(value) for value in point),
         }
-        point_within_grid, coord = uip.check_src_rx_point(self.point, self.params_str())
+        point_within_grid, coord = uip.check_src_rx_point(point, self.params_str())
         if not point_within_grid:
             return
         if any(
@@ -888,7 +886,7 @@ class NetworkTerminal(GridUserObject):
 
         terminal = RationalNetworkTerminal(self.ID, model, coord, self.polarisation)
         grid.networkterminals.append(terminal)
-        position = uip.round_to_grid_static_point(self.point)
+        position = uip.round_to_grid_static_point(point)
         logger.info(
             self.grid_name(grid) + f"Network terminal {self.ID!r} using {self.network_id!r}, "
             f"{self.polarisation}-polarised at {position[0]:g}m, "
@@ -1164,7 +1162,7 @@ class VoltageSource(GridUserObject):
         voltage_source.coord = coord
         voltage_source.coordorigin = coord.copy()
         uip = self._create_uip(grid)
-        x, y, z = uip.discretise_static_point(self.point)
+        x, y, z = uip.discretise_static_point(uip.resolve_inf_point(self.point))
         voltage_source.ID = f"{voltage_source.__class__.__name__}({x},{y},{z})"
         voltage_source.study_id = getattr(self, "_study_id", None)
         voltage_source.resistance = self.resistance
@@ -1267,13 +1265,13 @@ class VoltageSource(GridUserObject):
         self._port_output_id = None
         # Check the position of the voltage source
         uip = self._create_uip(grid)
-        self.point = uip.resolve_inf_point(self.point)
-        point_within_grid, discretised_point = uip.check_src_rx_point(self.point, self.params_str())
+        point = uip.resolve_inf_point(self.point)
+        point_within_grid, discretised_point = uip.check_src_rx_point(point, self.params_str())
 
         # Every MPI rank parses the same scene. Reserve the public ID before
         # reducing the point object to its owning rank so automatic IDs remain
         # globally deterministic.
-        global_discretised_point = uip.discretise_static_point(self.point)
+        global_discretised_point = uip.discretise_static_point(point)
         mpi_port_supported = _hard_source_current_loop_available(
             self.polarisation, self.resistance, global_discretised_point
         )
@@ -1310,7 +1308,7 @@ class VoltageSource(GridUserObject):
                         discretised_point,
                         self._port_output_id,
                     )
-            position = uip.round_to_grid_static_point(self.point)
+            position = uip.round_to_grid_static_point(point)
             self._log(grid, voltage_source, *position)
 
 
@@ -1440,7 +1438,7 @@ class HertzianDipole(GridUserObject):
         h.coord = coord
         h.coordorigin = coord
         uip = self._create_uip(grid)
-        x, y, z = uip.discretise_static_point(self.point)
+        x, y, z = uip.discretise_static_point(uip.resolve_inf_point(self.point))
         h.ID = f"{h.__class__.__name__}({x},{y},{z})"
         h.study_id = getattr(self, "_study_id", None)
         h.waveformID = self.waveform_id
@@ -1483,14 +1481,14 @@ class HertzianDipole(GridUserObject):
     def build(self, grid: FDTDGrid):
         # Check the position of the hertzian dipole
         uip = self._create_uip(grid)
-        self.point = uip.resolve_inf_point(self.point)
-        point_within_grid, discretised_point = uip.check_src_rx_point(self.point, self.params_str())
+        point = uip.resolve_inf_point(self.point)
+        point_within_grid, discretised_point = uip.check_src_rx_point(point, self.params_str())
 
         if point_within_grid:
             self._validate_parameters(grid, discretised_point)
             hertzian_dipole = self._create_hertzian_dipole(grid, discretised_point)
             grid.add_source(hertzian_dipole)
-            position = uip.round_to_grid_static_point(self.point)
+            position = uip.round_to_grid_static_point(point)
             self._log(grid, hertzian_dipole, *position)
 
 
@@ -1536,14 +1534,14 @@ class MagneticDipole(GridUserObject):
     def build(self, grid: FDTDGrid):
         # Check the position of the magnetic dipole
         uip = self._create_uip(grid)
-        self.point = uip.resolve_inf_point(self.point)
-        point_within_grid, discretised_point = uip.check_src_rx_point(self.point, self.params_str())
+        point = uip.resolve_inf_point(self.point)
+        point_within_grid, discretised_point = uip.check_src_rx_point(point, self.params_str())
 
         if point_within_grid:
             self._validate_parameters(grid, discretised_point)
             magnetic_dipole = self._create_magnetic_dipole(grid, discretised_point)
             grid.add_source(magnetic_dipole)
-            position = uip.round_to_grid_static_point(self.point)
+            position = uip.round_to_grid_static_point(point)
             self._log(grid, magnetic_dipole, *position)
 
     def _validate_parameters(
@@ -1625,7 +1623,7 @@ class MagneticDipole(GridUserObject):
         m.coord = coord
         m.coordorigin = coord
         uip = self._create_uip(grid)
-        x, y, z = uip.discretise_static_point(self.point)
+        x, y, z = uip.discretise_static_point(uip.resolve_inf_point(self.point))
         m.ID = f"{m.__class__.__name__}({x},{y},{z})"
         m.study_id = getattr(self, "_study_id", None)
         m.waveformID = self.waveform_id
@@ -1705,14 +1703,14 @@ class TransmissionLine(GridUserObject):
     def build(self, grid: FDTDGrid):
         # Check the position of the voltage source
         uip = self._create_uip(grid)
-        self.point = uip.resolve_inf_point(self.point)
-        point_within_grid, discretised_point = uip.check_src_rx_point(self.point, self.params_str())
+        point = uip.resolve_inf_point(self.point)
+        point_within_grid, discretised_point = uip.check_src_rx_point(point, self.params_str())
 
         if point_within_grid:
             self._validate_parameters(grid)
             transmission_line = self._create_transmission_line(grid, discretised_point)
             grid.add_source(transmission_line)
-            position = uip.round_to_grid_static_point(self.point)
+            position = uip.round_to_grid_static_point(point)
             self._log(grid, transmission_line, *position)
 
     def _validate_parameters(self, grid: FDTDGrid):
@@ -1778,7 +1776,7 @@ class TransmissionLine(GridUserObject):
         t.polarisation = self.polarisation
         t.coord = coord
         uip = self._create_uip(grid)
-        x, y, z = uip.discretise_static_point(self.point)
+        x, y, z = uip.discretise_static_point(uip.resolve_inf_point(self.point))
         t.ID = f"{t.__class__.__name__}({x},{y},{z})"
         t.study_id = getattr(self, "_study_id", None)
         t.resistance = self.resistance
@@ -1882,12 +1880,12 @@ class MagneticFrillSource(GridUserObject):
 
     def build(self, grid: FDTDGrid):
         uip = self._create_uip(grid)
-        self.point = uip.resolve_inf_point(self.point)
-        point_within_grid, discretised_point = uip.check_src_rx_point(self.point, self.params_str())
+        point = uip.resolve_inf_point(self.point)
+        point_within_grid, discretised_point = uip.check_src_rx_point(point, self.params_str())
 
         self._validate_parameters(grid)
         if config.sim_config.mpi:
-            global_coord = np.asarray(uip.discretise_static_point(self.point), dtype=np.int32)
+            global_coord = np.asarray(uip.discretise_static_point(point), dtype=np.int32)
             global_index = len(grid.magneticfrill_specs) + 1
             grid.magneticfrill_specs.append(
                 {
@@ -1903,12 +1901,12 @@ class MagneticFrillSource(GridUserObject):
             frill_source.mpi_primary = bool(point_within_grid)
             grid.add_source(frill_source)
             if point_within_grid:
-                position = uip.round_to_grid_static_point(self.point)
+                position = uip.round_to_grid_static_point(point)
                 self._log(grid, frill_source, *position)
         elif point_within_grid:
             frill_source = self._create_magnetic_frill_source(grid, discretised_point)
             grid.add_source(frill_source)
-            position = uip.round_to_grid_static_point(self.point)
+            position = uip.round_to_grid_static_point(point)
             self._log(grid, frill_source, *position)
 
     def _validate_parameters(self, grid: FDTDGrid):
@@ -1960,7 +1958,7 @@ class MagneticFrillSource(GridUserObject):
         f.polarisation = self.polarisation
         f.coord = coord
         uip = self._create_uip(grid)
-        x, y, z = uip.discretise_static_point(self.point)
+        x, y, z = uip.discretise_static_point(uip.resolve_inf_point(self.point))
         f.ID = f"{f.__class__.__name__}({x},{y},{z})"
         f.study_id = getattr(self, "_study_id", None)
         f.Z0 = self.zcoax
@@ -3668,23 +3666,20 @@ class Rx(GridUserObject):
 
         if self.id is None:
             uip = self._create_uip(grid)
-            x, y, z = uip.discretise_static_point(self.point)
+            x, y, z = uip.discretise_static_point(uip.resolve_inf_point(self.point))
             r.ID = f"{r.__class__.__name__}({x},{y},{z})"
         else:
             r.ID = self.id
         r.study_id = getattr(self, "_study_id", None)
 
-        if self.outputs is None:
-            self.outputs = RxUser.defaultoutputs
-
-        self.outputs.sort()
+        outputs = sorted(RxUser.defaultoutputs if self.outputs is None else self.outputs)
         # Get allowable outputs
         if config.sim_config.general["solver"] in ["cuda", "opencl", "metal"]:
             allowableoutputs = RxUser.allowableoutputs_dev
         else:
             allowableoutputs = RxUser.allowableoutputs
         # Check and add field output names
-        for field in self.outputs:
+        for field in outputs:
             if field in allowableoutputs:
                 r.outputs[field] = np.zeros(
                     grid.iterations, dtype=config.sim_config.dtypes["float_or_double"]
@@ -3702,8 +3697,10 @@ class Rx(GridUserObject):
     def build(self, grid: FDTDGrid):
         # Check position of the receiver
         uip = self._create_uip(grid)
-        self.point = uip.resolve_inf_point(self.point)
-        point_within_grid, discretised_point = uip.check_src_rx_point(self.point, self.params_str())
+        # Keep symbolic coordinates in the reusable declaration. The active
+        # plane/domain edge is a property of this build, not of the object.
+        point = uip.resolve_inf_point(self.point)
+        point_within_grid, discretised_point = uip.check_src_rx_point(point, self.params_str())
 
         build_index = grid.register_receiver(
             self.id,
@@ -3716,7 +3713,7 @@ class Rx(GridUserObject):
             receiver.name_kind = "generated" if self.id is None else "user"
             grid.add_receiver(receiver)
 
-            x, y, z = uip.round_to_grid_static_point(self.point)
+            x, y, z = uip.round_to_grid_static_point(point)
             logger.info(
                 f"{self.grid_name(grid)}Receiver at {x:g}m,"
                 f" {y:g}m, {z:g}m with output component(s)"

--- a/gprMax/user_objects/cmds_output.py
+++ b/gprMax/user_objects/cmds_output.py
@@ -506,10 +506,10 @@ class Snapshot(OutputUserObject):
 
     def build(self, model: Model, grid: FDTDGrid):
         uip = self._create_uip(grid)
-        self.lower_bound = uip.resolve_inf_point(self.lower_bound, role="lower")
-        self.upper_bound = uip.resolve_inf_point(self.upper_bound, role="upper")
+        lower_bound = uip.resolve_inf_point(self.lower_bound, role="lower")
+        upper_bound = uip.resolve_inf_point(self.upper_bound, role="upper")
         discretised_lower_bound, discretised_upper_bound = uip.check_output_object_bounds(
-            self.lower_bound, self.upper_bound, self.params_str()
+            lower_bound, upper_bound, self.params_str()
         )
         geometry = mode2d_geometry(config.get_model_config().mode)
         if geometry is not None:
@@ -768,9 +768,9 @@ class NTFFSurface(OutputUserObject):
             raise ValueError(f"{self.params_str()} must leave at least one active NTFF face")
         self.omit_faces = tuple(face for face in valid_faces if face in self.omit_faces)
         uip = self._create_uip(grid)
-        self.lower_bound = uip.resolve_inf_point(self.lower_bound, role="lower")
-        self.upper_bound = uip.resolve_inf_point(self.upper_bound, role="upper")
-        lower, upper = uip.check_output_object_bounds(self.lower_bound, self.upper_bound, self.params_str())
+        lower_bound = uip.resolve_inf_point(self.lower_bound, role="lower")
+        upper_bound = uip.resolve_inf_point(self.upper_bound, role="upper")
+        lower, upper = uip.check_output_object_bounds(lower_bound, upper_bound, self.params_str())
         # Main-grid user coordinates are translated into each rank's local
         # frame during MPI parsing. NTFF surfaces are global objects which
         # are partitioned only after the Yee grid has been built, so retain
@@ -793,7 +793,7 @@ class NTFFSurface(OutputUserObject):
         )
         logger.info(
             f"{self.grid_name(grid)}NTFF integration surface {self.ID!r} from "
-            f"{tuple(self.lower_bound)}m to {tuple(self.upper_bound)}m registered"
+            f"{tuple(lower_bound)}m to {tuple(upper_bound)}m registered"
             + (
                 "."
                 if not self.omit_faces
@@ -1886,10 +1886,10 @@ class GeometryView(OutputUserObject):
 
     def build(self, model: Model, grid: FDTDGrid):
         uip = self._create_uip(grid)
-        self.lower_bound = uip.resolve_inf_point(self.lower_bound, role="lower")
-        self.upper_bound = uip.resolve_inf_point(self.upper_bound, role="upper")
+        lower_bound = uip.resolve_inf_point(self.lower_bound, role="lower")
+        upper_bound = uip.resolve_inf_point(self.upper_bound, role="upper")
         discretised_lower_bound, discretised_upper_bound = uip.check_output_object_bounds(
-            self.lower_bound, self.upper_bound, self.params_str()
+            lower_bound, upper_bound, self.params_str()
         )
         discretised_dl = uip.discretise_static_point(self.dl)
 
@@ -1926,8 +1926,8 @@ class GeometryView(OutputUserObject):
             raise ValueError(f"{self.params_str()} requires type to be either n (normal) or f (fine).")
 
         if g is not None:
-            p1 = uip.round_to_grid_static_point(self.lower_bound)
-            p2 = uip.round_to_grid_static_point(self.upper_bound)
+            p1 = uip.round_to_grid_static_point(lower_bound)
+            p2 = uip.round_to_grid_static_point(upper_bound)
             dl = discretised_dl * grid.dl
 
             logger.info(
@@ -1971,18 +1971,18 @@ class GeometryObjectsWrite(OutputUserObject):
             raise ValueError(f"{self.params_str()} do not add geometry objects to subgrids.")
 
         uip = self._create_uip(grid)
-        self.lower_bound = uip.resolve_inf_point(self.lower_bound, role="lower")
-        self.upper_bound = uip.resolve_inf_point(self.upper_bound, role="upper")
+        lower_bound = uip.resolve_inf_point(self.lower_bound, role="lower")
+        upper_bound = uip.resolve_inf_point(self.upper_bound, role="upper")
 
         discretised_lower_bound, discretised_upper_bound = uip.check_output_object_bounds(
-            self.lower_bound, self.upper_bound, self.params_str()
+            lower_bound, upper_bound, self.params_str()
         )
 
         g = model.add_geometry_object(grid, discretised_lower_bound, discretised_upper_bound, self.basefilename)
 
         if g is not None:
-            p1 = uip.round_to_grid_static_point(self.lower_bound)
-            p2 = uip.round_to_grid_static_point(self.upper_bound)
+            p1 = uip.round_to_grid_static_point(lower_bound)
+            p2 = uip.round_to_grid_static_point(upper_bound)
 
             logger.info(
                 f"Geometry objects in the volume from {p1[0]:g}m,"

--- a/gprMax/user_objects/cmds_singleuse.py
+++ b/gprMax/user_objects/cmds_singleuse.py
@@ -890,7 +890,9 @@ class OutputDir(ModelUserObject):
     """Set the directory where output file(s) will be stored.
 
     Attributes:
-        output_dir (str): File path to directory.
+        output_dir (str): File path to directory. Relative Python API paths
+            are resolved against the working directory at build time. Hash
+            commands resolve them against the top-level input file instead.
     """
 
     @property

--- a/gprMax/user_objects/user_objects.py
+++ b/gprMax/user_objects/user_objects.py
@@ -60,7 +60,11 @@ class UserObject(ABC):
         return self.order < obj.order
 
     def __str__(self) -> str:
-        """Readable user object as per hash commands."""
+        """Readable hash-style diagnostic, not a general input-file serializer.
+
+        Omitted optional fields need not round-trip through the positional
+        hash grammar. Use the documented hash syntax to author input files.
+        """
         args: List[str] = []
         for value in self.kwargs.values():
             if isinstance(value, (tuple, list)):

--- a/reframe_tests/tests/regression_checks.py
+++ b/reframe_tests/tests/regression_checks.py
@@ -20,9 +20,12 @@ from pathlib import Path
 from shutil import copyfile
 from typing import Literal, Optional, Union
 
+import h5py
 import reframe.utility.sanity as sn
 from reframe.core.runtime import runtime
 from reframe.utility import osext
+
+from toolboxes.Utilities.receiver_identity import match_receiver, receiver_catalogue, select_receiver
 
 
 class RegressionCheck:
@@ -42,6 +45,7 @@ class RegressionCheck:
         self.reference_file = Path(reference_file)
         self.cmd = "diff"
         self.options: list[str] = []
+        self.objects: list[str] = []
 
     @property
     def error_msg(self) -> str:
@@ -93,19 +97,28 @@ class RegressionCheck:
                 *self.options,
                 str(self.output_file.absolute()),
                 str(self.reference_file),
+                *self.objects,
             ]
         )
 
-        return sn.assert_true(
-            sn.path_isfile(self.output_file),
-            f"Expected output file '{self.output_file}' does not exist",
-        ) and sn.assert_false(
-            completed_process.stdout,
-            (
-                f"{self.error_msg}\n"
-                f"For more details run: '{' '.join(completed_process.args)}'\n"
-                f"To re-create regression file, delete '{self.reference_file}' and rerun the test."
-            ),
+        return (
+            sn.assert_true(
+                sn.path_isfile(self.output_file),
+                f"Expected output file '{self.output_file}' does not exist",
+            )
+            and sn.assert_eq(
+                completed_process.returncode,
+                0,
+                f"{self.error_msg}\n{completed_process.stdout}\n{completed_process.stderr}",
+            )
+            and sn.assert_false(
+                completed_process.stdout,
+                (
+                    f"{self.error_msg}\n"
+                    f"For more details run: '{' '.join(completed_process.args)}'\n"
+                    f"To re-create regression file, delete '{self.reference_file}' and rerun the test."
+                ),
+            )
         )
 
 
@@ -152,9 +165,23 @@ class ReceiverRegressionCheck(H5RegressionCheck):
         self.output_receiver = output_receiver
         self.reference_receiver = reference_receiver
 
-        self.options.append(f"rxs/{self.output_receiver}")
-        if self.reference_receiver is not None:
-            self.options.append(f"rxs/{self.reference_receiver}")
+    def run(self) -> Literal[True]:
+        # Resolve only after the simulation has written the output. Explicit
+        # reference selections still permit intentional different-point checks.
+        with h5py.File(self.output_file) as output, h5py.File(self.reference_file) as reference:
+            selected = select_receiver(receiver_catalogue(output), self.output_receiver)
+            candidates = receiver_catalogue(reference)
+            counterpart = (
+                match_receiver(selected, candidates)
+                if self.reference_receiver is None
+                else select_receiver(candidates, self.reference_receiver)
+            )
+        original = self.objects
+        self.objects = [selected.path, counterpart.path]
+        try:
+            return super().run()
+        finally:
+            self.objects = original
 
     @property
     def error_msg(self) -> str:

--- a/reframe_tests/utilities/data.py
+++ b/reframe_tests/utilities/data.py
@@ -23,6 +23,7 @@ import numpy as np
 import numpy.typing as npt
 
 from gprMax.utilities.logging import logging_config
+from toolboxes.Utilities.receiver_identity import receiver_catalogue, select_receiver
 
 logger = logging.getLogger(__name__)
 logging_config(name=__name__)
@@ -31,12 +32,13 @@ logging_config(name=__name__)
 FIELD_COMPONENTS_BASE_PATH = "/rxs/rx1/"
 
 
-def get_data_from_h5_file(h5_filepath: str) -> Tuple[npt.NDArray, npt.NDArray]:
+def get_data_from_h5_file(h5_filepath: str, receiver="rx1") -> Tuple[npt.NDArray, npt.NDArray]:
     with h5py.File(h5_filepath, "r") as h5_file:
+        receiver_path = select_receiver(receiver_catalogue(h5_file), receiver).path + "/"
         # Get available field output component names and datatype
-        field_components = list(h5_file[FIELD_COMPONENTS_BASE_PATH].keys())
-        dtype = h5_file[FIELD_COMPONENTS_BASE_PATH + field_components[0]].dtype
-        shape = h5_file[FIELD_COMPONENTS_BASE_PATH + str(field_components[0])].shape
+        field_components = list(h5_file[receiver_path].keys())
+        dtype = h5_file[receiver_path + field_components[0]].dtype
+        shape = h5_file[receiver_path + str(field_components[0])].shape
 
         # Arrays for storing field data
         if len(shape) == 1:
@@ -46,7 +48,7 @@ def get_data_from_h5_file(h5_filepath: str) -> Tuple[npt.NDArray, npt.NDArray]:
                 (h5_file.attrs["Iterations"], len(field_components), shape[1]), dtype=dtype
             )
         for index, field_component in enumerate(field_components):
-            data[:, index] = h5_file[FIELD_COMPONENTS_BASE_PATH + str(field_component)]
+            data[:, index] = h5_file[receiver_path + str(field_component)]
             if np.any(np.isnan(data[:, index])):
                 logger.exception("Data contains NaNs")
                 raise ValueError

--- a/reframe_tests/utilities/plotting.py
+++ b/reframe_tests/utilities/plotting.py
@@ -21,6 +21,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from reframe_tests.utilities.data import calculate_diffs, get_data_from_h5_file
+from toolboxes.Utilities.receiver_identity import matching_receiver_path
 
 
 def _plot_data(subplots, time, data, label=None, colour="r", line_style="-"):
@@ -119,7 +120,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     input_time, input_data = get_data_from_h5_file(args.input_file)
-    ref_time, ref_data = get_data_from_h5_file(args.reference_file)
+    reference_receiver = matching_receiver_path(args.input_file, "/rxs/rx1", args.reference_file)
+    ref_time, ref_data = get_data_from_h5_file(args.reference_file, receiver=reference_receiver)
 
     figure = plot_dataset_comparison(input_time, input_data, ref_time, ref_data, args.model_name)
     figure.tight_layout(h_pad=3, w_pad=4, pad=2)

--- a/testing/diff_output_files.py
+++ b/testing/diff_output_files.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import h5py
 import numpy as np
+from toolboxes.Utilities.receiver_identity import matching_receiver_path
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +37,7 @@ def diff_output_files(filename1, filename2):
         datadiffs: numpy array containing power (dB) of differences.
     """
 
+    reference_path = matching_receiver_path(filename1, "/rxs/rx1", filename2) + "/"
     file1 = h5py.File(Path(filename1), "r")
     file2 = h5py.File(Path(filename2), "r")
     # Path to receivers in files
@@ -43,18 +45,18 @@ def diff_output_files(filename1, filename2):
 
     # Get available field output component names
     outputs1 = list(file1[path].keys())
-    outputs2 = list(file2[path].keys())
+    outputs2 = list(file2[reference_path].keys())
     if outputs1 != outputs2:
         logger.exception("Field output components are not the same in each file")
         raise ValueError
 
     # Check that type of float used to store fields matches
     floattype1 = file1[path + outputs1[0]].dtype
-    floattype2 = file2[path + outputs2[0]].dtype
+    floattype2 = file2[reference_path + outputs2[0]].dtype
     if floattype1 != floattype2:
         logger.warning(
             f"Type of floating point number in test model ({file1[path + outputs1[0]].dtype}) "
-            f"does not match type in reference solution ({file2[path + outputs2[0]].dtype})\n"
+            f"does not match type in reference solution ({file2[reference_path + outputs2[0]].dtype})\n"
         )
 
     # Arrays for storing time
@@ -68,7 +70,7 @@ def diff_output_files(filename1, filename2):
     data2 = np.zeros((file2.attrs["Iterations"], len(outputs2)), dtype=floattype2)
     for ID, name in enumerate(outputs1):
         data1[:, ID] = file1[path + str(name)][:]
-        data2[:, ID] = file2[path + str(name)][:]
+        data2[:, ID] = file2[reference_path + str(name)][:]
         if np.any(np.isnan(data1[:, ID])) or np.any(np.isnan(data2[:, ID])):
             logger.exception("Data contains NaNs")
             raise ValueError

--- a/testing/test_models.py
+++ b/testing/test_models.py
@@ -27,6 +27,7 @@ from colorama import Fore, Style
 import gprMax
 from gprMax.utilities.logging import logging_config
 from testing.analytical_solutions import hertzian_dipole_fs
+from toolboxes.Utilities.receiver_identity import match_receiver, receiver_catalogue, select_receiver
 
 logger = logging.getLogger(__name__)
 
@@ -139,14 +140,17 @@ def main():
             testresults[model]["Test version"] = filetest.attrs["gprMax"]
 
             # Get available field output component names
-            outputsref = list(fileref[path].keys())
+            reference_path = (
+                match_receiver(select_receiver(receiver_catalogue(filetest), 1), receiver_catalogue(fileref)).path + "/"
+            )
+            outputsref = list(fileref[reference_path].keys())
             outputstest = list(filetest[path].keys())
             if outputsref != outputstest:
                 logger.exception("Field output components do not match reference solution")
                 raise ValueError
 
             # Check that type of float used to store fields matches
-            float_or_doubleref = fileref[path + outputsref[0]].dtype
+            float_or_doubleref = fileref[reference_path + outputsref[0]].dtype
             float_or_doubletest = filetest[path + outputstest[0]].dtype
             if float_or_doubleref != float_or_doubletest:
                 logger.warning(
@@ -181,7 +185,7 @@ def main():
                 (filetest.attrs["Iterations"], len(outputstest)), dtype=float_or_doubletest
             )
             for ID, name in enumerate(outputsref):
-                dataref[:, ID] = fileref[path + str(name)][:]
+                dataref[:, ID] = fileref[reference_path + str(name)][:]
                 datatest[:, ID] = filetest[path + str(name)][:]
                 if np.any(np.isnan(datatest[:, ID])):
                     logger.exception("Test data contains NaNs")

--- a/tests/cmds_multiuse/test_rx_array_bounds.py
+++ b/tests/cmds_multiuse/test_rx_array_bounds.py
@@ -1,0 +1,222 @@
+# Copyright (C) 2015-2026: The University of Edinburgh, United Kingdom
+#
+# This file is part of the gprMax source code base.
+#
+# gprMax is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gprMax is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gprMax. If not, see <https://www.gnu.org/licenses/>.
+
+"""Receiver arrays must stay within their snapped, inclusive grid bounds."""
+
+from itertools import product
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+from gprMax.model import Model
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def built_model(monkeypatch):
+    captured = {}
+    original = Model.build
+
+    def capture(model):
+        result = original(model)
+        captured["grid"] = model.G
+        captured["subgrids"] = list(model.subgrids)
+        return result
+
+    monkeypatch.setattr(Model, "build", capture)
+    return captured
+
+
+def _scene(dl, domain):
+    scene = gprMax.Scene()
+    scene.add(gprMax.Discretisation(p1=dl))
+    scene.add(gprMax.Domain(p1=domain))
+    scene.add(gprMax.PMLThickness(thickness=0))
+    scene.add(gprMax.OMPThreads(1))
+    scene.add(gprMax.TimeWindow(iterations=1))
+    return scene
+
+
+def _build(scene, built_model, tmp_path, **kwargs):
+    gprMax.run(
+        scenes=[scene],
+        geometry_only=True,
+        outputfile=tmp_path / "array",
+        hide_progress_bars=True,
+        **kwargs,
+    )
+    return built_model["grid"]
+
+
+@pytest.mark.parametrize("spacing", (0.001, 0.002, 0.0025, 0.005))
+@pytest.mark.parametrize("zero_step", (True, False))
+def test_documented_line_has_no_extra_rows(built_model, tmp_path, spacing, zero_step):
+    scene = _scene((spacing,) * 3, (0.15, 0.12, 0.10))
+    transverse_step = 0 if zero_step else spacing
+    scene.add(
+        gprMax.RxArray(
+            p1=(0.02, 0.10, 0.05),
+            p2=(0.12, 0.10, 0.05),
+            dl=(0.01, transverse_step, transverse_step),
+        )
+    )
+    grid = _build(scene, built_model, tmp_path)
+    expected = [(x / 100, 0.10, 0.05) for x in range(2, 13)]
+    np.testing.assert_allclose([rx.coord * grid.dl for rx in grid.rxs], expected, rtol=0, atol=1e-15)
+
+
+@pytest.mark.parametrize("boundary_axis", range(3))
+def test_array_on_far_domain_face_does_not_step_outside(built_model, tmp_path, boundary_axis):
+    domain = np.full(3, 0.08)
+    domain[boundary_axis] = 0.07
+    lower = np.full(3, 0.03)
+    lower[boundary_axis] = 0.07
+    upper = lower.copy()
+    varying_axis = (boundary_axis + 1) % 3
+    upper[varying_axis] = 0.07
+    step = np.zeros(3)
+    step[varying_axis] = 0.01
+    scene = _scene((0.002,) * 3, tuple(domain))
+    scene.add(gprMax.RxArray(p1=tuple(lower), p2=tuple(upper), dl=tuple(step)))
+    grid = _build(scene, built_model, tmp_path)
+    expected = np.tile(np.rint(lower / grid.dl).astype(int), (5, 1))
+    expected[:, varying_axis] = (15, 20, 25, 30, 35)
+    np.testing.assert_array_equal([rx.coord for rx in grid.rxs], expected)
+
+
+@pytest.mark.parametrize(
+    "dl,lower,upper,step,expected_axes",
+    [
+        pytest.param(
+            (0.001,) * 3,
+            (0.011,) * 3,
+            (0.011,) * 3,
+            (0,) * 3,
+            ([11], [11], [11]),
+            id="singleton",
+        ),
+        pytest.param(
+            (0.001,) * 3,
+            (0.011,) * 3,
+            (0.013,) * 3,
+            (0,) * 3,
+            ([11, 12, 13],) * 3,
+            id="zero-step-means-one-cell",
+        ),
+        pytest.param(
+            (0.001,) * 3,
+            (0.002,) * 3,
+            (0.010,) * 3,
+            (0.003,) * 3,
+            ([2, 5, 8],) * 3,
+            id="non-divisible-volume",
+        ),
+        pytest.param(
+            (0.001,) * 3,
+            (0.011,) * 3,
+            (0.013,) * 3,
+            (0.003,) * 3,
+            ([11],) * 3,
+            id="step-larger-than-extent",
+        ),
+        pytest.param(
+            (0.001, 0.002, 0.005),
+            (0.0106, 0.0211, 0.051),
+            (0.0164, 0.0291, 0.059),
+            (0.0016, 0.0051, 0.014),
+            ([11, 13, 15], [11, 14], [10]),
+            id="anisotropic-snapped-bounds-and-steps",
+        ),
+    ],
+)
+def test_cartesian_array_uses_bounded_integer_steps(built_model, tmp_path, dl, lower, upper, step, expected_axes):
+    scene = _scene(dl, (0.03, 0.04, 0.08))
+    scene.add(gprMax.RxArray(p1=lower, p2=upper, dl=step))
+    grid = _build(scene, built_model, tmp_path)
+    # Assert every coordinate in x/y/z nesting order, not just the count.
+    np.testing.assert_array_equal([rx.coord for rx in grid.rxs], list(product(*expected_axes)))
+
+
+@pytest.mark.parametrize("family", ("TM", "TE"))
+@pytest.mark.parametrize("invariant_axis", range(3))
+def test_reduced_array_preserves_single_live_layer(built_model, tmp_path, family, invariant_axis):
+    domain = np.full(3, 0.08)
+    domain[invariant_axis] = float("inf")
+    lower = np.full(3, 0.03)
+    lower[invariant_axis] = float("inf")
+    upper = lower.copy()
+    varying_axis = (invariant_axis + 1) % 3
+    upper[varying_axis] = 0.07
+    step = np.zeros(3)
+    step[varying_axis] = 0.01
+    scene = _scene((0.001,) * 3, tuple(domain))
+    scene.add(gprMax.DomainMode(mode=family))
+    scene.add(gprMax.RxArray(p1=tuple(lower), p2=tuple(upper), dl=tuple(step)))
+    grid = _build(scene, built_model, tmp_path)
+    expected = np.full((5, 3), 30)
+    expected[:, invariant_axis] = 1 if family == "TE" else 0
+    expected[:, varying_axis] = (30, 40, 50, 60, 70)
+    np.testing.assert_array_equal([rx.coord for rx in grid.rxs], expected)
+
+
+@pytest.mark.parametrize("autotranslate", (True, False))
+def test_off_origin_subgrid_uses_fine_grid_and_correct_coordinate_frame(built_model, tmp_path, autotranslate):
+    scene = _scene((0.003,) * 3, (0.09,) * 3)
+    fine = gprMax.SubGridHSG(p1=(0.03,) * 3, p2=(0.06,) * 3, ratio=3, id="fine")
+    fine.add(gprMax.RxArray(p1=(0.041, 0.05, 0.05), p2=(0.048, 0.05, 0.05), dl=(0.002, 0, 0)))
+    scene.add(fine)
+    _build(scene, built_model, tmp_path, subgrid=True, autotranslate=autotranslate)
+    grid = built_model["subgrids"][0]
+    expected = np.array([(x, 50, 50) for x in (41, 43, 45, 47)])
+    if autotranslate:
+        expected += np.array((grid.n_boundary_cells_x, grid.n_boundary_cells_y, grid.n_boundary_cells_z)) - 30
+    np.testing.assert_array_equal([rx.coord for rx in grid.rxs], expected)
+    np.testing.assert_allclose(grid.dl, (0.001,) * 3, rtol=0, atol=1e-15)
+    assert [rx.build_index for rx in grid.rxs] == list(range(4))
+
+
+@pytest.mark.parametrize("precision", ("single", "double"))
+@pytest.mark.parametrize("on_edge", (False, True))
+def test_hash_array_writes_only_requested_receivers(built_model, tmp_path, precision, on_edge):
+    if on_edge:
+        domain = "0.160 0.070 0.002"
+        array = "0.030 0.070 0 0.140 0.070 0 0.010 0 0"
+        expected = [(i * 0.002, 0.070, 0) for i in range(15, 71, 5)]
+    else:
+        domain = "0.240 0.060 0.002"
+        array = "0.014 0.030 0 0.214 0.030 0 0.020 0.002 0.002"
+        expected = [(i * 0.002, 0.030, 0) for i in range(7, 108, 10)]
+    path = tmp_path / "array.in"
+    path.write_text(
+        f"#domain: {domain}\n"
+        "#dx_dy_dz: 0.002 0.002 0.002\n"
+        "#time_window: 2e-10\n"
+        "#pml_cells: 0\n"
+        "#num_threads: 1\n"
+        "#waveform: ricker 1 3e9 w\n"
+        "#hertzian_dipole: z 0.020 0.030 0 w\n"
+        f"#rx_array: {array}\n"
+    )
+    gprMax.run(inputfile=path, cpu_precision=precision, hide_progress_bars=True)
+    grid = built_model["grid"]
+    np.testing.assert_allclose([rx.coord * grid.dl for rx in grid.rxs], expected, rtol=0, atol=1e-15)
+    with h5py.File(path.with_suffix(".h5"), "r") as output:
+        positions = [output[f"rxs/rx{i+1}"].attrs["Position"] for i in range(len(expected))]
+        np.testing.assert_allclose(positions, expected, rtol=0, atol=1e-15)

--- a/tests/config/test_subgrid_preflight.py
+++ b/tests/config/test_subgrid_preflight.py
@@ -1,0 +1,48 @@
+"""Reject contradictory or ambiguous subgrid declarations before any build/device work."""
+import pytest
+
+import gprMax
+from gprMax import config
+
+pytestmark = pytest.mark.unit
+
+
+def scene_with(*identifiers, ratio=1):
+    scene = gprMax.Scene()
+    for identifier in identifiers:
+        scene.add(gprMax.SubGridHSG(p1=(0.02,) * 3, p2=(0.04,) * 3, ratio=ratio, id=identifier))
+    return scene
+
+
+@pytest.mark.parametrize("backend", [{}, {"gpu": [0]}, {"opencl": [0]}, {"metal": [0]}, {"mpi": [1, 1, 1]}])
+@pytest.mark.parametrize("ratio", [1, 3])
+def test_subgrid_flag_required_before_hardware_discovery(make_args, monkeypatch, backend, ratio):
+    def unexpected():
+        pytest.fail("Preflight must run before hardware discovery")
+
+    monkeypatch.setattr(config, "get_host_info", unexpected)
+    args = make_args(scenes=[scene_with("fine", ratio=ratio)], **backend)
+    with pytest.raises(ValueError, match="subgrid=True"):
+        config.SimulationConfig(args)
+
+
+@pytest.mark.parametrize("identifier", ["", " ", ".", "..", "a/b", "a\\b", "a\x00b", None, 1])
+def test_invalid_subgrid_identifier_rejected(make_args, identifier):
+    with pytest.raises(ValueError, match="Subgrid ID"):
+        config.SimulationConfig(make_args(scenes=[scene_with(identifier)], subgrid=True))
+
+
+def test_duplicate_ids_rejected_before_build(make_args):
+    with pytest.raises(ValueError, match="Duplicate subgrid ID 'fine'"):
+        config.SimulationConfig(make_args(scenes=[scene_with("fine", "fine")], subgrid=True))
+
+
+def test_ids_may_repeat_in_independent_scenes(make_sim_config):
+    cfg = make_sim_config(scenes=[scene_with("fine"), scene_with("fine")], n=2, subgrid=True)
+    assert cfg.general["subgrid"] is True
+
+
+@pytest.mark.parametrize("backend", [{"gpu": [0]}, {"opencl": [0]}, {"metal": [0]}, {"mpi": [1, 1, 1]}])
+def test_enabled_subgrid_still_rejects_incompatible_backend(make_sim_config, backend):
+    with pytest.raises(ValueError):
+        make_sim_config(scenes=[scene_with("fine")], subgrid=True, **backend)

--- a/tests/grid/test_mpi_release_regressions.py
+++ b/tests/grid/test_mpi_release_regressions.py
@@ -139,13 +139,31 @@ def test_mpi_errors_return_nonzero(tmp_path):
     assert not (tmp_path / "bad.h5").exists()
 
 
-def test_taskfarm_finishes_good_jobs_but_reports_failed_jobs(tmp_path):
+@pytest.mark.parametrize("repeat", range(3))
+def test_taskfarm_finishes_good_jobs_but_reports_failed_jobs(tmp_path, repeat):
     result = _run("taskfarm", tmp_path / "farm")
     assert result.returncode != 0
     assert "1 task-farm job(s) failed: job 1" in result.stdout + result.stderr
     assert "missing_waveform" in result.stdout + result.stderr
     assert not (tmp_path / "farm1.h5").exists()
     assert (tmp_path / "farm2.h5").is_file()
+
+
+@pytest.mark.parametrize("result_kind", ["success", "failure", "caught"])
+def test_taskfarm_collective_completion_and_catchable_errors(tmp_path, result_kind):
+    result = _run("taskfarm", tmp_path / "farm", farm_result=result_kind)
+    if result_kind == "failure":
+        assert result.returncode != 0
+        assert "2 task-farm job(s) failed" in result.stdout + result.stderr
+        assert not list(tmp_path.glob("farm*.h5"))
+    else:
+        assert result.returncode == 0, result.stdout + result.stderr
+        if result_kind == "success":
+            _success(result)
+            assert all((tmp_path / f"farm{index}.h5").is_file() for index in (1, 2))
+        else:
+            assert all((tmp_path / f"caught_rank{rank}.txt").is_file() for rank in range(3))
+            assert (tmp_path / "farm2.h5").is_file()
 
 
 @pytest.mark.parametrize("averaging", ("y", "n"))
@@ -236,7 +254,23 @@ def _worker(args):
         good.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=6e9, id="pulse"))
         good.add(gprMax.HertzianDipole(p1=(0.010,) * 3, polarisation="z", waveform_id="pulse"))
         good.add(gprMax.Rx(p1=(0.012,) * 3))
-        gprMax.run(scenes=[scene, good], n=2, taskfarm=True, **options)
+        models = [good, good] if args.farm_result == "success" else [scene, scene] if args.farm_result == "failure" else [scene, good]
+        if args.farm_result == "caught":
+            from gprMax.taskfarm import TaskfarmError
+            from mpi4py import MPI
+
+            try:
+                gprMax.run(scenes=models, n=2, taskfarm=True, **options)
+            except TaskfarmError as error:
+                assert set(error.failures) == {0}
+                # The communicator remains usable and the exception is
+                # catchable on every rank; no implicit MPI.Abort is needed.
+                MPI.COMM_WORLD.Barrier()
+                (output.parent / f"caught_rank{MPI.COMM_WORLD.rank}.txt").write_text(str(error))
+            else:
+                raise AssertionError("Every rank must receive the failed-batch exception")
+        else:
+            gprMax.run(scenes=models, n=2, taskfarm=True, **options)
         return
     if args.case == "scan":
         position = np.array([0.012] * 3)
@@ -336,4 +370,5 @@ if __name__ == "__main__":
     parser.add_argument("--kind", default="hertzian")
     parser.add_argument("--restart", type=int, default=1)
     parser.add_argument("--averaging", default="y")
+    parser.add_argument("--farm-result", default="mixed", choices=("mixed", "success", "failure", "caught"))
     _worker(parser.parse_args())

--- a/tests/hash_cmds/test_hash_cmds_file.py
+++ b/tests/hash_cmds/test_hash_cmds_file.py
@@ -200,7 +200,7 @@ class TestProcessIncludeFiles:
         monkeypatch.setattr(config, "sim_config", SimpleNamespace(input_file_path=tmp_path / "model/main.in"))
         with pytest.raises(FileNotFoundError) as error:
             process_include_files(["#include_file: extra.in\n"])
-        assert str(tmp_path / "model" / "extra.in") in str(error.value)
+        assert Path(error.value.filename) == tmp_path / "model" / "extra.in"
 
     @pytest.mark.parametrize("symlink", [False, True])
     def test_include_cycles_are_rejected_with_chain(self, tmp_path, monkeypatch, symlink):

--- a/tests/hash_cmds/test_hash_cmds_file.py
+++ b/tests/hash_cmds/test_hash_cmds_file.py
@@ -26,9 +26,8 @@ Coverage targets:
 * ``process_python_include_code`` — strips comments and blank lines,
   executes any ``#python:`` blocks and captures the commands they ``print``,
   preserves regular hash lines, then re-runs include-file resolution.
-* ``process_include_files`` — replaces ``#include_file: path`` lines with
-  the contents of the named file; falls back to ``input_file_path.parent``
-  if the path isn't absolute and doesn't exist relative to CWD.
+* ``process_include_files`` — recursively expands includes relative to their
+  containing files, independently of the working directory.
 * ``check_cmd_names`` — routes each command line into the singleuse /
   multiuse / geometry buckets and validates command names, the
   command-name/parameters split, single-instance rule, and essentials
@@ -38,6 +37,7 @@ Coverage targets:
 
 import io
 import sys
+from contextlib import redirect_stdout
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -104,14 +104,27 @@ class TestProcessPythonIncludeCode:
         with pytest.raises(SyntaxError):
             process_python_include_code(text, {})
 
-    def test_stdout_reset_to_os_stdout_after_python_block(self):
-        # The internal redirect to a StringIO is reverted with the
-        # explicit ``sys.stdout = sys.__stdout__`` line — so after the
-        # block, ``sys.stdout`` is the OS stdout (not whatever wrapper
-        # the surrounding test runner had in place).
+    def test_stdout_restored_to_callers_stream_after_python_block(self):
         text = io.StringIO("#python:\n" "print('#title: demo')\n" "#end_python:\n")
-        process_python_include_code(text, {})
-        assert sys.stdout is sys.__stdout__
+        caller = io.StringIO()
+        with redirect_stdout(caller):
+            process_python_include_code(text, {})
+            assert sys.stdout is caller
+            print("after")
+        assert caller.getvalue() == "after\n"
+
+    @pytest.mark.parametrize("exception", [RuntimeError, SystemExit, KeyboardInterrupt])
+    def test_exception_restores_callers_stdout(self, exception):
+        text = io.StringIO("#python:\nraise failure('test')\n#end_python:\n")
+        caller = io.StringIO()
+        with redirect_stdout(caller):
+            with pytest.raises(exception):
+                process_python_include_code(text, {"failure": exception})
+            assert sys.stdout is caller
+
+    def test_terminal_empty_python_block_reports_missing_end(self):
+        with pytest.raises(SyntaxError, match="missing #end_python"):
+            process_python_include_code(io.StringIO("#python:\n"), {})
 
 
 # ---------------------------------------------------------------------------
@@ -144,22 +157,80 @@ class TestProcessIncludeFiles:
         with pytest.raises(ValueError):
             process_include_files(["#include_file: a b\n"])
 
-    def test_relative_path_falls_back_to_input_file_parent(self, tmp_path, monkeypatch):
+    def test_relative_path_uses_input_file_parent(self, tmp_path, monkeypatch):
         # Place the included file next to a faked input file
         included = tmp_path / "sidecar.in"
         included.write_text("#title: sidecar wins\n")
         fake_input = tmp_path / "main.in"
-        # Path the dispatcher reads when the requested path doesn't exist
+        # The input file determines the include-search root.
         from gprMax import config
 
         fake_sim_config = SimpleNamespace(input_file_path=fake_input)
         monkeypatch.setattr(config, "sim_config", fake_sim_config)
 
-        # Pass only the bare filename — first attempt (relative to CWD) misses,
-        # then the fallback to ``input_file_path.parent`` resolves
+        # Pass only the bare filename.
         cmds = ["#include_file: sidecar.in\n"]
         out = process_include_files(cmds)
         assert out == ["#title: sidecar wins\n"]
+
+    def test_nested_paths_order_repetition_and_cwd_collision(self, tmp_path, monkeypatch):
+        from gprMax import config
+
+        model = tmp_path / "model"
+        model.mkdir()
+        nested = model / "nested"
+        nested.mkdir()
+        caller = tmp_path / "caller"
+        caller.mkdir()
+        (caller / "outer.in").write_text("#title: wrong CWD file\n")
+        (model / "outer.in").write_text(
+            "#box: before\n#include_file: nested/inner.in\n#box: after\n"
+        )
+        (nested / "inner.in").write_text("#box: inner\n")
+        monkeypatch.chdir(caller)
+        monkeypatch.setattr(config, "sim_config", SimpleNamespace(input_file_path=model / "main.in"))
+        expected = ["#box: before\n", "#box: inner\n", "#box: after\n"]
+        assert process_include_files(["#include_file: outer.in\n"] * 2) == expected * 2
+
+    def test_missing_input_relative_file_never_uses_cwd_fallback(self, tmp_path, monkeypatch):
+        from gprMax import config
+
+        (tmp_path / "extra.in").write_text("#title: unrelated\n")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(config, "sim_config", SimpleNamespace(input_file_path=tmp_path / "model/main.in"))
+        with pytest.raises(FileNotFoundError, match="model/extra.in"):
+            process_include_files(["#include_file: extra.in\n"])
+
+    @pytest.mark.parametrize("symlink", [False, True])
+    def test_include_cycles_are_rejected_with_chain(self, tmp_path, monkeypatch, symlink):
+        from gprMax import config
+
+        root = tmp_path / "main.in"
+        child = tmp_path / "child.in"
+        root.write_text("#include_file: child.in\n")
+        if symlink:
+            alias = tmp_path / "alias.in"
+            alias.symlink_to(root)
+        child.write_text(f"#include_file: {'alias.in' if symlink else 'main.in'}\n")
+        monkeypatch.setattr(config, "sim_config", SimpleNamespace(input_file_path=root))
+        with pytest.raises(ValueError, match="cycle detected:.*main.in.*child.in.*main.in"):
+            process_include_files(["#include_file: child.in\n"])
+
+    def test_nested_missing_file_raises(self, tmp_path):
+        outer = tmp_path / "outer.in"
+        outer.write_text("#include_file: missing.in\n")
+        with pytest.raises(FileNotFoundError, match="missing.in"):
+            process_include_files([f"#include_file: {outer}\n"])
+
+    def test_python_blocks_in_include_are_explicitly_unsupported(self, tmp_path):
+        outer = tmp_path / "outer.in"
+        outer.write_text("#python:\nraise RuntimeError('must not execute')\n#end_python:\n")
+        with pytest.raises(SyntaxError, match="Python blocks in included files are unsupported"):
+            process_include_files([f"#include_file: {outer}\n"])
+
+    def test_unexpanded_include_cannot_be_silently_dispatched(self):
+        with pytest.raises(ValueError, match="must be expanded"):
+            get_user_objects(["#include_file: unused.in\n"], checkessential=False)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hash_cmds/test_hash_cmds_file.py
+++ b/tests/hash_cmds/test_hash_cmds_file.py
@@ -198,8 +198,9 @@ class TestProcessIncludeFiles:
         (tmp_path / "extra.in").write_text("#title: unrelated\n")
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(config, "sim_config", SimpleNamespace(input_file_path=tmp_path / "model/main.in"))
-        with pytest.raises(FileNotFoundError, match="model/extra.in"):
+        with pytest.raises(FileNotFoundError) as error:
             process_include_files(["#include_file: extra.in\n"])
+        assert str(tmp_path / "model" / "extra.in") in str(error.value)
 
     @pytest.mark.parametrize("symlink", [False, True])
     def test_include_cycles_are_rejected_with_chain(self, tmp_path, monkeypatch, symlink):

--- a/tests/hash_cmds/test_hash_cmds_singleuse.py
+++ b/tests/hash_cmds/test_hash_cmds_singleuse.py
@@ -26,6 +26,8 @@ These tests drive the dispatcher with hand-built dicts so each command's
 branch is exercised in isolation — no file I/O, no globals.
 """
 
+from pathlib import Path
+
 import pytest
 
 from gprMax.hash_cmds_multiuse import process_multicmds
@@ -82,7 +84,7 @@ class TestOutputDir:
         objs = process_singlecmds(singlecmds_template)
         assert isinstance(objs[0], OutputDir)
         # OutputDir kwarg is ``dir``
-        assert objs[0].kwargs["dir"] == "results/run1"
+        assert Path(objs[0].kwargs["dir"]) == Path("results") / "run1"
 
 
 class TestOMPThreads:

--- a/tests/ntff/test_port_power.py
+++ b/tests/ntff/test_port_power.py
@@ -460,15 +460,18 @@ def test_rational_network_port_uses_external_network_current_sign(monkeypatch):
     assert result.accepted_power[0] > 0
 
 
-def test_hard_voltage_port_uses_time_aligned_loop_current(monkeypatch):
+@pytest.mark.parametrize("voltage_offset", [0.0, 1.0], ids=["initial-E0", "legacy"])
+def test_hard_voltage_port_uses_time_aligned_loop_current(monkeypatch, voltage_offset):
     dt = 1e-3
     nsamples = 64
     frequency = 1 / (nsamples * dt)
-    voltage_time = (np.arange(nsamples) + 1) * dt
-    current_time = (np.arange(nsamples) + 0.5) * dt
+    voltage_time = (np.arange(nsamples) + voltage_offset) * dt
+    current_time = (np.arange(nsamples) + voltage_offset - 0.5) * dt
     voltage = 2.0 * np.cos(2 * np.pi * frequency * voltage_time + 0.2)
     current = 0.04 * np.cos(2 * np.pi * frequency * current_time - 0.1)
     output, grid = _hard_voltage_port(voltage, current, dt=dt)
+    output.hard_voltage_time_offset = voltage_offset * dt
+    output.hard_current_time_offset = (voltage_offset - 0.5) * dt
     monkeypatch.setattr(
         ports,
         "_port_mesh_valid",
@@ -476,12 +479,12 @@ def test_hard_voltage_port_uses_time_aligned_loop_current(monkeypatch):
     )
 
     result = evaluate_port_power_spectrum(output, grid, [frequency])
-    expected_voltage = engineering_dft(voltage, [frequency], dt, time_offset=dt)
+    expected_voltage = engineering_dft(voltage, [frequency], dt, time_offset=voltage_offset * dt)
     expected_current = engineering_dft(
         current,
         [frequency],
         dt,
-        time_offset=0.5 * dt,
+        time_offset=(voltage_offset - 0.5) * dt,
     )
     expected_incident = 0.5 * (expected_voltage + output.reference_impedance * expected_current)
 

--- a/tests/ntff/test_subgrid_ksir_tfsf_integration.py
+++ b/tests/ntff/test_subgrid_ksir_tfsf_integration.py
@@ -20,6 +20,7 @@
 import h5py
 import numpy as np
 import pytest
+import pytest
 
 import gprMax
 
@@ -41,7 +42,8 @@ def _base_scene():
     return scene, subgrid
 
 
-def test_antenna_metrics_use_subgrid_port_and_time_step(tmp_path):
+@pytest.mark.parametrize("resistance", [0, 50], ids=["hard", "finite-R"])
+def test_antenna_metrics_use_subgrid_port_and_time_step(tmp_path, resistance):
     scene, subgrid = _base_scene()
     source_position = (0.045, 0.045, 0.045)
     subgrid.add(gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"))
@@ -49,7 +51,7 @@ def test_antenna_metrics_use_subgrid_port_and_time_step(tmp_path):
         gprMax.VoltageSource(
             p1=source_position,
             polarisation="z",
-            resistance=50,
+            resistance=resistance,
             waveform_id="pulse",
             id="feed",
             spectrum_limit="nyquist",

--- a/tests/outputs/test_fields_outputs.py
+++ b/tests/outputs/test_fields_outputs.py
@@ -173,7 +173,7 @@ def test_hard_voltage_source_records_applied_electric_time(tmp_path):
 
     with h5py.File(output, "r") as file:
         excitation = file["srcs/src1/excitation"]
-        assert excitation.attrs["TimeSampleOffset"] == grid.dt
+        assert excitation.attrs["TimeSampleOffset"] == 0.0
         assert excitation.attrs["WaveformEvaluationTimeOffset"] == 0.0
         assert excitation.attrs["DrivingQuantity"] == "imposed_gap_voltage"
 

--- a/tests/outputs/test_fields_outputs_unit.py
+++ b/tests/outputs/test_fields_outputs_unit.py
@@ -32,11 +32,9 @@ implementation of ``FDTDGrid.calculate_Ix``/``Iy``/``Iz``, tested in PR 9.
 Nothing in the codebase checks that the two agree, and a fix applied to one
 would silently leave the other behind, so a cross-check is included below.
 
-**Receivers must be named.** ``write_hd5_data`` sorts ``grid.rxs`` by
-``rx.ID``, but ``Rx.__init__`` only *annotates* ``self.ID: str`` — it never
-assigns it. An unnamed receiver therefore raises ``AttributeError`` from inside
-the writer. Every receiver built here is given an explicit ID; the defect is
-recorded for the maintainers rather than asserted.
+Low-level receiver fixtures supply IDs explicitly. Public command-built
+receivers additionally carry construction indices; their output-order
+contract is tested in ``test_receiver_order.py``.
 """
 
 import logging
@@ -601,12 +599,8 @@ class TestWriteReceivers:
         _, data = read_h5(path)
         assert data["rxs/rx1/Ex"] == pytest.approx([1, 2, 3, 4, 5])
 
-    def test_receivers_are_sorted_by_id(self, make_view_grid, make_rx, tmp_path, read_h5):
-        """Expects ``rx1`` to be the alphabetically first ID, not the first
-        one added.
-
-        The sort exists so that a multi-rank MPI run, where receivers arrive in
-        arbitrary order, always writes them in the same sequence."""
+    def test_low_level_receivers_keep_runtime_order(self, make_view_grid, make_rx, tmp_path, read_h5):
+        """Unindexed low-level serial objects retain list order, not name order."""
         import h5py
 
         g = make_view_grid(nx=8, ny=8, nz=8)
@@ -618,7 +612,8 @@ class TestWriteReceivers:
         with h5py.File(path, "w") as f:
             write_hd5_data(f, g)
         attrs, _ = read_h5(path)
-        assert attrs["rxs/rx1/Name"] == "alpha"
+        assert attrs["rxs/rx1/Name"] == "zulu"
+        assert attrs["ReceiverOrder"] == "runtime"
 
     def test_the_sort_mutates_the_grids_receiver_list(self, make_view_grid, make_rx, tmp_path):
         """``grid.rxs`` is NOT mutated — the writer sorts a local copy, so

--- a/tests/outputs/test_receiver_order.py
+++ b/tests/outputs/test_receiver_order.py
@@ -1,0 +1,96 @@
+"""Public construction order is independent of labels, runtime pages and ranks."""
+
+import copy
+
+import h5py
+import numpy as np
+import pytest
+
+from gprMax.fields_outputs import write_hd5_data
+from gprMax.grid.fdtd_grid import FDTDGrid
+from gprMax.user_objects.cmds_multiuse import Rx
+
+pytestmark = pytest.mark.unit
+
+
+def test_output_sorts_ordinals_not_runtime_pages(make_view_grid, make_rx, tmp_path):
+    grid = make_view_grid(nx=8, ny=8, nz=8)
+    receivers = []
+    for index, name in enumerate(("zulu", "alpha", "same", "same")):
+        rx = make_rx(ID=name, position=(2, 2, 2), outputs=("Ex",))
+        rx.build_index, rx.name_kind = index, "user"
+        rx.outputs["Ex"][:] = index + 10
+        receivers.append(rx)
+    private = make_rx(ID="private", outputs=("Ex",))
+    private.internal = True
+    # Simulate arbitrary rank gather/migration order, including coincident IDs.
+    grid.rxs = [receivers[2], private, receivers[0], receivers[3], receivers[1]]
+    original = list(grid.rxs)
+    path = tmp_path / "ordered.h5"
+    with h5py.File(path, "w") as output:
+        write_hd5_data(output, grid)
+    assert grid.rxs == original
+    with h5py.File(path) as output:
+        assert output.attrs["ReceiverOrder"] == "construction"
+        assert output.attrs["ReceiverOrderSchemaVersion"] == 1
+        assert output.attrs["nrx"] == 4
+        for index, receiver in enumerate(receivers):
+            group = output[f"rxs/rx{index+1}"]
+            assert group.attrs["BuildIndex"] == index
+            assert group.attrs["Name"] == receiver.ID
+            np.testing.assert_array_equal(group["Ex"], index + 10)
+
+
+@pytest.mark.parametrize("indices", [(0, 0), (0, None), (0, 2), (-1, 0)])
+def test_writer_rejects_invalid_global_indices(make_view_grid, make_rx, tmp_path, indices):
+    grid = make_view_grid(nx=8, ny=8, nz=8)
+    grid.rxs = [make_rx(ID="same", outputs=("Ex",)) for _ in indices]
+    for rx, index in zip(grid.rxs, indices):
+        rx.build_index = index
+    with h5py.File(tmp_path / "invalid.h5", "w") as output:
+        with pytest.raises(ValueError, match="build indices"):
+            write_hd5_data(output, grid)
+
+
+def test_ordinals_allocated_on_every_rank_before_ownership(monkeypatch):
+    grids = [FDTDGrid(), FDTDGrid()]
+    owner = [False, True, False, True]
+    for rank, grid in enumerate(grids):
+        for number, belongs_to_one in enumerate(owner):
+            command = Rx(p1=(number, 0, 0), id=f"name{3-number}")
+
+            class Inputs:
+                def resolve_inf_point(self, point):
+                    return point
+
+                def check_src_rx_point(self, point, message):
+                    return belongs_to_one == bool(rank), np.array(point)
+
+                def round_to_grid_static_point(self, point):
+                    return point
+
+            monkeypatch.setattr(command, "_create_uip", lambda grid: Inputs())
+            monkeypatch.setattr(
+                command, "_create_receiver", lambda grid, coord: type("Receiver", (), {"outputs": {}, "coord": coord})()
+            )
+            command.build(grid)
+    assert grids[0].receiver_definitions == grids[1].receiver_definitions
+    assert [rx.build_index for rx in grids[0].rxs] == [0, 2]
+    assert [rx.build_index for rx in grids[1].rxs] == [1, 3]
+    # MPI transmits the object; insertion on a new owner must not allocate again.
+    migrated = copy.deepcopy(grids[0].rxs[1])
+    grids[1].add_receiver(migrated)
+    assert migrated.build_index == 2
+    assert len(grids[1].receiver_definitions) == 4
+
+
+@pytest.mark.parametrize("count", (0, 1))
+def test_writer_rejects_lost_tail_of_gathered_receivers(make_view_grid, make_rx, tmp_path, count):
+    grid = make_view_grid(nx=8, ny=8, nz=8)
+    grid.receiver_definitions = [("one", ["Ex"], None), ("two", ["Ex"], None)]
+    grid.rxs = [make_rx(ID="one", outputs=("Ex",)) for _ in range(count)]
+    for rx in grid.rxs:
+        rx.build_index = 0
+    with h5py.File(tmp_path / "incomplete.h5", "w") as output:
+        with pytest.raises(ValueError, match="registered declarations"):
+            write_hd5_data(output, grid)

--- a/tests/outputs/test_receiver_order_integration.py
+++ b/tests/outputs/test_receiver_order_integration.py
@@ -1,0 +1,143 @@
+"""Actual solver/gather/reuse checks, with labels that defeat ID sorting."""
+
+import importlib.util
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import h5py
+import numpy as np
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+MPIEXEC = str(Path(sys.executable).parent / "mpiexec")
+if not Path(MPIEXEC).is_file():
+    MPIEXEC = shutil.which("mpiexec")
+
+
+def run_model(tmp_path, name, extra=()):
+    model = tmp_path / "receivers.in"
+    model.write_text(
+        "\n".join(
+            (
+                "#domain: 0.04 0.04 0.04",
+                "#dx_dy_dz: 0.001 0.001 0.001",
+                "#time_window: 80",
+                "#pml_cells: 0",
+                "#omp_threads: 1",
+                "#waveform: ricker 1 2e10 pulse",
+                "#voltage_source: z 0.012 0.012 0.012 50 pulse",
+                "#rx: 0.018 0.018 0.018 zulu Ex Ey Ez Hx Hy Hz Ix Iy Iz",
+                "#rx: 0.022 0.022 0.022 alpha Ez",
+                "#rx: 0.018 0.018 0.018 duplicate Ez",
+                "#rx: 0.018 0.018 0.018 duplicate Ez",
+                "#rx_array: 0.007 0.016 0.018 0.027 0.016 0.018 0.002 0 0",
+                "#rx_steps: 0.003 0.003 0.003",
+                "",
+            )
+        )
+    )
+    command = [
+        sys.executable,
+        "-m",
+        "gprMax",
+        str(model),
+        "-n",
+        "3",
+        "--geometry-fixed",
+        "--hide-progress-bars",
+        "-cpu_precision",
+        "double",
+        "-o",
+        str(tmp_path / name),
+        *extra,
+    ]
+    if "--mpi" in extra:
+        command = [MPIEXEC, "-n", "2", *command]
+    environment = os.environ.copy()
+    environment.pop("MPI4PY_RC_FINALIZE", None)
+    environment.pop("FI_PROVIDER", None)
+    environment.update(
+        PYTHONPATH=str(ROOT),
+        OMP_NUM_THREADS="1",
+        OPENBLAS_NUM_THREADS="1",
+        MKL_NUM_THREADS="1",
+        OMPI_MCA_rmaps_base_oversubscribe="1",
+    )
+    result = subprocess.run(command, cwd=tmp_path, env=environment, capture_output=True, text=True, timeout=120)
+    assert result.returncode == 0, result.stdout + result.stderr
+    return [tmp_path / f"{name}{run}.h5" for run in range(1, 4)]
+
+
+def check_order(files):
+    layouts = []
+    for run, path in enumerate(files):
+        with h5py.File(path) as output:
+            assert output.attrs["ReceiverOrder"] == "construction"
+            assert output.attrs["nrx"] == 15  # private voltage monitor excluded
+            layouts.append(output.attrs["ReceiverLayout"])
+            names = [output[f"rxs/rx{i}"].attrs["Name"] for i in range(1, 16)]
+            assert names[:4] == ["zulu", "alpha", "duplicate", "duplicate"]
+            assert [output[f"rxs/rx{i}"].attrs["BuildIndex"] for i in range(1, 16)] == list(range(15))
+            positions = [output[f"rxs/rx{i}"].attrs["Position"] for i in range(5, 16)]
+            expected = np.array([(x * 0.001, 0.016, 0.018) for x in range(7, 28, 2)]) + run * 0.003
+            np.testing.assert_allclose(positions, expected, rtol=0, atol=1e-16)
+            assert output["rxs/rx1"].attrs["NameKind"] == "user"
+            assert output["rxs/rx5"].attrs["NameKind"] == "generated"
+            assert "ports/port1" in output
+    assert len(set(layouts)) == 1
+
+
+@pytest.mark.integration
+def test_serial_reuse_preserves_array_and_duplicate_receiver_order(tmp_path):
+    check_order(run_model(tmp_path, "serial"))
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    MPIEXEC is None or importlib.util.find_spec("mpi4py") is None, reason="requires MPI launcher and mpi4py"
+)
+@pytest.mark.parametrize("partition", [(2, 1, 1), (1, 2, 1), (1, 1, 2)])
+def test_mpi_gather_and_migration_match_serial_identity_and_samples(tmp_path, partition):
+    serial = run_model(tmp_path, "serial")
+    distributed = run_model(tmp_path, "mpi", ("--mpi", *map(str, partition)))
+    check_order(serial)
+    check_order(distributed)
+    for reference, candidate in zip(serial, distributed):
+        with h5py.File(reference) as left, h5py.File(candidate) as right:
+            assert left.attrs["ReceiverLayout"] == right.attrs["ReceiverLayout"]
+            for rx in left["rxs"]:
+                for key in left[f"rxs/{rx}"].attrs:
+                    np.testing.assert_array_equal(left[f"rxs/{rx}"].attrs[key], right[f"rxs/{rx}"].attrs[key])
+                for component in left[f"rxs/{rx}"]:
+                    np.testing.assert_allclose(
+                        left[f"rxs/{rx}/{component}"], right[f"rxs/{rx}/{component}"], rtol=2e-12, atol=1e-12
+                    )
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+@pytest.mark.parametrize("backend", ("cuda", "opencl"))
+def test_device_receiver_pages_keep_identity_across_reuse(tmp_path, request, backend):
+    device = request.getfixturevalue("gpu_device" if backend == "cuda" else "opencl_device")
+    serial = run_model(tmp_path, "serial")
+    option = "-gpu" if backend == "cuda" else "-opencl"
+    accelerated = run_model(tmp_path, backend, (option, str(device), "-gpu_precision", "double"))
+    check_order(accelerated)
+    for reference, candidate in zip(serial, accelerated):
+        with h5py.File(reference) as left, h5py.File(candidate) as right:
+            for key in left["rxs"]:
+                assert left[f"rxs/{key}"].attrs["Name"] == right[f"rxs/{key}"].attrs["Name"]
+                for comp in left[f"rxs/{key}"]:
+                    expected = left[f"rxs/{key}/{comp}"][:]
+                    # Symmetry-null channels contain roundoff, not a signal
+                    # against which a relative tolerance can be normalised.
+                    np.testing.assert_allclose(
+                        right[f"rxs/{key}/{comp}"],
+                        expected,
+                        rtol=2e-10,
+                        atol=2e-12,
+                        err_msg=f"{candidate.name}: {key}/{comp}",
+                    )

--- a/tests/outputs/test_sar.py
+++ b/tests/outputs/test_sar.py
@@ -535,7 +535,8 @@ def test_sar_current_moment_normalises_the_hertzian_source_length():
     assert result.sar[0, 0] == pytest.approx(0.4)
 
 
-def test_sar_real_port_power_normalisation_scales_with_target_power(tmp_path):
+@pytest.mark.parametrize("resistance", [0, 50], ids=["hard", "finite-R"])
+def test_sar_real_port_power_normalisation_scales_with_target_power(tmp_path, resistance):
     scene, one_watt = _scene()
     one_watt.normalisation = "incident_power"
     one_watt.port_id = "feed"
@@ -545,6 +546,7 @@ def test_sar_real_port_power_normalisation_scales_with_target_power(tmp_path):
         item for item in scene.grid_objects if isinstance(item, gprMax.VoltageSource)
     )
     voltage_source.id = "feed"
+    voltage_source.resistance = resistance
     four_watt = SAR(
         frequencies=one_watt.frequencies,
         tags="target",

--- a/tests/ports/test_integration.py
+++ b/tests/ports/test_integration.py
@@ -259,8 +259,8 @@ def test_hard_source_port_uses_phase_aligned_ampere_current(tmp_path, polarisati
         assert port.attrs["PortMode"] == "hard_delta_gap"
         assert port.attrs["ReferenceImpedance"] == 50
         assert port.attrs["ReferenceImpedanceSource"] == "voltage_source"
-        assert port.attrs["TimeSampleOffset"] == pytest.approx(output.attrs["dt"])
-        assert port.attrs["CurrentTimeSampleOffset"] == pytest.approx(0.5 * output.attrs["dt"])
+        assert port.attrs["TimeSampleOffset"] == 0.0
+        assert port.attrs["CurrentTimeSampleOffset"] == pytest.approx(-0.5 * output.attrs["dt"])
         assert port.attrs["CurrentTimeAlignment"] == "explicit_fft_half_step_phase"
         assert port["Iloop"].shape == port["time"].shape
         assert port["time_current"].shape == port["time"].shape

--- a/tests/ports/test_subgrid_integration.py
+++ b/tests/ports/test_subgrid_integration.py
@@ -90,7 +90,7 @@ def test_subgrid_port_uses_owning_grid_and_returns_api_result(subgrid_port_resul
         assert port.attrs["PortMode"] == "hard_delta_gap"
         assert port.attrs["CellLength"] == pytest.approx(0.001)
         assert port.attrs["NyquistFrequency"] == pytest.approx(1 / (2 * subgrid.attrs["dt"]))
-        assert port["time"].size == subgrid.attrs["Iterations"] - 1
+        assert port["time"].size == subgrid.attrs["Iterations"]
         assert port["Iloop"].shape == port["time"].shape
         assert port["valid_Zin"][...].astype(bool).any()
 
@@ -173,7 +173,7 @@ def test_ratio_one_subgrid_hard_source_current_has_uniform_grid_phase(tmp_path):
         actual = localised["subgrids/fine_grid/ports/feed"]
         assert actual.attrs["CurrentTimeAlignment"] == "explicit_fft_half_step_phase"
         assert actual.attrs["CurrentTimeSampleOffset"] == pytest.approx(
-            0.5 * localised["subgrids/fine_grid"].attrs["dt"]
+            -0.5 * localised["subgrids/fine_grid"].attrs["dt"], rel=1e-12, abs=0
         )
 
         for dataset in ("Vtotal", "Iloop"):

--- a/tests/sources/test_hard_source_initialisation.py
+++ b/tests/sources/test_hard_source_initialisation.py
@@ -1,0 +1,92 @@
+"""Physical-time hard assignments, independent of waveform amplitude."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from gprMax.sources import VoltageSource, initialise_hard_source_fields
+
+
+def source(axis="z", *, start=0.0, stop=10.0, resistance=0.0, values=None):
+    result = VoltageSource()
+    result.polarisation = axis
+    result.coord[:] = (1, 1, 1)
+    result.start, result.stop, result.resistance = start, stop, resistance
+    result.waveformvalues_wholedt = np.arange(6.0) + 1 if values is None else values
+    return result
+
+
+def grid(sources, dtype=np.float64):
+    return SimpleNamespace(
+        voltagesources=sources,
+        dt=0.1,
+        dx=0.5,
+        dy=0.25,
+        dz=0.125,
+        Ex=np.full((3, 3, 3), 9, dtype=dtype),
+        Ey=np.full((3, 3, 3), 9, dtype=dtype),
+        Ez=np.full((3, 3, 3), 9, dtype=dtype),
+    )
+
+
+@pytest.mark.parametrize("axis", "xyz")
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_initial_field_then_next_sample_and_final_lookahead(axis, dtype):
+    src = source(axis)
+    g = grid([src], dtype)
+    values = src.waveformvalues_wholedt.copy()
+    field, dl = getattr(g, "E" + axis), getattr(g, "d" + axis)
+    assert initialise_hard_source_fields(g)
+    assert field[1, 1, 1] == -values[0] / dl
+    for iteration in range(5):
+        # The hard branch must not read coefficients/IDs or additive samples.
+        src.update_electric(iteration, None, None, g.Ex, g.Ey, g.Ez, g)
+        assert field[1, 1, 1] == -values[iteration + 1] / dl
+    np.testing.assert_array_equal(src.waveformvalues_wholedt, values)
+
+
+def test_initialisation_skips_other_source_types_and_delayed_hard_sources():
+    delayed = source(start=0.05)
+    soft = source(resistance=50)
+    soft.waveformvalues_wholedt = None
+    g = grid([soft, delayed])
+    assert not initialise_hard_source_fields(g)
+    for axis in "xyz":
+        np.testing.assert_array_equal(getattr(g, "E" + axis), 9)
+
+
+def test_zero_amplitude_clamps_and_coincident_initialisation_keeps_list_order():
+    first = source(values=np.ones(6))
+    last = source(values=np.zeros(6))
+    g = grid([first, last])
+    assert initialise_hard_source_fields(g)
+    assert g.Ez[1, 1, 1] == 0
+    g.voltagesources.reverse()
+    assert initialise_hard_source_fields(g)
+    assert g.Ez[1, 1, 1] == -1 / g.dz
+
+
+@pytest.mark.parametrize("bound", [0.1, np.nextafter(0.1, 0), np.nextafter(0.1, np.inf)])
+def test_inclusive_activity_uses_applied_electric_time(bound):
+    for start, stop in ((0, bound), (bound, 0.5)):
+        src = source(start=start, stop=stop, values=np.zeros(6))
+        g = grid([src])
+        initialise_hard_source_fields(g)
+        for iteration in range(5):
+            g.Ez.fill(9)
+            src.update_electric(iteration, None, None, g.Ex, g.Ey, g.Ez, g)
+            active = start <= (iteration + 1) * g.dt <= stop
+            assert g.Ez[1, 1, 1] == (0 if active else 9)
+
+
+def test_initialisation_repeats_after_reset_with_current_waveform_and_position():
+    src = source()
+    g = grid([src])
+    initialise_hard_source_fields(g)
+    g.Ez.fill(0)
+    src.coord[:] = (2, 1, 1)
+    src.waveformvalues_wholedt = np.full(6, 3.0)
+    initialise_hard_source_fields(g)
+    assert g.Ez[1, 1, 1] == 0
+    assert g.Ez[2, 1, 1] == -3 / g.dz

--- a/tests/sources/test_sampled_waveforms.py
+++ b/tests/sources/test_sampled_waveforms.py
@@ -1,0 +1,73 @@
+"""Sample counts, interpolation boundaries and source-specific time lattices."""
+
+import numpy as np
+import pytest
+from scipy.interpolate import interp1d
+
+from gprMax.sources import VoltageSource
+from gprMax.user_objects.cmds_multiuse import ExcitationFile, Waveform
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("iterations", [5, 7, 16, 125, 189, 200, 257])
+@pytest.mark.parametrize("dl", [0.001, 0.002, 0.005])
+def test_implicit_time_axis_has_exactly_iterations_samples(fake_grid, iterations, dl):
+    dt = dl / (299792458.0 * np.sqrt(3))
+    grid = fake_grid(iterations=iterations, dt=dt, timewindow=(iterations - 1) * dt)
+    values = np.arange(iterations, dtype=float)
+    Waveform(wave_type="user", user_values=values, id="sampled").build(grid)
+    np.testing.assert_array_equal(grid.waveforms[0].userfunc.x, np.arange(iterations) * dt)
+    np.testing.assert_array_equal(grid.waveforms[0].userfunc(np.arange(iterations) * dt), values)
+
+
+@pytest.mark.parametrize("path", ["api", "file", "file_with_time"])
+@pytest.mark.parametrize("fill", [None, 0, 3.5, "extrapolate"])
+def test_sampled_boundaries_use_default_zero_or_explicit_fill(tmp_path, fake_grid, path, fill):
+    grid = fake_grid(iterations=3, dt=1.0, timewindow=2.0)
+    kwargs = {} if fill is None else dict(kind="linear", fill_value=fill)
+    if path == "api":
+        Waveform(wave_type="user", user_values=[1, 2, 3], user_time=[0, 1, 2], id="sampled", **kwargs).build(grid)
+    else:
+        filename = tmp_path / "samples.txt"
+        filename.write_text("time sampled\n0 1\n1 2\n2 3\n" if path == "file_with_time" else "sampled\n1\n2\n3\n")
+        ExcitationFile(filename, **kwargs).build(grid)
+    function = grid.waveforms[0].userfunc
+    np.testing.assert_array_equal(function([0, 0.5, 2]), [1, 1.5, 3])
+    expected = [0.5, 3.5] if fill == "extrapolate" else [0 if fill is None else fill] * 2
+    np.testing.assert_array_equal(function([-0.5, 2.5]), expected)
+
+
+def test_api_explicit_none_interpolation_options_use_defaults(fake_grid):
+    grid = fake_grid(iterations=3, dt=1.0, timewindow=2.0)
+    Waveform(wave_type="user", user_values=[1, 2, 3], id="sampled", kind=None, fill_value=None).build(grid)
+    np.testing.assert_array_equal(grid.waveforms[0].userfunc([-0.5, 0.5, 2.5]), [0, 1.5, 0])
+
+
+def test_hard_source_never_evaluates_unused_half_steps(fake_grid):
+    grid = fake_grid(iterations=16, dt=1.0, timewindow=15.0)
+    Waveform(wave_type="user", user_values=np.ones(16), id="sampled").build(grid)
+    # Strict interpolation proves that zero-extension is not hiding an
+    # unnecessary hard-source lookup past the final whole-step sample.
+    grid.waveforms[0].userfunc = interp1d(np.arange(16), np.ones(16), bounds_error=True)
+    source = VoltageSource()
+    source.resistance, source.waveformID, source.stop = 0, "sampled", grid.timewindow
+    source.calculate_waveform_values(grid)
+    assert source.waveformvalues_halfdt is None
+    np.testing.assert_array_equal(source.waveformvalues_wholedt, [1] * 16 + [0])
+
+
+@pytest.mark.parametrize("resistances", [(0, 50, 0, 75), (50, 0, 75, 0)])
+def test_hard_and_resistive_cache_donors_do_not_cross_lattices(fake_grid, resistances):
+    grid = fake_grid(iterations=4, dt=1.0, timewindow=3.0)
+    Waveform(wave_type="user", user_func=lambda time: 1 + time, id="ramp").build(grid)
+    for resistance in resistances:
+        source = VoltageSource()
+        source.resistance, source.waveformID, source.stop = resistance, "ramp", grid.timewindow
+        source.calculate_waveform_values(grid)
+        grid.voltagesources.append(source)
+        values = source.waveformvalues_wholedt if resistance == 0 else source.waveformvalues_halfdt
+        np.testing.assert_array_equal(values[:4], np.arange(4) + (1 if resistance == 0 else 1.5))
+    for first, second in ((0, 2), (1, 3)):
+        name = "waveformvalues_wholedt" if resistances[first] == 0 else "waveformvalues_halfdt"
+        assert getattr(grid.voltagesources[first], name) is getattr(grid.voltagesources[second], name)

--- a/tests/sources/test_sources.py
+++ b/tests/sources/test_sources.py
@@ -237,7 +237,7 @@ class TestVoltageSourceUpdateElectric:
         self, fake_grid, polarisation, field_idx, d_along
     ):
         """Per ``sources.py:187`` hard-source case (``resistance == 0``):
-        E[i,j,k] = -waveform_wholedt[it] / d_along
+        E[i,j,k] = -waveform_wholedt[it + 1] / d_along
         """
         IDlookup, ID, updatecoeffsE, _ = _make_id_arrays()
         G = fake_grid(dt=1.0, dx=2.0, dy=2.0, dz=2.0, iterations=5, IDlookup=IDlookup, ID=ID)
@@ -248,7 +248,7 @@ class TestVoltageSourceUpdateElectric:
         src.stop = G.timewindow
         src.xcoord = src.ycoord = src.zcoord = 1
         src.waveformvalues_halfdt = np.zeros(6)
-        src.waveformvalues_wholedt = np.array([0.0, 3.0, 0.0, 0.0, 0.0, 0.0])
+        src.waveformvalues_wholedt = np.array([0.0, 7.0, 3.0, 0.0, 0.0, 0.0])
 
         # Seed the cell with a known value to confirm the assignment is a
         # *replacement*, not a decrement.

--- a/tests/sources/test_sources.py
+++ b/tests/sources/test_sources.py
@@ -141,10 +141,11 @@ class TestVoltageSourceInit:
 
 
 class TestVoltageSourceCalculateWaveformValues:
-    def test_populates_both_arrays_inside_window(self, fake_grid, make_constant_waveform):
+    @pytest.mark.parametrize("resistance", [0, 50])
+    def test_populates_only_required_lattice_inside_window(self, fake_grid, make_constant_waveform, resistance):
         w = make_constant_waveform(ID="wf", value=2.5)
         G = fake_grid(iterations=10, dt=1e-12, waveforms=[w])
-        src = _make_voltage_source(polarisation="x", resistance=50.0)
+        src = _make_voltage_source(polarisation="x", resistance=resistance)
         src.start = 0.0
         src.stop = G.timewindow
 
@@ -152,11 +153,12 @@ class TestVoltageSourceCalculateWaveformValues:
 
         # All in-window values equal the constant waveform value (2.5).
         # _ConstantWaveform returns 2.5 for any t >= 0.
-        assert np.all(src.waveformvalues_wholedt == 2.5)
-        assert np.all(src.waveformvalues_halfdt == 2.5)
+        values = src.waveformvalues_wholedt if resistance == 0 else src.waveformvalues_halfdt
+        unused = src.waveformvalues_halfdt if resistance == 0 else src.waveformvalues_wholedt
+        assert np.all(values == 2.5)
+        assert unused is None
         # Shape is iterations + 1 (so the solver can index past the last step).
-        assert src.waveformvalues_wholedt.shape == (G.iterations + 1,)
-        assert src.waveformvalues_halfdt.shape == (G.iterations + 1,)
+        assert values.shape == (G.iterations + 1,)
 
     def test_zero_outside_window(self, fake_grid, make_constant_waveform):
         w = make_constant_waveform(value=1.0)
@@ -172,7 +174,7 @@ class TestVoltageSourceCalculateWaveformValues:
         for it in range(G.iterations + 1):
             t = G.dt * it
             expected = 1.0 if src.start <= t <= src.stop else 0.0
-            assert src.waveformvalues_wholedt[it] == expected
+            assert src.waveformvalues_halfdt[it] == expected
 
     def test_reuses_precomputed_values_from_matching_source(
         self, fake_grid, make_constant_waveform

--- a/tests/sources/test_voltage_source_activity.py
+++ b/tests/sources/test_voltage_source_activity.py
@@ -134,12 +134,13 @@ def test_every_shared_template_gates_only_hard_assignment(backend, real):
     body = update_voltage_source["func"].substitute(REAL=real, CUDA_IDX="")
     assert args.count("srcinfo1") == 1
     assert "int activity_offset = 4 * NVOLTSRC + 2 * source;" in body
-    assert "int active = iteration >= first_active && iteration <= last_active;" in body
+    assert "int hard_sample = iteration + 1;" in body
+    assert "int active = hard_sample >= first_active && hard_sample <= last_active;" in body
     assert body.count("else if (active)") == 3
     assert body.count("if (resistance != 0)") == 3
     assert "return;" not in body  # An inactive source must not skip later sources.
     for component, spacing in zip(("Ex", "Ey", "Ez"), ("dx", "dy", "dz")):
         assert (
-            f"{component}[IDX3D_FIELDS(x,y,z)] = -1 * srcwaveforms[IDX2D_SRCWAVES(source,iteration)] / {spacing};"
+            f"{component}[IDX3D_FIELDS(x,y,z)] = -1 * srcwaveforms[IDX2D_SRCWAVES(source,hard_sample)] / {spacing};"
             in body
         )

--- a/tests/subgrids/test_subgrid_updates.py
+++ b/tests/subgrids/test_subgrid_updates.py
@@ -29,6 +29,7 @@ be asserted without any physics by recording the call sequence.
 
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 from gprMax.subgrids.precursor_nodes import (
@@ -100,6 +101,27 @@ class TestCreateUpdates:
     def test_updater_holds_the_subgrid(self, make_model):
         model, _ = make_model()
         assert create_updates(model).updaters[0].grid is model.subgrids[0]
+
+    @pytest.mark.parametrize("ratio", [1, 3, 5])
+    @pytest.mark.parametrize("filtered", [False, True])
+    def test_initial_electric_precursors_are_seeded_before_first_half_step(
+        self, make_model, ratio, filtered
+    ):
+        model, _ = make_model(filtered=filtered, ratio=ratio)
+        # A nonzero E(0) must reach the coupling surfaces before hsg_2;
+        # pre-start E and both H history levels remain zero.
+        model.G.Ex.fill(2)
+        model.G.Ey.fill(3)
+        model.G.Ez.fill(4)
+        precursors = create_updates(model).updaters[0].precursors
+        precursors.calc_exact_electric_in_time()
+        for name in precursors.fn_e:
+            expected = {"ex": 2, "ey": 3, "ez": 4}[name[:2]]
+            np.testing.assert_allclose(getattr(precursors, name), expected)
+            np.testing.assert_array_equal(getattr(precursors, name + "_0"), 0)
+        for name in precursors.fn_m:
+            for level in ("_0", "_1"):
+                np.testing.assert_array_equal(getattr(precursors, name + level), 0)
 
 
 class TestSubgridUpdaterState:

--- a/tests/test_api_hash_execution_fixes.py
+++ b/tests/test_api_hash_execution_fixes.py
@@ -1,0 +1,294 @@
+"""End-to-end regressions for the 2026-09-11 API/hash lifecycle review."""
+import importlib.util
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+from gprMax.model import Model
+
+pytestmark = pytest.mark.integration
+ROOT = Path(__file__).resolve().parents[1]
+BACKENDS = ["cpu"] + [pytest.param(name, marks=pytest.mark.gpu) for name in ("cuda", "opencl", "metal")]
+HASH_BASE = """#domain: 0.064 0.064 0.064
+#dx_dy_dz: 0.002 0.002 0.002
+#time_window: 24
+#pml_cells: 0
+#omp_threads: 1
+#waveform: gaussian 1 1e10 w
+#hertzian_dipole: z 0.032 0.032 0.032 w
+#rx: 0.032 0.032 0.032 probe Ez
+"""
+
+
+def backend_options(request, backend):
+    if backend == "cpu":
+        return {"cpu_precision": "double"}
+    if backend == "metal":
+        metal = pytest.importorskip("Metal")
+        if metal.MTLCreateSystemDefaultDevice() is None:
+            pytest.skip("No Metal device")
+        return {"metal": True}
+    index = request.getfixturevalue("gpu_device" if backend == "cuda" else "opencl_device")
+    return {"gpu" if backend == "cuda" else "opencl": [index], "gpu_precision": "double"}
+
+
+def scene(*, ratio=None):
+    model = gprMax.Scene()
+    for obj in (
+        gprMax.Domain(p1=(0.064,) * 3),
+        gprMax.Discretisation(p1=(0.002,) * 3),
+        gprMax.TimeWindow(iterations=24),
+        gprMax.PMLThickness(thickness=0),
+        gprMax.OMPThreads(1),
+    ):
+        model.add(obj)
+    owner = model
+    if ratio is not None:
+        owner = gprMax.SubGridHSG(p1=(0.020,) * 3, p2=(0.044,) * 3, ratio=ratio, id="fine")
+        model.add(owner)
+    owner.add(gprMax.Waveform(wave_type="gaussian", amp=1, freq=1e10, id="w"))
+    owner.add(gprMax.HertzianDipole(p1=(0.032,) * 3, polarisation="z", waveform_id="w"))
+    owner.add(gprMax.Rx(p1=(0.032,) * 3, id="probe", outputs=["Ez"]))
+    return model
+
+
+def run(model, target, **kwargs):
+    return gprMax.run(
+        scenes=[model] * kwargs.get("n", 1), outputfile=target, hide_progress_bars=True, log_level=50, **kwargs
+    )
+
+
+def trace(path, group="rxs/rx1/Ez"):
+    with h5py.File(path) as handle:
+        return handle[group][:]
+
+
+@pytest.mark.parametrize("ratio", [1, 3])
+@pytest.mark.parametrize("explicit_false", [False, True])
+def test_subgrid_omission_is_rejected_without_outputs(tmp_path, ratio, explicit_false):
+    kwargs = {"subgrid": False} if explicit_false else {}
+    with pytest.raises(ValueError, match="subgrid=True"):
+        run(scene(ratio=ratio), tmp_path / "omitted", **kwargs)
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize("ratio", [1, 3])
+def test_enabled_subgrid_actually_advances_across_reuse(tmp_path, ratio):
+    run(
+        scene(ratio=ratio),
+        tmp_path / "fine",
+        n=2,
+        geometry_fixed=True,
+        subgrid=True,
+        autotranslate=True,
+        cpu_precision="double",
+    )
+    first = trace(tmp_path / "fine1.h5", "subgrids/fine/rxs/rx1/Ez")
+    assert np.isfinite(first).all() and np.count_nonzero(first) > 1
+    np.testing.assert_array_equal(first, trace(tmp_path / "fine2.h5", "subgrids/fine/rxs/rx1/Ez"))
+
+
+def test_duplicate_subgrid_id_never_starts_build_or_truncates_output(tmp_path, monkeypatch):
+    model = scene(ratio=1)
+    model.add(gprMax.SubGridHSG(p1=(0.020,) * 3, p2=(0.044,) * 3, ratio=1, id="fine"))
+    target = tmp_path / "existing.h5"
+    target.write_bytes(b"must survive validation")
+    monkeypatch.setattr(Model, "build", lambda self: pytest.fail("Invalid Scene reached build"))
+    with pytest.raises(ValueError, match="Duplicate subgrid ID"):
+        run(model, target, subgrid=True)
+    assert target.read_bytes() == b"must survive validation"
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("restart", [1, 3])
+def test_output_dir_and_snapshots_survive_geometry_reuse(tmp_path, request, backend, restart):
+    model = scene()
+    requested = tmp_path / "requested"
+    model.add(gprMax.OutputDir(dir=requested))
+    model.add(
+        gprMax.Snapshot(
+            p1=(0.028,) * 3, p2=(0.038,) * 3, dl=(0.002,) * 3, iterations=3, filename="frame", fileext=".h5"
+        )
+    )
+    run(model, tmp_path / "fallback", n=2, i=restart, geometry_fixed=True, **backend_options(request, backend))
+    arrays = []
+    frames = []
+    for index in (restart, restart + 1):
+        arrays.append(trace(requested / f"fallback{index}.h5"))
+        with h5py.File(requested / f"fallback{index}_snaps/frame.h5") as handle:
+            frames.append(handle["Ez"][:])
+        assert not (tmp_path / f"fallback{index}.h5").exists()
+    assert np.count_nonzero(arrays[0]) > 0
+    np.testing.assert_array_equal(*arrays)
+    np.testing.assert_array_equal(*frames)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_nested_include_material_resolution_and_hash_output_dir(tmp_path, monkeypatch, request, backend):
+    modeldir, caller = tmp_path / "model", tmp_path / "caller"
+    nested = modeldir / "nested"
+    nested.mkdir(parents=True)
+    caller.mkdir()
+    (caller / "outer.in").write_text("#material: 9 0 1 0 sample\n")
+    (modeldir / "outer.in").write_text("#include_file: nested/inner.in\n")
+    (nested / "inner.in").write_text("#material: 4 0 1 0 sample\n#box: 0.040 0.040 0.040 0.048 0.048 0.048 pec\n")
+    source = modeldir / "nested.in"
+    source.write_text(HASH_BASE + "#include_file: outer.in\n#output_dir: results\n")
+    built = []
+    original = Model.build
+
+    def observe(model):
+        original(model)
+        built.append((np.count_nonzero(model.G.solid == 0), next(m.er for m in model.G.materials if m.ID == "sample")))
+
+    monkeypatch.setattr(Model, "build", observe)
+    monkeypatch.chdir(caller)
+    gprMax.run(
+        inputfile=source,
+        n=2,
+        geometry_fixed=True,
+        hide_progress_bars=True,
+        log_level=50,
+        **backend_options(request, backend),
+    )
+    assert built == [(64, 4), (64, 4)]
+    for index in (1, 2):
+        assert np.isfinite(trace(modeldir / f"results/nested{index}.h5")).all()
+    assert not (caller / "results").exists()
+
+
+def test_api_relative_output_dir_keeps_cwd_semantics(tmp_path, monkeypatch):
+    caller = tmp_path / "caller"
+    caller.mkdir()
+    monkeypatch.chdir(caller)
+    model = scene()
+    model.add(gprMax.OutputDir(dir="results"))
+    run(model, tmp_path / "output")
+    assert (caller / "results/output.h5").is_file()
+    assert not (tmp_path / "results").exists()
+
+
+def fractal_scene(*, mixing=False):
+    model = scene()
+    if mixing:
+        model.add(
+            gprMax.MaterialRange(
+                er_lower=2,
+                er_upper=4,
+                sigma_lower=0,
+                sigma_upper=0,
+                mr_lower=1,
+                mr_upper=1,
+                ro_lower=0,
+                ro_upper=0,
+                id="mix",
+            )
+        )
+    model.add(
+        gprMax.FractalBox(
+            p1=(0.040,) * 3,
+            p2=(0.052,) * 3,
+            frac_dim=1.5,
+            weighting=(1, 1, 1),
+            n_materials=4 if mixing else 1,
+            mixing_model_id="mix" if mixing else "pec",
+            id="fb",
+            seed=1,
+        )
+    )
+    model.add(
+        gprMax.AddSurfaceRoughness(
+            p1=(0.040, 0.040, 0.052),
+            p2=(0.052,) * 3,
+            frac_dim=1.5,
+            weighting=(1, 1),
+            limits=(0.050, 0.054),
+            fractal_box_id="fb",
+            seed=1,
+        )
+    )
+    return model
+
+
+@pytest.mark.parametrize("mixing", [False, True])
+@pytest.mark.parametrize("workflow", ["preview", "solve", "retry", "shared_scenes"])
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_fractal_definition_rebuilds_fresh_volume(tmp_path, monkeypatch, request, mixing, workflow, backend):
+    options = backend_options(request, backend)
+    built = []
+    original = Model.build
+
+    def observe(model):
+        original(model)
+        grid = model.G
+        assert len(grid.fractalvolumes) == 1
+        assert int(grid.ID.max()) < len(grid.materials)
+        built.append((grid.fractalvolumes[0], grid.solid.copy()))
+
+    monkeypatch.setattr(Model, "build", observe)
+    model = fractal_scene(mixing=mixing)
+    if workflow == "retry":
+        modifier = model.geometry_objects[-1]
+        modifier.kwargs["fractal_box_id"] = "missing"
+        with pytest.raises(ValueError, match="cannot find FractalBox missing"):
+            run(model, tmp_path / "failed", geometry_only=True, **options)
+        modifier.kwargs["fractal_box_id"] = "fb"
+    elif workflow == "shared_scenes":
+        run(model, tmp_path / "shared", n=2, **options)
+    else:
+        run(model, tmp_path / "first", geometry_only=workflow == "preview", **options)
+    run(model, tmp_path / "rebuilt", **options)
+    run(fractal_scene(mixing=mixing), tmp_path / "fresh", **options)
+    assert len({id(volume) for volume, _ in built}) == len(built)
+    for volume, solid in built:
+        assert volume.fractalvolume is None and volume.mask is None
+        np.testing.assert_array_equal(solid, built[-1][1])
+    np.testing.assert_array_equal(trace(tmp_path / "rebuilt.h5"), trace(tmp_path / "fresh.h5"))
+
+
+def test_mpi_nested_include_output_dir_reuse_matches_serial(tmp_path):
+    launcher = Path(sys.executable).parent / "mpiexec"
+    launcher = str(launcher) if launcher.is_file() else shutil.which("mpiexec")
+    if not launcher or importlib.util.find_spec("mpi4py") is None:
+        pytest.skip("MPI launcher/mpi4py required")
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / "geometry.in").write_text("#box: 0.040 0.040 0.040 0.048 0.048 0.048 pec\n")
+    (tmp_path / "outer.in").write_text("#include_file: nested/geometry.in\n")
+    environment = os.environ.copy()
+    environment.pop("FI_PROVIDER", None)
+    environment.pop("MPI4PY_RC_FINALIZE", None)
+    environment.update(PYTHONPATH=str(ROOT), OMP_NUM_THREADS="1")
+    for mode in ("serial", "mpi"):
+        source = tmp_path / f"{mode}.in"
+        source.write_text(HASH_BASE + f"#include_file: outer.in\n#output_dir: {mode}_results\n")
+        command = [
+            sys.executable,
+            "-m",
+            "gprMax",
+            str(source),
+            "-n",
+            "2",
+            "-i",
+            "3",
+            "--geometry-fixed",
+            "--hide-progress-bars",
+            "-cpu_precision",
+            "double",
+        ]
+        if mode == "mpi":
+            command = [launcher, "-n", "2", *command, "--mpi", "2", "1", "1"]
+        result = subprocess.run(command, cwd=ROOT, env=environment, capture_output=True, text=True, timeout=60)
+        assert result.returncode == 0, result.stdout + result.stderr
+    for index in (3, 4):
+        a = trace(tmp_path / f"serial_results/serial{index}.h5")
+        b = trace(tmp_path / f"mpi_results/mpi{index}.h5")
+        assert np.count_nonzero(a) > 0
+        np.testing.assert_array_equal(a, b)

--- a/tests/test_hash_command_consistency.py
+++ b/tests/test_hash_command_consistency.py
@@ -72,7 +72,9 @@ def test_every_registered_multiuse_command_has_parser_dispatch():
     process_multicmds(tracked)
 
     # Include files are expanded before multi-use user objects are constructed.
-    assert tracked.accessed == set(commands) - {"#include_file"}
+    # Includes are expanded upstream, but the dispatcher must explicitly
+    # reject any residual include instead of silently dropping it.
+    assert tracked.accessed == set(commands)
 
 
 def test_omp_threads_hash_round_trip_uses_documented_command():

--- a/tests/test_processing_execution_fixes.py
+++ b/tests/test_processing_execution_fixes.py
@@ -1,0 +1,164 @@
+"""End-to-end include/preflight and study-parameter regression coverage."""
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+from gprMax.hash_includes import static_hash_commands
+from gprMax.studies import _find_hash_array_codebook, _find_hash_study
+
+BASE = """#domain: 0.064 0.064 0.064
+#dx_dy_dz: 0.002 0.002 0.002
+#time_window: 24
+#pml_cells: 0
+#omp_threads: 1
+#waveform: gaussian 1 1e10 w
+#hertzian_dipole: z 0.032 0.032 0.032 w
+#rx: 0.032 0.032 0.032 probe Ez
+"""
+BACKENDS = ["cpu", pytest.param("cuda", marks=pytest.mark.gpu), pytest.param("opencl", marks=pytest.mark.gpu)]
+
+
+def backend_options(request, backend):
+    if backend == "cpu":
+        return {"cpu_precision": "double"}
+    index = request.getfixturevalue("gpu_device" if backend == "cuda" else "opencl_device")
+    return {"gpu" if backend == "cuda" else "opencl": [index], "gpu_precision": "double"}
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_run_nested_includes_never_consults_cwd_study(tmp_path, monkeypatch, request, backend):
+    model, caller = tmp_path / "model", tmp_path / "caller"
+    nested = model / "nested"
+    nested.mkdir(parents=True)
+    caller.mkdir()
+    source = model / "main.in"
+    source.write_text(BASE + "#include_file: nested/outer.in\n")
+    (nested / "outer.in").write_text("#include_file: inner.in\n")
+    (nested / "inner.in").write_text("#material: 4 0 1 0 medium\n")
+    (caller / "nested").mkdir()
+    (caller / "nested/outer.in").write_text("#study: gpr phantom.csv\n")
+    (model / "phantom.csv").write_text("case_id,object_id\noff,rx_1\n")
+    monkeypatch.chdir(caller)
+    gprMax.run(inputfile=source, hide_progress_bars=True, log_level=50, **backend_options(request, backend))
+    with h5py.File(source.with_suffix(".h5")) as output:
+        assert "study" not in output
+        assert np.count_nonzero(output["srcs/src1/excitation/samples"]) == 24
+        assert np.count_nonzero(output["rxs/rx1/Ez"]) == 23
+
+
+@pytest.mark.parametrize(
+    "scanner, command",
+    [(_find_hash_study, "#study: gpr cases.csv"), (_find_hash_array_codebook, "#array_codebook: modes.json")],
+)
+def test_preflight_shares_nested_directory_and_occurrence_policy(tmp_path, scanner, command):
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    main = tmp_path / "main.in"
+    main.write_text("#include_file: nested/outer.in\n")
+    (nested / "outer.in").write_text("#include_file: inner.in\n")
+    (nested / "inner.in").write_text(command + "\n")
+    result = scanner(main)
+    path = result[1] if isinstance(result, tuple) else result
+    assert path.parent == tmp_path  # Study CSV/codebook paths remain top-level relative.
+    main.write_text("#include_file: nested/outer.in\n" * 2)
+    with pytest.raises(ValueError, match="Only one"):
+        scanner(main)
+
+
+@pytest.mark.parametrize("alias", [False, True])
+def test_preflight_rejects_include_cycles(tmp_path, alias):
+    main, child = tmp_path / "main.in", tmp_path / "child.in"
+    main.write_text("#include_file: child.in\n")
+    if alias:
+        (tmp_path / "alias.in").symlink_to(main)
+    child.write_text(f"#include_file: {'alias.in' if alias else 'main.in'}\n")
+    with pytest.raises(ValueError, match="cycle detected"):
+        static_hash_commands(main)
+
+
+def test_preflight_bounds_depth_and_does_not_execute_python(tmp_path):
+    main = tmp_path / "main.in"
+    main.write_text(
+        "#python:\nraise RuntimeError('must not execute')\nprint('#study: gpr bad.csv')\n#end_python:\n#title: valid\n"
+    )
+    assert static_hash_commands(main) == ["#title: valid\n"]
+    for index in range(101):
+        (tmp_path / f"{index}.in").write_text(f"#include_file: {index+1}.in\n")
+    with pytest.raises(ValueError, match="nesting exceeds"):
+        static_hash_commands(tmp_path / "0.in")
+
+
+@pytest.mark.parametrize("command", ["#study: gpr ignored.csv", "#array_codebook: ignored.json"])
+def test_python_cannot_silently_introduce_run_controls(tmp_path, command):
+    source = tmp_path / "dynamic.in"
+    source.write_text(BASE + f"#python:\nprint({command!r})\n#end_python:\n")
+    with pytest.raises(ValueError, match="must be declared literally"):
+        gprMax.run(inputfile=source, hide_progress_bars=True, log_level=50)
+    assert not list(tmp_path.glob("*.h5"))
+
+
+@pytest.mark.parametrize(
+    "study_type", [gprMax.GPRStudy, gprMax.SourceStudy, gprMax.PortStudy, gprMax.PlaneWaveStudy, gprMax.EigenmodeStudy]
+)
+def test_all_study_families_reject_common_invalid_parameters(study_type):
+    study = study_type([gprMax.StudyCase("invalid", [gprMax.ObjectState("source", start=np.nan)])])
+    with pytest.raises(ValueError, match="must be finite"):
+        study.bind_scene(gprMax.Scene())
+
+
+def study_scene(parameters):
+    model = gprMax.Scene()
+    source = gprMax.HertzianDipole(p1=(0.032,) * 3, polarisation="z", waveform_id="w")
+    receiver = gprMax.Rx(p1=(0.032,) * 3, id="probe", outputs=["Ez"])
+    for item in (
+        gprMax.Domain(p1=(0.064,) * 3),
+        gprMax.Discretisation(p1=(0.002,) * 3),
+        gprMax.TimeWindow(iterations=24),
+        gprMax.PMLThickness(thickness=0),
+        gprMax.OMPThreads(1),
+        gprMax.Waveform(wave_type="gaussian", amp=1, freq=1e10, id="w"),
+        source,
+        receiver,
+    ):
+        model.add(item)
+    study = gprMax.GPRStudy([gprMax.StudyCase("case", [gprMax.ObjectState(source, **parameters)])])
+    return model, study, receiver
+
+
+@pytest.mark.parametrize("parameter", ["start", "stop"])
+@pytest.mark.parametrize("value", [np.nan, np.inf, -np.inf])
+def test_api_study_rejects_nonfinite_time_before_output(tmp_path, parameter, value):
+    model, study, _ = study_scene({parameter: value})
+    with pytest.raises(ValueError, match="must be finite"):
+        gprMax.run(scenes=[model], study=study, outputfile=tmp_path / "invalid", log_level=50)
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize("parameter", ["active", "record"])
+@pytest.mark.parametrize("value", [0, 1, "false", None, [], np.array([False])])
+def test_study_rejects_nonboolean_flags(parameter, value):
+    _, study, _ = study_scene({parameter: value})
+    with pytest.raises(ValueError, match="must be a boolean"):
+        study.reset_runtime()
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("value", [False, np.bool_(False), True, np.bool_(True)])
+def test_api_study_python_and_numpy_flags_agree(tmp_path, value):
+    model, study, _ = study_scene({"active": value})
+    output = tmp_path / "study.h5"
+    gprMax.run(scenes=[model], study=study, outputfile=output, hide_progress_bars=True, log_level=50)
+    with h5py.File(output) as handle:
+        assert bool(np.any(handle["srcs/src1/excitation/samples"])) == bool(value)
+        assert bool(np.any(handle["rxs/rx1/Ez"])) == bool(value)
+
+
+def test_numpy_record_false_is_rejected_not_silently_enabled(tmp_path):
+    model, study, receiver = study_scene({})
+    study.cases[0].states.append(gprMax.ObjectState(receiver, record=np.bool_(False)))
+    with pytest.raises(ValueError, match="record=false"):
+        gprMax.run(scenes=[model], study=study, outputfile=tmp_path / "record", log_level=50)
+    assert not list(tmp_path.glob("*.h5"))

--- a/tests/toolboxes/test_antenna_patterns.py
+++ b/tests/toolboxes/test_antenna_patterns.py
@@ -69,3 +69,16 @@ def test_pattern_processing_and_plotting_workflow(tmp_path):
     assert np.all(data["patterns"] >= 0)
     assert plotfile.is_file()
     assert plotfile.stat().st_size > 0
+
+    # The writer may renumber public groups; physical angle order is defined
+    # by these zero-padded Names, not by rxN. An ordinary feed is not a bin.
+    with h5py.File(outputfile, "r+") as output:
+        output.move("rxs/rx1", "rxs/temporary")
+        output.move("rxs/rx3", "rxs/rx1")
+        output.move("rxs/temporary", "rxs/rx3")
+        feed = output.create_group("rxs/rx4")
+        feed.attrs["Name"] = "ordinary_feed"
+        feed.attrs["Position"] = (0, 0, 0)
+        feed["Ez"] = np.ones(8) * 1e6
+    process_pattern(outputfile, configfile, patternfile)
+    np.testing.assert_array_equal(load_pattern_data(patternfile)["patterns"], data["patterns"])

--- a/tests/toolboxes/test_fmcw.py
+++ b/tests/toolboxes/test_fmcw.py
@@ -80,6 +80,28 @@ def test_chirp_uses_endpoint_exclusive_frequencies_and_physical_resolution():
     assert chirp.delay[-1] < chirp.samples / chirp.bandwidth
 
 
+@pytest.mark.parametrize("receiver_offset", [0.0, -0.5], ids=["electric", "magnetic"])
+def test_corrected_and_legacy_hard_source_clocks_give_same_channel(tmp_path, receiver_offset):
+    dt = 2e-11
+    chirp = Chirp(100e6, 900e6, 1e-3, 32)
+    responses = []
+    for source_steps in (0, 1):
+        path = tmp_path / f"hard_{source_steps}.h5"
+        trace = np.zeros(128)
+        trace[9 + source_steps] = 2
+        _write_signal_file(path, 2, trace, dt)
+        with h5py.File(path, "r+") as output:
+            source = output["srcs/src1/excitation"]
+            source.attrs["TimeSampleOffset"] = source_steps * dt
+            source.attrs["WaveformEvaluationTimeOffset"] = 0.0
+            source.attrs["DrivingQuantity"] = "imposed_gap_voltage"
+            output["rxs/rx1/Ez"].attrs["TimeSampleOffset"] = receiver_offset * dt
+        responses.append(process_channel(path, chirp).response)
+    expected = np.exp(-2j * np.pi * chirp.frequency * (9 + receiver_offset) * dt)
+    for response in responses:
+        assert_allclose(response, expected, rtol=2e-12, atol=2e-12)
+
+
 def test_point_target_maps_to_correct_positive_beat_and_fast_time():
     chirp = Chirp(100e6, 900e6, 80e-6, 128)
     delay_index = 11

--- a/tests/toolboxes/test_impulse_response.py
+++ b/tests/toolboxes/test_impulse_response.py
@@ -170,14 +170,20 @@ def test_builtin_samples_match_gprmax_waveform_definition(waveform_type):
     assert_allclose(result.samples, expected, rtol=2e-13, atol=2e-13)
 
 
-def test_hard_source_uses_evaluation_offset_not_physical_output_offset(tmp_path):
+@pytest.mark.parametrize("physical_steps", [0, 1], ids=["initial-E0", "legacy"])
+@pytest.mark.parametrize("explicit_evaluation", [False, True])
+def test_hard_source_uses_evaluation_offset_not_physical_output_offset(
+    tmp_path, physical_steps, explicit_evaluation
+):
     output = tmp_path / "hard.h5"
     dt = 2e-11
     with h5py.File(output, "w") as file:
         file.attrs["dt"] = dt
         excitation = file.create_group("srcs/src1/excitation")
         excitation.attrs["SampleInterval"] = dt
-        excitation.attrs["TimeSampleOffset"] = dt
+        excitation.attrs["TimeSampleOffset"] = physical_steps * dt
+        if explicit_evaluation:
+            excitation.attrs["WaveformEvaluationTimeOffset"] = 0.0
         excitation.attrs["DrivingQuantity"] = "imposed_gap_voltage"
         excitation.attrs["UpdateLattice"] = "electric"
         excitation.create_dataset("samples", data=np.r_[1.0, np.zeros(15)])
@@ -185,7 +191,7 @@ def test_hard_source_uses_evaluation_offset_not_physical_output_offset(tmp_path)
     source = load_source_sampling(output)
     waveform = sample_builtin_waveform(source, "impulse", 1, 1, "impulse")
 
-    assert source.signal.time_offset == dt
+    assert source.signal.time_offset == physical_steps * dt
     assert source.evaluation_time_offset == 0
     assert_array_equal(np.flatnonzero(waveform.samples), [0])
 
@@ -350,6 +356,37 @@ def test_batch_synthesis_writes_receiver_compatible_hdf5(tmp_path):
         assert file.attrs["Format"] == "gprMax impulse-response waveform synthesis"
         assert file["/rxs/rx1/Ez"].attrs["SynthesisedFromImpulse"]
         assert_allclose(file["/impulse_reference/source_samples"], source.signal.samples)
+
+
+def test_named_subset_preserves_identity_and_is_readable_by_plot_and_merge(tmp_path):
+    from toolboxes.Utilities.outputfiles_merge import get_output_data, merge_files
+    from toolboxes.Plotting.plot_Bscan import gather_receiver_outputs
+
+    original = tmp_path / "subset-input.h5"
+    _write_impulse_h5(original)
+    with h5py.File(original, "r+") as output:
+        output.attrs.update(
+            nrx=2, ReceiverOrder="construction", ReceiverOrderSchemaVersion=1, ReceiverLayout="original-layout"
+        )
+        output.move("rxs/rx1", "rxs/rx2")
+        output["rxs/rx2"].attrs.update(BuildIndex=1, NameKind="user", Position=(0, 0, 0))
+        rx = output.create_group("rxs/rx1")
+        rx.attrs.update(Name="other", BuildIndex=0, NameKind="user")
+        rx["Ez"] = np.ones(64)
+    source = load_source_sampling(original)
+    waveform = sample_builtin_waveform(source, "ricker", 1.0, 300e6, "target")
+    result = synthesise_output(original, waveform, receiver_selections=[("name:response", "Ez")])
+    output = write_synthesised_output(tmp_path / "subset.h5", result)
+    assert load_receiver(output, "name:response", "Ez").path == "/rxs/rx2/Ez"
+    values = result.receivers[0].samples
+    assert_allclose(get_output_data(output, 2, "Ez")[0], values)
+    assert_allclose(gather_receiver_outputs(output, "Ez")[0][:, 0], values)
+    merged = merge_files([output, output], tmp_path / "subset-merged.h5")
+    with h5py.File(merged) as stored:
+        assert stored.attrs["nrx"] == 1
+        assert stored["rxs/rx2"].attrs["BuildIndex"] == 1
+        assert stored.attrs["ReceiverLayout"] == "original-layout"
+        assert_allclose(stored["rxs/rx2/Ez"][:, 0], values)
 
 
 @pytest.fixture

--- a/tests/toolboxes/test_impulse_response_integration.py
+++ b/tests/toolboxes/test_impulse_response_integration.py
@@ -55,7 +55,9 @@ def _hard_voltage_scene(wave_type):
     scene.add(gprMax.DomainMode(mode="TM"))
     scene.add(gprMax.Discretisation(p1=(0.005, 0.005, 0.005)))
     scene.add(gprMax.Domain(p1=(0.2, 0.2, inf)))
-    scene.add(gprMax.TimeWindow(time=20e-9))
+    # An exact iteration window keeps the hard boundary active through the
+    # last observation, also for waveforms that have not decayed at the end.
+    scene.add(gprMax.TimeWindow(iterations=1700))
     scene.add(gprMax.OMPThreads(n=2))
     scene.add(gprMax.Waveform(wave_type=wave_type, amp=1, freq=500e6, id="source"))
     scene.add(
@@ -66,7 +68,7 @@ def _hard_voltage_scene(wave_type):
             waveform_id="source",
         )
     )
-    scene.add(gprMax.Rx(p1=(0.12, 0.1, inf), id="response", outputs=["Ez"]))
+    scene.add(gprMax.Rx(p1=(0.12, 0.1, inf), id="response", outputs=["Ez", "Hy", "Iz"]))
     return scene
 
 
@@ -97,9 +99,10 @@ def test_toolbox_ricker_synthesis_reproduces_direct_fdtd_run(tmp_path):
     assert relative_error < 1e-11
 
 
-def test_toolbox_preserves_hard_voltage_source_evaluation_timing(tmp_path):
+@pytest.mark.parametrize("wave_type", ["ricker", "gaussian", "contsine"])
+def test_toolbox_preserves_hard_voltage_source_evaluation_timing(tmp_path, wave_type):
     files = {}
-    for waveform_type in ("impulse", "ricker"):
+    for waveform_type in ("impulse", wave_type):
         output = tmp_path / f"hard_{waveform_type}"
         gprMax.run(
             scenes=[_hard_voltage_scene(waveform_type)],
@@ -112,14 +115,17 @@ def test_toolbox_preserves_hard_voltage_source_evaluation_timing(tmp_path):
         files[waveform_type] = output.with_suffix(".h5")
 
     impulse_source = load_source_sampling(files["impulse"])
-    target = sample_builtin_waveform(impulse_source, "ricker", 1, 500e6, "ricker500")
-    synthesis = synthesise_output(files["impulse"], target)
-    direct_source = load_source(files["ricker"])
-    direct_receiver = load_receiver(files["ricker"])
+    target = sample_builtin_waveform(impulse_source, wave_type, 1, 500e6, "target500")
+    direct_source = load_source(files[wave_type])
 
-    assert impulse_source.signal.time_offset == pytest.approx(impulse_source.signal.dt)
+    assert impulse_source.signal.time_offset == 0.0
     assert impulse_source.evaluation_time_offset == 0.0
     np.testing.assert_allclose(target.samples, direct_source.samples, rtol=2e-13, atol=2e-16)
-    peak = np.max(np.abs(direct_receiver.samples))
-    relative_error = np.max(np.abs(synthesis.receivers[0].samples - direct_receiver.samples)) / peak
-    assert relative_error < 1e-11
+    for component in ("Ez", "Hy", "Iz"):
+        synthesis = synthesise_output(
+            files["impulse"], target, receiver_selections=[("rxs/rx1", component)]
+        )
+        direct_receiver = load_receiver(files[wave_type], component=component)
+        peak = np.max(np.abs(direct_receiver.samples))
+        relative_error = np.max(np.abs(synthesis.receivers[0].samples - direct_receiver.samples)) / peak
+        assert relative_error < 1e-11

--- a/tests/toolboxes/test_marimo_trace_matrix.py
+++ b/tests/toolboxes/test_marimo_trace_matrix.py
@@ -152,10 +152,11 @@ class TestProcessTrace:
         assert result["receiver"] == "rx2"
         assert result["array"][0] == pytest.approx(2.0)
 
-    def test_falls_back_to_first_receiver_if_preferred_not_present(self, tmp_path):
+    def test_rejects_missing_explicit_receiver(self, tmp_path):
         fdata = load_file(_write_trace_two_receivers(tmp_path / "t1.h5", x_pos=0.05))
         result = process_trace(fdata, "Ez", expected_len=None, preferred_receiver="rx99")
-        assert result["receiver"] == "rx1"
+        assert not result["ok"]
+        assert "missing" in result["reason"]
 
 
 class TestStackTraces:

--- a/tests/toolboxes/test_matlab_h5_tools.py
+++ b/tests/toolboxes/test_matlab_h5_tools.py
@@ -97,9 +97,32 @@ def test_matlab_reader_and_converter_round_trip(tmp_path):
     batch_mat = tmp_path / "batch-output.mat"
     _write_fixture(first)
     _write_fixture(second, offset=100)
+    renumbered = tmp_path / "renumbered.h5"
+    _write_fixture(renumbered)
+    with h5py.File(renumbered, "r+") as output:
+        output.move("rxs/rx1", "rxs/rx10")
+        output.move("trace_metadata/rxs/rx1", "trace_metadata/rxs/rx10")
+        other = output.create_group("rxs/rx1")
+        other.attrs["Name"] = "other receiver"
+        other["Ex"] = np.ones(4) * 999
 
     script = f"""
 addpath('{_matlab_path(MATLAB_TOOLS)}');
+assert(gprmax_receiver_path('{_matlab_path(renumbered)}', 'test receiver') == "/rxs/rx10");
+[namedFigure, namedScan] = plot_Bscan('{_matlab_path(renumbered)}', 'Ez', ...
+    'ReceiverName', 'test receiver', 'Visible', false);
+assert(isequal(namedScan.values, single(reshape(0:11, 3, 4)')));
+close(namedFigure);
+[namedFigures, namedTraces] = plot_Ascan('{_matlab_path(renumbered)}', ...
+    'ReceiverName', 'test receiver', 'Outputs', 'Ex', 'Visible', false);
+assert(numel(namedFigures) == 1);
+close(namedFigures);
+try
+    gprmax_receiver_path('{_matlab_path(renumbered)}', 'absent');
+    error('gprMax:test:MissingIdentityAccepted', 'Missing name accepted');
+catch exception
+    assert(strcmp(exception.identifier, 'gprMax:MATLAB:ReceiverIdentity'));
+end
 g = gprmax_read_h5('{_matlab_path(first)}', ...
     'Paths', ["/rxs", "/port-feed"]);
 assert(isequal(size(g.data.rxs.rx1.Ez), [4 3]));

--- a/tests/toolboxes/test_output_path_safety.py
+++ b/tests/toolboxes/test_output_path_safety.py
@@ -1,0 +1,80 @@
+"""Merging must not damage inputs or publish partial outputs on failure."""
+
+import os
+
+import h5py
+import numpy as np
+import pytest
+
+from toolboxes.Utilities import outputfiles_merge as merger
+
+pytestmark = pytest.mark.unit
+
+
+def _inputs(tmp_path):
+    paths = [tmp_path / f"input{index}.h5" for index in range(2)]
+    for index, path in enumerate(paths):
+        with h5py.File(path, "w") as output:
+            output.attrs.update(Iterations=8, dt=1e-10, nrx=1)
+            receiver = output.create_group("rxs/rx1")
+            receiver.attrs.update(Name="probe", Position=(0.02,) * 3)
+            receiver["Ez"] = np.arange(8.0) + index
+    return paths
+
+
+@pytest.mark.parametrize("alias", ["same", "symlink", "hardlink"])
+@pytest.mark.parametrize("input_index", [0, 1])
+@pytest.mark.parametrize("removefiles", [False, True])
+def test_merge_rejects_all_input_aliases_without_writes(tmp_path, alias, input_index, removefiles):
+    inputs = _inputs(tmp_path)
+    before = [path.read_bytes() for path in inputs]
+    destination = tmp_path / "merged.h5"
+    if alias == "same":
+        destination = inputs[input_index]
+    else:
+        try:
+            if alias == "symlink":
+                destination.symlink_to(inputs[input_index])
+            else:
+                os.link(inputs[input_index], destination)
+        except OSError as error:
+            pytest.skip(f"Filesystem does not permit {alias}: {error}")
+    with pytest.raises(ValueError, match="must not overwrite an input"):
+        merger.merge_files(inputs, destination, removefiles=removefiles)
+    assert [path.read_bytes() for path in inputs] == before
+
+
+@pytest.mark.parametrize("exists", [False, True])
+@pytest.mark.parametrize("removefiles", [False, True])
+def test_failed_merge_preserves_destination_inputs_and_cleans_staging(tmp_path, monkeypatch, exists, removefiles):
+    inputs = _inputs(tmp_path)
+    before = [path.read_bytes() for path in inputs]
+    destination = tmp_path / "merged.h5"
+    previous = b"previous successful output"
+    if exists:
+        destination.write_bytes(previous)
+    original = merger._write_trace_metadata
+
+    def fail_second_column(*args):
+        if args[2] == 1:
+            raise OSError("injected write failure")
+        return original(*args)
+
+    monkeypatch.setattr(merger, "_write_trace_metadata", fail_second_column)
+    with pytest.raises(OSError, match="injected write failure"):
+        merger.merge_files(inputs, destination, removefiles=removefiles)
+    assert [path.read_bytes() for path in inputs] == before
+    assert destination.read_bytes() == previous if exists else not destination.exists()
+    assert not list(tmp_path.glob(".merged.h5.*"))
+
+
+def test_successful_merge_publishes_then_removes_inputs(tmp_path):
+    inputs = _inputs(tmp_path)
+    destination = tmp_path / "merged.h5"
+    destination.write_bytes(b"replace me")
+    result = merger.merge_files(inputs, destination, removefiles=True)
+    assert result == destination
+    assert not any(path.exists() for path in inputs)
+    with h5py.File(destination) as output:
+        np.testing.assert_array_equal(output["rxs/rx1/Ez"][:], np.arange(8.0)[:, None] + [0, 1])
+    assert not list(tmp_path.glob(".merged.h5.*"))

--- a/tests/toolboxes/test_physical_trace_consumers.py
+++ b/tests/toolboxes/test_physical_trace_consumers.py
@@ -1,0 +1,266 @@
+"""Cross-consumer identity, physical time and native buffer-length checks."""
+
+import ast
+from pathlib import Path
+
+import h5py
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+import gprMax
+from toolboxes.Marimo.h5_reader import get_trace, load_file
+from toolboxes.Marimo.reference import subtract_receiver_reference
+from toolboxes.Plotting import plot_Ascan, plot_Bscan
+from toolboxes.Plotting.plot_port import read_port_output
+from toolboxes.Utilities.outputfiles_merge import get_output_data, merge_files
+from toolboxes.Utilities.outputfiles_trace import collect_traces
+from toolboxes.Utilities.trace_time import read_time_history
+
+
+def receiver_file(path, names=("A", "B"), dt=1e-10):
+    with h5py.File(path, "w") as output:
+        output.attrs.update(
+            Iterations=8, dt=dt, nrx=len(names), nsrc=0, Title="trace tests", dx_dy_dz=[0.001] * 3, nx_ny_nz=[32] * 3
+        )
+        for index, name in enumerate(names, 1):
+            group = output.create_group(f"rxs/rx{index}")
+            group.attrs.update(Name=name, Position=[index, 0, 0])
+            for component in ("Ex", "Ey", "Ez", "Hx", "Hy", "Hz", "Ix", "Iy", "Iz"):
+                values = np.full(8, 10.0 if name == "A" else 2.0)
+                dataset = group.create_dataset(component, data=values)
+                dataset.attrs.update(SampleInterval=dt, TimeSampleOffset=0 if component.startswith("E") else -dt / 2)
+    return path
+
+
+def test_marimo_dashboard_subtraction_matches_identity(tmp_path):
+    target = load_file(receiver_file(tmp_path / "target.h5"))
+    background = load_file(receiver_file(tmp_path / "background.h5", ("B", "A")))
+    # Execute the actual dashboard callback too, not just the reusable helper.
+    module = ast.parse(Path("toolboxes/Marimo/ascan_dashboard.py").read_text())
+    helper = next(
+        node for node in ast.walk(module) if isinstance(node, ast.FunctionDef) and node.name == "_apply_subtraction"
+    )
+    namespace = dict(
+        _ref_name="background",
+        _files={"background": background},
+        subtract_receiver_reference=subtract_receiver_reference,
+        _sub_warnings=[],
+        _subtracted=[],
+    )
+    exec(compile(ast.Module(body=[helper], type_ignores=[]), "ascan_dashboard.py", "exec"), namespace)
+    result = namespace["_apply_subtraction"](
+        get_trace(target, "Ez", "rx1"), dict(filename="target", component="Ez", receiver="rx1", label="A"), target
+    )
+    np.testing.assert_array_equal(result, 0)
+    assert not namespace["_sub_warnings"]
+    assert namespace["_subtracted"] == ["A"]
+
+
+@pytest.mark.parametrize("names", [("B",), ("A", "A")])
+def test_background_missing_or_ambiguous_identity_is_rejected(tmp_path, names):
+    target = load_file(receiver_file(tmp_path / "target.h5"))
+    reference = load_file(receiver_file(tmp_path / "reference.h5", names))
+    with pytest.raises(ValueError, match="identity"):
+        subtract_receiver_reference(get_trace(target, "Ez"), target, reference, receiver="rx1", component="Ez")
+
+
+def test_background_physical_times_checked_after_matching(tmp_path):
+    target = load_file(receiver_file(tmp_path / "target.h5", dt=1e-15))
+    path = receiver_file(tmp_path / "reference.h5", ("B", "A"), dt=1e-15)
+    with h5py.File(path, "r+") as handle:
+        handle["rxs/rx2/Ez"].attrs["TimeSampleOffset"] = 0.5e-15
+    with pytest.raises(ValueError, match="sample times differ"):
+        subtract_receiver_reference(get_trace(target, "Ez"), target, load_file(path), receiver="rx1", component="Ez")
+
+
+@pytest.mark.parametrize(
+    "outputs",
+    [
+        ("Ez", "Ix"),
+        ("Ix", "Iy", "Iz"),
+        ("Ex", "Hx", "Iz-"),
+        ("Ix",),
+        ("Ex", "Ey", "Ez", "Hx", "Hy", "Hz", "Ix", "Iy", "Iz"),
+    ],
+)
+def test_ascan_subsets_and_physical_axes(tmp_path, monkeypatch, outputs):
+    path = receiver_file(tmp_path / "fields.h5", ("A",))
+    captured = []
+    monkeypatch.setattr(plot_Ascan, "handle_plot_output", lambda _plt, fig, *a, **k: captured.append(fig))
+    try:
+        plot_Ascan.mpl_plot(path, outputs=outputs, show=False)
+        lines = [line for ax in captured[0].axes for line in ax.lines]
+        assert len(lines) == len(outputs)
+        for line in lines:
+            label = line.get_label().strip("-")
+            expected_offset = 0 if label.startswith("E") else -0.5e-10
+            np.testing.assert_allclose(line.get_xdata(), expected_offset + np.arange(8) * 1e-10, rtol=1e-14, atol=0)
+            if line.get_label().startswith("-"):
+                np.testing.assert_array_equal(line.get_ydata(), -10)
+    finally:
+        plt.close("all")
+
+
+def test_ascan_fft_uses_dataset_interval_and_offset(tmp_path, monkeypatch):
+    path = receiver_file(tmp_path / "fields.h5", ("A",))
+    with h5py.File(path, "r+") as handle:
+        handle["rxs/rx1/Hx"].attrs.update(SampleInterval=2e-10, TimeSampleOffset=-1e-10)
+    figures = []
+    monkeypatch.setattr(plot_Ascan, "handle_plot_output", lambda _plt, fig, *a, **k: figures.append(fig))
+    try:
+        plot_Ascan.mpl_plot(path, outputs=["Hx"], fft=True, show=False)
+        np.testing.assert_allclose(figures[0].axes[0].lines[0].get_xdata(), (np.arange(8) - 0.5) * 2e-10)
+    finally:
+        plt.close("all")
+
+
+@pytest.mark.parametrize("component", ["Ez", "Hx", "Ix"])
+def test_bscan_gather_preserves_sample_centres(tmp_path, monkeypatch, component):
+    path = receiver_file(tmp_path / "fields.h5")
+    samples, dt, offset = plot_Bscan.gather_receiver_outputs(path, component, return_time_offset=True)
+    figures = []
+    monkeypatch.setattr(plot_Bscan, "handle_plot_output", lambda _plt, fig, *a, **k: figures.append(fig))
+    try:
+        plot_Bscan.mpl_plot(path, samples, dt, 1, component, show=False, time_offset=offset)
+        extent = figures[0].axes[0].images[0].get_extent()
+        centres = extent[3] + (np.arange(8) + 0.5) * (extent[2] - extent[3]) / 8
+        np.testing.assert_allclose(centres, offset + np.arange(8) * dt, atol=1e-25)
+    finally:
+        plt.close("all")
+
+
+@pytest.mark.parametrize("attribute, value", [("TimeSampleOffset", 1e-10), ("SampleInterval", 2e-10)])
+def test_gather_rejects_inconsistent_timing(tmp_path, attribute, value):
+    path = receiver_file(tmp_path / "fields.h5")
+    with h5py.File(path, "r+") as handle:
+        handle["rxs/rx2/Ez"].attrs[attribute] = value
+    with pytest.raises(ValueError, match="inconsistent sample times"):
+        plot_Bscan.gather_receiver_outputs(path, "Ez")
+
+
+def test_terminal_bscan_loader_preserves_offset_and_legacy_return(tmp_path, monkeypatch):
+    path = tmp_path / "terminal.h5"
+    dt, offset = 2e-10, 1e-10
+    values = np.arange(16, dtype=float).reshape(8, 2)
+    with h5py.File(path, "w") as output:
+        output.attrs.update(Iterations=8, dt=dt, nrx=0)
+        group = output.create_group("ports/feed")
+        group.attrs["TimeSampleOffset"] = offset
+        group["time"] = offset + np.arange(8) * dt
+        group["Vtotal"] = values
+    legacy = get_output_data(path, 1, "Vtotal", trace_group="ports/feed")
+    assert len(legacy) == 2
+    np.testing.assert_array_equal(legacy[0], values)
+    samples, interval, start = get_output_data(path, 1, "Vtotal", trace_group="ports/feed", return_time_offset=True)
+    assert interval == dt and start == offset
+    figures = []
+    monkeypatch.setattr(plot_Bscan, "handle_plot_output", lambda _plt, fig, *a, **k: figures.append(fig))
+    try:
+        plot_Bscan.mpl_plot(
+            path, samples, interval, 1, "Vtotal", trace_group="ports/feed", time_offset=start, show=False
+        )
+        extent = figures[0].axes[0].images[0].get_extent()
+        centres = extent[3] + (np.arange(8) + 0.5) * (extent[2] - extent[3]) / 8
+        np.testing.assert_allclose(centres, offset + np.arange(8) * dt, atol=1e-25)
+    finally:
+        plt.close("all")
+
+
+@pytest.mark.parametrize(
+    "family, component, time_name, offset_attr, offset_steps",
+    [
+        ("tls", "Itotal", "time_current", "TimeCurrentOffset", -0.5),
+        ("tls", "Vtotal", "time_voltage", "TimeVoltageOffset", 0),
+        ("ports", "Vtotal", "time", "TimeSampleOffset", 0.5),
+        ("ports", "Iloop", "time_current", "CurrentTimeSampleOffset", -0.5),
+        ("ports", "Inetwork", "time", "TimeSampleOffset", 0.5),
+        ("frills", "Itot", "time", "TimeOffset", 0),
+    ],
+)
+@pytest.mark.parametrize("with_axis", [False, True])
+def test_native_source_families_use_owning_grid_times(
+    tmp_path, family, component, time_name, offset_attr, offset_steps, with_axis
+):
+    with h5py.File(tmp_path / "native.h5", "w") as output:
+        output.attrs.update(Iterations=3, dt=3e-10)
+        grid = output.create_group("subgrids/fine")
+        grid.attrs.update(Iterations=9, dt=1e-10)
+        group = grid.create_group(f"{family}/source")
+        group.attrs[offset_attr] = offset_steps * 1e-10
+        if with_axis:
+            group[time_name] = (np.arange(9) + offset_steps) * 1e-10
+        dataset = group.create_dataset(component, data=np.arange(10 if family == "frills" else 9, dtype=float))
+        history = read_time_history(dataset)
+        assert history.samples.size == 9
+        assert history.dt == 1e-10
+        np.testing.assert_allclose(history.time, (np.arange(9) + offset_steps) * 1e-10, atol=1e-25)
+
+
+def test_reader_rejects_wrong_axis_without_inventing_replacement(tmp_path):
+    with h5py.File(tmp_path / "bad.h5", "w") as output:
+        output.attrs.update(Iterations=8, dt=1e-10)
+        group = output.create_group("ports/feed")
+        group["Vtotal"] = np.ones(8)
+        group["time"] = np.arange(7) * 1e-10
+        with pytest.raises(ValueError, match="Invalid time axis"):
+            read_time_history(group["Vtotal"])
+        del group["time"]
+        group["time"] = np.arange(8) * 2e-10
+        with pytest.raises(ValueError, match="disagree"):
+            read_time_history(group["Vtotal"])
+
+
+@pytest.fixture(scope="module")
+def native_frill(tmp_path_factory):
+    output = tmp_path_factory.mktemp("physical_frill") / "frill.h5"
+    scene = gprMax.Scene()
+    for item in (
+        gprMax.Domain(p1=(0.02,) * 3),
+        gprMax.Discretisation(p1=(0.001,) * 3),
+        gprMax.TimeWindow(iterations=64),
+        gprMax.PMLThickness(thickness=0),
+        gprMax.OMPThreads(1),
+        gprMax.Waveform(wave_type="gaussian", amp=1, freq=1e10, id="w"),
+        gprMax.Box(p1=(0, 0, 0), p2=(0.02, 0.02, 0.001), material_id="pec"),
+        gprMax.ThinWire(p1=(0.01, 0.01, 0), p2=(0.01, 0.01, 0.01), radius=1e-4),
+        gprMax.MagneticFrillSource(p1=(0.01, 0.01, 0), polarisation="z", zcoax=50, waveform_id="w"),
+    ):
+        scene.add(item)
+    gprMax.run(scenes=[scene], outputfile=output, hide_progress_bars=True, log_level=50, cpu_precision="double")
+    return output
+
+
+@pytest.mark.integration
+def test_real_frill_plot_export_and_merge_agree(native_frill, tmp_path):
+    with h5py.File(native_frill) as output:
+        physical_time = output["frills/frill1/time"][:]
+        current = output["frills/frill1/Itot"][:64]
+        assert output["frills/frill1/Itot"].size == 65
+    records, dt, offset, *_ = collect_traces([native_frill], 1, "Itot", trace_group="frills/frill1")
+    assert records[0].samples.size == 64 and offset == 0
+    np.testing.assert_array_equal(records[0].samples, current)
+    plot = read_port_output(native_frill, "frills/frill1")
+    for trace in plot.time_traces:
+        assert trace.values.size == 64
+        np.testing.assert_allclose(trace.time, physical_time, atol=1e-25)
+    voltage, _, voltage_offset = get_output_data(
+        native_frill, 1, "Vtotal", trace_group="frills/frill1", return_time_offset=True
+    )
+    assert voltage.size == 64 and voltage_offset == 0
+    merged = merge_files([native_frill, native_frill], tmp_path / "merged.h5")
+    matrix, _, _ = get_output_data(merged, 1, "Vtotal", trace_group="frills/frill1", return_time_offset=True)
+    assert matrix.shape == (64, 2)
+    np.testing.assert_array_equal(matrix[:, 0], voltage)
+
+
+@pytest.mark.integration
+def test_real_frill_all_exporters_use_physical_length(native_frill, tmp_path):
+    from toolboxes.Utilities.outputfiles_seg2 import export_seg2
+    from toolboxes.Utilities.outputfiles_segy import export_segy
+    from toolboxes.Utilities.outputfiles_dt1 import export_dt1
+
+    for function, suffix in ((export_seg2, "sg2"), (export_segy, "sgy"), (export_dt1, "dt1")):
+        result = function([native_frill], tmp_path / f"frill.{suffix}", 1, "Itot", trace_group="frills/frill1")
+        assert result.sample_count == 64
+        assert result.time_sample_offset == 0

--- a/tests/toolboxes/test_receiver_identity.py
+++ b/tests/toolboxes/test_receiver_identity.py
@@ -1,0 +1,223 @@
+"""Identity-routing regressions: same receivers, deliberately permuted rxN."""
+
+from dataclasses import replace
+
+import h5py
+import numpy as np
+import pytest
+
+from toolboxes.Utilities.receiver_identity import (
+    ReceiverIdentity,
+    match_receiver,
+    receiver_catalogue,
+    select_receiver,
+)
+from toolboxes.Utilities.outputfiles_merge import get_output_data, merge_files
+from toolboxes.Utilities.outputfiles_trace import collect_traces
+from toolboxes.Marimo.h5_reader import load_file, list_receivers as marimo_receivers
+from toolboxes.Marimo.trace_matrix import stack_traces, process_trace
+from toolboxes.SFCW.processing import load_receiver, list_receivers
+from toolboxes.FMCW.processing import Chirp, process_channel, process_incident_referenced_channel
+
+
+def write_output(path, names=("zulu", "alpha"), *, new=False, shift=0, subgrid=False):
+    with h5py.File(path, "w") as output:
+        output.attrs.update(
+            Iterations=32,
+            dt=2e-11,
+            nrx=len(names),
+            nsrc=1,
+            dx_dy_dz=(0.001,) * 3,
+            nx_ny_nz=(100,) * 3,
+            Title="identity",
+        )
+        grid = output.create_group("subgrids/fine") if subgrid else output
+        if subgrid:
+            grid.attrs.update(dict(output.attrs))
+            output.attrs["nrx"] = 0
+        if new:
+            grid.attrs.update(
+                ReceiverOrderSchemaVersion=1, ReceiverOrder="construction", ReceiverLayout="same-test-declarations"
+            )
+        src = grid.create_group("srcs/src1")
+        src.attrs.update(Position=(shift, 0, 0), Type="HertzianDipole")
+        excitation = src.create_group("excitation")
+        excitation.attrs.update(SampleInterval=2e-11, TimeSampleOffset=0.0)
+        excitation["samples"] = np.r_[1.0, np.zeros(31)]
+        for index, name in enumerate(names):
+            rx = grid.create_group(f"rxs/rx{index+1}")
+            marker = 10 if name == "zulu" else 1
+            rx.attrs.update(Position=(shift + marker, 0, 0), GridPosition=(marker, 0, 0))
+            if name is not None:
+                rx.attrs["Name"] = name
+            if new:
+                rx.attrs.update(BuildIndex=index, NameKind="user")
+            for comp in ("Ex", "Ey", "Ez"):
+                ds = rx.create_dataset(comp, data=np.r_[0.0, 0.0, marker, np.zeros(29)])
+                ds.attrs.update(SampleInterval=2e-11, TimeSampleOffset=0.0)
+    return path
+
+
+@pytest.fixture
+def permuted(tmp_path):
+    return (write_output(tmp_path / "new.h5", new=True), write_output(tmp_path / "old.h5", ("alpha", "zulu"), shift=3))
+
+
+def test_named_selection_and_natural_discovery(permuted, tmp_path):
+    from toolboxes.Optimisation.quantities import read_receiver
+
+    for path in permuted:
+        assert load_receiver(path, "name:zulu", "Ez").samples[2] == 10
+        assert get_output_data(path, 1, "Ez", receiver_name="zulu")[0][2] == 10
+        assert read_receiver(path, "zulu", "Ez").values[2] == 10
+    many = write_output(tmp_path / "many.h5", tuple(f"r{i}" for i in range(13)))
+    assert list(list_receivers(many)) == [f"/rxs/rx{i}" for i in range(1, 14)]
+    assert marimo_receivers(load_file(many)) == [f"rx{i}" for i in range(1, 14)]
+
+
+@pytest.mark.parametrize("reverse", (False, True))
+def test_merge_and_export_follow_identity_and_positions(permuted, tmp_path, reverse):
+    files = permuted[::-1] if reverse else permuted
+    expected = 1 if reverse else 10
+    traces, *_ = collect_traces(files, 1, "Ez")
+    assert [trace.samples[2] for trace in traces] == [expected, expected]
+    merged = merge_files(files, tmp_path / "merged.h5")
+    with h5py.File(merged) as output:
+        np.testing.assert_array_equal(output["rxs/rx1/Ez"][2], [expected, expected])
+        assert output["trace_metadata/rxs/rx1/InputReceiverPath"].asstr()[:].tolist() == ["rxs/rx1", "rxs/rx2"]
+        np.testing.assert_array_equal(
+            output["trace_metadata/rxs/rx1/Position"][:, 0], [record.receiver_position[0] for record in traces]
+        )
+
+
+def test_marimo_stack_and_live_reader_follow_first_identity(permuted):
+    files = [load_file(path) for path in permuted]
+    result = stack_traces(files, "Ez", "rx1")
+    assert not result["warnings"]
+    np.testing.assert_array_equal(result["matrix"][2], [10, 10])
+    first = process_trace(files[0], "Ez", None, "rx1")
+    second = process_trace(files[1], "Ez", 32, "rx1", expected_identity=first["identity"])
+    assert second["receiver"] == "rx2"
+    assert second["array"][2] == 10
+
+
+def test_fmcw_background_and_incident_follow_identity(permuted):
+    chirp = Chirp(0.1e9, 1.1e9, 1e-3, 16)
+    target, background = permuted
+    response = process_channel(target, chirp, background_filename=background, receiver_path="name:zulu", component="Ez")
+    np.testing.assert_array_equal(response.response, 0)
+    assert response.background.receiver.path == "/rxs/rx2/Ez"
+    incident = process_incident_referenced_channel(target, background, chirp, receiver_path="/rxs/rx1", component="Ez")
+    np.testing.assert_array_equal(incident.response, 0)
+    # A different incident/reference point is legitimate only when explicitly selected.
+    explicit = process_channel(
+        target,
+        chirp,
+        background_filename=background,
+        receiver_path="/rxs/rx1",
+        component="Ez",
+        background_receiver_path="/rxs/rx1",
+    )
+    assert np.max(np.abs(explicit.response)) > 8
+
+
+@pytest.mark.parametrize("names", [("different", "other"), ("zulu", "zulu"), (None, None)])
+def test_ambiguous_cross_file_inputs_fail_before_merge_write(permuted, tmp_path, names):
+    bad = write_output(tmp_path / "bad.h5", names)
+    destination = tmp_path / "must-survive.h5"
+    destination.write_bytes(b"do not truncate")
+    with pytest.raises(ValueError, match="identity"):
+        merge_files([permuted[0], bad], destination)
+    assert destination.read_bytes() == b"do not truncate"
+    with pytest.raises(ValueError, match="identity"):
+        collect_traces([permuted[0], bad], 1, "Ez")
+    stack = stack_traces([load_file(permuted[0]), load_file(bad)], "Ez", "rx1")
+    assert len(stack["warnings"]) == 1
+    assert stack["matrix"].shape == (32, 1)
+
+
+def test_construction_identity_tracks_moving_generated_names():
+    first = ReceiverIdentity(
+        "rxs/rx1", "Rx(1,0,0)", name_kind="generated", build_index=0, layout="layout", name_unique=True, count=2
+    )
+    second = replace(first, name="Rx(2,0,0)")
+    crossed = replace(first, path="rxs/rx2", build_index=1)
+    assert match_receiver(first, {second.path: second, crossed.path: crossed}) == second
+    duplicate = replace(first, name="duplicate", name_kind="user", name_unique=False)
+    assert match_receiver(duplicate, {duplicate.path: duplicate}) == duplicate
+    with pytest.raises(ValueError, match="identity"):
+        match_receiver(duplicate, {duplicate.path: replace(duplicate, layout="different")})
+
+
+def test_study_identity_is_authoritative_and_unique():
+    first = ReceiverIdentity("rxs/rx1", "old", "moving", study_unique=True)
+    other = replace(first, path="rxs/rx2", name="new")
+    assert match_receiver(first, {other.path: other}) == other
+    with pytest.raises(ValueError, match="StudyID"):
+        match_receiver(first, {first.path: first, other.path: other})
+
+
+def test_subgrid_matching_stays_in_its_namespace(tmp_path):
+    first = write_output(tmp_path / "a.h5", new=True, subgrid=True)
+    second = write_output(tmp_path / "b.h5", ("alpha", "zulu"), subgrid=True)
+    traces, *_ = collect_traces([first, second], 1, "Ez", grid_path="subgrids/fine")
+    assert [trace.samples[2] for trace in traces] == [10, 10]
+    merged = merge_files([first, second], tmp_path / "sub.h5")
+    with h5py.File(merged) as output:
+        np.testing.assert_array_equal(output["subgrids/fine/rxs/rx1/Ez"][2], [10, 10])
+
+
+def test_duplicate_metadata_or_explicit_name_is_rejected(tmp_path):
+    path = write_output(tmp_path / "dup.h5", ("same", "same"), new=True)
+    with h5py.File(path, "r+") as output:
+        catalogue = receiver_catalogue(output)
+        with pytest.raises(ValueError, match="2 matches"):
+            select_receiver(catalogue, "name:same")
+        assert select_receiver(catalogue, "build:1").path == "rxs/rx2"
+        output["rxs/rx2"].attrs["BuildIndex"] = 0
+        with pytest.raises(ValueError, match="duplicate"):
+            receiver_catalogue(output)
+
+
+def test_legacy_comparison_matches_receiver_not_group_number(permuted):
+    from testing.diff_output_files import diff_output_files
+
+    _, differences = diff_output_files(*permuted)
+    np.testing.assert_array_equal(differences, 0)
+
+
+def test_reframe_resolves_paths_after_files_exist(permuted, monkeypatch):
+    from types import SimpleNamespace
+
+    pytest.importorskip("reframe")
+    from reframe_tests.tests import regression_checks as checks
+    import reframe.utility.sanity as sn
+
+    monkeypatch.setattr(checks, "runtime", lambda: SimpleNamespace(system=SimpleNamespace(name="local")))
+    captured = []
+
+    def run(command):
+        captured.append(command)
+        return SimpleNamespace(returncode=0, stdout="", stderr="", args=command)
+
+    monkeypatch.setattr(checks.osext, "run_command", run)
+    check = checks.ReceiverRegressionCheck(permuted[0], permuted[1], "rx1")
+    assert sn.evaluate(check.run())
+    assert captured[0][-4:] == [str(permuted[0]), str(permuted[1]), "rxs/rx1", "rxs/rx2"]
+    assert check.objects == []
+
+    from reframe.core.exceptions import SanityError
+
+    monkeypatch.setattr(
+        checks.osext,
+        "run_command",
+        lambda command: SimpleNamespace(
+            returncode=2,
+            stdout="",
+            stderr="h5diff could not read the file",
+            args=command,
+        ),
+    )
+    with pytest.raises(SanityError, match="could not read"):
+        sn.evaluate(check.run())
+    assert check.objects == []

--- a/tests/updates/test_coincident_sources_solve.py
+++ b/tests/updates/test_coincident_sources_solve.py
@@ -229,19 +229,22 @@ def _voltage_specs(case):
 def _check_hard_assignments(result, polarisation, case):
     """The last active hard source writes -V/dl at its electric edge."""
     edge = result["fields"][f"edge/E{polarisation}"]
-    iterations = np.arange(edge.size) - 1  # Output precedes the next field update.
-    time = iterations * result["dt"]
+    samples = np.arange(edge.size)
+    iterations = samples - 1  # Additive updates precede this stored E sample.
     expected, prescribed = np.zeros_like(edge), np.zeros(edge.size, dtype=bool)
     soft_active = np.zeros(edge.size, dtype=bool)
     for source in result["sources"]:
         if not isinstance(source, gprMax.VoltageSource):
             continue
         internal = source._source
-        active = (iterations >= 0) & (time >= internal.start) & (time <= internal.stop)
         if internal.resistance == 0:
-            expected[active] = -internal.waveformvalues_wholedt[iterations[active]] / DL
+            time = samples * result["dt"]
+            active = (time >= internal.start) & (time <= internal.stop)
+            expected[active] = -internal.waveformvalues_wholedt[samples[active]] / DL
             prescribed |= active
         else:
+            time = iterations * result["dt"]
+            active = (iterations >= 0) & (time >= internal.start) & (time <= internal.stop)
             soft_active |= active
     if case == "hard_then_soft":
         # A later soft source adds its correction; it must not be erased by

--- a/tests/updates/test_hard_source_timing_solve.py
+++ b/tests/updates/test_hard_source_timing_solve.py
@@ -1,0 +1,259 @@
+"""End-to-end initial hard fields, applied-time gates and output timing."""
+
+import importlib.util
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+
+pytestmark = pytest.mark.integration
+ROOT = Path(__file__).resolve().parents[2]
+DL = 0.001
+COMPONENTS = tuple(kind + axis for kind in "EHI" for axis in "xyz")
+BACKENDS = ["cpu"] + [pytest.param(name, marks=pytest.mark.gpu) for name in ("cuda", "opencl", "metal")]
+
+
+def backend_options(request, backend, precision):
+    if backend == "cpu":
+        return {"cpu_precision": precision}
+    if backend == "metal":
+        if precision == "double":
+            pytest.skip("Metal supports single precision only")
+        metal = pytest.importorskip("Metal")
+        if metal.MTLCreateSystemDefaultDevice() is None:
+            pytest.skip("No Metal device")
+        return {"metal": True, "gpu_precision": precision}
+    device = request.getfixturevalue("gpu_device" if backend == "cuda" else "opencl_device")
+    return {"gpu" if backend == "cuda" else "opencl": [device], "gpu_precision": precision}
+
+
+def scene(axis, case, *, dl=DL, ratio=None, iterations=32):
+    model = gprMax.Scene()
+    extent = 0.012 if ratio is None else 0.09
+    point = (extent / 2,) * 3
+    for obj in (
+        gprMax.Domain(p1=(extent,) * 3),
+        gprMax.Discretisation(p1=(dl,) * 3),
+        gprMax.PMLThickness(thickness=0),
+        gprMax.OMPThreads(n=1),
+        gprMax.TimeWindow(iterations=iterations),
+    ):
+        model.add(obj)
+    owner = model
+    if ratio is not None:
+        owner = gprMax.SubGridHSG(p1=(0.03,) * 3, p2=(0.06,) * 3, ratio=ratio, id="fine")
+        model.add(owner)
+    if case == "ramp":
+        wave = gprMax.Waveform(wave_type="user", id="pulse", user_func=lambda t: 1 + 1e11 * t)
+    else:
+        wave = gprMax.Waveform(wave_type="impulse", amp=1, freq=1e9, id="pulse")
+    owner.add(wave)
+    window = {"start": 0, "stop": 1e-13} if case == "released" else {}
+    if case == "delayed":
+        window = {"start": 5e-12, "stop": 1.5e-11}
+    source = gprMax.VoltageSource(
+        p1=point, polarisation=axis, resistance=0, waveform_id="pulse", id="feed", spectrum_limit="nyquist", **window
+    )
+    owner.add(source)
+    owner.add(gprMax.Rx(p1=point, id="edge", outputs=list(COMPONENTS)))
+    owner.add(gprMax.Rx(p1=tuple(p + dl for p in point), id="remote", outputs=list(COMPONENTS)))
+    return model, source
+
+
+def check_output(path, axis, case, source, *, group="", precision="double"):
+    with h5py.File(path) as f:
+        owner = f[group] if group else f
+        dt, count = float(owner.attrs["dt"]), int(owner.attrs["Iterations"])
+        dl = float(owner.attrs["dx_dy_dz"]["xyz".index(axis)])
+        edge = next(rx for rx in owner["rxs"].values() if rx.attrs["Name"] == "edge")
+        electric = edge["E" + axis][:]
+        time = np.arange(count) * dt
+        active = (time >= source.start) & (time <= source.stop)
+        local = time - source.start
+        waveform = 1 + 1e11 * local if case == "ramp" else (local < dt).astype(float)
+        waveform = np.where(active, waveform, 0)
+        tolerance = 3e-6 if precision == "single" else 3e-14
+        np.testing.assert_allclose(electric[active], -waveform[active] / dl, rtol=tolerance, atol=0)
+        assert electric[0] == pytest.approx(0 if case == "delayed" else -1 / dl, rel=tolerance, abs=0)
+        assert all(edge["H" + a][0] == 0 for a in "xyz")
+        assert any(np.any(edge["H" + a][1:] != 0) for a in "xyz")
+        if case == "released":
+            assert electric[1] != 0  # No second hard assignment to zero.
+        if case == "impulse":
+            # Fine-grid coupling can store samples beyond the coarse source
+            # stop time; those are correctly released, not clamped.
+            assert np.count_nonzero(electric[1:][active[1:]]) == 0
+        excitation = owner["srcs/src1/excitation"]
+        assert excitation.attrs["TimeSampleOffset"] == 0
+        assert excitation.attrs["WaveformEvaluationTimeOffset"] == 0
+        np.testing.assert_allclose(excitation["samples"][:], waveform, rtol=tolerance, atol=0)
+        port = owner["ports/feed"]
+        assert port["Vtotal"].shape == port["Iloop"].shape == (count,)
+        np.testing.assert_allclose(port["Vtotal"][:], -dl * electric, rtol=tolerance, atol=0)
+        assert port.attrs["TimeSampleOffset"] == 0
+        assert port.attrs["CurrentTimeSampleOffset"] == -0.5 * dt
+        np.testing.assert_allclose(port["time"][:], time, rtol=tolerance, atol=0)
+        np.testing.assert_allclose(port["time_current"][:], time - 0.5 * dt, rtol=tolerance, atol=dt * tolerance)
+        np.testing.assert_allclose(port["frequency"][:], np.fft.rfftfreq(count, dt), rtol=tolerance, atol=0)
+        assert port.attrs["IndependentFrequencyResolution"] == 1 / (count * dt)
+        phase = np.exp(1j * np.pi * port["frequency"][:] * dt)
+        np.testing.assert_allclose(
+            port["Vtotal_spectrum"][:], dt * np.fft.rfft(port["Vtotal"][:]), rtol=tolerance, atol=dt * tolerance
+        )
+        np.testing.assert_allclose(
+            port["Iloop_spectrum"][:], dt * phase * np.fft.rfft(port["Iloop"][:]), rtol=tolerance, atol=dt * tolerance
+        )
+        if case == "impulse" and np.all(active):
+            np.testing.assert_allclose(port["Vtotal_spectrum"][:], dt, rtol=tolerance, atol=0)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("precision", ["single", "double"])
+@pytest.mark.parametrize("axis", "xyz")
+@pytest.mark.parametrize("case", ["impulse", "ramp", "released", "delayed"])
+def test_hard_source_initial_field_and_physical_time(tmp_path, request, backend, precision, axis, case):
+    options = backend_options(request, backend, precision)
+    model, api_source = scene(axis, case)
+    stem = tmp_path / "hard"
+    gprMax.run(scenes=[model], outputfile=stem, hide_progress_bars=True, log_level=50, **options)
+    check_output(stem.with_suffix(".h5"), axis, case, api_source._source, precision=precision)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("step", [0, DL])
+def test_reused_geometry_reinitialises_hard_sources_every_run(tmp_path, request, backend, step):
+    precision = "single" if backend == "metal" else "double"
+    options = backend_options(request, backend, precision)
+    model, api_source = scene("z", "impulse", iterations=31)
+    if step:
+        # Legacy #src_steps moves only electric/magnetic dipoles, not
+        # fixed voltage terminals. Startup must preserve that restriction.
+        model.add(gprMax.SrcSteps(p1=(step, 0, 0)))
+    stem = tmp_path / "reuse"
+    gprMax.run(
+        scenes=[model], n=3, geometry_fixed=True, outputfile=stem, hide_progress_bars=True, log_level=50, **options
+    )
+    for index in (1, 2, 3):
+        check_output(tmp_path / f"reuse{index}.h5", "z", "impulse", api_source._source, precision=precision)
+        with h5py.File(tmp_path / f"reuse{index}.h5") as output:
+            np.testing.assert_allclose(output["srcs/src1"].attrs["Position"], (0.006, 0.006, 0.006))
+    with h5py.File(tmp_path / "reuse1.h5") as a, h5py.File(tmp_path / "reuse3.h5") as b:
+        for rx in a["rxs"]:
+            for component in COMPONENTS:
+                np.testing.assert_array_equal(a[f"rxs/{rx}/{component}"][:], b[f"rxs/{rx}/{component}"][:])
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_snapshot_zero_includes_initial_hard_field(tmp_path, request, backend):
+    precision = "single" if backend == "metal" else "double"
+    model, _ = scene("z", "impulse", iterations=4)
+    model.add(
+        gprMax.Snapshot(p1=(0.004,) * 3, p2=(0.009,) * 3, dl=(DL,) * 3, iterations=0, filename="initial", fileext=".h5")
+    )
+    gprMax.run(
+        scenes=[model],
+        outputfile=tmp_path / "snapshot",
+        hide_progress_bars=True,
+        log_level=50,
+        **backend_options(request, backend, precision),
+    )
+    files = list(tmp_path.rglob("initial*.h5"))
+    assert len(files) == 1
+    with h5py.File(files[0]) as output:
+        # A z Yee edge contributes to four cell-centred Ez samples.
+        assert np.count_nonzero(output["Ez"][:]) == 4
+        np.testing.assert_array_equal(output["Ez"][:][output["Ez"][:] != 0], -250)
+        for component in ("Ex", "Ey", "Hx", "Hy", "Hz"):
+            np.testing.assert_array_equal(output[component][:], 0)
+
+
+@pytest.mark.parametrize("ratio", [1, 3, 5])
+@pytest.mark.parametrize("axis", "xyz")
+@pytest.mark.parametrize("case", ["impulse", "released"])
+def test_subgrid_uses_local_electric_clock_at_startup(tmp_path, ratio, axis, case):
+    model, api_source = scene(axis, case, dl=0.003, ratio=ratio, iterations=8)
+    stem = tmp_path / "subgrid"
+    gprMax.run(
+        scenes=[model],
+        outputfile=stem,
+        subgrid=True,
+        autotranslate=True,
+        hide_progress_bars=True,
+        log_level=50,
+        cpu_precision="double",
+    )
+    check_output(stem.with_suffix(".h5"), axis, case, api_source._source, group="subgrids/fine")
+
+
+@pytest.mark.parametrize("axis", "xyz")
+@pytest.mark.parametrize("case", ["impulse", "released"])
+def test_mpi_initial_halos_include_hard_source_on_rank_face(tmp_path, axis, case):
+    launcher = Path(sys.executable).parent / "mpiexec"
+    launcher = str(launcher) if launcher.is_file() else shutil.which("mpiexec")
+    if not launcher or importlib.util.find_spec("mpi4py") is None:
+        pytest.skip("MPI launcher/mpi4py required")
+    split = ("xyz".index(axis) + 1) % 3
+    partition = [1, 1, 1]
+    partition[split] = 2
+    window = " 0 1e-13" if case == "released" else ""
+    model = tmp_path / "hard.in"
+    model.write_text(
+        "\n".join(
+            (
+                "#domain: 0.012 0.012 0.012",
+                "#dx_dy_dz: 0.001 0.001 0.001",
+                "#time_window: 32",
+                "#pml_cells: 0",
+                "#omp_threads: 1",
+                "#waveform: impulse 1 1e9 pulse",
+                f"#voltage_source: {axis} 0.006 0.006 0.006 0 pulse{window}",
+                "#rx: 0.006 0.006 0.006 edge Ex Ey Ez Hx Hy Hz Ix Iy Iz",
+                "#rx: 0.005 0.005 0.005 neighbour Ex Ey Ez Hx Hy Hz Ix Iy Iz",
+                "",
+            )
+        )
+    )
+    environment = os.environ.copy()
+    environment.pop("MPI4PY_RC_FINALIZE", None)
+    environment.pop("FI_PROVIDER", None)
+    environment.update(PYTHONPATH=str(ROOT), OMP_NUM_THREADS="1")
+    common = [
+        sys.executable,
+        "-m",
+        "gprMax",
+        str(model),
+        "--hide-progress-bars",
+        "-cpu_precision",
+        "double",
+        "-n",
+        "2",
+        "--geometry-fixed",
+    ]
+    for name, command in (
+        ("serial", common),
+        ("mpi", [launcher, "-n", "2", *common, "--mpi", *map(str, partition)]),
+    ):
+        result = subprocess.run(
+            [*command, "-o", str(tmp_path / name)],
+            cwd=ROOT,
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=90,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+    for index in (1, 2):
+        with h5py.File(tmp_path / f"serial{index}.h5") as a, h5py.File(tmp_path / f"mpi{index}.h5") as b:
+            assert a[f"rxs/rx1/E{axis}"][0] == b[f"rxs/rx1/E{axis}"][0] == -1000
+            for rx in a["rxs"]:
+                for component in COMPONENTS:
+                    np.testing.assert_array_equal(a[f"rxs/{rx}/{component}"][:], b[f"rxs/{rx}/{component}"][:])
+            for name in a["ports/port1"]:
+                np.testing.assert_array_equal(a[f"ports/port1/{name}"][:], b[f"ports/port1/{name}"][:])

--- a/tests/updates/test_sampled_sources_solve.py
+++ b/tests/updates/test_sampled_sources_solve.py
@@ -1,0 +1,96 @@
+"""Sampled API/hash excitations must reach each backend on the right lattice."""
+
+import decimal
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+from gprMax.utilities.utilities import round_value
+from tests.updates.test_hard_source_timing_solve import backend_options, BACKENDS
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("interface", ["api", "hash"])
+@pytest.mark.parametrize("family", ["hard", "resistive", "hertzian", "magnetic"])
+def test_sampled_source_matches_callable_and_writes_correct_excitation(tmp_path, request, backend, interface, family):
+    precision = "single" if backend == "metal" else "double"
+    options = backend_options(request, backend, precision)
+    dl, count = 0.002, 16
+    dt = round_value(1 / (299792458.0 * np.sqrt(3 / dl**2)), decimalplaces=decimal.getcontext().prec - 1)
+    times, values = np.arange(count) * dt, 1 + 0.05 * np.arange(count)
+    point = (0.012,) * 3
+
+    def scene(callable_control):
+        result = gprMax.Scene()
+        for obj in (
+            gprMax.Domain((0.024,) * 3),
+            gprMax.Discretisation((dl,) * 3),
+            gprMax.TimeWindow(iterations=count),
+            gprMax.PMLThickness(2),
+            gprMax.OMPThreads(1),
+        ):
+            result.add(obj)
+        result.add(
+            gprMax.Waveform(
+                wave_type="user",
+                id="sampled",
+                **(
+                    {"user_func": lambda time: np.interp(time, times, values, left=0, right=0)}
+                    if callable_control
+                    else {"user_values": values}
+                ),
+            )
+        )
+        kwargs = dict(p1=point, polarisation="z", waveform_id="sampled")
+        source = (
+            gprMax.MagneticDipole(**kwargs)
+            if family == "magnetic"
+            else gprMax.HertzianDipole(**kwargs)
+            if family == "hertzian"
+            else gprMax.VoltageSource(**kwargs, resistance=0 if family == "hard" else 50)
+        )
+        result.add(source)
+        result.add(gprMax.Rx(point, outputs=[kind + axis for kind in "EH" for axis in "xyz"]))
+        return result
+
+    run_options = dict(log_level=50, hide_progress_bars=True, **options)
+    if interface == "api":
+        gprMax.run(scenes=[scene(False)], outputfile=tmp_path / "sampled", **run_options)
+    else:
+        samples = tmp_path / "wave.txt"
+        np.savetxt(samples, values, header="sampled", comments="")
+        command = {
+            "hard": "#voltage_source: z 0.012 0.012 0.012 0 sampled",
+            "resistive": "#voltage_source: z 0.012 0.012 0.012 50 sampled",
+            "hertzian": "#hertzian_dipole: z 0.012 0.012 0.012 sampled",
+            "magnetic": "#magnetic_dipole: z 0.012 0.012 0.012 sampled",
+        }[family]
+        source = tmp_path / "model.in"
+        source.write_text(
+            f"#domain: 0.024 0.024 0.024\n#dx_dy_dz: {dl} {dl} {dl}\n"
+            f"#time_window: {count}\n#pml_cells: 2\n#omp_threads: 1\n"
+            f"#excitation_file: {samples}\n{command}\n#rx: 0.012 0.012 0.012\n"
+        )
+        gprMax.run(inputfile=source, outputfile=tmp_path / "sampled", **run_options)
+    gprMax.run(scenes=[scene(True)], outputfile=tmp_path / "control", **run_options)
+    rtol, atol = (3e-5, 1e-4) if precision == "single" else (3e-12, 3e-11)
+    with h5py.File(tmp_path / "sampled.h5") as sampled, h5py.File(tmp_path / "control.h5") as control:
+        assert sampled.attrs["dt"] == dt
+        for component in (kind + axis for kind in "EH" for axis in "xyz"):
+            np.testing.assert_allclose(
+                sampled[f"rxs/rx1/{component}"][:], control[f"rxs/rx1/{component}"][:], rtol=rtol, atol=atol
+            )
+        field = sampled["rxs/rx1/Hz" if family == "magnetic" else "rxs/rx1/Ez"][:]
+        assert np.isfinite(field).all() and np.count_nonzero(field) > 1
+        excitation = sampled["srcs/src1/excitation"]
+        expected = np.interp(
+            times + (0.5 * dt if family in ("resistive", "hertzian") else 0), times, values, left=0, right=0
+        )
+        np.testing.assert_allclose(excitation["samples"][:], expected, rtol=rtol, atol=atol)
+        if family == "hard":
+            np.testing.assert_allclose(field, -values / dl, rtol=rtol, atol=atol)
+            assert excitation.attrs["TimeSampleOffset"] == 0

--- a/tests/updates/test_source_windows_solve.py
+++ b/tests/updates/test_source_windows_solve.py
@@ -172,8 +172,9 @@ def _hard_scene(polarisation, variant, *, start=START, stop=STOP):
 
 def _check_release(traces, dt, polarisation, variant, start=START, stop=STOP):
     edge = traces[f"rx/edge/E{polarisation}"]
-    # Receivers record the fields before this iteration's updates.
-    updated_at = (np.arange(edge.size) - 1) * dt
+    # Hard sources prescribe the stored electric time itself; additive
+    # voltage-source updates still precede the stored E sample by one step.
+    updated_at = (np.arange(edge.size) - (variant == "soft")) * dt
     if variant != "full":
         before = (updated_at >= 0) & (updated_at < start)
         after = updated_at > stop

--- a/tests/user_objects/test_reusable_symbolic_coordinates.py
+++ b/tests/user_objects/test_reusable_symbolic_coordinates.py
@@ -1,0 +1,105 @@
+"""Symbolic coordinates belong to declarations, not their first built grid."""
+
+from copy import deepcopy
+
+import h5py
+import numpy as np
+import pytest
+
+import gprMax
+from gprMax.model import Model
+
+pytestmark = pytest.mark.integration
+
+
+def _scene(dl, mode, axis, objects):
+    extent = [0.04] * 3
+    extent[axis] = float("inf")
+    scene = gprMax.Scene()
+    for obj in (
+        gprMax.DomainMode(mode),
+        gprMax.Domain(tuple(extent)),
+        gprMax.Discretisation((dl,) * 3),
+        gprMax.TimeWindow(iterations=32),
+        gprMax.OMPThreads(1),
+        gprMax.PMLThickness(0),
+        gprMax.Waveform(wave_type="ricker", amp=1, freq=5e9, id="pulse"),
+        *objects,
+    ):
+        scene.add(obj)
+    return scene
+
+
+def _run(scene, path):
+    gprMax.run(scenes=[scene], outputfile=path, cpu_precision="double", log_level=50, hide_progress_bars=True)
+
+
+@pytest.mark.parametrize("axis", range(3), ids=list("xyz"))
+@pytest.mark.parametrize("mode", ["TM", "TE"])
+@pytest.mark.parametrize("family", ["hertzian", "magnetic", "hard", "resistive"])
+def test_reused_source_and_receiver_match_fresh_grid(tmp_path, monkeypatch, axis, mode, family):
+    point = [0.02] * 3
+    point[axis] = float("inf")
+    magnetic = family == "magnetic"
+    polarisation = "xyz"[axis if (mode == "TE") == magnetic else (axis + 1) % 3]
+    component = ("H" if magnetic else "E") + polarisation
+    options = dict(p1=tuple(point), polarisation=polarisation, waveform_id="pulse")
+    source = (
+        gprMax.MagneticDipole(**options)
+        if magnetic
+        else gprMax.HertzianDipole(**options)
+        if family == "hertzian"
+        else gprMax.VoltageSource(**options, resistance=0 if family == "hard" else 50)
+    )
+    outputs = [component]
+    receiver = gprMax.Rx(tuple(point), outputs=outputs)
+    fresh = deepcopy((source, receiver))
+    original = Model.build
+    grids = []
+
+    def capture(model):
+        original(model)
+        grids.append(model.G)
+
+    monkeypatch.setattr(Model, "build", capture)
+    for name, dl, objects in (
+        ("coarse", 0.002, (source, receiver)),
+        ("reused", 0.001, (source, receiver)),
+        ("fresh", 0.001, fresh),
+    ):
+        _run(_scene(dl, mode, axis, objects), tmp_path / name)
+        assert source.point == receiver.point == tuple(point)
+        assert receiver.outputs == outputs == [component]
+    with h5py.File(tmp_path / "reused.h5") as reused, h5py.File(tmp_path / "fresh.h5") as control:
+        actual = reused[f"rxs/rx1/{component}"][:]
+        np.testing.assert_array_equal(actual, control[f"rxs/rx1/{component}"][:])
+        assert np.count_nonzero(actual) > 1
+        assert reused["rxs/rx1"].attrs["Name"] == control["rxs/rx1"].attrs["Name"]
+        np.testing.assert_array_equal(reused["rxs/rx1"].attrs["Position"], control["rxs/rx1"].attrs["Position"])
+    assert grids[1].rxs[0].coord[axis] == (1 if mode == "TE" else 0)
+
+
+@pytest.mark.parametrize("mode", ["TM", "TE"])
+@pytest.mark.parametrize("kind", ["snapshot", "view", "geometry"])
+def test_output_bounds_remain_symbolic_across_grid_changes(tmp_path, mode, kind):
+    lower, upper = (0.01, 0.01, -float("inf")), (0.03, 0.03, float("inf"))
+    if kind == "snapshot":
+        output = gprMax.Snapshot(lower, upper, (0.002,) * 3, "frame", iterations=2, fileext=".h5")
+    elif kind == "view":
+        output = gprMax.GeometryView(lower, upper, (0.002,) * 3, "n", "view")
+    else:
+        output = gprMax.GeometryObjectsWrite(lower, upper, "geometry")
+    for index, dl in enumerate((0.002, 0.001)):
+        if kind != "geometry":
+            # A normal view's stride must fit the single TM invariant cell.
+            output.dl = (dl,) * 3
+        _run(_scene(dl, mode, 2, [output]), tmp_path / f"model{index}")
+        assert output.lower_bound == lower
+        assert output.upper_bound == upper
+
+
+def test_receiver_build_does_not_sort_callers_output_list(tmp_path):
+    outputs = ["Hz", "Ex"]
+    receiver = gprMax.Rx((0.02, 0.02, float("inf")), outputs=outputs)
+    _run(_scene(0.002, "TE", 2, [receiver]), tmp_path / "model")
+    assert outputs == receiver.outputs == ["Hz", "Ex"]

--- a/tests/utilities/test_taskfarm_failures.py
+++ b/tests/utilities/test_taskfarm_failures.py
@@ -7,6 +7,7 @@ import pytest
 
 pytest.importorskip("mpi4py")
 from gprMax.taskfarm import TaskFailure, TaskfarmError, TaskfarmExecutor
+from gprMax.taskfarm import Tags
 
 
 @pytest.mark.unit
@@ -40,3 +41,99 @@ def test_executor_context_joins_even_when_submit_raises():
     executor = SimpleNamespace(join=lambda: joined.append(True))
     assert TaskfarmExecutor.__exit__(executor, RuntimeError, RuntimeError("failed"), None) is False
     assert joined == [True]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("exception", [None, "jobs", "master", "interrupt"])
+def test_collective_batch_joins_before_reporting_on_all_ranks(exception):
+    events = []
+    broadcasts = []
+    results = [None, {"output": "completed"}]
+    failure = TaskFailure("ValueError", "bad input")
+    error = (
+        TaskfarmError([failure, results[1]])
+        if exception == "jobs"
+        else ValueError("master failure")
+        if exception == "master"
+        else KeyboardInterrupt()
+        if exception == "interrupt"
+        else None
+    )
+
+    def submit(jobs):
+        if error is not None:
+            raise error
+        return results
+
+    def broadcast(value, root):
+        assert events[-1] == "joined"
+        broadcasts.append(value)
+        return value
+
+    master = SimpleNamespace(
+        master=0,
+        start=lambda: events.append("started"),
+        join=lambda: events.append("joined"),
+        is_master=lambda: True,
+        submit=submit,
+        comm=SimpleNamespace(bcast=broadcast),
+    )
+    if error is None:
+        assert TaskfarmExecutor.run_collective(master, [{}, {}]) is results
+    else:
+        with pytest.raises(type(error)) as caught:
+            TaskfarmExecutor.run_collective(master, [{}, {}])
+        assert caught.value is error
+        if exception == "jobs":
+            assert caught.value.results[1] == results[1]
+    assert events == ["started", "joined"]
+    worker = SimpleNamespace(
+        master=0,
+        start=lambda: None,
+        join=lambda: None,
+        is_master=lambda: False,
+        comm=SimpleNamespace(bcast=lambda value, root: broadcasts[0]),
+    )
+    if error is None:
+        assert TaskfarmExecutor.run_collective(worker, [{}, {}]) is None
+    elif exception == "jobs":
+        with pytest.raises(TaskfarmError) as caught:
+            TaskfarmExecutor.run_collective(worker, [{}, {}])
+        assert caught.value.failures == {0: failure}
+    else:
+        with pytest.raises(RuntimeError, match="Task-farm master failed"):
+            TaskfarmExecutor.run_collective(worker, [{}, {}])
+
+
+@pytest.mark.unit
+def test_join_drains_ready_and_inflight_done_before_exit():
+    pending = {1: [Tags.READY, Tags.EXIT], 2: [Tags.DONE, Tags.READY, Tags.EXIT]}
+    sent = []
+
+    class Comm:
+        name = "test"
+
+        def send(self, value, dest, tag):
+            sent.append((dest, tag))
+
+        def Iprobe(self, source, tag, status):
+            if not pending[source]:
+                return False
+            status.Set_tag(pending[source][0])
+            return True
+
+        def recv(self, source, tag):
+            assert pending[source].pop(0) == tag
+
+    executor = SimpleNamespace(
+        is_master=lambda: True,
+        comm=Comm(),
+        workers=(1, 2),
+        busy=[False, True],
+        _up=True,
+    )
+    TaskfarmExecutor.join(executor)
+    assert sent == [(1, Tags.EXIT), (2, Tags.EXIT)]
+    assert pending == {1: [], 2: []}
+    assert executor.busy == [False, False]
+    assert not executor._up

--- a/toolboxes/FMCW/README.rst
+++ b/toolboxes/FMCW/README.rst
@@ -7,6 +7,12 @@ Frequency-Modulated Continuous-Wave GPR
 Information
 ===========
 
+Receiver selections accept ``name:label`` and ``study:id`` as well as paths.
+An omitted background/incident receiver is matched by identity, not by the
+target's numeric path. Explicit background selections are intentional
+per-file overrides. Missing/ambiguous identity is rejected. See
+:ref:`receiver-numbering` for old/new output compatibility.
+
 This toolbox synthesises frequency-modulated continuous-wave (FMCW) GPR
 outputs from one broadband gprMax simulation. It follows the short-pulse FDTD
 method of Eide *et al.* [EID2022FMCW]_, including background removal, source

--- a/toolboxes/FMCW/cli.py
+++ b/toolboxes/FMCW/cli.py
@@ -42,10 +42,10 @@ def build_parser() -> argparse.ArgumentParser:
     process.add_argument("--source-file", type=Path)
     process.add_argument("--background-source-file", type=Path)
     process.add_argument("--source", help="target HDF5 source group")
-    process.add_argument("--receiver", help="target HDF5 receiver group")
+    process.add_argument("--receiver", help="target receiver path, name:label, or study:id")
     process.add_argument("--component", help="receiver component, e.g. Ez")
     process.add_argument("--background-source", help="background HDF5 source group")
-    process.add_argument("--background-receiver", help="background HDF5 receiver group")
+    process.add_argument("--background-receiver", help="explicit background path/name:label override; otherwise match target identity")
     process.add_argument("--background-component", help="background receiver component")
     process.add_argument(
         "--incident-reference",

--- a/toolboxes/FMCW/processing.py
+++ b/toolboxes/FMCW/processing.py
@@ -25,6 +25,7 @@ import h5py
 import numpy as np
 import numpy.typing as npt
 
+from toolboxes.Utilities.receiver_identity import matching_receiver_path
 from toolboxes.SFCW.processing import (
     FrequencyResponse,
     _validate_output_path,
@@ -177,6 +178,8 @@ def process_channel(
     source would instead assume identical source histories. One background
     trace may be broadcast across all target traces. A merged receiver file
     can use source metadata from a separate original A-scan file.
+    Unless explicitly overridden, the background receiver is matched by
+    identity, not by reusing the target's file-local group number.
     """
 
     frequency = chirp.frequency
@@ -200,8 +203,10 @@ def process_channel(
         )
         background_receiver = load_receiver(
             background_filename,
-            background_receiver_path or receiver_path,
-            background_component or component,
+            background_receiver_path
+            if background_receiver_path is not None
+            else matching_receiver_path(filename, target_receiver.path.rsplit("/", 1)[0], background_filename),
+            background_component or target_receiver.quantity,
         )
         background = direct_frequency_response(
             background_source,
@@ -251,13 +256,17 @@ def process_incident_referenced_channel(
     do not expose a scalar stored-source history. The returned response is
     ``(total - incident) / incident``. One incident trace may normalise every
     trace of a merged target B-scan.
+    An omitted incident receiver is identity-matched to the total-field
+    receiver. Supply an explicit override for an intentionally different point.
     """
 
     total = load_receiver(filename, receiver_path, component)
     incident = load_receiver(
         incident_filename,
-        incident_receiver_path or receiver_path,
-        incident_component or component,
+        incident_receiver_path
+        if incident_receiver_path is not None
+        else matching_receiver_path(filename, total.path.rsplit("/", 1)[0], incident_filename),
+        incident_component or total.quantity,
     )
     tolerance = 32 * np.finfo(float).eps * total.dt
     if not np.isclose(total.dt, incident.dt, rtol=0, atol=tolerance):

--- a/toolboxes/ImpulseResponse/README.rst
+++ b/toolboxes/ImpulseResponse/README.rst
@@ -7,6 +7,10 @@ Impulse-response waveform synthesis
 Information
 ===========
 
+Use ``--receiver name:label:Ez`` (or ``study:id:Ez``) for numbering-independent
+selection. A selected subset retains original receiver paths and identity
+metadata, so receiver numbers can have gaps. See :ref:`receiver-numbering`.
+
 This toolbox uses one impulse-excited gprMax model to generate receiver
 histories for many different source pulses. It is useful when the geometry,
 materials, source type, and receiver arrangement remain fixed, but the source
@@ -63,13 +67,21 @@ reference source. gprMax output records both:
 * ``WaveformEvaluationTimeOffset`` -- the time at which the waveform function
   was evaluated during that update.
 
-These are normally identical. A hard voltage source is the important
-exception: its waveform value for update :math:`n` is evaluated at
-:math:`n\Delta t`, but it is imposed on :math:`E^{n+1}` and therefore has a
-physical ``TimeSampleOffset`` of :math:`\Delta t`. The toolbox uses the
-evaluation offset when constructing target samples and retains the physical
-offset in the output. Older files without the new evaluation attribute are
-handled using the source type and driving quantity.
+These are identical for current local sources. A hard voltage source
+prescribes :math:`E^0` before the first observation and then :math:`E^{n+1}`
+using the waveform at :math:`(n+1)\Delta t`; both offsets are zero. Its
+sample-zero impulse is therefore retained in the measured response.
+
+Older hard-source files have an evaluation offset of zero but a physical
+offset of :math:`\Delta t`. The toolbox uses each file's evaluation offset
+when constructing target samples and retains its physical offset in the
+output. Older files without the evaluation attribute are handled using the
+source type and driving quantity; do not manually relabel their time axes.
+
+A zero-valued hard waveform still clamps the feed while the source is active.
+An impulse reference and a directly driven model must use the same feed
+boundary condition. Removing the impulse clamp is not equivalent to leaving
+a hard voltage source in place for subsequent waveform synthesis.
 
 The output receiver samples retain their original electric, magnetic, or
 current Yee-time offset. No additional half-step phase correction is needed.

--- a/toolboxes/ImpulseResponse/processing.py
+++ b/toolboxes/ImpulseResponse/processing.py
@@ -58,8 +58,9 @@ class SourceSampling:
     """Stored scalar source and its waveform-evaluation convention.
 
     ``evaluation_time_offset`` is in seconds and can differ from the physical
-    sample-zero time in ``signal``. For a hard voltage source, waveform sample
-    n is evaluated at ``n*dt`` but imposed on the field stored at ``(n+1)*dt``.
+    sample-zero time in ``signal``. Older hard-source files evaluate sample
+    n at ``n*dt`` but impose it at ``(n+1)*dt``; corrected files initialise
+    E(0) and use zero for both offsets. Preserve each file's convention.
     """
 
     signal: SampledSignal
@@ -154,8 +155,9 @@ def load_source_sampling(
         if "WaveformEvaluationTimeOffset" in excitation.attrs:
             evaluation_offset = float(excitation.attrs["WaveformEvaluationTimeOffset"])
         elif driving_quantity == "imposed_gap_voltage":
-            # A hard voltage source evaluates waveform sample n at n*dt but
-            # imposes it on the electric field stored at (n+1)*dt.
+            # Legacy hard-source files can omit the evaluation attribute.
+            # Their waveform clock starts at zero even if the physical
+            # history is delayed by dt. Corrected files also evaluate at zero.
             evaluation_offset = 0.0
         else:
             evaluation_offset = signal.time_offset
@@ -273,7 +275,8 @@ def sample_builtin_waveform(
 
     Activation is tested at update indices ``n*dt`` with inclusive start/stop
     bounds. Active values are evaluated at ``n*dt-start_time+evaluation_offset``.
-    Using the physical output offset instead would shift hard-source values.
+    Using the physical output offset instead would shift legacy hard-source
+    values. Corrected hard sources use zero for both offsets.
     """
 
     if not np.isfinite(start_time) or start_time < 0:
@@ -469,7 +472,11 @@ def _receiver_selections(
         return requested
     requested: list[tuple[str, str]] = []
     for path, component in selections:
-        normalised = _normalise_path(path)
+        normalised = (
+            load_receiver(filename, path, component).path.rsplit("/", 1)[0]
+            if path.startswith(("name:", "study:"))
+            else _normalise_path(path)
+        )
         if normalised not in available or component not in available[normalised]:
             raise ValueError(
                 f"receiver selection {normalised}:{component} is unavailable; "
@@ -604,6 +611,9 @@ def write_synthesised_output(filename: str | Path, result: SynthesisResult) -> P
         for receiver in result.receivers:
             dataset_path = _normalise_path(receiver.input.path)
             group_path = dataset_path.rsplit("/", 1)[0]
+            grid_path = group_path.rsplit("/rxs/", 1)[0]
+            if grid_path:
+                _copy_attrs(original[grid_path], output.require_group(grid_path))
             group = output.require_group(group_path)
             _copy_group_attrs(result.receiver_file, group_path, group)
             dataset = group.create_dataset(
@@ -616,4 +626,11 @@ def write_synthesised_output(filename: str | Path, result: SynthesisResult) -> P
                 _copy_attrs(receiver_source[dataset_path], dataset)
             dataset.attrs["SynthesisedFromImpulse"] = True
             dataset.attrs["ImpulseTailRelativeDB"] = receiver.impulse_tail_relative_db
+        # A selected subset retains original paths/BuildIndices, not a new
+        # acquisition layout. Counts are local to each emitted grid namespace.
+        grids = [output]
+        if "subgrids" in output:
+            grids.extend(output["subgrids"].values())
+        for grid in grids:
+            grid.attrs["nrx"] = len(grid.get("rxs", {}))
     return path

--- a/toolboxes/Marimo/README.md
+++ b/toolboxes/Marimo/README.md
@@ -9,6 +9,13 @@ The dashboards use [marimo](https://marimo.io), whose reactive cells update only
 the calculations affected by a changed control. Reusable numerical operations
 are kept in ordinary Python modules and do not depend on marimo.
 
+Receiver menus use numeric group order (`rx9` before `rx10`). When stacking
+files or monitoring live traces, the first accepted receiver's identity is
+matched in later files even if its group number changes. Missing or ambiguous
+identities are skipped with a warning; a missing requested receiver is not
+silently replaced by `rx1`. Review saved numeric selections when upgrading
+from the earlier v4 alphabetical numbering policy.
+
 ## Installation
 
 Install gprMax with the optional dashboard dependencies:
@@ -101,6 +108,13 @@ target_only = subtract_traces(
 Both runs must use the same grid, source, receiver, and time sampling. The
 helper checks shape and time-step compatibility, but it cannot prove that the
 geometries differ only by the target.
+
+The A-scan dashboard additionally matches the selected receiver's identity in
+the background file and compares the two physical sample axes. It does not
+assume that `rx1` in both files names the same receiver. The reusable
+`reference.subtract_receiver_reference` helper provides this behaviour for
+loaded files. Missing/ambiguous identities or mismatched timing produce a
+warning in the dashboard and leave the trace unsubtracted.
 
 Mean-trace removal is a different operation. It is appropriate when the
 direct wave and layered background response are stationary across a B-scan.

--- a/toolboxes/Marimo/ascan_dashboard.py
+++ b/toolboxes/Marimo/ascan_dashboard.py
@@ -30,8 +30,8 @@ def _():
         fft_spectrum,
         gain_label,
         spectrum_view_limit,
-        subtract_traces,
     )
+    from toolboxes.Marimo.reference import subtract_receiver_reference
 
     # Research-quality colour palette (Matplotlib tab10, colorblind-friendly)
     PALETTE = [
@@ -84,7 +84,7 @@ def _():
         mo,
         np,
         spectrum_view_limit,
-        subtract_traces,
+        subtract_receiver_reference,
     )
 
 
@@ -667,7 +667,7 @@ def _(
     show_grid,
     spectrum_view_limit,
     subtract_ref,
-    subtract_traces,
+    subtract_receiver_reference,
     time_slider,
 ):
     _traces = get_traces()
@@ -701,24 +701,11 @@ def _(
             return arr
         _ref_fdata = _files[_ref_name]
         try:
-            _ref_arr = get_trace(_ref_fdata, trace["component"], trace["receiver"])
-            _time = get_time_axis(
-                fdata,
-                unit="s",
+            _out = subtract_receiver_reference(
+                arr, fdata, _ref_fdata,
                 receiver=trace["receiver"],
                 component=trace["component"],
             )
-            _ref_time = get_time_axis(
-                _ref_fdata,
-                unit="s",
-                receiver=trace["receiver"],
-                component=trace["component"],
-            )
-            if _time.shape != _ref_time.shape or not np.allclose(
-                _time, _ref_time, rtol=1e-9, atol=1e-15
-            ):
-                raise ValueError("target and background sample times differ")
-            _out = subtract_traces(arr, _ref_arr)
         except (KeyError, ValueError) as _err:
             _sub_warnings.append(f"{trace['label']}: {_err}")
             return arr

--- a/toolboxes/Marimo/bscan_dashboard.py
+++ b/toolboxes/Marimo/bscan_dashboard.py
@@ -679,6 +679,7 @@ def _(
         _sample_file = _prev["sample_file"]
 
     _known_components = _prev["known_components"]
+    _receiver_identity = None if _needs_reset else _prev.get("receiver_identity")
     _new_warnings = []
     _new_trace_count = 0
     _should_scan = live_toggle.value or poll_now_button.value or _needs_reset
@@ -695,7 +696,12 @@ def _(
                 continue  # still being written — retry next tick, don't mark seen
 
             _result = process_trace(
-                _fdata, _current_component, len(_cols[0]) if _cols else None, _current_receiver
+                _fdata,
+                _current_component,
+                len(_cols[0]) if _cols else None,
+                _current_receiver,
+                expected_time_ns=_time_ns,
+                expected_identity=_receiver_identity,
             )
             if _result["known_components"]:
                 _known_components = _result["known_components"]
@@ -709,6 +715,7 @@ def _(
                 _time_ns = _result["time_ns"]
             if _sample_file is None:
                 _sample_file = _fdata
+                _receiver_identity = _result["identity"]
             if _result["x"] is None:
                 _all_physical = False
 
@@ -745,6 +752,7 @@ def _(
                 "warnings": _all_warnings,
                 "last_poll": _scan_time,
                 "sample_file": _sample_file,
+                "receiver_identity": _receiver_identity,
             }
         )
 

--- a/toolboxes/Marimo/h5_reader.py
+++ b/toolboxes/Marimo/h5_reader.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any
 
 import h5py
+from toolboxes.Utilities.receiver_identity import natural_key, receiver_catalogue
 import numpy as np
 
 # ComponentMap: {"Ez": np.ndarray, "Hx": np.ndarray, ...}
@@ -352,7 +353,8 @@ def _read_receivers(f: h5py.File) -> dict[str, ReceiverInfo]:
     if "rxs" not in f:
         return receivers
 
-    for rx_key in f["rxs"].keys():
+    identities = receiver_catalogue(f)
+    for rx_key in sorted(f["rxs"].keys(), key=natural_key):
         rx_group = f["rxs"][rx_key]
         rx_attrs = dict(rx_group.attrs)
 
@@ -371,6 +373,7 @@ def _read_receivers(f: h5py.File) -> dict[str, ReceiverInfo]:
         position = list(map(float, rx_attrs.get("Position", [0.0, 0.0, 0.0])))
 
         receivers[rx_key] = {
+            "identity": identities[f"rxs/{rx_key}"],
             "name": str(rx_attrs.get("Name", rx_key)),
             "position": position,
             "components": components,

--- a/toolboxes/Marimo/reference.py
+++ b/toolboxes/Marimo/reference.py
@@ -1,0 +1,35 @@
+"""Identity- and time-aware background subtraction for loaded A-scans."""
+
+import numpy as np
+
+from toolboxes.Marimo.h5_reader import get_time_axis, get_trace
+from toolboxes.Marimo.processing import subtract_traces
+from toolboxes.Utilities.receiver_identity import match_receiver
+
+
+def subtract_receiver_reference(samples, target, background, *, receiver, component):
+    """Subtract the same declared receiver, not a coincident file-local rxN.
+
+    Loaded files carry immutable receiver identities. Refuse missing/ambiguous
+    identities or incompatible physical times instead of guessing a receiver.
+    The dashboard catches these errors and reports an unapplied subtraction.
+    """
+    reference = target["receivers"][receiver]["identity"]
+    catalogue = {f"rxs/{key}": info["identity"] for key, info in background["receivers"].items()}
+    matched = match_receiver(reference, catalogue).path.split("/")[-1]
+    a_time = get_time_axis(target, unit="s", receiver=receiver, component=component)
+    b_time = get_time_axis(background, unit="s", receiver=matched, component=component)
+    # Avoid an absolute tolerance in seconds that would hide differences for
+    # very fine grids. Compare relative to the actual physical sample spacing.
+    info = target["receivers"][receiver].get("component_meta", {}).get(component, {})
+    dt = float(info.get("sample_interval", target["meta"]["dt"]))
+    if (
+        a_time.shape != b_time.shape
+        or not np.all(np.isfinite(a_time))
+        or not np.all(np.isfinite(b_time))
+        or not np.isfinite(dt)
+        or dt <= 0
+        or not np.allclose(a_time, b_time, rtol=1e-9, atol=32 * np.finfo(float).eps * dt)
+    ):
+        raise ValueError("target and background sample times differ")
+    return subtract_traces(samples, get_trace(background, component, matched))

--- a/toolboxes/Marimo/trace_matrix.py
+++ b/toolboxes/Marimo/trace_matrix.py
@@ -11,6 +11,7 @@ tick) and its load-files path (all traces at once).
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import Any
 
 import numpy as np
@@ -22,6 +23,7 @@ from toolboxes.Marimo.h5_reader import (
     list_components,
     list_receivers,
 )
+from toolboxes.Utilities.receiver_identity import ReceiverIdentity, match_receiver
 
 ProcessedTrace = dict[str, Any]
 # success: {"ok": True, "component", "receiver", "array", "time_ns", "x",
@@ -41,20 +43,45 @@ def process_trace(
     expected_len: int | None,
     preferred_receiver: str | None = None,
     expected_time_ns: np.ndarray | None = None,
+    expected_identity: ReceiverIdentity | None = None,
 ) -> ProcessedTrace:
     """Validate and extract one column from a loaded single-trace file.
 
     `expected_len`, if given, must match the trace's sample count — this
     is what catches a run where dt or iteration count drifted mid-sequence.
-    `preferred_receiver` picks a specific receiver key when the file has
-    more than one; falls back to the first receiver found otherwise.
+    `preferred_receiver` selects a file-local key; a missing explicit key is
+    rejected. `expected_identity` anchors later traces to the first selection,
+    even when another file assigns that receiver a different key.
     """
     rxs = list_receivers(file_data)
-    rx = preferred_receiver if preferred_receiver in rxs else (rxs[0] if rxs else "rx1")
+    rx = preferred_receiver if preferred_receiver is not None else (rxs[0] if rxs else "rx1")
+    receiver_infos = file_data.get("receivers", {})
+    names = Counter(info.get("name", "") for info in receiver_infos.values())
+    identities = {
+        f"rxs/{key}": info.get(
+            "identity",
+            ReceiverIdentity(
+                path=f"rxs/{key}",
+                name=info.get("name", ""),
+                name_unique=bool(info.get("name")) and names[info.get("name")] == 1,
+                count=len(receiver_infos),
+            ),
+        )
+        for key, info in receiver_infos.items()
+    }
+    if expected_identity is not None:
+        try:
+            rx = match_receiver(expected_identity, identities).path.split("/")[-1]
+        except ValueError as error:
+            return {"ok": False, "reason": str(error), "known_components": []}
+    if rx not in rxs:
+        return {"ok": False, "reason": f"receiver {rx!r} is missing", "known_components": []}
     comps = list_components(file_data, rx)
 
     if not comps:
         return {"ok": False, "reason": "no field components found", "known_components": comps}
+    if expected_identity is not None and preferred_component not in comps:
+        return {"ok": False, "reason": f"component {preferred_component!r} is missing", "known_components": comps}
 
     comp = (
         preferred_component
@@ -87,6 +114,7 @@ def process_trace(
         "ok": True,
         "component": comp,
         "receiver": rx,
+        "identity": identities.get(f"rxs/{rx}"),
         "array": arr,
         "time_ns": time_ns,
         "x": x,
@@ -114,6 +142,7 @@ def stack_traces(
     component = preferred_component
     receiver = None
     all_physical = True
+    identity = None
 
     for i, fdata in enumerate(file_datas):
         expected_len = len(cols[0]) if cols else None
@@ -123,6 +152,7 @@ def stack_traces(
             expected_len,
             preferred_receiver,
             expected_time_ns=time_ns,
+            expected_identity=identity,
         )
 
         if not result["ok"]:
@@ -130,7 +160,9 @@ def stack_traces(
             continue
 
         component = result["component"]
-        receiver = result["receiver"]
+        if receiver is None:
+            receiver = result["receiver"]
+            identity = result["identity"]
         if time_ns is None:
             time_ns = result["time_ns"]
 

--- a/toolboxes/Plotting/README.rst
+++ b/toolboxes/Plotting/README.rst
@@ -34,6 +34,11 @@ For example to plot the ``Ez`` output component with it's FFT:
 
     python -m toolboxes.Plotting.plot_Ascan my_outputfile.h5 --outputs Ez -fft
 
+Any supported component subset may include currents, for example
+``--outputs Ez Ix Iz-``. Each curve uses its dataset's ``SampleInterval`` and
+``TimeSampleOffset``. H-field and receiver loop-current traces therefore
+normally start at ``-dt/2``, not zero; electric traces normally start at zero.
+
 
 plot_Bscan.py
 -------------
@@ -65,6 +70,15 @@ Voltage-source and rational-network ports use ``ports/<ID>``. Transmission
 lines and magnetic frills use paths such as ``tls/tl1`` and
 ``frills/frill1``. S-parameters, impedance, and spectra are intentionally not
 B-scan quantities and cannot be selected here.
+
+Image pixel centres are placed at the physical sample times. Gathering
+receivers rejects mismatched time axes. For Python callers,
+``get_output_data(..., return_time_offset=True)`` and
+``gather_receiver_outputs(..., return_time_offset=True)`` return
+``(samples, dt, offset)``; pass the offset as ``time_offset=offset`` to
+``plot_Bscan.mpl_plot``. The default two-value loader return is unchanged.
+Direct matrix plotting without an explicit offset uses the receiver-component
+convention; terminal voltages should always use the offset from the loader.
 
 plot_port.py
 ------------

--- a/toolboxes/Plotting/plot_Ascan.py
+++ b/toolboxes/Plotting/plot_Ascan.py
@@ -19,12 +19,14 @@ import argparse
 from pathlib import Path
 
 import h5py
+from toolboxes.Utilities.receiver_identity import natural_key
 import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
 import numpy as np
 
 from gprMax.receivers import Rx
 from gprMax.utilities.utilities import fft_power, handle_plot_output
+from toolboxes.Utilities.trace_time import read_time_history
 
 
 def fft_plot_range(freqs, power, floor_db=-60):
@@ -64,10 +66,12 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False, show=True):
         plt: matplotlib plot object.
     """
 
-    file = Path(filename)
+    with h5py.File(filename, "r") as output:
+        return _mpl_plot_file(Path(filename), outputs, fft, show, output)
 
-    # Open output file and read iterations
-    f = h5py.File(file, "r")
+
+def _mpl_plot_file(file, outputs, fft, show, f):
+    """Plot while the public entry point owns the file's lifetime."""
 
     # Paths to grid(s) to traverse for outputs
     paths = ["/"]
@@ -87,19 +91,15 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False, show=True):
 
     # Loop through all grids
     for path in paths:
-        iterations = f[path].attrs["Iterations"]
-        nrx = f[path].attrs["nrx"]
-        dt = f[path].attrs["dt"]
-        time = np.linspace(0, (iterations - 1) * dt, num=iterations)
-
         # Check for single output component when doing a FFT
         if fft and not len(outputs) == 1:
             f.close()
             raise ValueError("A single output must be specified when using the -fft option")
 
         # New plot for each receiver
-        for rx in range(1, nrx + 1):
-            rxpath = path + "rxs/rx" + str(rx) + "/"
+        for receiver_key in sorted(f[path + "rxs"], key=natural_key):
+            rx = receiver_key.removeprefix("rx")
+            rxpath = path + "rxs/" + receiver_key + "/"
             availableoutputs = list(f[rxpath].keys())
 
             # If only a single output is required, create one subplot
@@ -122,7 +122,9 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False, show=True):
                         + f"{', '.join(availableoutputs)}"
                     )
 
-                outputdata = f[rxpath + output][:] * polarity
+                history = read_time_history(f[rxpath + output], allow_matrix=not fft)
+                outputdata = history.samples * polarity
+                time, dt = history.time, history.dt
 
                 # Plotting if FFT required
                 if fft:
@@ -142,7 +144,7 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False, show=True):
                     line1 = ax1.plot(time, outputdata, "r", lw=2, label=outputtext)
                     ax1.set_xlabel("Time [s]")
                     ax1.set_ylabel(outputtext + " field strength [V/m]")
-                    ax1.set_xlim([0, np.amax(time)])
+                    ax1.set_xlim([time[0], time[-1]])
                     ax1.grid(which="both", axis="both", linestyle="-.")
 
                     # Plot frequency spectra
@@ -185,7 +187,7 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False, show=True):
                         edgecolor="w",
                     )
                     line = ax.plot(time, outputdata, "r", lw=2, label=outputtext)
-                    ax.set_xlim([0, np.amax(time)])
+                    ax.set_xlim([time[0], time[-1]])
                     # ax.set_ylim([-15, 20])
                     ax.grid(which="both", axis="both", linestyle="-.")
 
@@ -199,7 +201,7 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False, show=True):
             # If multiple outputs required, create all nine subplots and
             # populate only the specified ones
             else:
-                plt_cols = 3 if len(outputs) == 9 else 2
+                plt_cols = 3 if any(output.startswith("I") for output in outputs) else 2
 
                 fig, axs = plt.subplots(
                     subplot_kw=dict(xlabel="Time [s]"),
@@ -232,7 +234,9 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False, show=True):
                             + f"{', '.join(availableoutputs)}"
                         )
 
-                    outputdata = f[rxpath + output][:] * polarity
+                    history = read_time_history(f[rxpath + output], allow_matrix=True)
+                    outputdata = history.samples * polarity
+                    time = history.time
 
                     if output == "Ex":
                         axs[0, 0].plot(time, outputdata, "r", lw=2, label=outputtext)
@@ -262,7 +266,9 @@ def mpl_plot(filename, outputs=Rx.defaultoutputs, fft=False, show=True):
                         axs[2, 2].plot(time, outputdata, "b", lw=2, label=outputtext)
                         axs[2, 2].set_ylabel(outputtext + ", current [A]")
                 for ax in fig.axes:
-                    ax.set_xlim([0, np.amax(time)])
+                    if ax.lines:
+                        ax.set_xlim([min(line.get_xdata()[0] for line in ax.lines),
+                                     max(line.get_xdata()[-1] for line in ax.lines)])
                     ax.grid(which="both", axis="both", linestyle="-.")
 
             # Show or save this receiver's figure now, rather than after the

--- a/toolboxes/Plotting/plot_Bscan.py
+++ b/toolboxes/Plotting/plot_Bscan.py
@@ -25,22 +25,38 @@ import numpy as np
 from gprMax.utilities.utilities import handle_plot_output
 
 from ..Utilities.outputfiles_merge import get_output_data
+from ..Utilities.receiver_identity import natural_key
+from ..Utilities.trace_time import receiver_time_offset
 
 
-def gather_receiver_outputs(filename, rxcomponent):
+def gather_receiver_outputs(filename, rxcomponent, *, return_time_offset=False):
     """Gather one component from all receivers without duplicating rx1."""
     with h5py.File(filename, "r") as output:
         nrx = int(output.attrs["nrx"])
+        receivers = sorted(output.get("rxs", {}), key=natural_key)
 
     if nrx == 0:
         raise ValueError(f"No receivers found in {filename}")
 
     traces = []
     dt = None
-    for rx in range(1, nrx + 1):
-        outputdata, dt = get_output_data(filename, rx, rxcomponent)
+    offset = None
+    for key in receivers:
+        rx = int(key.removeprefix("rx"))
+        outputdata, candidate_dt, candidate_offset = get_output_data(
+            filename, rx, rxcomponent, return_time_offset=True
+        )
+        if dt is not None and (
+            not np.isclose(dt, candidate_dt, rtol=1e-12, atol=0.0)
+            or not np.isclose(offset, candidate_offset, rtol=1e-12, atol=1e-30)
+            or outputdata.shape[0] != traces[0].shape[0]
+        ):
+            raise ValueError("Gathered receivers have inconsistent sample times")
+        dt, offset = candidate_dt, candidate_offset
         traces.append(np.asarray(outputdata))
 
+    if return_time_offset:
+        return np.column_stack(traces), dt, offset
     return np.column_stack(traces), dt
 
 
@@ -52,6 +68,7 @@ def mpl_plot(
     rxcomponent,
     show=True,
     trace_group=None,
+    time_offset=None,
 ):
     """Creates a plot of the B-scan.
 
@@ -65,12 +82,27 @@ def mpl_plot(
             if the current matplotlib backend is not interactive, the plot
             is saved to file instead.
         trace_group: optional HDF5 group for a terminal-voltage B-scan.
+        time_offset: physical sample-zero time from the loader. Without it,
+            use the legacy receiver component convention (voltage defaults to zero).
 
     Returns:
         plt: matplotlib plot object.
     """
 
     file = Path(filename)
+    outputdata = np.asarray(outputdata)
+    if (
+        outputdata.ndim != 2
+        or 0 in outputdata.shape
+        or not np.all(np.isfinite(outputdata))
+        or np.iscomplexobj(outputdata)
+    ):
+        raise ValueError("A B-scan must be a nonempty finite real time-by-trace matrix")
+    if not np.isfinite(dt) or dt <= 0:
+        raise ValueError("B-scan sample interval must be finite and positive")
+    time_offset = receiver_time_offset(rxcomponent, dt) if time_offset is None else float(time_offset)
+    if not np.isfinite(time_offset):
+        raise ValueError("B-scan time offset must be finite")
 
     trace_id = str(trace_group).strip("/") if trace_group else f"rx{rxnumber}"
     safe_trace_id = trace_id.replace("/", "_")
@@ -86,7 +118,7 @@ def mpl_plot(
 
     plt.imshow(
         outputdata,
-        extent=[0, outputdata.shape[1], outputdata.shape[0] * dt, 0],
+        extent=[0, outputdata.shape[1], time_offset + (outputdata.shape[0] - 0.5) * dt, time_offset - 0.5 * dt],
         interpolation="nearest",
         aspect="auto",
         cmap="seismic",
@@ -131,7 +163,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--trace-group",
         default=None,
-        help=("time-domain terminal-voltage group in a merged file, e.g. " "ports/receive, tls/tl1, or frills/frill1"),
+        help="trace group (e.g. ports/receive) or receiver selector (e.g. name:surface)",
     )
     parser.add_argument(
         "-gather",
@@ -150,13 +182,14 @@ if __name__ == "__main__":
     if args.trace_group is not None:
         if args.gather:
             parser.error("--trace-group and -gather cannot be used together")
-        if args.rx_component != "Vtotal":
+        if args.rx_component != "Vtotal" and not args.trace_group.startswith(("name:", "study:", "build:", "rxs/")):
             parser.error("--trace-group requires the Vtotal component")
-        outputdata, dt = get_output_data(
+        outputdata, dt, offset = get_output_data(
             args.outputfile,
             1,
             args.rx_component,
             trace_group=args.trace_group,
+            return_time_offset=True,
         )
         mpl_plot(
             args.outputfile,
@@ -166,19 +199,22 @@ if __name__ == "__main__":
             args.rx_component,
             show=not args.save,
             trace_group=args.trace_group,
+            time_offset=offset,
         )
     elif args.rx_component == "Vtotal":
         parser.error("Vtotal requires --trace-group")
     elif args.gather:
-        rxsgather, dt = gather_receiver_outputs(args.outputfile, args.rx_component)
+        rxsgather, dt, offset = gather_receiver_outputs(args.outputfile, args.rx_component, return_time_offset=True)
         with h5py.File(args.outputfile, "r") as f:
             nrx = int(f.attrs["nrx"])
-        mpl_plot(args.outputfile, rxsgather, dt, nrx, args.rx_component, show=not args.save)
+        mpl_plot(args.outputfile, rxsgather, dt, nrx, args.rx_component, show=not args.save, time_offset=offset)
     else:
         with h5py.File(args.outputfile, "r") as f:
             nrx = int(f.attrs["nrx"])
+            receivers = sorted(f.get("rxs", {}), key=natural_key)
         if nrx == 0:
             raise ValueError(f"No receivers found in {args.outputfile}")
-        for rx in range(1, nrx + 1):
-            outputdata, dt = get_output_data(args.outputfile, rx, args.rx_component)
-            mpl_plot(args.outputfile, outputdata, dt, rx, args.rx_component, show=not args.save)
+        for key in receivers:
+            rx = int(key.removeprefix("rx"))
+            outputdata, dt, offset = get_output_data(args.outputfile, rx, args.rx_component, return_time_offset=True)
+            mpl_plot(args.outputfile, outputdata, dt, rx, args.rx_component, show=not args.save, time_offset=offset)

--- a/toolboxes/Plotting/plot_port.py
+++ b/toolboxes/Plotting/plot_port.py
@@ -239,22 +239,10 @@ def _source_type(path, group):
 def _time_trace(output, group, name, label, quantity, time_names):
     if name not in group:
         return None
-    values = np.asarray(group[name], dtype=np.float64)
-    if values.ndim != 1:
-        raise ValueError(f"{group.name}/{name} must be a one-dimensional history")
-    time = None
-    for time_name in time_names:
-        if time_name in group:
-            candidate = np.asarray(group[time_name], dtype=np.float64)
-            if candidate.shape == values.shape:
-                time = candidate
-                break
-    if time is None:
-        dt = output.attrs.get("dt")
-        if dt is None:
-            return None
-        time = np.arange(values.size, dtype=np.float64) * float(dt)
-    return TimeTrace(name, label, time, values, quantity)
+    from toolboxes.Utilities.trace_time import read_time_history
+
+    history = read_time_history(group[name])
+    return TimeTrace(name, label, history.time, np.asarray(history.samples, dtype=np.float64), quantity)
 
 
 def read_port_output(filename: str | Path, port: str | None = None) -> PortData:

--- a/toolboxes/SFCW/README.rst
+++ b/toolboxes/SFCW/README.rst
@@ -7,6 +7,10 @@ Stepped-Frequency Continuous-Wave GPR
 Information
 ===========
 
+Receiver selections accept a file-local path, ``name:label``, or ``study:id``.
+Group numbers changed from alphabetical Name order to construction order;
+review saved numeric paths when upgrading. See :ref:`receiver-numbering`.
+
 This toolbox synthesises stepped-frequency continuous-wave (SFCW) responses
 from one broadband gprMax simulation. It implements the impulse-response
 method presented by Giannopoulos, Warren, and Giannakis [GIA2023SFCW]_. The

--- a/toolboxes/SFCW/cli.py
+++ b/toolboxes/SFCW/cli.py
@@ -39,7 +39,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="file containing the source history (needed for a merged B-scan)",
     )
     process.add_argument("--source", help="HDF5 source group, e.g. /srcs/src1")
-    process.add_argument("--receiver", help="HDF5 receiver group, e.g. /rxs/rx1")
+    process.add_argument("--receiver", help="receiver path (e.g. /rxs/rx1), name:label, or study:id")
     process.add_argument("--component", help="receiver component, e.g. Ez")
     process.add_argument("--f-start", type=float, required=True, help="first frequency [Hz]")
     process.add_argument("--f-stop", type=float, required=True, help="last frequency [Hz]")

--- a/toolboxes/SFCW/processing.py
+++ b/toolboxes/SFCW/processing.py
@@ -25,6 +25,8 @@ import numpy as np
 import numpy.typing as npt
 from scipy.signal import czt, fftconvolve
 
+from toolboxes.Utilities.receiver_identity import natural_key
+
 
 @dataclass(frozen=True)
 class SampledSignal:
@@ -137,7 +139,7 @@ def list_receivers(filename: str | Path) -> dict[str, tuple[str, ...]]:
                 result["/" + name.strip("/")] = components
 
         output.visititems(visitor)
-    return dict(sorted(result.items()))
+    return dict(sorted(result.items(), key=lambda item: natural_key(item[0])))
 
 
 def _nearest_dt(item) -> float:
@@ -196,6 +198,9 @@ def load_receiver(
 ) -> SampledSignal:
     """Load a field/current history and its sample-zero time in seconds.
 
+    ``receiver_path`` may instead be ``name:label`` or ``study:id``; these
+    must resolve uniquely across the file's receiver grid namespaces.
+
     Dataset timing metadata takes precedence. Without an explicit offset,
     E samples start at zero and H/current samples at ``-dt/2``. The sample
     interval falls back to the nearest ancestor carrying a ``dt`` attribute,
@@ -210,6 +215,20 @@ def load_receiver(
                 f"available receivers: {list(available)}"
             )
         receiver_path = next(iter(available))
+    for prefix, attribute in (("name:", "Name"), ("study:", "StudyID")):
+        if receiver_path.startswith(prefix):
+            with h5py.File(filename, "r") as output:
+                matches = [
+                    path
+                    for path in available
+                    if _text(output[path].attrs.get(attribute, "")) == receiver_path[len(prefix) :]
+                ]
+            if len(matches) != 1:
+                raise ValueError(
+                    f"Receiver selector {receiver_path!r} has {len(matches)} matches; use a unique identity"
+                )
+            receiver_path = matches[0]
+            break
     receiver_path = _normalise_path(receiver_path)
     if receiver_path not in available:
         raise ValueError(f"receiver group {receiver_path!r} is not present in {filename}")

--- a/toolboxes/SFCW/processing.py
+++ b/toolboxes/SFCW/processing.py
@@ -689,21 +689,9 @@ def _validate_output_path(filename: str | Path, input_filenames) -> Path:
     catches distinct hard links. Empty provenance names carry no input path.
     """
 
-    path = Path(filename)
-    resolved_output = path.resolve()
-    for input_filename in input_filenames:
-        if not input_filename:
-            continue
-        input_path = Path(input_filename)
-        aliases_input = resolved_output == input_path.resolve()
-        if not aliases_input:
-            try:
-                aliases_input = path.samefile(input_path)
-            except FileNotFoundError:
-                aliases_input = False
-        if aliases_input:
-            raise ValueError("processed output must not overwrite an input HDF5 file")
-    return path
+    from toolboxes.Utilities.output_paths import validate_output_path
+
+    return validate_output_path(filename, input_filenames)
 
 
 def write_sfcw_output(

--- a/toolboxes/Utilities/MATLAB/gprmax_receiver_path.m
+++ b/toolboxes/Utilities/MATLAB/gprmax_receiver_path.m
@@ -1,0 +1,26 @@
+function path = gprmax_receiver_path(filename, receiverName, gridPath)
+%GPRMAX_RECEIVER_PATH Resolve a unique receiver Name, independent of rxN.
+%   PATH = GPRMAX_RECEIVER_PATH(FILE, NAME, GRID) searches the main grid by
+%   default, or a grid such as '/subgrids/fine'. Missing/duplicate names fail.
+if nargin < 3
+    gridPath = "/";
+end
+root = "/" + strip(string(gridPath), 'both', '/') + "/rxs";
+root = replace(root, "//", "/");
+info = h5info(filename, char(root));
+matches = strings(0, 1);
+for index = 1:numel(info.Groups)
+    group = info.Groups(index);
+    names = string({group.Attributes.Name});
+    attribute = find(names == "Name");
+    if numel(attribute) == 1 && string(group.Attributes(attribute).Value) == string(receiverName)
+        matches(end + 1, 1) = string(group.Name); %#ok<AGROW>
+    end
+end
+if numel(matches) ~= 1
+    error('gprMax:MATLAB:ReceiverIdentity', ...
+        'Receiver Name "%s" has %d matches in %s; use a unique name or an explicit Path.', ...
+        receiverName, numel(matches), root);
+end
+path = matches(1);
+end

--- a/toolboxes/Utilities/MATLAB/outputfile_converter.m
+++ b/toolboxes/Utilities/MATLAB/outputfile_converter.m
@@ -27,7 +27,13 @@ HDR.fext  = 'h5';
 
 % Read data from HDF5 file ================================================
 infile = [HDR.pname infile];
-rxinfo = h5info(infile, '/rxs/rx1');
+receivers = h5info(infile, '/rxs');
+if numel(receivers.Groups) ~= 1
+    error('gprMax:MATLAB:ReceiverIdentity', ...
+        'This legacy converter requires one receiver. Use gprmax_h5_to_mat with an explicit Path for multiple receivers.');
+end
+receiverpath = receivers.Groups(1).Name;
+rxinfo = h5info(infile, receiverpath);
 available = {rxinfo.Datasets.Name};
 components = intersect({'Ex', 'Ey', 'Ez'}, available, 'stable');
 if isempty(components)
@@ -37,7 +43,7 @@ end
 % Use the available electric-field component with the largest absolute peak.
 peak = -Inf;
 for componentindex = 1:numel(components)
-    candidate = h5read(infile, ['/rxs/rx1/' components{componentindex}]);
+    candidate = h5read(infile, [receiverpath '/' components{componentindex}]);
     candidatepeak = max(abs(candidate(:)));
     if candidatepeak > peak
         data = candidate';

--- a/toolboxes/Utilities/MATLAB/plot_Ascan.m
+++ b/toolboxes/Utilities/MATLAB/plot_Ascan.m
@@ -12,6 +12,7 @@ function [figures, traces] = plot_Ascan(filename, varargin)
 %       Grid             Main grid "/" or a subgrid path such as
 %                        "/subgrids/fine" (default "/").
 %       Receiver         Numeric receiver indices (default all).
+%       ReceiverName     Unique receiver name(s), independent of numbering.
 %       Path             One or more arbitrary HDF5 groups, such as
 %                        "/ports/feed"; cannot be combined with Receiver.
 %       Outputs          Components such as ["Ex", "Hz"] (default all).
@@ -42,6 +43,8 @@ addParameter(parser, 'Receiver', [], ...
     && all(x >= 1) && all(mod(x, 1) == 0));
 addParameter(parser, 'Path', strings(0, 1), ...
     @(x) ischar(x) || isstring(x) || iscellstr(x));
+addParameter(parser, 'ReceiverName', strings(0, 1), ...
+    @(x) ischar(x) || isstring(x) || iscellstr(x));
 addParameter(parser, 'Outputs', strings(0, 1), ...
     @(x) ischar(x) || isstring(x) || iscellstr(x));
 addParameter(parser, 'FFT', false, @(x) islogical(x) && isscalar(x));
@@ -60,6 +63,16 @@ gridPath = normalise_group_path(parser.Results.Grid);
 receiverIndices = parser.Results.Receiver;
 requestedPaths = string(parser.Results.Path);
 requestedPaths = requestedPaths(:);
+receiverNames = string(parser.Results.ReceiverName);
+if ~isempty(receiverNames)
+    if ~isempty(receiverIndices) || ~isempty(requestedPaths)
+        error('gprMax:MATLAB:ConflictingSelection', ...
+            'ReceiverName cannot be combined with Receiver or Path.');
+    end
+    for index = 1:numel(receiverNames)
+        requestedPaths(index, 1) = gprmax_receiver_path(filename, receiverNames(index), gridPath);
+    end
+end
 if any(ismissing(requestedPaths) | strlength(strtrim(requestedPaths)) == 0)
     error('gprMax:MATLAB:InvalidHDF5Path', ...
         'Path cannot contain missing or empty values.');

--- a/toolboxes/Utilities/MATLAB/plot_Bscan.m
+++ b/toolboxes/Utilities/MATLAB/plot_Bscan.m
@@ -15,6 +15,8 @@ function [figureHandle, scan] = plot_Bscan(filename, output, varargin)
 %
 %   Name-value options:
 %       Path             Dataset parent (default "/rxs/rx1").
+%       ReceiverName     Unique receiver name; cannot be combined with Path.
+%       Grid             Namespace for ReceiverName (default "/").
 %       UseDistance      Use cumulative receiver/port path distance when
 %                        trace metadata exist (default true).
 %       Visible          Display the figure (default true).
@@ -42,6 +44,8 @@ addRequired(parser, 'filename', @(x) ischar(x) || (isstring(x) && isscalar(x)));
 addRequired(parser, 'output', @(x) ischar(x) || (isstring(x) && isscalar(x)));
 addParameter(parser, 'Path', "/rxs/rx1", ...
     @(x) ischar(x) || (isstring(x) && isscalar(x)));
+addParameter(parser, 'ReceiverName', "", @(x) ischar(x) || (isstring(x) && isscalar(x)));
+addParameter(parser, 'Grid', "/", @(x) ischar(x) || (isstring(x) && isscalar(x)));
 addParameter(parser, 'UseDistance', true, @(x) islogical(x) && isscalar(x));
 addParameter(parser, 'Visible', true, @(x) islogical(x) && isscalar(x));
 addParameter(parser, 'Save', false, @(x) islogical(x) && isscalar(x));
@@ -57,6 +61,13 @@ if ~isfile(filename)
         'The HDF5 file does not exist: %s', filename);
 end
 groupPath = normalise_group_path(parser.Results.Path);
+if strlength(string(parser.Results.ReceiverName)) > 0
+    if ~ismember('Path', parser.UsingDefaults)
+        error('gprMax:MATLAB:ConflictingSelection', ...
+            'ReceiverName and Path cannot be supplied together.');
+    end
+    groupPath = gprmax_receiver_path(filename, parser.Results.ReceiverName, parser.Results.Grid);
+end
 output = strtrim(string(parser.Results.output));
 if strlength(output) == 0
     error('gprMax:MATLAB:InvalidOutput', 'Output cannot be empty.');

--- a/toolboxes/Utilities/README.rst
+++ b/toolboxes/Utilities/README.rst
@@ -9,6 +9,21 @@ Information
 
 This package contains various scripts and helper functions.
 
+Receiver identity and numbering
+------------------------------
+
+Public receiver numbering follows construction order, not alphabetical Names.
+Merge and SEG-Y/SEG-2/DT1 collection match receiver identities across files;
+``--receiver N`` selects N in the first file and follows that receiver in later
+files. ``--trace-group name:label`` selects by unique Name. Ambiguous legacy
+multi-receiver files fail rather than silently mix traces. See
+:ref:`receiver-numbering` for the schema and migration policy.
+
+MATLAB users can resolve a unique label with
+``gprmax_receiver_path(file, name, grid)`` or pass ``ReceiverName`` to
+``plot_Ascan`` / ``plot_Bscan``. Numeric paths remain file-local. The legacy
+interactive converter accepts only single-receiver files.
+
 Package contents
 ================
 
@@ -316,6 +331,15 @@ The resulting voltage B-scan can be plotted directly. For example:
         --trace-group ports/receive
 
 The trace group can similarly be ``tls/tl1`` or ``frills/frill1``.
+
+Physical trace timing and native source-buffer lengths are also shared by the
+SEG-Y/SEG-2/DT1 collectors and Python port plotting. Frill ``Vinc``, ``Vtotal``
+and ``Itot`` use only the first ``Iterations`` samples; their extra allocation
+endpoint is not exported or plotted. Frill current is already averaged onto
+the integer voltage lattice, so its offset is zero, unlike a receiver loop
+current. Native terminal time axes and group metadata are validated, and
+subgrid histories use the owning grid's interval. Malformed time axes are
+rejected rather than replaced with a guessed root-grid axis.
 
 
 outputfiles_segy.py

--- a/toolboxes/Utilities/README.rst
+++ b/toolboxes/Utilities/README.rst
@@ -291,6 +291,12 @@ where:
 * ``basefilename`` is the base name file of the output file series, e.g. for ``myoutput1.h5``, ``myoutput2.h5`` the base file name would be ``myoutput``
 * ``remove-files`` is an optional argument (flag) that when given will remove the separate output files after the merge.
 
+The destination must not be an input file, including symbolic-link and
+hard-link aliases. The merger validates all inputs and writes to a temporary
+sibling location before atomically publishing the completed result. A failed
+write preserves an existing destination and all inputs; ``--remove-files``
+is applied only after successful publication.
+
 The columns of every merged receiver dataset correspond to the naturally
 ordered input files. Per-trace physical and grid positions for receivers and
 position-bearing sources are retained below ``/trace_metadata`` (and below

--- a/toolboxes/Utilities/output_paths.py
+++ b/toolboxes/Utilities/output_paths.py
@@ -1,0 +1,48 @@
+"""File-identity checks and transactional writes for processed outputs."""
+
+from contextlib import contextmanager
+import os
+from pathlib import Path
+import stat
+import tempfile
+
+
+def validate_output_path(
+    filename, input_filenames, *, message="processed output must not overwrite an input HDF5 file"
+):
+    """Reject direct, symbolic-link and hard-link aliases of an input."""
+    path = Path(filename)
+    resolved_output = path.resolve()
+    for input_filename in input_filenames:
+        if not input_filename:
+            continue
+        input_path = Path(input_filename)
+        aliases_input = resolved_output == input_path.resolve()
+        if not aliases_input:
+            try:
+                aliases_input = path.samefile(input_path)
+            except FileNotFoundError:
+                aliases_input = False
+        if aliases_input:
+            raise ValueError(message)
+    return path
+
+
+@contextmanager
+def atomic_output_path(filename):
+    """Publish a completed sibling file, preserving the destination on error.
+
+    The caller must close all handles to the temporary file before returning.
+    Resolve a destination symlink to preserve the writer's existing target
+    semantics. Replacement is on the same filesystem and never truncates an
+    existing destination inode (including any of its other hard links).
+    """
+    destination = Path(filename).resolve()
+    # A private staging directory lets the actual writer create the file with
+    # its normal umask, unlike mkstemp's unconditional 0600 file permissions.
+    with tempfile.TemporaryDirectory(prefix=f".{destination.name}.", dir=destination.parent) as directory:
+        temporary = Path(directory) / destination.name
+        yield temporary
+        if destination.exists():
+            temporary.chmod(stat.S_IMODE(destination.stat().st_mode))
+        os.replace(temporary, destination)

--- a/toolboxes/Utilities/outputfiles_dt1.py
+++ b/toolboxes/Utilities/outputfiles_dt1.py
@@ -364,7 +364,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--grid", default="/", help="HDF5 grid path (default: /)")
     parser.add_argument("--source", default=None, help="source position path, e.g. srcs/src1")
     parser.add_argument(
-        "--trace-group", default=None, help="position-bearing trace group, e.g. tls/tl1"
+        "--trace-group", default=None, help="trace group (e.g. tls/tl1) or receiver selector (e.g. name:surface)"
     )
     parser.add_argument(
         "--nominal-frequency",

--- a/toolboxes/Utilities/outputfiles_merge.py
+++ b/toolboxes/Utilities/outputfiles_merge.py
@@ -24,6 +24,8 @@ import h5py
 import numpy as np
 
 from gprMax.utilities.utilities import natural_keys
+from toolboxes.Utilities.receiver_identity import match_receiver, receiver_catalogue, select_receiver
+from toolboxes.Utilities.trace_time import read_time_history
 
 
 TIME_DOMAIN_RECEIVER_OUTPUTS = frozenset(("Ex", "Ey", "Ez", "Hx", "Hy", "Hz", "Ix", "Iy", "Iz"))
@@ -37,7 +39,9 @@ def _grid_group(output, grid_path="/"):
     return output[grid_path] if grid_path else output
 
 
-def get_output_data(filename, rxnumber, rxcomponent, grid_path="/", trace_group=None):
+def get_output_data(
+    filename, rxnumber, rxcomponent, grid_path="/", trace_group=None, *, receiver_name=None, return_time_offset=False
+):
     """Gets B-scan output data from a model.
 
     Args:
@@ -46,28 +50,35 @@ def get_output_data(filename, rxnumber, rxcomponent, grid_path="/", trace_group=
         rxcomponent: string of receiver output field/current component.
         grid_path: optional main-grid or subgrid HDF5 path.
         trace_group: optional voltage-trace group, e.g. ``ports/receive``.
+        return_time_offset: if True, also return physical sample-zero time.
 
     Returns:
         outputdata: array of A-scans, i.e. B-scan data.
-        dt: float of temporal resolution of the model.
+        dt: float of temporal sample interval.
+        time_offset: physical sample-zero time, only if requested.
     """
 
     # Open output file and read some attributes
     with h5py.File(filename, "r") as f:
         grid = _grid_group(f, grid_path)
-        dt = grid.attrs["dt"]
         if trace_group is None:
             nrx = int(grid.attrs["nrx"])
             if nrx == 0:
                 raise ValueError(f"No receivers found in {filename}")
-            if rxnumber < 1 or rxnumber > nrx:
+            if receiver_name is None and f"rxs/rx{rxnumber}" not in grid:
                 raise ValueError(f"Receiver {rxnumber} is outside the valid range 1-{nrx}")
-            path = f"rxs/rx{rxnumber}"
+            path = select_receiver(
+                receiver_catalogue(grid), f"name:{receiver_name}" if receiver_name is not None else rxnumber
+            ).path
             allowed = TIME_DOMAIN_RECEIVER_OUTPUTS
             description = f"receiver {rxnumber}"
         else:
             path = str(trace_group).strip("/")
-            allowed = TIME_DOMAIN_VOLTAGE_OUTPUTS
+            if path.startswith(("name:", "study:", "build:", "rxs/")):
+                path = select_receiver(receiver_catalogue(grid), path).path
+                allowed = TIME_DOMAIN_RECEIVER_OUTPUTS
+            else:
+                allowed = TIME_DOMAIN_VOLTAGE_OUTPUTS
             description = f"trace group {path}"
             if path not in grid or not isinstance(grid[path], h5py.Group):
                 raise ValueError(f"Trace group {path!r} was not found in {filename}")
@@ -84,11 +95,11 @@ def get_output_data(filename, rxnumber, rxcomponent, grid_path="/", trace_group=
                 + f"{', '.join(availableoutputs)}"
             )
 
-        dataset = grid[f"{path}/{rxcomponent}"]
-        outputdata = np.asarray(dataset)
-        if outputdata.ndim not in (1, 2) or np.iscomplexobj(outputdata):
-            raise ValueError(f"{path}/{rxcomponent} is not a real time-domain A-scan or B-scan")
+        history = read_time_history(grid[f"{path}/{rxcomponent}"], allow_matrix=True)
+        outputdata, dt = history.samples, history.dt
 
+    if return_time_offset:
+        return outputdata, dt, history.offset
     return outputdata, dt
 
 
@@ -306,62 +317,63 @@ def _validate_grid(reference, candidate, grid_path, filename):
             raise ValueError(f"Inconsistent {attribute} for grid {grid_path or '/'} in {filename}")
 
     nrx = int(reference.attrs["nrx"])
-    for rx in range(1, nrx + 1):
-        rxpath = f"rxs/rx{rx}"
+    reference_receivers = receiver_catalogue(reference)
+    candidate_receivers = receiver_catalogue(candidate)
+    receiver_paths = {}
+    if len(reference_receivers) != nrx or len(candidate_receivers) != nrx:
+        raise ValueError(f"Receiver count does not match nrx in grid {grid_path or '/'} of {filename}")
+    for rxpath in reference_receivers:
         if rxpath not in reference:
             raise ValueError(f"Missing {rxpath} in reference grid {grid_path or '/'}")
-        if rxpath not in candidate:
-            raise ValueError(f"Missing {rxpath} in grid {grid_path or '/'} of {filename}")
-        if set(reference[rxpath].keys()) != set(candidate[rxpath].keys()):
+        if reference.file.filename == candidate.file.filename:
+            candidate_path = rxpath
+        else:
+            candidate_path = match_receiver(reference_receivers[rxpath], candidate_receivers).path
+        receiver_paths[rxpath] = candidate_path
+        if set(reference[rxpath].keys()) != set(candidate[candidate_path].keys()):
             raise ValueError(f"Receiver outputs differ for {rxpath} in grid {grid_path or '/'} of {filename}")
-        for attribute in ("Name", "StudyID"):
-            if (attribute in reference[rxpath].attrs) != (attribute in candidate[rxpath].attrs):
-                raise ValueError(
-                    f"Receiver metadata {attribute} differs for {rxpath} " f"in grid {grid_path or '/'} of {filename}"
-                )
-            if attribute in reference[rxpath].attrs and not _values_equal(
-                reference[rxpath].attrs[attribute], candidate[rxpath].attrs[attribute]
-            ):
-                raise ValueError(
-                    f"Receiver metadata {attribute} differs for {rxpath} " f"in grid {grid_path or '/'} of {filename}"
-                )
         _validate_position(
-            candidate[rxpath],
+            candidate[candidate_path],
             "Position",
             f"{grid_path or '/'}/{rxpath} in {filename}",
         )
         _validate_position(
-            candidate[rxpath],
+            candidate[candidate_path],
             "GridPosition",
             f"{grid_path or '/'}/{rxpath} in {filename}",
         )
         for output, dataset in reference[rxpath].items():
             _validate_receiver_dataset(
                 dataset,
-                candidate[f"{rxpath}/{output}"],
+                candidate[f"{candidate_path}/{output}"],
                 f"{grid_path or '/'}/{rxpath}/{output}",
                 filename,
                 int(reference.attrs["Iterations"]),
                 float(reference.attrs["dt"]),
             )
 
+    if len(set(receiver_paths.values())) != nrx:
+        raise ValueError(f"Receiver identity mapping is not one-to-one in {filename}")
     _validate_voltage_traces(reference, candidate, grid_path, filename)
 
     reference_paths = set(_position_group_paths(reference))
-    candidate_paths = set(_position_group_paths(candidate))
+    inverse_receivers = {value: key for key, value in receiver_paths.items()}
+    candidate_paths = {inverse_receivers.get(path, path) for path in _position_group_paths(candidate)}
     if candidate_paths != reference_paths:
         raise ValueError(
             f"Position-bearing source/receiver structure differs in " f"grid {grid_path or '/'} of {filename}"
         )
     for path in reference_paths:
-        _validate_position(candidate[path], "Position", f"{grid_path or '/'}/{path} in {filename}")
-        if ("GridPosition" in reference[path].attrs) != ("GridPosition" in candidate[path].attrs):
+        candidate_path = receiver_paths.get(path, path)
+        _validate_position(candidate[candidate_path], "Position", f"{grid_path or '/'}/{path} in {filename}")
+        if ("GridPosition" in reference[path].attrs) != ("GridPosition" in candidate[candidate_path].attrs):
             raise ValueError(f"GridPosition metadata differs for {grid_path or '/'}/{path} in {filename}")
         _validate_position(
-            candidate[path],
+            candidate[candidate_path],
             "GridPosition",
             f"{grid_path or '/'}/{path} in {filename}",
         )
+    return receiver_paths
 
 
 def _position_group_paths(grid):
@@ -394,12 +406,15 @@ def _create_trace_metadata(destination_grid, reference_grid, outputfiles):
 
     for path in _position_group_paths(reference_grid):
         group = metadata.require_group(path)
+        if path.startswith("rxs/"):
+            group.create_dataset("InputReceiverPath", shape=(len(outputfiles),), dtype=string_dtype)
+            group.create_dataset("Name", shape=(len(outputfiles),), dtype=string_dtype)
         group.create_dataset("Position", shape=(len(outputfiles), 3), dtype=np.float64)
         if "GridPosition" in reference_grid[path].attrs:
             group.create_dataset("GridPosition", shape=(len(outputfiles), 3), dtype=np.int64)
 
 
-def _write_trace_metadata(destination_grid, source_grid, index, filename):
+def _write_trace_metadata(destination_grid, source_grid, index, filename, receiver_paths):
     """Write acquisition positions for one B-scan column."""
 
     metadata = destination_grid["trace_metadata"]
@@ -411,11 +426,16 @@ def _write_trace_metadata(destination_grid, source_grid, index, filename):
                 for name in metadata[parent_name]
                 if isinstance(metadata[f"{parent_name}/{name}"], h5py.Group)
             )
-    if set(_position_group_paths(source_grid)) != expected_paths:
+    inverse_receivers = {value: key for key, value in receiver_paths.items()}
+    if {inverse_receivers.get(path, path) for path in _position_group_paths(source_grid)} != expected_paths:
         raise ValueError(f"Position-bearing source/receiver structure differs in {filename}")
 
     for path in expected_paths:
-        source = source_grid[path]
+        source_path = receiver_paths.get(path, path)
+        source = source_grid[source_path]
+        if path.startswith("rxs/"):
+            metadata[f"{path}/InputReceiverPath"][index] = source_path
+            metadata[f"{path}/Name"][index] = source.attrs.get("Name", "")
         _validate_position(source, "Position", f"{path} in {filename}")
         if "Position" not in source.attrs:
             raise ValueError(f"Missing Position metadata for {path} in {filename}")
@@ -519,17 +539,20 @@ def merge_files(outputfiles, merged_outputfile=None, removefiles=False):
             )
 
         # Validate every input before creating/truncating the destination.
+        receiver_mappings = []
         for outputfile in outputfiles:
+            file_mapping = {}
             with h5py.File(outputfile, "r") as source:
                 if _output_grid_paths(source) != grid_paths:
                     raise ValueError(f"Grid structure differs in {outputfile}")
                 for grid_path in grid_paths:
-                    _validate_grid(
+                    file_mapping[grid_path] = _validate_grid(
                         _grid_group(reference, grid_path),
                         _grid_group(source, grid_path),
                         grid_path,
                         outputfile,
                     )
+            receiver_mappings.append(file_mapping)
 
         with h5py.File(merged_outputfile, "w") as merged:
             for name, value in reference.attrs.items():
@@ -545,9 +568,7 @@ def merge_files(outputfiles, merged_outputfile=None, removefiles=False):
                 destination_grid.attrs["MergedContent"] = "real_time_domain_receivers_and_terminal_voltages"
                 destination_grid.attrs["ntraces"] = len(outputfiles)
 
-                nrx = int(source_grid.attrs["nrx"])
-                for rx in range(1, nrx + 1):
-                    rxpath = f"rxs/rx{rx}"
+                for rxpath in receiver_catalogue(source_grid):
                     source_rx = source_grid[rxpath]
                     destination_rx = destination_grid.require_group(rxpath)
                     for name, value in source_rx.attrs.items():
@@ -568,12 +589,14 @@ def merge_files(outputfiles, merged_outputfile=None, removefiles=False):
                     for grid_path in grid_paths:
                         source_grid = _grid_group(source, grid_path)
                         destination_grid = _grid_group(merged, grid_path)
-                        _write_trace_metadata(destination_grid, source_grid, index, outputfile)
+                        receiver_paths = receiver_mappings[index][grid_path]
+                        _write_trace_metadata(destination_grid, source_grid, index, outputfile, receiver_paths)
                         _write_voltage_outputs(destination_grid, source_grid, index)
-                        for rx in range(1, int(source_grid.attrs["nrx"]) + 1):
-                            rxpath = f"rxs/rx{rx}"
-                            for output in source_grid[rxpath]:
-                                destination_grid[f"{rxpath}/{output}"][:, index] = source_grid[f"{rxpath}/{output}"][:]
+                        for rxpath, source_rxpath in receiver_paths.items():
+                            for output in source_grid[source_rxpath]:
+                                destination_grid[f"{rxpath}/{output}"][:, index] = source_grid[
+                                    f"{source_rxpath}/{output}"
+                                ][:]
 
     if removefiles:
         for outputfile in outputfiles:

--- a/toolboxes/Utilities/outputfiles_merge.py
+++ b/toolboxes/Utilities/outputfiles_merge.py
@@ -24,6 +24,7 @@ import h5py
 import numpy as np
 
 from gprMax.utilities.utilities import natural_keys
+from toolboxes.Utilities.output_paths import atomic_output_path, validate_output_path
 from toolboxes.Utilities.receiver_identity import match_receiver, receiver_catalogue, select_receiver
 from toolboxes.Utilities.trace_time import read_time_history
 
@@ -523,8 +524,9 @@ def merge_files(outputfiles, merged_outputfile=None, removefiles=False):
     merged_outputfile = (
         Path(merged_outputfile) if merged_outputfile is not None else _default_merged_filename(outputfiles)
     )
-    if merged_outputfile.resolve() in {filename.resolve() for filename in outputfiles}:
-        raise ValueError("Merged output file must not overwrite an input file")
+    validate_output_path(
+        merged_outputfile, outputfiles, message="Merged output file must not overwrite an input file"
+    )
 
     with h5py.File(outputfiles[0], "r") as reference:
         grid_paths = _output_grid_paths(reference)
@@ -554,7 +556,7 @@ def merge_files(outputfiles, merged_outputfile=None, removefiles=False):
                     )
             receiver_mappings.append(file_mapping)
 
-        with h5py.File(merged_outputfile, "w") as merged:
+        with atomic_output_path(merged_outputfile) as temporary, h5py.File(temporary, "w") as merged:
             for name, value in reference.attrs.items():
                 merged.attrs[name] = value
 

--- a/toolboxes/Utilities/outputfiles_seg2.py
+++ b/toolboxes/Utilities/outputfiles_seg2.py
@@ -297,7 +297,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--grid", default="/", help="HDF5 grid path (default: /)")
     parser.add_argument("--source", default=None, help="source position path, e.g. srcs/src1")
     parser.add_argument(
-        "--trace-group", default=None, help="position-bearing trace group, e.g. tls/tl1"
+        "--trace-group", default=None, help="trace group (e.g. tls/tl1) or receiver selector (e.g. name:surface)"
     )
     parser.add_argument("--overwrite", action="store_true", help="replace an existing output file")
     args = parser.parse_args(argv)

--- a/toolboxes/Utilities/outputfiles_segy.py
+++ b/toolboxes/Utilities/outputfiles_segy.py
@@ -509,7 +509,7 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help=(
             "group containing a real time-domain quantity and Position metadata, "
-            "e.g. tls/tl1 for Vtotal (default: rxs/rxN)"
+            "e.g. tls/tl1 for Vtotal, or name:surface (default: rxs/rxN in first file)"
         ),
     )
     parser.add_argument("--line-number", type=int, default=1, help="SEG-Y line number")

--- a/toolboxes/Utilities/outputfiles_trace.py
+++ b/toolboxes/Utilities/outputfiles_trace.py
@@ -27,6 +27,8 @@ import h5py
 import numpy as np
 
 from gprMax.utilities.utilities import natural_keys
+from toolboxes.Utilities.receiver_identity import match_receiver, receiver_catalogue, select_receiver
+from toolboxes.Utilities.trace_time import read_time_history, receiver_time_offset
 
 TIME_DOMAIN_QUANTITIES = {
     "Ex",
@@ -120,11 +122,7 @@ def default_time_offset(component: str, dt: float) -> float:
     dataset offsets override this fallback, including source-specific timing.
     """
 
-    if component.startswith("E"):
-        return 0.0
-    if component.startswith(("H", "I")):
-        return -0.5 * dt
-    return 0.0
+    return receiver_time_offset(component, dt)
 
 
 def quantity_units(component: str) -> str:
@@ -171,6 +169,9 @@ def collect_traces(
 
     ``rxnumber`` is one-based. Source and trace-group paths are relative to
     ``grid_path``; a supplied trace group replaces the default ``rxs/rxN``.
+    A public receiver path/number selects in the first file; later files are
+    matched by identity. ``trace_group`` also accepts ``name:``/``study:``
+    selectors. Ambiguous legacy multi-receiver identities are rejected.
     Only finite, real, one-dimensional histories with matching sample counts,
     intervals and time offsets are accepted. Stored positions are copied
     without another coordinate transform.
@@ -198,13 +199,23 @@ def collect_traces(
     expected_offset: float | None = None
     resolved_source: str | None = None
     title = ""
+    reference_receiver = None
 
     for filename in files:
         with h5py.File(filename, "r") as output:
             grid = _grid_group(output, grid_path)
-            receiver_path = (
-                trace_group.strip("/") if trace_group is not None else f"rxs/rx{rxnumber}"
-            )
+            receiver_path = trace_group.strip("/") if trace_group is not None else f"rxs/rx{rxnumber}"
+            # Public paths/selectors identify the first file's receiver;
+            # source/terminal trace groups keep their independent namespaces.
+            if receiver_path.startswith(("rxs/", "name:", "study:", "build:")):
+                catalogue = receiver_catalogue(grid)
+                selected = (
+                    select_receiver(catalogue, receiver_path)
+                    if reference_receiver is None
+                    else match_receiver(reference_receiver, catalogue)
+                )
+                reference_receiver = reference_receiver or selected
+                receiver_path = selected.path
             dataset_path = f"{receiver_path}/{rxcomponent}"
             if receiver_path not in grid:
                 raise ValueError(f"Trace group {receiver_path!r} is not available in {filename}")
@@ -221,21 +232,9 @@ def collect_traces(
                     f"{filename}:{dataset_path} has shape {dataset.shape}; export requires "
                     "original one-dimensional A-scan files, not a legacy merged file"
                 )
-            raw_samples = np.asarray(dataset)
-            if np.iscomplexobj(raw_samples):
-                raise ValueError(f"Complex-valued trace data cannot be exported: {filename}")
-            samples = np.asarray(raw_samples, dtype=np.float64)
-            if not np.all(np.isfinite(samples)):
-                raise ValueError(f"Trace data contain NaN or infinite values: {filename}")
-
-            dt = float(dataset.attrs.get("SampleInterval", grid.attrs.get("dt", math.nan)))
-            if not math.isfinite(dt) or dt <= 0:
-                raise ValueError(f"Invalid or missing sample interval in {filename}")
-            offset = float(
-                dataset.attrs.get("TimeSampleOffset", default_time_offset(rxcomponent, dt))
-            )
-            if not math.isfinite(offset):
-                raise ValueError(f"Invalid sample-zero time offset in {filename}")
+            history = read_time_history(dataset)
+            samples = np.asarray(history.samples, dtype=np.float64)
+            dt, offset = history.dt, history.offset
 
             candidate = _resolve_source_path(grid, source_path)
             if resolved_source is None:

--- a/toolboxes/Utilities/receiver_identity.py
+++ b/toolboxes/Utilities/receiver_identity.py
@@ -1,0 +1,174 @@
+"""Public receiver selection and cross-file identity, independent of HDF5 order.
+
+Numbers and paths select a receiver in ONE file. A sequence is anchored to that
+receiver in its first file, then matched by StudyID, unique Name, or a versioned
+construction layout/index. Coordinates are not identities (receivers can move
+or coincide). Legacy multi-receiver files without unique labels are ambiguous.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+
+import h5py
+
+
+def text(value) -> str:
+    return value.decode("utf-8") if isinstance(value, bytes) else str(value)
+
+
+def natural_key(value):
+    """Numeric receiver/path order, including rx9 before rx10."""
+    return tuple((1, int(part)) if part.isdigit() else (0, part) for part in re.split(r"(\d+)", str(value)))
+
+
+@dataclass(frozen=True)
+class ReceiverIdentity:
+    path: str
+    name: str = ""
+    study_id: str = ""
+    name_kind: str = ""
+    build_index: int | None = None
+    layout: str = ""
+    name_unique: bool = False
+    study_unique: bool = False
+    count: int = 0
+
+
+class ReceiverCatalogue(dict):
+    """Indexed identity lookup keeps multi-receiver merges linear in count."""
+
+    def __init__(self, receivers):
+        super().__init__(receivers)
+        self.names = defaultdict(list)
+        self.studies = defaultdict(list)
+        self.ordinals = defaultdict(list)
+        for rx in self.values():
+            self.names[rx.name].append(rx)
+            self.studies[rx.study_id].append(rx)
+            self.ordinals[(rx.layout, rx.build_index)].append(rx)
+
+
+def receiver_catalogue(grid) -> dict[str, ReceiverIdentity]:
+    """Snapshot identities in one grid namespace; safe after the file closes."""
+    if "rxs" not in grid:
+        return {}
+    groups = {f"rxs/{key}": group for key, group in grid["rxs"].items() if isinstance(group, h5py.Group)}
+    names = Counter(text(g.attrs.get("Name", "")) for g in groups.values())
+    studies = Counter(text(g.attrs.get("StudyID", "")) for g in groups.values())
+    versioned = (
+        grid.attrs.get("ReceiverOrderSchemaVersion") == 1
+        and text(grid.attrs.get("ReceiverOrder", "")) == "construction"
+    )
+    layout = text(grid.attrs.get("ReceiverLayout", "")) if versioned else ""
+    result = {}
+    for path in sorted(groups, key=natural_key):
+        attrs = groups[path].attrs
+        name = text(attrs.get("Name", ""))
+        study = text(attrs.get("StudyID", ""))
+        index = attrs.get("BuildIndex") if versioned else None
+        if index is not None and (int(index) != index or index < 0):
+            raise ValueError(f"Invalid receiver BuildIndex at {groups[path].name}")
+        result[path] = ReceiverIdentity(
+            path,
+            name,
+            study,
+            text(attrs.get("NameKind", "")),
+            int(index) if index is not None else None,
+            layout,
+            bool(name) and names[name] == 1,
+            bool(study) and studies[study] == 1,
+            len(groups),
+        )
+    indices = [rx.build_index for rx in result.values()]
+    if versioned and (None in indices or len(set(indices)) != len(indices)):
+        raise ValueError(f"Missing or duplicate receiver BuildIndex in {grid.name}")
+    return ReceiverCatalogue(result)
+
+
+def select_receiver(catalogue, selector) -> ReceiverIdentity:
+    """Resolve a number/path, ``name:label``, ``study:id``, or ``build:N``."""
+    value = str(selector)
+    for prefix, attr in (("name:", "name"), ("study:", "study_id"), ("build:", "build_index")):
+        if value.startswith(prefix):
+            wanted = value[len(prefix) :]
+            matches = [rx for rx in catalogue.values() if str(getattr(rx, attr)) == wanted]
+            if len(matches) != 1:
+                raise ValueError(f"Receiver selector {value!r} has {len(matches)} matches; use a unique identity")
+            return matches[0]
+    path = f"rxs/rx{value}" if value.isdigit() else value.strip("/")
+    if path.startswith("rx") and "/" not in path:
+        path = "rxs/" + path
+    if path not in catalogue:
+        raise ValueError(f"Receiver {value!r} is not present; available: {list(catalogue)}")
+    return catalogue[path]
+
+
+def match_receiver(reference: ReceiverIdentity, catalogue) -> ReceiverIdentity:
+    """Find the same declared receiver, never silently fall back to its path.
+
+    A construction layout describes ordered labels/output requests, not an
+    entire model. Ordinal matching is valid for the same declared acquisition
+    layout, including moving/generated or duplicate-labelled receivers.
+    """
+    candidates = catalogue.values()
+    indexed = isinstance(catalogue, ReceiverCatalogue)
+    if reference.study_id:
+        matches = (
+            catalogue.studies.get(reference.study_id, [])
+            if indexed
+            else [rx for rx in candidates if rx.study_id == reference.study_id]
+        )
+        if reference.study_unique and len(matches) == 1:
+            return matches[0]
+        raise ValueError(f"Receiver identity StudyID {reference.study_id!r} is missing or ambiguous")
+
+    ordinal = (
+        catalogue.ordinals.get((reference.layout, reference.build_index), [])
+        if indexed
+        else [rx for rx in candidates if rx.layout == reference.layout and rx.build_index == reference.build_index]
+    )
+    if not reference.layout or reference.build_index is None:
+        ordinal = []
+    # Generated coordinate labels can change (or cross another receiver's old
+    # position) during a scan. In the same layout the ordinal is authoritative.
+    if reference.name_kind == "generated" and len(ordinal) == 1:
+        return ordinal[0]
+    if reference.name and reference.name_unique:
+        matches = (
+            catalogue.names.get(reference.name, [])
+            if indexed
+            else [rx for rx in candidates if rx.name == reference.name]
+        )
+        if len(matches) == 1:
+            if matches[0].study_id:
+                raise ValueError("Receiver identity StudyID differs between files")
+            return matches[0]
+    if len(ordinal) == 1:
+        return ordinal[0]
+    # Preserve genuinely anonymous, single-receiver legacy files. Different
+    # nonempty labels are NOT made compatible just because both files have rx1.
+    if reference.count == 1 and len(candidates) == 1:
+        other = next(iter(candidates))
+        if not reference.name and not other.name and not other.study_id:
+            return other
+    raise ValueError(
+        f"Receiver identity {reference.name or reference.path!r} is missing or ambiguous; "
+        "group numbers are file-local. Supply unique receiver names/StudyIDs or "
+        "an explicit per-file receiver selection."
+    )
+
+
+def matching_receiver_path(reference_filename, reference_path, filename) -> str:
+    """Match within the reference receiver's grid, including subgrids."""
+    grid_path, _, leaf = str(reference_path).rpartition("/rxs/")
+    if not leaf:
+        raise ValueError(f"Not a public receiver path: {reference_path!r}")
+    with h5py.File(reference_filename, "r") as source, h5py.File(filename, "r") as target:
+        reference = select_receiver(receiver_catalogue(source[grid_path or "/"]), f"rxs/{leaf}")
+        if (grid_path or "/") not in target:
+            raise ValueError(f"Receiver grid {grid_path or '/'} is not present in {filename}")
+        match = match_receiver(reference, receiver_catalogue(target[grid_path or "/"]))
+        return f"{grid_path}/{match.path}"

--- a/toolboxes/Utilities/trace_time.py
+++ b/toolboxes/Utilities/trace_time.py
@@ -1,0 +1,115 @@
+"""Physical time-domain histories shared by plotting and trace exporters.
+
+Raw source buffers are not always physical output histories: magnetic frills
+have an extra allocation endpoint, and source-terminal currents need not lie
+on the receiver H/current lattice. Do not infer source timing from 'I' alone.
+"""
+
+from dataclasses import dataclass
+
+import h5py
+import numpy as np
+
+
+@dataclass(frozen=True)
+class TimeHistory:
+    samples: np.ndarray
+    dt: float
+    offset: float
+
+    @property
+    def time(self):
+        return self.offset + np.arange(self.samples.shape[0]) * self.dt
+
+
+def receiver_time_offset(component, dt):
+    """Legacy receiver fallback; explicit dataset metadata takes precedence."""
+    return -0.5 * dt if component.startswith(("H", "I")) else 0.0
+
+
+def _nearest_attribute(group, name):
+    while True:
+        if name in group.attrs:
+            return group.attrs[name]
+        if group.name == "/":
+            return None
+        group = group.parent
+
+
+def read_time_history(dataset, *, allow_matrix=False):
+    """Read a real history with validated sampling and source-specific length.
+
+    Dataset metadata is authoritative; native terminal time vectors and group
+    offsets are checked for consistency. Missing interval metadata falls back
+    to the nearest owning grid, not unconditionally the root grid. Only native
+    frill buffers may have their extra endpoint trimmed. Merged frill matrices
+    already contain physical samples and are never trimmed.
+    """
+    if not isinstance(dataset, h5py.Dataset):
+        raise ValueError("A time-domain HDF5 dataset is required")
+    values = np.asarray(dataset)
+    if values.ndim not in ((1, 2) if allow_matrix else (1,)) or values.shape[0] == 0:
+        raise ValueError(
+            f"{dataset.name} must be a nonempty {'one- or two-' if allow_matrix else 'one-'}dimensional history"
+        )
+    if np.iscomplexobj(values):
+        raise ValueError(f"Complex-valued time-domain trace data are unsupported: {dataset.name}")
+    if not np.issubdtype(values.dtype, np.number):
+        raise ValueError(f"{dataset.name} must contain real numeric time-domain samples")
+    group = dataset.parent
+    family = group.parent.name.rsplit("/", 1)[-1]
+    component = dataset.name.rsplit("/", 1)[-1]
+    interval = dataset.attrs.get("SampleInterval", _nearest_attribute(group, "dt"))
+    if interval is None or not np.isfinite(float(interval)) or float(interval) <= 0:
+        raise ValueError(f"Invalid or missing sample interval for {dataset.name}")
+    dt = float(interval)
+    offset = None
+    time_name = None
+    if family == "tls":
+        current = component.startswith("I")
+        time_name = "time_current" if current else "time_voltage"
+        offset = group.attrs.get("TimeCurrentOffset" if current else "TimeVoltageOffset")
+        fallback = -0.5 * dt if current else 0.0
+    elif family == "frills":
+        time_name = "time"
+        offset = group.attrs.get("TimeOffset")
+        fallback = 0.0
+        if values.ndim == 1:
+            iterations = _nearest_attribute(group, "Iterations")
+            if iterations is None and time_name in group:
+                iterations = group[time_name].shape[0]
+            if iterations is not None:
+                count = int(iterations)
+                if count <= 0 or count != iterations or values.shape[0] not in (count, count + 1):
+                    raise ValueError(f"Invalid physical frill history length for {dataset.name}")
+                values = values[:count]
+    elif family == "ports":
+        current = component.startswith("I")
+        time_name = "time_current" if current and "time_current" in group else "time"
+        offset = group.attrs.get("CurrentTimeSampleOffset") if current else None
+        if offset is None:
+            offset = group.attrs.get("TimeSampleOffset")
+        fallback = 0.0
+    else:
+        fallback = receiver_time_offset(component, dt)
+    offset = dataset.attrs.get("TimeSampleOffset", offset)
+    if time_name is not None and time_name in group:
+        axis = np.asarray(group[time_name])
+        if (
+            axis.shape != (values.shape[0],)
+            or not np.issubdtype(axis.dtype, np.number)
+            or np.iscomplexobj(axis)
+            or not np.all(np.isfinite(axis))
+        ):
+            raise ValueError(f"Invalid time axis {group.name}/{time_name} for {dataset.name}")
+        if offset is None:
+            offset = float(axis[0])
+        expected = float(offset) + np.arange(values.shape[0]) * dt
+        if not np.allclose(axis, expected, rtol=1e-6, atol=32 * np.finfo(float).eps * dt):
+            raise ValueError(f"Time axis and sampling metadata disagree for {dataset.name}")
+    offset = float(fallback if offset is None else offset)
+    if not np.isfinite(offset):
+        raise ValueError(f"Invalid sample-zero time offset for {dataset.name}")
+    if not np.all(np.isfinite(values)):
+        raise ValueError(f"Trace data contain NaN or infinite values: {dataset.name}")
+    return TimeHistory(values, dt, offset)


### PR DESCRIPTION
## Summary

Collect the completed release-review fixes for receivers, hard voltage sources,
model building/execution, and result-processing consumers. This PR targets
`devel` and includes the latest processing/plotting corrections as well as the
earlier fixes.

### Receivers and downstream identity

- Build `RxArray` on bounded integer grid coordinates: no floating-point extra
  rows, domain-edge overshoot, or repeated subgrid coordinate translation.
- Assign per-grid receiver construction indices before MPI ownership filtering;
  write deterministic public groups without lexicographically sorting generated
  coordinate names or changing runtime/device receiver order.
- Persist receiver order/layout/name-kind metadata and share identity-aware
  selection across merging, exporters, Marimo, FMCW, SFCW, impulse-response
  processing, MATLAB helpers, comparisons and ReFrame checks.
- Preserve AntennaPatterns' intentional angle/radius name ordering and separate
  native port/NTFF namespaces. Reject ambiguous cross-file identity matches.

### Hard voltage sources

- Prescribe active zero-resistance sources at E(0), then at E(n+1) after each
  electric update. Keep finite-resistance and other source conventions unchanged.
- Cover host initialisation/device uploads, shared CUDA/OpenCL/Metal source
  templates, MPI initial electric halos, geometry reuse and local subgrid clocks.
- Update hard-source excitation/port histories and impulse-response consumers so
  sample zero is retained and physical versus waveform-evaluation times agree.
- Document that an active zero-valued hard source remains a clamp; an initial
  impulse with `0 < stop < dt` releases the feed after sample zero.

### API/hash model building and execution

- Reject undeclared subgrid execution and invalid/duplicate subgrid IDs before
  building/output; retain explicit CPU-only subgrid backend requirements.
- Rebuild fractal definition runtime state when a Scene is reused.
- Preserve output-directory policy and per-model snapshot paths across geometry
  reuse/restarts; resolve hash output paths relative to the top-level input.
- Share recursive containing-file-relative include traversal across parsing and
  study/codebook preflight, with cycle/depth checks and no CWD shadow fallback.
- Reject study/codebook controls generated only after preflight, restore the
  caller's stdout after legacy Python exceptions, and normalise common study
  boolean/time validation across study families.

### Processing and plotting

- Match Marimo A-scan background receivers by identity before fetching samples
  and their physical time axes.
- Share a physical-history reader across A-scan plotting, B-scan loading,
  port-history plotting and the SEG-2/SEG-Y/DT1 collector. Honour dataset timing,
  source-family conventions and the owning grid's interval.
- Plot B-scan pixel centres at sample times; support current-containing A-scan
  subsets without indexing past the subplot grid.
- Exclude native frill allocation padding from physical histories and retain
  the frill current's integer-time offset; reject malformed native time axes
  rather than inventing replacement axes.

## Compatibility notes

- Public receiver group numbering intentionally changes from the previous v4
  development ID sort to construction order (including existing builder
  priorities). Numeric selectors remain file-local; cross-file processing uses
  validated receiver identity. Old files are readable, not rewritten.
- Hard-source port histories now retain N samples instead of N-1; native FFT
  bins can therefore differ. Consumers must use stored axes. Finite-R source
  timing/port conventions are unchanged.
- `get_output_data()` and `gather_receiver_outputs()` still return two values
  by default; `return_time_offset=True` opts into the physical time offset.
- `active`/`record` accept Python and NumPy booleans, not arbitrary truthiness.
  `record=False` remains explicitly unsupported. Study times must be finite.
- Include paths are relative to the containing file; study CSV/codebook JSON
  paths remain relative to the top-level input. Run controls must be literal
  commands visible at preflight, not printed by a Python block.

## Verification

The latest completed implementation campaign passed **2,132 distinct selected
tests**, with **44 unavailable optional-dependency skips** and no failures.
Counts were deduplicated across overlapping runs, and include actual CUDA,
OpenCL and two-rank MPI checks. Earlier completed campaigns additionally cover
hard-source CPU/subgrid behaviour, 280 CUDA/OpenCL source tests, six MPI startup
cases, and MATLAB plotting/conversion. These campaign counts overlap and must
not be added together.

Fresh pre-PR checks also passed:

| Selection | Result |
|---|---|
| Combined RxArray/order, hard-source CPU/subgrid, API/hash and processing regressions | 194 passed, 128 deselected |
| CUDA/OpenCL receiver reuse, hard-source startup/snapshots and include preflight | 10 passed, 3 Metal skips, 163 deselected |
| Two-rank MPI receiver gather/migration, hard-source startup and hash/reuse | 10 passed, 181 deselected |

`git diff --cached --check` passed. The fresh selections used
`OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MPLBACKEND=Agg` in the development
environment:

```bash
python -m pytest -q tests/cmds_multiuse/test_rx_array_bounds.py \
  tests/outputs/test_receiver_order.py tests/outputs/test_receiver_order_integration.py \
  tests/sources/test_hard_source_initialisation.py tests/updates/test_hard_source_timing_solve.py \
  tests/test_api_hash_execution_fixes.py tests/test_processing_execution_fixes.py \
  tests/toolboxes/test_receiver_identity.py tests/toolboxes/test_physical_trace_consumers.py \
  -m 'not gpu' -k 'not mpi'

python -m pytest -q tests/outputs/test_receiver_order_integration.py \
  tests/updates/test_hard_source_timing_solve.py tests/test_processing_execution_fixes.py \
  -m gpu -k 'device_receiver_pages or reused_geometry_reinitialises or snapshot_zero or run_nested_includes'

python -m pytest -q tests/outputs/test_receiver_order_integration.py \
  tests/updates/test_hard_source_timing_solve.py tests/test_api_hash_execution_fixes.py -k mpi
```

This is targeted verification, not an all-repository/all-hardware claim. Metal
hardware requires an Apple host; Linux covers the shared templates/packing.
The Marimo callback and cell registration were checked without an interactive
browser. Optional geometry-import/optimisation dependencies were unavailable.

No reference outputs are regenerated. Separate Vivaldi comparison work and
local stage-specific review/evidence archives are intentionally outside this PR.

## Third-review follow-up

This PR also includes the fixes found in the third release-readiness review:

- Correct the two Windows CI path assertions using native path comparisons,
  including the exception's filename rather than escaped display text.
- Keep symbolic source/receiver coordinates and output bounds reusable across
  builds; recalculate each grid's active plane and generated IDs without
  mutating declarations or caller-owned receiver output lists.
- Build implicit sampled-waveform axes from an exact integer sample count.
  Define linear interpolation with zero-extension by default, honour explicit
  numeric fill/extrapolation, and sample only the voltage source's required
  whole-step (hard) or half-step (resistive) lattice. Source timing and window
  gating are unchanged by this follow-up.
- Reject direct, symlink and hard-link merge-output aliases of inputs. Publish
  completed merges atomically, preserving inputs and prior output on write
  failure; delete input files only after successful publication. Share the
  identity guard with SFCW/FMCW processing.
- Drain outstanding task-farm READY/DONE messages before shutdown completes and
  propagate failed batches on every MPI rank without MPI.Abort. Retain good
  outputs and catchable API errors with a usable communicator.
- Clarify that user-object string representations are diagnostics, not a
  general API-to-hash serializer.

### Fresh follow-up verification

These selections overlap and must not be summed:

| Selection | Result |
|---|---|
| Repository unit selection, excluding MPI-named tests and unrelated local Vivaldi work | 4,894 passed; 3 unavailable optional-dependency collection skips |
| Final sampled-waveform, merge safety, taskfarm unit and hash parser selection | 136 passed |
| Source tests, output safety and symbolic-coordinate real-solve regressions | 375 passed |
| Sampled-source and hard-source timing on actual CUDA/OpenCL devices | 70 passed |
| MPI regression selection on each installed MPICH environment | 13 passed in each environment |
| Repeated final taskfarm protocol checks: MPICH 4.1.1 and 4.3.2, mixed/success/all-failure/caught-error batches | 48/48 batches passed (24 per environment) |
| CPU Mie scattering, analytic Hertzian pattern and selected subgrid KSIR/TFSF integration | 8 passed |
| Advanced output API/hash parity smoke | 198 numeric datasets identical; all 21 receiver/transformed-field datasets finite and nonzero |
| Broader CPU model-building, ports, subgrids and processing integration | 1,200 passed; 50 skipped; one MATLAB startup failure in the restricted sandbox |
| Unchanged MATLAB reader/converter/plotting test rerun with normal runtime access | 1 passed |

The independent third-review defect probes and all 16 geometry primitive
API/hash parity checks also pass after these changes. The broader integration
run completed; its only failure was MATLAB exiting without diagnostics inside
the restricted sandbox. The identical test passed outside it without code or
test changes. No assertion was weakened to suppress that result.

CI on head `e93dd362`: **Windows, Linux and macOS unit tests are green**, as
are Python 3.11/3.12/3.13 core installs, MPI fractals and the source distribution.
The full CPU integration job and wheel builds are still running. Metal requires
Apple hardware and is not claimed as locally executed. The local review/evidence
archive and unrelated Vivaldi work remain outside this PR.
